### PR TITLE
feat(editor): date slash command backed by a first-class date-picker suggestion surface

### DIFF
--- a/packages/core/editor/src/components/date-picker-menu.tsx
+++ b/packages/core/editor/src/components/date-picker-menu.tsx
@@ -1,0 +1,175 @@
+import { useCoreServices } from '@bangle.io/context';
+import { $suggestions, $suggestionUi } from '@bangle.io/prosemirror-plugins';
+import { Calendar, CommandHints } from '@bangle.io/ui-components';
+import { format } from 'date-fns';
+import { useAtomValue, useSetAtom } from 'jotai';
+import React, {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { DATE_SUGGESTION } from '../extensions';
+import {
+  FLOATING_INITIAL_STYLE,
+  useFloatingPosition,
+} from './use-floating-position';
+
+// Bound the calendar's month/year dropdowns to a generous window around the
+// current year so far-off dates remain reachable without endless clicking.
+const CALENDAR_YEAR_SPAN = 100;
+
+/**
+ * DatePickerMenu is the floating surface for the `date_suggestion` mark.
+ * It activates when the user types the `$date` trigger directly, or when the
+ * slash menu's "Date" item swaps the slash mark for the trigger text.
+ * Committing a day replaces the trigger text with the formatted date.
+ */
+export function DatePickerMenu({
+  editorName,
+}: {
+  editorName: string;
+}): ReactElement | null {
+  const suggestions = useAtomValue($suggestions);
+  const setSuggestionUi = useSetAtom($suggestionUi);
+  const [selectedDate, setSelectedDate] = useState(() => new Date());
+  const selectedDateRef = useRef(selectedDate);
+  selectedDateRef.current = selectedDate;
+  const { pmEditorService } = useCoreServices();
+  const editorView = pmEditorService.getEditor(editorName);
+  const ext = pmEditorService.extensions;
+  const suggestion = editorView ? suggestions.get(editorView) : undefined;
+  const active =
+    suggestion?.markName === DATE_SUGGESTION.markName ? suggestion : undefined;
+
+  const insertDate = useCallback(
+    (date: Date) => {
+      if (!editorView) {
+        return;
+      }
+      // `focus: true` (the default) returns focus to the editor so the caret
+      // lands right after the inserted date.
+      ext.dateSuggestions.command.replaceSuggestMarkWith({
+        content: format(date, 'PP'),
+      })(editorView.state, editorView.dispatch, editorView);
+    },
+    [editorView, ext],
+  );
+
+  const dismiss = useCallback(() => {
+    if (!editorView || !active) {
+      return;
+    }
+    ext.dateSuggestions.command.replaceSuggestMarkWith({
+      content: '',
+    })(editorView.state, editorView.dispatch, editorView);
+  }, [editorView, active, ext]);
+
+  useEffect(() => {
+    if (!active?.show) {
+      setSelectedDate(new Date());
+    }
+  }, [active?.show]);
+
+  useEffect(() => {
+    if (!editorView || !active) {
+      return;
+    }
+
+    setSuggestionUi((existing) => {
+      const next = new Map(existing);
+      next.set(editorView, {
+        ...(next.get(editorView) ?? {}),
+        [DATE_SUGGESTION.markName]: {
+          // Enter while the editor still has focus commits the highlighted
+          // day; once focus is inside the calendar react-day-picker handles
+          // Enter/arrow navigation itself.
+          onSelect: () => insertDate(selectedDateRef.current),
+        },
+      });
+      return next;
+    });
+
+    return () => {
+      setSuggestionUi((existing) => {
+        const next = new Map(existing);
+        const handlers = { ...(next.get(editorView) ?? {}) };
+        delete handlers[DATE_SUGGESTION.markName];
+        if (Object.keys(handlers).length) {
+          next.set(editorView, handlers);
+        } else {
+          next.delete(editorView);
+        }
+        return next;
+      });
+    };
+  }, [active, editorView, insertDate, setSuggestionUi]);
+
+  const floatingRef = useFloatingPosition({
+    show: Boolean(active?.show),
+    anchorEl: () => active?.anchorEl() ?? null,
+    boundarySelector: '.ProseMirror:not([contenteditable="false"])',
+  });
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      // Unlike the shared suggestion keymap (which only strips the mark),
+      // an explicit Escape inside the calendar also removes the trigger
+      // text and hands focus back to the editor.
+      dismiss();
+      editorView?.focus();
+    },
+    [dismiss, editorView],
+  );
+
+  if (!editorView || !active?.show) {
+    return null;
+  }
+
+  const currentYear = new Date().getFullYear();
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: Escape handling for a floating popover, not an interactive control.
+    <div
+      ref={floatingRef}
+      style={FLOATING_INITIAL_STYLE}
+      className="w-fit overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+      onKeyDown={handleKeyDown}
+    >
+      <Calendar
+        mode="single"
+        // Move focus to the selected day so arrow keys navigate the grid and
+        // Enter commits, without any editor-side key forwarding.
+        autoFocus
+        captionLayout="dropdown"
+        // Hide adjacent-month days so only the visible month is selectable
+        // (avoids ambiguous day cells near month boundaries).
+        showOutsideDays={false}
+        startMonth={new Date(currentYear - CALENDAR_YEAR_SPAN, 0)}
+        endMonth={new Date(currentYear + CALENDAR_YEAR_SPAN, 11)}
+        defaultMonth={selectedDate}
+        selected={selectedDate}
+        onSelect={(date) => {
+          if (!date) {
+            return;
+          }
+          setSelectedDate(date);
+          insertDate(date);
+        }}
+      />
+      <CommandHints
+        hints={[
+          t.app.editor.datePicker.hintSelect,
+          t.app.editor.datePicker.hintDismiss,
+        ]}
+      />
+    </div>
+  );
+}

--- a/packages/core/editor/src/components/date-picker-menu.tsx
+++ b/packages/core/editor/src/components/date-picker-menu.tsx
@@ -1,12 +1,13 @@
 import { useCoreServices } from '@bangle.io/context';
-import { $suggestions, $suggestionUi } from '@bangle.io/prosemirror-plugins';
+import { $suggestions } from '@bangle.io/prosemirror-plugins';
 import { Calendar, CommandHints } from '@bangle.io/ui-components';
 import { format } from 'date-fns';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import React, {
   type ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -16,6 +17,7 @@ import {
   FLOATING_INITIAL_STYLE,
   useFloatingPosition,
 } from './use-floating-position';
+import { useSuggestionUiHandler } from './use-suggestion-ui-handler';
 
 // Bound the calendar's month/year dropdowns to a generous window around the
 // current year so far-off dates remain reachable without endless clicking.
@@ -33,7 +35,6 @@ export function DatePickerMenu({
   editorName: string;
 }): ReactElement | null {
   const suggestions = useAtomValue($suggestions);
-  const setSuggestionUi = useSetAtom($suggestionUi);
   const [selectedDate, setSelectedDate] = useState(() => new Date());
   const selectedDateRef = useRef(selectedDate);
   selectedDateRef.current = selectedDate;
@@ -73,39 +74,22 @@ export function DatePickerMenu({
     }
   }, [active?.show]);
 
-  useEffect(() => {
-    if (!editorView || !active) {
-      return;
-    }
+  const dateSuggestionUiHandler = useMemo(
+    () => ({
+      // Enter while the editor still has focus commits the highlighted day;
+      // once focus is inside the calendar react-day-picker handles Enter/arrow
+      // navigation itself.
+      onSelect: () => insertDate(selectedDateRef.current),
+    }),
+    [insertDate],
+  );
 
-    setSuggestionUi((existing) => {
-      const next = new Map(existing);
-      next.set(editorView, {
-        ...(next.get(editorView) ?? {}),
-        [DATE_SUGGESTION.markName]: {
-          // Enter while the editor still has focus commits the highlighted
-          // day; once focus is inside the calendar react-day-picker handles
-          // Enter/arrow navigation itself.
-          onSelect: () => insertDate(selectedDateRef.current),
-        },
-      });
-      return next;
-    });
-
-    return () => {
-      setSuggestionUi((existing) => {
-        const next = new Map(existing);
-        const handlers = { ...(next.get(editorView) ?? {}) };
-        delete handlers[DATE_SUGGESTION.markName];
-        if (Object.keys(handlers).length) {
-          next.set(editorView, handlers);
-        } else {
-          next.delete(editorView);
-        }
-        return next;
-      });
-    };
-  }, [active, editorView, insertDate, setSuggestionUi]);
+  useSuggestionUiHandler({
+    active: Boolean(active),
+    editorView,
+    handler: dateSuggestionUiHandler,
+    markName: DATE_SUGGESTION.markName,
+  });
 
   const floatingRef = useFloatingPosition({
     show: Boolean(active?.show),

--- a/packages/core/editor/src/components/index.ts
+++ b/packages/core/editor/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './date-picker-menu';
 export * from './inline-selection-menu';
 export * from './link-menu';
 export * from './slash-command';

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -11,6 +11,7 @@ import {
   CommandList,
   CommandSeparator,
   cn,
+  Input,
 } from '@bangle.io/ui-components';
 import {
   addMonths,
@@ -193,6 +194,19 @@ export function SlashCommand({
     })(editorView.state, editorView.dispatch, editorView);
   }, [editorView, active, ext]);
 
+  const handleCommandKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      dismissCommandUi();
+    },
+    [dismissCommandUi],
+  );
+
   if (!editorView || !active?.show) {
     return null;
   }
@@ -203,6 +217,7 @@ export function SlashCommand({
         <Command
           ref={commandRef}
           className="min-w-72 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+          onKeyDown={handleCommandKeyDown}
         >
           <CommandInput
             hidden
@@ -231,6 +246,7 @@ export function SlashCommand({
       <Command
         ref={commandRef}
         className="overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+        onKeyDown={handleCommandKeyDown}
       >
         <CommandInput
           hidden
@@ -464,6 +480,38 @@ function DateCommandCalendar({
 }): ReactElement {
   const days = getCalendarDays(month);
   const today = new Date();
+  const [jumpMonth, setJumpMonth] = useState(() =>
+    String(month.getMonth() + 1),
+  );
+  const [jumpYear, setJumpYear] = useState(() => String(month.getFullYear()));
+
+  useEffect(() => {
+    setJumpMonth(String(month.getMonth() + 1));
+    setJumpYear(String(month.getFullYear()));
+  }, [month]);
+
+  const jumpToMonth = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const monthNumber = Number(jumpMonth);
+    const yearNumber = Number(jumpYear);
+
+    if (
+      !Number.isInteger(monthNumber) ||
+      !Number.isInteger(yearNumber) ||
+      monthNumber < 1 ||
+      monthNumber > 12 ||
+      yearNumber < 1 ||
+      yearNumber > 9999
+    ) {
+      return;
+    }
+
+    const nextMonth = new Date(month);
+    nextMonth.setFullYear(yearNumber, monthNumber - 1, 1);
+    nextMonth.setHours(0, 0, 0, 0);
+    onMonthChange(startOfMonth(nextMonth));
+  };
 
   return (
     <div className="p-3">
@@ -499,6 +547,40 @@ function DateCommandCalendar({
           <ChevronRight aria-hidden="true" />
         </Button>
       </div>
+      <form
+        aria-label="Go to month and year"
+        className="mb-3 grid grid-cols-[4.5rem_1fr_auto] gap-2"
+        onKeyDown={(event) => {
+          if (event.key !== 'Escape') {
+            event.stopPropagation();
+          }
+        }}
+        onSubmit={jumpToMonth}
+      >
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={1}
+          max={12}
+          value={jumpMonth}
+          aria-label="Month"
+          className="h-8 px-2 text-sm"
+          onChange={(event) => setJumpMonth(event.target.value)}
+        />
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={1}
+          max={9999}
+          value={jumpYear}
+          aria-label="Year"
+          className="h-8 px-2 text-sm"
+          onChange={(event) => setJumpYear(event.target.value)}
+        />
+        <Button type="submit" variant="secondary" size="sm" className="h-8">
+          Go
+        </Button>
+      </form>
       <section className="grid grid-cols-7 gap-1" aria-label="Calendar">
         {WEEKDAY_LABELS.map((label) => (
           <div

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -1,9 +1,5 @@
 import { useCoreServices } from '@bangle.io/context';
-import {
-  $suggestions,
-  $suggestionUi,
-  Fragment,
-} from '@bangle.io/prosemirror-plugins';
+import { $suggestions, Fragment } from '@bangle.io/prosemirror-plugins';
 import {
   Command,
   CommandEmpty,
@@ -22,11 +18,12 @@ import {
   startOfWeek,
   subDays,
 } from 'date-fns';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import React, {
   type ReactElement,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
 } from 'react';
 
@@ -35,6 +32,7 @@ import {
   FLOATING_INITIAL_STYLE,
   useFloatingPosition,
 } from './use-floating-position';
+import { useSuggestionUiHandler } from './use-suggestion-ui-handler';
 
 /**
  * SlashCommand displays a floating "slash" menu when the user is inside
@@ -46,7 +44,6 @@ export function SlashCommand({
   editorName: string;
 }): ReactElement | null {
   const suggestions = useAtomValue($suggestions);
-  const setSuggestionUi = useSetAtom($suggestionUi);
   const commandRef = useRef<HTMLDivElement>(null);
   const prevSelectedIndexRef = useRef<number>(0);
   const { pmEditorService } = useCoreServices();
@@ -75,45 +72,28 @@ export function SlashCommand({
     prevSelectedIndexRef.current = selectedIndex;
   }, [active?.selectedIndex]);
 
-  useEffect(() => {
-    if (!editorView || !active) {
-      return;
-    }
-
-    setSuggestionUi((existing) => {
-      const next = new Map(existing);
-      next.set(editorView, {
-        ...(next.get(editorView) ?? {}),
-        slash_command: {
-          onSelect: () => {
-            if (commandRef.current) {
-              const event = new KeyboardEvent('keydown', {
-                key: 'Enter',
-                cancelable: true,
-                bubbles: true,
-              });
-              commandRef.current.dispatchEvent(event);
-            }
-          },
-        },
-      });
-      return next;
-    });
-
-    return () => {
-      setSuggestionUi((existing) => {
-        const next = new Map(existing);
-        const handlers = { ...(next.get(editorView) ?? {}) };
-        delete handlers.slash_command;
-        if (Object.keys(handlers).length) {
-          next.set(editorView, handlers);
-        } else {
-          next.delete(editorView);
+  const slashCommandUiHandler = useMemo(
+    () => ({
+      onSelect: () => {
+        if (commandRef.current) {
+          const event = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            cancelable: true,
+            bubbles: true,
+          });
+          commandRef.current.dispatchEvent(event);
         }
-        return next;
-      });
-    };
-  }, [active, editorView, setSuggestionUi]);
+      },
+    }),
+    [],
+  );
+
+  useSuggestionUiHandler({
+    active: Boolean(active),
+    editorView,
+    handler: slashCommandUiHandler,
+    markName: 'slash_command',
+  });
 
   const slashRef = useFloatingPosition({
     show: Boolean(active?.show),

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -9,6 +9,7 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
+  Input,
 } from '@bangle.io/ui-components';
 import {
   addMonths,
@@ -24,12 +25,29 @@ import React, {
   useCallback,
   useEffect,
   useRef,
+  useState,
 } from 'react';
 
 import {
   FLOATING_INITIAL_STYLE,
   useFloatingPosition,
 } from './use-floating-position';
+
+type SlashCommandView = 'menu' | 'date-picker';
+
+function formatDateInputValue(date: Date): string {
+  return format(date, 'yyyy-MM-dd');
+}
+
+function parseDateInputValue(value: string): Date | undefined {
+  const [year, month, day] = value.split('-').map(Number);
+
+  if (!year || !month || !day) {
+    return undefined;
+  }
+
+  return new Date(year, month - 1, day);
+}
 
 /**
  * SlashCommand displays a floating "slash" menu when the user is inside
@@ -43,9 +61,15 @@ export function SlashCommand({
   const suggestions = useAtomValue($suggestions);
   const setSuggestionUi = useSetAtom($suggestionUi);
   const commandRef = useRef<HTMLDivElement>(null);
+  const dateInputRef = useRef<HTMLInputElement>(null);
   const prevSelectedIndexRef = useRef<number>(0);
+  const [commandView, setCommandView] = useState<SlashCommandView>('menu');
+  const [selectedDate, setSelectedDate] = useState(() =>
+    formatDateInputValue(new Date()),
+  );
   const { pmEditorService } = useCoreServices();
   const editorView = pmEditorService.getEditor(editorName);
+  const ext = pmEditorService.extensions;
   const suggestion = editorView ? suggestions.get(editorView) : undefined;
   const active =
     suggestion?.markName === 'slash_command' ? suggestion : undefined;
@@ -70,6 +94,44 @@ export function SlashCommand({
     prevSelectedIndexRef.current = selectedIndex;
   }, [active?.selectedIndex]);
 
+  const replaceSlashCommandWithText = useCallback(
+    (text: string) => {
+      if (!editorView || !active) {
+        return;
+      }
+
+      ext.suggestions.command.replaceSuggestMarkWith({
+        content: text,
+      })(editorView.state, editorView.dispatch, editorView);
+    },
+    [editorView, active, ext],
+  );
+
+  const insertSelectedDate = useCallback(
+    (dateValue: string) => {
+      const date = parseDateInputValue(dateValue);
+      if (!date) {
+        return;
+      }
+
+      replaceSlashCommandWithText(format(date, 'PP'));
+    },
+    [replaceSlashCommandWithText],
+  );
+
+  useEffect(() => {
+    if (!active?.show) {
+      setCommandView('menu');
+      setSelectedDate(formatDateInputValue(new Date()));
+    }
+  }, [active?.show]);
+
+  useEffect(() => {
+    if (commandView === 'date-picker') {
+      dateInputRef.current?.focus();
+    }
+  }, [commandView]);
+
   useEffect(() => {
     if (!editorView || !active) {
       return;
@@ -81,6 +143,11 @@ export function SlashCommand({
         ...(next.get(editorView) ?? {}),
         slash_command: {
           onSelect: () => {
+            if (commandView === 'date-picker') {
+              insertSelectedDate(selectedDate);
+              return;
+            }
+
             if (commandRef.current) {
               const event = new KeyboardEvent('keydown', {
                 key: 'Enter',
@@ -108,15 +175,20 @@ export function SlashCommand({
         return next;
       });
     };
-  }, [active, editorView, setSuggestionUi]);
+  }, [
+    active,
+    commandView,
+    editorView,
+    insertSelectedDate,
+    selectedDate,
+    setSuggestionUi,
+  ]);
 
   const slashRef = useFloatingPosition({
     show: Boolean(active?.show),
     anchorEl: () => active?.anchorEl() ?? null,
     boundarySelector: '.ProseMirror:not([contenteditable="false"])',
   });
-
-  const ext = pmEditorService.extensions;
 
   const dismissCommandUi = useCallback(() => {
     if (!editorView || !active) {
@@ -130,6 +202,46 @@ export function SlashCommand({
 
   if (!editorView || !active?.show) {
     return null;
+  }
+
+  if (commandView === 'date-picker') {
+    return (
+      <div ref={slashRef} style={FLOATING_INITIAL_STYLE}>
+        <Command
+          ref={commandRef}
+          className="min-w-64 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+        >
+          <CommandInput
+            hidden
+            value={active.text.slice(1)}
+            onValueChange={() => {}}
+          />
+          <div className="flex flex-col gap-3 p-3">
+            <label
+              htmlFor="slash-command-date-picker"
+              className="font-medium text-foreground text-sm"
+            >
+              Select date
+            </label>
+            <Input
+              ref={dateInputRef}
+              id="slash-command-date-picker"
+              aria-label="Select date"
+              type="date"
+              value={selectedDate}
+              onChange={(event) => {
+                const { value } = event.currentTarget;
+                setSelectedDate(value);
+                insertSelectedDate(value);
+              }}
+            />
+          </div>
+          <CommandHints
+            hints={['Pick a date to insert', 'Escape to dismiss']}
+          />
+        </Command>
+      </div>
+    );
   }
 
   return (
@@ -278,6 +390,14 @@ export function SlashCommand({
           <CommandSeparator />
 
           <CommandGroup heading="Time">
+            <CommandItem
+              value="date calendar"
+              onSelect={() => {
+                setCommandView('date-picker');
+              }}
+            >
+              Date
+            </CommandItem>
             <CommandItem
               value="today"
               onSelect={() => {

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -121,12 +121,11 @@ export function SlashCommand({
       next.set(editorView, {
         ...(next.get(editorView) ?? {}),
         slash_command: {
+          // Enter is only wired for the menu view: forward it to cmdk so the
+          // highlighted item is chosen. In the date-picker view the calendar
+          // owns pointer selection and Escape dismisses; committing "today" on
+          // Enter is already covered by the dedicated "Today" menu item.
           onSelect: () => {
-            if (commandView === 'date-picker') {
-              insertSelectedDate(selectedDate);
-              return;
-            }
-
             if (commandRef.current) {
               const event = new KeyboardEvent('keydown', {
                 key: 'Enter',
@@ -154,14 +153,7 @@ export function SlashCommand({
         return next;
       });
     };
-  }, [
-    active,
-    commandView,
-    editorView,
-    insertSelectedDate,
-    selectedDate,
-    setSuggestionUi,
-  ]);
+  }, [active, editorView, setSuggestionUi]);
 
   const slashRef = useFloatingPosition({
     show: Boolean(active?.show),
@@ -210,6 +202,9 @@ export function SlashCommand({
         <Calendar
           mode="single"
           captionLayout="dropdown"
+          // Hide adjacent-month days so only the visible month is selectable
+          // (avoids ambiguous day cells near month boundaries).
+          showOutsideDays={false}
           startMonth={new Date(currentYear - CALENDAR_YEAR_SPAN, 0)}
           endMonth={new Date(currentYear + CALENDAR_YEAR_SPAN, 11)}
           defaultMonth={selectedDate}

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -1,6 +1,7 @@
 import { useCoreServices } from '@bangle.io/context';
 import { $suggestions, $suggestionUi } from '@bangle.io/prosemirror-plugins';
 import {
+  Button,
   Command,
   CommandEmpty,
   CommandGroup,
@@ -9,17 +10,23 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
-  Input,
+  cn,
 } from '@bangle.io/ui-components';
 import {
   addMonths,
   addWeeks,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
   format,
+  isSameDay,
+  isSameMonth,
   startOfMonth,
   startOfWeek,
   subDays,
 } from 'date-fns';
 import { useAtomValue, useSetAtom } from 'jotai';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import React, {
   type ReactElement,
   useCallback,
@@ -35,18 +42,13 @@ import {
 
 type SlashCommandView = 'menu' | 'date-picker';
 
-function formatDateInputValue(date: Date): string {
-  return format(date, 'yyyy-MM-dd');
-}
+const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
-function parseDateInputValue(value: string): Date | undefined {
-  const [year, month, day] = value.split('-').map(Number);
-
-  if (!year || !month || !day) {
-    return undefined;
-  }
-
-  return new Date(year, month - 1, day);
+function getCalendarDays(month: Date): Date[] {
+  return eachDayOfInterval({
+    start: startOfWeek(startOfMonth(month)),
+    end: endOfWeek(endOfMonth(month)),
+  });
 }
 
 /**
@@ -61,11 +63,11 @@ export function SlashCommand({
   const suggestions = useAtomValue($suggestions);
   const setSuggestionUi = useSetAtom($suggestionUi);
   const commandRef = useRef<HTMLDivElement>(null);
-  const dateInputRef = useRef<HTMLInputElement>(null);
   const prevSelectedIndexRef = useRef<number>(0);
   const [commandView, setCommandView] = useState<SlashCommandView>('menu');
-  const [selectedDate, setSelectedDate] = useState(() =>
-    formatDateInputValue(new Date()),
+  const [selectedDate, setSelectedDate] = useState(() => new Date());
+  const [calendarMonth, setCalendarMonth] = useState(() =>
+    startOfMonth(new Date()),
   );
   const { pmEditorService } = useCoreServices();
   const editorView = pmEditorService.getEditor(editorName);
@@ -108,12 +110,7 @@ export function SlashCommand({
   );
 
   const insertSelectedDate = useCallback(
-    (dateValue: string) => {
-      const date = parseDateInputValue(dateValue);
-      if (!date) {
-        return;
-      }
-
+    (date: Date) => {
       replaceSlashCommandWithText(format(date, 'PP'));
     },
     [replaceSlashCommandWithText],
@@ -122,15 +119,11 @@ export function SlashCommand({
   useEffect(() => {
     if (!active?.show) {
       setCommandView('menu');
-      setSelectedDate(formatDateInputValue(new Date()));
+      const today = new Date();
+      setSelectedDate(today);
+      setCalendarMonth(startOfMonth(today));
     }
   }, [active?.show]);
-
-  useEffect(() => {
-    if (commandView === 'date-picker') {
-      dateInputRef.current?.focus();
-    }
-  }, [commandView]);
 
   useEffect(() => {
     if (!editorView || !active) {
@@ -209,35 +202,24 @@ export function SlashCommand({
       <div ref={slashRef} style={FLOATING_INITIAL_STYLE}>
         <Command
           ref={commandRef}
-          className="min-w-64 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+          className="min-w-72 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
         >
           <CommandInput
             hidden
             value={active.text.slice(1)}
             onValueChange={() => {}}
           />
-          <div className="flex flex-col gap-3 p-3">
-            <label
-              htmlFor="slash-command-date-picker"
-              className="font-medium text-foreground text-sm"
-            >
-              Select date
-            </label>
-            <Input
-              ref={dateInputRef}
-              id="slash-command-date-picker"
-              aria-label="Select date"
-              type="date"
-              value={selectedDate}
-              onChange={(event) => {
-                const { value } = event.currentTarget;
-                setSelectedDate(value);
-                insertSelectedDate(value);
-              }}
-            />
-          </div>
+          <DateCommandCalendar
+            month={calendarMonth}
+            selectedDate={selectedDate}
+            onMonthChange={setCalendarMonth}
+            onSelectDate={(date) => {
+              setSelectedDate(date);
+              insertSelectedDate(date);
+            }}
+          />
           <CommandHints
-            hints={['Pick a date to insert', 'Escape to dismiss']}
+            hints={['Click a day to insert', 'Escape to dismiss']}
           />
         </Command>
       </div>
@@ -465,6 +447,93 @@ export function SlashCommand({
         </CommandList>
         <CommandHints hints={['Enter to select', 'Escape to dismiss']} />
       </Command>
+    </div>
+  );
+}
+
+function DateCommandCalendar({
+  month,
+  selectedDate,
+  onMonthChange,
+  onSelectDate,
+}: {
+  month: Date;
+  selectedDate: Date;
+  onMonthChange: (month: Date) => void;
+  onSelectDate: (date: Date) => void;
+}): ReactElement {
+  const days = getCalendarDays(month);
+  const today = new Date();
+
+  return (
+    <div className="p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label="Previous month"
+          onClick={() => {
+            onMonthChange(startOfMonth(addMonths(month, -1)));
+          }}
+        >
+          <ChevronLeft aria-hidden="true" />
+        </Button>
+        <div
+          className="min-w-32 text-center font-medium text-sm"
+          aria-live="polite"
+        >
+          {format(month, 'MMMM yyyy')}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label="Next month"
+          onClick={() => {
+            onMonthChange(startOfMonth(addMonths(month, 1)));
+          }}
+        >
+          <ChevronRight aria-hidden="true" />
+        </Button>
+      </div>
+      <section className="grid grid-cols-7 gap-1" aria-label="Calendar">
+        {WEEKDAY_LABELS.map((label) => (
+          <div
+            key={label}
+            className="flex size-8 items-center justify-center text-muted-foreground text-xs"
+          >
+            {label.slice(0, 2)}
+          </div>
+        ))}
+        {days.map((day) => {
+          const inCurrentMonth = isSameMonth(day, month);
+          const selected = isSameDay(day, selectedDate);
+
+          return (
+            <Button
+              key={day.toISOString()}
+              type="button"
+              variant={selected ? 'secondary' : 'ghost'}
+              size="icon"
+              className={cn(
+                'size-8 rounded-md font-normal text-sm',
+                !inCurrentMonth && 'text-muted-foreground opacity-50',
+                isSameDay(day, today) &&
+                  !selected &&
+                  'border border-primary text-primary',
+              )}
+              aria-current={isSameDay(day, today) ? 'date' : undefined}
+              aria-label={`Select ${format(day, 'PP')}`}
+              onClick={() => onSelectDate(day)}
+            >
+              {format(day, 'd')}
+            </Button>
+          );
+        })}
+      </section>
     </div>
   );
 }

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -1,7 +1,10 @@
 import { useCoreServices } from '@bangle.io/context';
-import { $suggestions, $suggestionUi } from '@bangle.io/prosemirror-plugins';
 import {
-  Calendar,
+  $suggestions,
+  $suggestionUi,
+  Fragment,
+} from '@bangle.io/prosemirror-plugins';
+import {
   Command,
   CommandEmpty,
   CommandGroup,
@@ -25,19 +28,13 @@ import React, {
   useCallback,
   useEffect,
   useRef,
-  useState,
 } from 'react';
 
+import { DATE_SUGGESTION } from '../extensions';
 import {
   FLOATING_INITIAL_STYLE,
   useFloatingPosition,
 } from './use-floating-position';
-
-type SlashCommandView = 'menu' | 'date-picker';
-
-// Bound the calendar's month/year dropdowns to a generous window around the
-// current year so far-off dates remain reachable without endless clicking.
-const CALENDAR_YEAR_SPAN = 100;
 
 /**
  * SlashCommand displays a floating "slash" menu when the user is inside
@@ -52,11 +49,8 @@ export function SlashCommand({
   const setSuggestionUi = useSetAtom($suggestionUi);
   const commandRef = useRef<HTMLDivElement>(null);
   const prevSelectedIndexRef = useRef<number>(0);
-  const [commandView, setCommandView] = useState<SlashCommandView>('menu');
-  const [selectedDate, setSelectedDate] = useState(() => new Date());
   const { pmEditorService } = useCoreServices();
   const editorView = pmEditorService.getEditor(editorName);
-  const ext = pmEditorService.extensions;
   const suggestion = editorView ? suggestions.get(editorView) : undefined;
   const active =
     suggestion?.markName === 'slash_command' ? suggestion : undefined;
@@ -81,36 +75,6 @@ export function SlashCommand({
     prevSelectedIndexRef.current = selectedIndex;
   }, [active?.selectedIndex]);
 
-  const replaceSlashCommandWithText = useCallback(
-    (text: string) => {
-      if (!editorView || !active) {
-        return;
-      }
-
-      ext.suggestions.command.replaceSuggestMarkWith({
-        content: text,
-      })(editorView.state, editorView.dispatch, editorView);
-    },
-    [editorView, active, ext],
-  );
-
-  const insertSelectedDate = useCallback(
-    (date: Date) => {
-      replaceSlashCommandWithText(format(date, 'PP'));
-      // Selecting a day moves DOM focus into the calendar; return focus to the
-      // editor so the caret lands right after the inserted date.
-      editorView?.focus();
-    },
-    [replaceSlashCommandWithText, editorView],
-  );
-
-  useEffect(() => {
-    if (!active?.show) {
-      setCommandView('menu');
-      setSelectedDate(new Date());
-    }
-  }, [active?.show]);
-
   useEffect(() => {
     if (!editorView || !active) {
       return;
@@ -121,10 +85,6 @@ export function SlashCommand({
       next.set(editorView, {
         ...(next.get(editorView) ?? {}),
         slash_command: {
-          // Enter is only wired for the menu view: forward it to cmdk so the
-          // highlighted item is chosen. In the date-picker view the calendar
-          // owns pointer selection and Escape dismisses; committing "today" on
-          // Enter is already covered by the dedicated "Today" menu item.
           onSelect: () => {
             if (commandRef.current) {
               const event = new KeyboardEvent('keydown', {
@@ -161,6 +121,8 @@ export function SlashCommand({
     boundarySelector: '.ProseMirror:not([contenteditable="false"])',
   });
 
+  const ext = pmEditorService.extensions;
+
   const dismissCommandUi = useCallback(() => {
     if (!editorView || !active) {
       return;
@@ -171,55 +133,25 @@ export function SlashCommand({
     })(editorView.state, editorView.dispatch, editorView);
   }, [editorView, active, ext]);
 
-  const handleCommandKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
-      if (event.key !== 'Escape') {
-        return;
-      }
+  const openDatePicker = useCallback(() => {
+    if (!editorView || !active) {
+      return;
+    }
 
-      event.preventDefault();
-      event.stopPropagation();
-      dismissCommandUi();
-    },
-    [dismissCommandUi],
-  );
+    // Swap the slash mark for the date trigger text carrying the
+    // `date_suggestion` mark — the same document state as if the user had
+    // typed the trigger — so the DatePickerMenu surface takes over.
+    const { schema } = editorView.state;
+    const mark = schema.mark(DATE_SUGGESTION.markName, {
+      trigger: DATE_SUGGESTION.trigger,
+    });
+    ext.suggestions.command.replaceSuggestMarkWith({
+      content: Fragment.from(schema.text(DATE_SUGGESTION.trigger, [mark])),
+    })(editorView.state, editorView.dispatch, editorView);
+  }, [editorView, active, ext]);
 
   if (!editorView || !active?.show) {
     return null;
-  }
-
-  if (commandView === 'date-picker') {
-    const currentYear = new Date().getFullYear();
-
-    return (
-      // biome-ignore lint/a11y/noStaticElementInteractions: Escape handling for a floating popover, not an interactive control.
-      <div
-        ref={slashRef}
-        style={FLOATING_INITIAL_STYLE}
-        className="w-fit overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
-        onKeyDown={handleCommandKeyDown}
-      >
-        <Calendar
-          mode="single"
-          captionLayout="dropdown"
-          // Hide adjacent-month days so only the visible month is selectable
-          // (avoids ambiguous day cells near month boundaries).
-          showOutsideDays={false}
-          startMonth={new Date(currentYear - CALENDAR_YEAR_SPAN, 0)}
-          endMonth={new Date(currentYear + CALENDAR_YEAR_SPAN, 11)}
-          defaultMonth={selectedDate}
-          selected={selectedDate}
-          onSelect={(date) => {
-            if (!date) {
-              return;
-            }
-            setSelectedDate(date);
-            insertSelectedDate(date);
-          }}
-        />
-        <CommandHints hints={['Click a day to insert', 'Escape to dismiss']} />
-      </div>
-    );
   }
 
   return (
@@ -227,7 +159,6 @@ export function SlashCommand({
       <Command
         ref={commandRef}
         className="overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
-        onKeyDown={handleCommandKeyDown}
       >
         <CommandInput
           hidden
@@ -369,13 +300,8 @@ export function SlashCommand({
           <CommandSeparator />
 
           <CommandGroup heading="Time">
-            <CommandItem
-              value="date calendar"
-              onSelect={() => {
-                setCommandView('date-picker');
-              }}
-            >
-              Date
+            <CommandItem value="date calendar" onSelect={openDatePicker}>
+              {t.app.editor.slashCommand.date}
             </CommandItem>
             <CommandItem
               value="today"

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -1,7 +1,7 @@
 import { useCoreServices } from '@bangle.io/context';
 import { $suggestions, $suggestionUi } from '@bangle.io/prosemirror-plugins';
 import {
-  Button,
+  Calendar,
   Command,
   CommandEmpty,
   CommandGroup,
@@ -10,24 +10,16 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
-  cn,
-  Input,
 } from '@bangle.io/ui-components';
 import {
   addMonths,
   addWeeks,
-  eachDayOfInterval,
-  endOfMonth,
-  endOfWeek,
   format,
-  isSameDay,
-  isSameMonth,
   startOfMonth,
   startOfWeek,
   subDays,
 } from 'date-fns';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
 import React, {
   type ReactElement,
   useCallback,
@@ -43,14 +35,9 @@ import {
 
 type SlashCommandView = 'menu' | 'date-picker';
 
-const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
-function getCalendarDays(month: Date): Date[] {
-  return eachDayOfInterval({
-    start: startOfWeek(startOfMonth(month)),
-    end: endOfWeek(endOfMonth(month)),
-  });
-}
+// Bound the calendar's month/year dropdowns to a generous window around the
+// current year so far-off dates remain reachable without endless clicking.
+const CALENDAR_YEAR_SPAN = 100;
 
 /**
  * SlashCommand displays a floating "slash" menu when the user is inside
@@ -67,9 +54,6 @@ export function SlashCommand({
   const prevSelectedIndexRef = useRef<number>(0);
   const [commandView, setCommandView] = useState<SlashCommandView>('menu');
   const [selectedDate, setSelectedDate] = useState(() => new Date());
-  const [calendarMonth, setCalendarMonth] = useState(() =>
-    startOfMonth(new Date()),
-  );
   const { pmEditorService } = useCoreServices();
   const editorView = pmEditorService.getEditor(editorName);
   const ext = pmEditorService.extensions;
@@ -113,16 +97,17 @@ export function SlashCommand({
   const insertSelectedDate = useCallback(
     (date: Date) => {
       replaceSlashCommandWithText(format(date, 'PP'));
+      // Selecting a day moves DOM focus into the calendar; return focus to the
+      // editor so the caret lands right after the inserted date.
+      editorView?.focus();
     },
-    [replaceSlashCommandWithText],
+    [replaceSlashCommandWithText, editorView],
   );
 
   useEffect(() => {
     if (!active?.show) {
       setCommandView('menu');
-      const today = new Date();
-      setSelectedDate(today);
-      setCalendarMonth(startOfMonth(today));
+      setSelectedDate(new Date());
     }
   }, [active?.show]);
 
@@ -212,31 +197,32 @@ export function SlashCommand({
   }
 
   if (commandView === 'date-picker') {
+    const currentYear = new Date().getFullYear();
+
     return (
-      <div ref={slashRef} style={FLOATING_INITIAL_STYLE}>
-        <Command
-          ref={commandRef}
-          className="min-w-72 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
-          onKeyDown={handleCommandKeyDown}
-        >
-          <CommandInput
-            hidden
-            value={active.text.slice(1)}
-            onValueChange={() => {}}
-          />
-          <DateCommandCalendar
-            month={calendarMonth}
-            selectedDate={selectedDate}
-            onMonthChange={setCalendarMonth}
-            onSelectDate={(date) => {
-              setSelectedDate(date);
-              insertSelectedDate(date);
-            }}
-          />
-          <CommandHints
-            hints={['Click a day to insert', 'Escape to dismiss']}
-          />
-        </Command>
+      // biome-ignore lint/a11y/noStaticElementInteractions: Escape handling for a floating popover, not an interactive control.
+      <div
+        ref={slashRef}
+        style={FLOATING_INITIAL_STYLE}
+        className="w-fit overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+        onKeyDown={handleCommandKeyDown}
+      >
+        <Calendar
+          mode="single"
+          captionLayout="dropdown"
+          startMonth={new Date(currentYear - CALENDAR_YEAR_SPAN, 0)}
+          endMonth={new Date(currentYear + CALENDAR_YEAR_SPAN, 11)}
+          defaultMonth={selectedDate}
+          selected={selectedDate}
+          onSelect={(date) => {
+            if (!date) {
+              return;
+            }
+            setSelectedDate(date);
+            insertSelectedDate(date);
+          }}
+        />
+        <CommandHints hints={['Click a day to insert', 'Escape to dismiss']} />
       </div>
     );
   }
@@ -463,159 +449,6 @@ export function SlashCommand({
         </CommandList>
         <CommandHints hints={['Enter to select', 'Escape to dismiss']} />
       </Command>
-    </div>
-  );
-}
-
-function DateCommandCalendar({
-  month,
-  selectedDate,
-  onMonthChange,
-  onSelectDate,
-}: {
-  month: Date;
-  selectedDate: Date;
-  onMonthChange: (month: Date) => void;
-  onSelectDate: (date: Date) => void;
-}): ReactElement {
-  const days = getCalendarDays(month);
-  const today = new Date();
-  const [jumpMonth, setJumpMonth] = useState(() =>
-    String(month.getMonth() + 1),
-  );
-  const [jumpYear, setJumpYear] = useState(() => String(month.getFullYear()));
-
-  useEffect(() => {
-    setJumpMonth(String(month.getMonth() + 1));
-    setJumpYear(String(month.getFullYear()));
-  }, [month]);
-
-  const jumpToMonth = (event: React.FormEvent) => {
-    event.preventDefault();
-
-    const monthNumber = Number(jumpMonth);
-    const yearNumber = Number(jumpYear);
-
-    if (
-      !Number.isInteger(monthNumber) ||
-      !Number.isInteger(yearNumber) ||
-      monthNumber < 1 ||
-      monthNumber > 12 ||
-      yearNumber < 1 ||
-      yearNumber > 9999
-    ) {
-      return;
-    }
-
-    const nextMonth = new Date(month);
-    nextMonth.setFullYear(yearNumber, monthNumber - 1, 1);
-    nextMonth.setHours(0, 0, 0, 0);
-    onMonthChange(startOfMonth(nextMonth));
-  };
-
-  return (
-    <div className="p-3">
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-8"
-          aria-label="Previous month"
-          onClick={() => {
-            onMonthChange(startOfMonth(addMonths(month, -1)));
-          }}
-        >
-          <ChevronLeft aria-hidden="true" />
-        </Button>
-        <div
-          className="min-w-32 text-center font-medium text-sm"
-          aria-live="polite"
-        >
-          {format(month, 'MMMM yyyy')}
-        </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-8"
-          aria-label="Next month"
-          onClick={() => {
-            onMonthChange(startOfMonth(addMonths(month, 1)));
-          }}
-        >
-          <ChevronRight aria-hidden="true" />
-        </Button>
-      </div>
-      <form
-        aria-label="Go to month and year"
-        className="mb-3 grid grid-cols-[4.5rem_1fr_auto] gap-2"
-        onKeyDown={(event) => {
-          if (event.key !== 'Escape') {
-            event.stopPropagation();
-          }
-        }}
-        onSubmit={jumpToMonth}
-      >
-        <Input
-          type="number"
-          inputMode="numeric"
-          min={1}
-          max={12}
-          value={jumpMonth}
-          aria-label="Month"
-          className="h-8 px-2 text-sm"
-          onChange={(event) => setJumpMonth(event.target.value)}
-        />
-        <Input
-          type="number"
-          inputMode="numeric"
-          min={1}
-          max={9999}
-          value={jumpYear}
-          aria-label="Year"
-          className="h-8 px-2 text-sm"
-          onChange={(event) => setJumpYear(event.target.value)}
-        />
-        <Button type="submit" variant="secondary" size="sm" className="h-8">
-          Go
-        </Button>
-      </form>
-      <section className="grid grid-cols-7 gap-1" aria-label="Calendar">
-        {WEEKDAY_LABELS.map((label) => (
-          <div
-            key={label}
-            className="flex size-8 items-center justify-center text-muted-foreground text-xs"
-          >
-            {label.slice(0, 2)}
-          </div>
-        ))}
-        {days.map((day) => {
-          const inCurrentMonth = isSameMonth(day, month);
-          const selected = isSameDay(day, selectedDate);
-
-          return (
-            <Button
-              key={day.toISOString()}
-              type="button"
-              variant={selected ? 'secondary' : 'ghost'}
-              size="icon"
-              className={cn(
-                'size-8 rounded-md font-normal text-sm',
-                !inCurrentMonth && 'text-muted-foreground opacity-50',
-                isSameDay(day, today) &&
-                  !selected &&
-                  'border border-primary text-primary',
-              )}
-              aria-current={isSameDay(day, today) ? 'date' : undefined}
-              aria-label={`Select ${format(day, 'PP')}`}
-              onClick={() => onSelectDate(day)}
-            >
-              {format(day, 'd')}
-            </Button>
-          );
-        })}
-      </section>
     </div>
   );
 }

--- a/packages/core/editor/src/components/use-suggestion-ui-handler.ts
+++ b/packages/core/editor/src/components/use-suggestion-ui-handler.ts
@@ -1,0 +1,50 @@
+import {
+  $suggestionUi,
+  type EditorView,
+  type SuggestionUiHandlers,
+} from '@bangle.io/prosemirror-plugins';
+import { useSetAtom } from 'jotai';
+import { useEffect } from 'react';
+
+export function useSuggestionUiHandler({
+  active,
+  editorView,
+  handler,
+  markName,
+}: {
+  active: boolean;
+  editorView: EditorView | undefined;
+  handler: SuggestionUiHandlers[string];
+  markName: string;
+}) {
+  const setSuggestionUi = useSetAtom($suggestionUi);
+
+  useEffect(() => {
+    if (!editorView || !active) {
+      return;
+    }
+
+    setSuggestionUi((existing) => {
+      const next = new Map(existing);
+      next.set(editorView, {
+        ...(next.get(editorView) ?? {}),
+        [markName]: handler,
+      });
+      return next;
+    });
+
+    return () => {
+      setSuggestionUi((existing) => {
+        const next = new Map(existing);
+        const handlers = { ...(next.get(editorView) ?? {}) };
+        delete handlers[markName];
+        if (Object.keys(handlers).length) {
+          next.set(editorView, handlers);
+        } else {
+          next.delete(editorView);
+        }
+        return next;
+      });
+    };
+  }, [active, editorView, handler, markName, setSuggestionUi]);
+}

--- a/packages/core/editor/src/components/wiki-link-menu.tsx
+++ b/packages/core/editor/src/components/wiki-link-menu.tsx
@@ -5,18 +5,18 @@ import {
 } from '@bangle.io/fuzzysearch';
 import {
   $suggestions,
-  $suggestionUi,
   Fragment,
   parseWikiLinkContent,
   type WikiLinkAttrs,
 } from '@bangle.io/prosemirror-plugins';
 import type { WsFilePath } from '@bangle.io/ws-path';
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue } from 'jotai';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   FLOATING_INITIAL_STYLE,
   useFloatingPosition,
 } from './use-floating-position';
+import { useSuggestionUiHandler } from './use-suggestion-ui-handler';
 
 type WikiSearchRecord = {
   searchText: string;
@@ -70,7 +70,6 @@ export function WikiLinkMenu({ editorName }: { editorName: string }) {
   const suggestions = useAtomValue($suggestions);
   const { pmEditorService, workspaceState } = useCoreServices();
   const index = useAtomValue(workspaceState.$wikiLinkIndex);
-  const setSuggestionUi = useSetAtom($suggestionUi);
   const listRef = useRef<HTMLDivElement>(null);
   const editorView = pmEditorService.getEditor(editorName);
   const suggestion = editorView ? suggestions.get(editorView) : undefined;
@@ -111,33 +110,21 @@ export function WikiLinkMenu({ editorName }: { editorName: string }) {
     [editorView, pmEditorService],
   );
 
-  useEffect(() => {
-    if (!active || !editorView) return;
-    setSuggestionUi((existing) => {
-      const next = new Map(existing);
-      next.set(editorView, {
-        ...(next.get(editorView) ?? {}),
-        wiki_link_suggestion: {
-          optionCount: options.length,
-          onSelect: () => select(options[selectedIndex]),
-        },
-      });
-      return next;
-    });
-    return () => {
-      setSuggestionUi((existing) => {
-        const next = new Map(existing);
-        const handlers = { ...(next.get(editorView) ?? {}) };
-        delete handlers.wiki_link_suggestion;
-        if (Object.keys(handlers).length) {
-          next.set(editorView, handlers);
-        } else {
-          next.delete(editorView);
-        }
-        return next;
-      });
-    };
-  }, [active, editorView, options, select, selectedIndex, setSuggestionUi]);
+  const selectedOption = options[selectedIndex];
+  const wikiSuggestionUiHandler = useMemo(
+    () => ({
+      optionCount: options.length,
+      onSelect: () => select(selectedOption),
+    }),
+    [options.length, select, selectedOption],
+  );
+
+  useSuggestionUiHandler({
+    active: Boolean(active),
+    editorView,
+    handler: wikiSuggestionUiHandler,
+    markName: 'wiki_link_suggestion',
+  });
 
   useEffect(() => {
     listRef.current

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -33,6 +33,16 @@ import {
 import { setupCodeHighlight } from './code-highlight';
 import { funPlaceholder } from './utils';
 
+/**
+ * The date picker is a first-class suggestion surface: `$date` is a real
+ * typed trigger, and the slash menu's "Date" item swaps the slash mark for
+ * this trigger text so both paths converge on the same suggestion mark.
+ */
+export const DATE_SUGGESTION = {
+  markName: 'date_suggestion',
+  trigger: '$date',
+} as const;
+
 export function setupExtensions(
   logger: Logger,
   onOpenLink?: LinkConfig['onOpenLink'],
@@ -77,6 +87,16 @@ export function setupExtensions(
       logger: logger.child('suggestions'),
     }),
     trailingNode: setupTrailingNode(),
+    dateSuggestions: setupSuggestions({
+      providerId: 'date-picker',
+      markName: DATE_SUGGESTION.markName,
+      trigger: DATE_SUGGESTION.trigger,
+      markClassName: 'text-pop',
+      // The suggestion keymap is installed once by the slash-command
+      // provider and dispatches by mark name, same as wikiSuggestions.
+      installKeymap: false,
+      logger: logger.child('date-suggestions'),
+    }),
     wikiSuggestions: setupSuggestions({
       providerId: 'wiki-link',
       markName: 'wiki_link_suggestion',

--- a/packages/core/editor/src/index.tsx
+++ b/packages/core/editor/src/index.tsx
@@ -5,6 +5,7 @@ import { cx } from '@bangle.io/base-utils';
 import { useCoreServices } from '@bangle.io/context';
 import React, { useCallback } from 'react';
 import {
+  DatePickerMenu,
   InlineSelectionMenu,
   LinkMenu,
   SlashCommand,
@@ -56,6 +57,7 @@ export function Editor({
           )}
         />
         <SlashCommand editorName={name} />
+        <DatePickerMenu editorName={name} />
         <TableMenu editorName={name} />
         <WikiLinkMenu editorName={name} />
         <LinkMenu editorName={name} />

--- a/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
@@ -95,6 +95,39 @@ function createEditor({
   return view;
 }
 
+function createPlainEditor({
+  text,
+  store,
+}: {
+  text: string;
+  store: ReturnType<typeof createStore>;
+}) {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', null, text ? [schema.text(text)] : undefined),
+  ]);
+  const mount = document.createElement('div');
+  document.body.append(mount);
+  const state = EditorState.create({
+    doc,
+    schema,
+    selection: TextSelection.create(doc, text.length + 1),
+    plugins: resolve([
+      collection({
+        id: 'test-store',
+        plugin: { store: editorStore.storePlugin(store) },
+      }),
+      setupBase(),
+      setupParagraph(),
+      setupLink(),
+      slashSuggestions,
+      wikiSuggestions,
+    ]).resolvePlugins({ schema }),
+  });
+  const view = new EditorView({ mount }, { state });
+  editors.push(view);
+  return view;
+}
+
 function pressKey(view: EditorView, key: string) {
   const event = new KeyboardEvent('keydown', { key, bubbles: true });
   let handled = false;
@@ -195,6 +228,20 @@ describe('suggestions provider state', () => {
     expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
       markName: 'slash_command',
       text: '/',
+    });
+  });
+
+  it('keeps typed slash query text in the active provider suggestion', () => {
+    const store = createStore();
+    const view = createPlainEditor({ text: '', store });
+
+    expect(handleTextInput(view, 1, 1, '/')).toBe(true);
+    view.dispatch(view.state.tr.insertText('date'));
+
+    expect(view.state.doc.textContent).toBe('/date');
+    expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
+      markName: 'slash_command',
+      text: '/date',
     });
   });
 

--- a/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
@@ -6,7 +6,13 @@ import { setupBase } from '../../base';
 import { collection, resolve } from '../../common';
 import { setupLink } from '../../link';
 import { setupParagraph } from '../../paragraph';
-import { EditorState, EditorView, Schema, TextSelection } from '../../pm';
+import {
+  EditorState,
+  EditorView,
+  Fragment,
+  Schema,
+  TextSelection,
+} from '../../pm';
 import { store as editorStore } from '../../store';
 import { setupSuggestions } from '../index';
 import {
@@ -28,6 +34,13 @@ const wikiSuggestions = setupSuggestions({
   markClassName: 'wiki',
   requireTriggerBoundary: false,
 });
+const dateSuggestions = setupSuggestions({
+  providerId: 'date-picker',
+  markName: 'date_suggestion',
+  trigger: '$date',
+  markClassName: 'date',
+  installKeymap: false,
+});
 const resolved = resolve([
   collection({ id: 'test-store' }),
   setupBase(),
@@ -35,6 +48,7 @@ const resolved = resolve([
   setupLink(),
   slashSuggestions,
   wikiSuggestions,
+  dateSuggestions,
 ]);
 const schema = new Schema({
   nodes: resolved.nodes,
@@ -83,6 +97,7 @@ function createEditor({
       setupLink(),
       slashSuggestions,
       wikiSuggestions,
+      dateSuggestions,
     ]).resolvePlugins({ schema }),
   });
   const view = new EditorView({ mount }, { state });
@@ -121,6 +136,7 @@ function createPlainEditor({
       setupLink(),
       slashSuggestions,
       wikiSuggestions,
+      dateSuggestions,
     ]).resolvePlugins({ schema }),
   });
   const view = new EditorView({ mount }, { state });
@@ -214,7 +230,7 @@ describe('suggestions provider state', () => {
     editors.push(plainView);
 
     expect(handleTextInput(plainView, 7, 7, '[[')).toBe(true);
-    expect(plainView.state.doc.textContent).toBe('plain[[');
+    expect(plainView.state.doc.textContent).toBe('plain [[');
   });
 
   it('keeps an active provider suggestion when another provider is inactive in the same editor view', () => {
@@ -243,6 +259,72 @@ describe('suggestions provider state', () => {
       markName: 'slash_command',
       text: '/date',
     });
+  });
+
+  it('activates a provider when its multi-char trigger is typed', () => {
+    const store = createStore();
+    const view = createPlainEditor({ text: '$dat', store });
+
+    expect(handleTextInput(view, 5, 5, 'e')).toBe(true);
+
+    expect(view.state.doc.textContent).toBe('$date');
+    expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
+      markName: 'date_suggestion',
+      text: '$date',
+      show: true,
+    });
+  });
+
+  it('activates a provider when its trigger arrives as a single inserted chunk', () => {
+    const store = createStore();
+    const view = createPlainEditor({ text: 'note ', store });
+
+    // Dictation/autocorrect can insert the whole trigger in one
+    // handleTextInput call; the boundary character must survive.
+    expect(handleTextInput(view, 6, 6, '$date')).toBe(true);
+
+    expect(view.state.doc.textContent).toBe('note $date');
+    expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
+      markName: 'date_suggestion',
+      text: '$date',
+      show: true,
+    });
+  });
+
+  it('hands off to another provider when the mark is swapped for its trigger text', () => {
+    const store = createStore();
+    const view = createPlainEditor({ text: '', store });
+
+    expect(handleTextInput(view, 1, 1, '/')).toBe(true);
+    view.dispatch(view.state.tr.insertText('date'));
+    expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
+      markName: 'slash_command',
+      text: '/date',
+    });
+
+    // This is the contract the slash menu's "Date" item relies on: replacing
+    // the slash mark with another provider's trigger text (carrying that
+    // provider's mark) activates the other provider's suggestion.
+    const mark = schema.mark('date_suggestion', { trigger: '$date' });
+    slashSuggestions.command.replaceSuggestMarkWith({
+      content: Fragment.from(schema.text('$date', [mark])),
+    })(view.state, view.dispatch, view);
+
+    expect(view.state.doc.textContent).toBe('$date');
+    expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
+      markName: 'date_suggestion',
+      text: '$date',
+      show: true,
+    });
+
+    // Committing the new provider replaces the trigger text with content and
+    // ends the suggestion.
+    dateSuggestions.command.replaceSuggestMarkWith({
+      content: 'Jul 2, 2026',
+    })(view.state, view.dispatch, view);
+
+    expect(view.state.doc.textContent).toBe('Jul 2, 2026');
+    expect(editorStore.get(view.state, $suggestions).get(view)).toBeUndefined();
   });
 
   it('keeps active suggestions and enter handlers scoped to each editor view', () => {

--- a/packages/js-lib/banger-editor/src/suggestions/input-rule.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/input-rule.ts
@@ -47,10 +47,9 @@ export function triggerInputRule({
         tr.setSelection(textSelection);
       }
       const marks = selection.$from.marks();
-      return tr.replaceSelectionWith(
-        schema.text(trigger, [mark, ...marks]),
-        false,
-      );
+      return tr
+        .replaceSelectionWith(schema.text(trigger, [mark, ...marks]), false)
+        .addStoredMark(mark);
     },
   );
 

--- a/packages/js-lib/banger-editor/src/suggestions/input-rule.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/input-rule.ts
@@ -1,4 +1,4 @@
-import { type EditorState, InputRule, TextSelection } from '../pm';
+import { type EditorState, InputRule } from '../pm';
 
 // ProseMirror uses the Unicode Character 'OBJECT REPLACEMENT CHARACTER' (U+FFFC) as text representation for
 // leaf nodes, i.e. nodes that don't have any content or text property (e.g. hardBreak, emoji)
@@ -21,7 +21,7 @@ export function triggerInputRule({
 
   const startRule = new InputRule(
     regexStart,
-    (editorState: EditorState, match: string[]) => {
+    (editorState: EditorState, match: string[], start: number, end: number) => {
       const linkMarkType = editorState.schema.marks.link;
       if (
         editorState.selection.$from.parent.type.spec.code ||
@@ -31,24 +31,21 @@ export function triggerInputRule({
       ) {
         return null;
       }
-      const trigger = match[3] || match[2] || match[1];
-      if (!trigger) {
+      const fullMatch = match[0];
+      const trigger = match[2] || match[1];
+      if (!fullMatch || !trigger) {
         return null;
       }
+      // `start`/`end` come from the input-rules plugin and are correct
+      // whether the trigger arrived one keystroke at a time or as a single
+      // inserted chunk (dictation, autocorrect). `match[0]` may include a
+      // boundary character before the trigger — keep it in the document.
+      const triggerStart = start + (fullMatch.length - trigger.length);
       const schema = editorState.schema;
       const mark = schema.mark(markName, { trigger });
-      const { tr, selection } = editorState;
-      if (trigger.length > 1) {
-        const textSelection = TextSelection.create(
-          tr.doc,
-          selection.from,
-          selection.from - trigger.length + 1,
-        );
-        tr.setSelection(textSelection);
-      }
-      const marks = selection.$from.marks();
-      return tr
-        .replaceSelectionWith(schema.text(trigger, [mark, ...marks]), false)
+      const marks = editorState.selection.$from.marks();
+      return editorState.tr
+        .replaceWith(triggerStart, end, schema.text(trigger, [mark, ...marks]))
         .addStoredMark(mark);
     },
   );

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -84,6 +84,11 @@ export const t = {
       },
       slashCommand: {
         table: 'Table',
+        date: 'Date',
+      },
+      datePicker: {
+        hintSelect: 'Click a day to insert',
+        hintDismiss: 'Escape to dismiss',
       },
       tableMenu: {
         label: 'Table options',

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -63,10 +63,7 @@ test('slash date command inserts a selected calendar date', async ({
   page,
 }) => {
   const workspaceName = 'slash-command-date-picker';
-  const selectedDate = new Date();
-  selectedDate.setDate(1);
-  selectedDate.setMonth(selectedDate.getMonth() + 1);
-  selectedDate.setDate(15);
+  const selectedDate = new Date(2028, 11, 15);
   selectedDate.setHours(0, 0, 0, 0);
   const selectedDateLabel = new Intl.DateTimeFormat('en-US', {
     month: 'short',
@@ -89,7 +86,10 @@ test('slash date command inserts a selected calendar date', async ({
   await dateCommand.click();
 
   await expect(page.getByRole('region', { name: 'Calendar' })).toBeVisible();
-  await page.getByRole('button', { name: 'Next month' }).click();
+  await page.getByRole('spinbutton', { name: 'Month' }).fill('12');
+  await page.getByRole('spinbutton', { name: 'Year' }).fill('2028');
+  await page.getByRole('button', { name: 'Go' }).click();
+  await expect(page.getByText('December 2028')).toBeVisible();
   await page
     .getByRole('button', { name: `Select ${selectedDateLabel}` })
     .click();
@@ -98,4 +98,36 @@ test('slash date command inserts a selected calendar date', async ({
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
     .toBe(selectedDateLabel);
+});
+
+test('slash date command dismisses with Escape after calendar interaction', async ({
+  page,
+}) => {
+  const workspaceName = 'slash-command-date-dismiss';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('/');
+  await page.keyboard.insertText('date');
+
+  const dateCommand = page.getByText('Date', { exact: true });
+  await expect(dateCommand).toBeVisible();
+  await dateCommand.click();
+
+  const calendar = page.getByRole('region', { name: 'Calendar' });
+  await expect(calendar).toBeVisible();
+  await page.getByRole('button', { name: 'Next month' }).click();
+  await page.keyboard.press('Escape');
+
+  await expect(calendar).toBeHidden();
+  await editor.click();
+  await page.keyboard.insertText('After Escape');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe('After Escape');
 });

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -59,17 +59,33 @@ test('slash command can insert a persisted code block', async ({ page }) => {
     .toBe('```\nconst viaSlash = true;\n```');
 });
 
-test('slash date command inserts a selected calendar date', async ({
-  page,
-}) => {
-  const workspaceName = 'slash-command-date-picker';
-  const selectedDate = new Date(2028, 11, 15);
-  selectedDate.setHours(0, 0, 0, 0);
-  const selectedDateLabel = new Intl.DateTimeFormat('en-US', {
+// Matches the date-fns `PP` format used by the slash command
+// (e.g. "Dec 15, 2028").
+function formatDateLabel(date: Date): string {
+  return new Intl.DateTimeFormat('en-US', {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-  }).format(selectedDate);
+  }).format(date);
+}
+
+// `data-day` is a stable contract set by our CalendarDayButton wrapper; it lets
+// us target a specific day without depending on react-day-picker's localized
+// aria labels, and disambiguates from same-numbered days of adjacent months.
+function daySelector(date: Date): string {
+  return `[data-day="${date.toLocaleDateString('en-US')}"]`;
+}
+
+test('slash date command inserts a day picked from the current month', async ({
+  page,
+}) => {
+  const workspaceName = 'slash-command-date-picker';
+  // The 15th always exists and needs no navigation, keeping the assertion
+  // deterministic regardless of when the suite runs.
+  const now = new Date();
+  const target = new Date(now.getFullYear(), now.getMonth(), 15);
+  const targetLabel = formatDateLabel(target);
+
   await createBrowserWorkspaceAndNote(page, {
     workspaceName,
     noteName: 'Home',
@@ -79,25 +95,58 @@ test('slash date command inserts a selected calendar date', async ({
   await editor.click();
   await waitForEditorFocus(page, {});
   await page.keyboard.insertText('/');
+  // Let the suggestion menu open before narrowing it; typing the query in the
+  // same tick as '/' races the mark creation and can drop the input.
+  await expect(page.getByText('Date', { exact: true })).toBeVisible();
   await page.keyboard.insertText('date');
 
   const dateCommand = page.getByText('Date', { exact: true });
   await expect(dateCommand).toBeVisible();
   await dateCommand.click();
 
-  await expect(page.getByRole('region', { name: 'Calendar' })).toBeVisible();
-  await page.getByRole('spinbutton', { name: 'Month' }).fill('12');
-  await page.getByRole('spinbutton', { name: 'Year' }).fill('2028');
-  await page.getByRole('button', { name: 'Go' }).click();
-  await expect(page.getByText('December 2028')).toBeVisible();
-  await page
-    .getByRole('button', { name: `Select ${selectedDateLabel}` })
-    .click();
+  await expect(page.locator('[data-slot="calendar"]')).toBeVisible();
+  await page.locator(daySelector(target)).click();
 
-  await expect(editor).toContainText(selectedDateLabel);
+  await expect(editor).toContainText(targetLabel);
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
-    .toBe(selectedDateLabel);
+    .toBe(targetLabel);
+});
+
+test('slash date command inserts a day after navigating months', async ({
+  page,
+}) => {
+  const workspaceName = 'slash-command-date-nav';
+  const now = new Date();
+  // Constructing from month + 1 naturally rolls over year boundaries.
+  const target = new Date(now.getFullYear(), now.getMonth() + 1, 10);
+  const targetLabel = formatDateLabel(target);
+
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('/');
+  // Let the suggestion menu open before narrowing it; typing the query in the
+  // same tick as '/' races the mark creation and can drop the input.
+  await expect(page.getByText('Date', { exact: true })).toBeVisible();
+  await page.keyboard.insertText('date');
+
+  await page.getByText('Date', { exact: true }).click();
+  await expect(page.locator('[data-slot="calendar"]')).toBeVisible();
+
+  // Advance one month using the calendar's built-in navigation.
+  await page.getByRole('button', { name: /next month/i }).click();
+  await page.locator(daySelector(target)).click();
+
+  await expect(editor).toContainText(targetLabel);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe(targetLabel);
 });
 
 test('slash date command dismisses with Escape after calendar interaction', async ({
@@ -113,15 +162,18 @@ test('slash date command dismisses with Escape after calendar interaction', asyn
   await editor.click();
   await waitForEditorFocus(page, {});
   await page.keyboard.insertText('/');
+  // Let the suggestion menu open before narrowing it; typing the query in the
+  // same tick as '/' races the mark creation and can drop the input.
+  await expect(page.getByText('Date', { exact: true })).toBeVisible();
   await page.keyboard.insertText('date');
 
   const dateCommand = page.getByText('Date', { exact: true });
   await expect(dateCommand).toBeVisible();
   await dateCommand.click();
 
-  const calendar = page.getByRole('region', { name: 'Calendar' });
+  const calendar = page.locator('[data-slot="calendar"]');
   await expect(calendar).toBeVisible();
-  await page.getByRole('button', { name: 'Next month' }).click();
+  await page.getByRole('button', { name: /next month/i }).click();
   await page.keyboard.press('Escape');
 
   await expect(calendar).toBeHidden();

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -63,6 +63,16 @@ test('slash date command inserts a selected calendar date', async ({
   page,
 }) => {
   const workspaceName = 'slash-command-date-picker';
+  const selectedDate = new Date();
+  selectedDate.setDate(1);
+  selectedDate.setMonth(selectedDate.getMonth() + 1);
+  selectedDate.setDate(15);
+  selectedDate.setHours(0, 0, 0, 0);
+  const selectedDateLabel = new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(selectedDate);
   await createBrowserWorkspaceAndNote(page, {
     workspaceName,
     noteName: 'Home',
@@ -78,14 +88,14 @@ test('slash date command inserts a selected calendar date', async ({
   await expect(dateCommand).toBeVisible();
   await dateCommand.click();
 
-  const dateInput = page.getByLabel('Select date');
-  await expect(dateInput).toBeVisible();
-  await expect(dateInput).toHaveAttribute('type', 'date');
+  await expect(page.getByRole('region', { name: 'Calendar' })).toBeVisible();
+  await page.getByRole('button', { name: 'Next month' }).click();
+  await page
+    .getByRole('button', { name: `Select ${selectedDateLabel}` })
+    .click();
 
-  await dateInput.fill('2025-12-24');
-
-  await expect(editor).toContainText('Dec 24, 2025');
+  await expect(editor).toContainText(selectedDateLabel);
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
-    .toBe('Dec 24, 2025');
+    .toBe(selectedDateLabel);
 });

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -58,3 +58,34 @@ test('slash command can insert a persisted code block', async ({ page }) => {
     .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
     .toBe('```\nconst viaSlash = true;\n```');
 });
+
+test('slash date command inserts a selected calendar date', async ({
+  page,
+}) => {
+  const workspaceName = 'slash-command-date-picker';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('/');
+  await page.keyboard.insertText('date');
+
+  const dateCommand = page.getByText('Date', { exact: true });
+  await expect(dateCommand).toBeVisible();
+  await dateCommand.click();
+
+  const dateInput = page.getByLabel('Select date');
+  await expect(dateInput).toBeVisible();
+  await expect(dateInput).toHaveAttribute('type', 'date');
+
+  await dateInput.fill('2025-12-24');
+
+  await expect(editor).toContainText('Dec 24, 2025');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe('Dec 24, 2025');
+});

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -6,6 +6,11 @@ import {
   waitForEditorFocus,
 } from './common';
 
+// Pin the browser locale so `data-day` (written with the browser's default
+// `toLocaleDateString()`) is deterministic and matches the `'en-US'` selectors
+// below regardless of the host/CI locale.
+test.use({ locale: 'en-US' });
+
 test('slash command stays active with multiple suggestion providers registered', async ({
   page,
 }) => {
@@ -111,6 +116,14 @@ test('slash date command inserts a day picked from the current month', async ({
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
     .toBe(targetLabel);
+
+  // Selecting a day must return focus to the editor and continue typing right
+  // after the inserted date (guards the post-insert focus handoff).
+  await expect(editor).toBeFocused();
+  await page.keyboard.insertText(' meeting');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe(`${targetLabel} meeting`);
 });
 
 test('slash date command inserts a day after navigating months', async ({

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -162,6 +162,63 @@ test('slash date command inserts a day after navigating months', async ({
     .toBe(targetLabel);
 });
 
+test('typing the $date trigger directly opens the calendar and inserts a day', async ({
+  page,
+}) => {
+  const workspaceName = 'date-trigger-direct';
+  const now = new Date();
+  const target = new Date(now.getFullYear(), now.getMonth(), 15);
+  const targetLabel = formatDateLabel(target);
+
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('$date');
+
+  await expect(page.locator('[data-slot="calendar"]')).toBeVisible();
+  await page.locator(daySelector(target)).click();
+
+  await expect(editor).toContainText(targetLabel);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe(targetLabel);
+});
+
+test('an abandoned $date trigger persists as plain text across reload', async ({
+  page,
+}) => {
+  const workspaceName = 'date-trigger-abandoned';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('note ');
+  await page.keyboard.insertText('$date');
+
+  const calendar = page.locator('[data-slot="calendar"]');
+  await expect(calendar).toBeVisible();
+
+  // The suggestion mark serializes to nothing; an abandoned trigger stays in
+  // the note as plain text — same contract as an abandoned `[[` wiki trigger.
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe('note $date');
+
+  await page.reload();
+  const reloadedEditor = getEditorLocator(page, {});
+  await expect(reloadedEditor).toContainText('note $date');
+  await expect(page.locator('[data-slot="calendar"]')).toBeHidden();
+});
+
 test('slash date command dismisses with Escape after calendar interaction', async ({
   page,
 }) => {

--- a/packages/ui/shadcn/package.json
+++ b/packages/ui/shadcn/package.json
@@ -47,9 +47,12 @@
     "cmdk": "^1.1.1",
     "lucide-react": "^1.23.0",
     "react": "19.2.7",
+    "react-day-picker": "^9.11.0",
     "react-dom": "19.2.7"
   },
   "devDependencies": {
-    "@storybook/react": "^10.4.6"
+    "@storybook/react": "^10.4.6",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2"
   }
 }

--- a/packages/ui/shadcn/src/__tests__/calendar.spec.tsx
+++ b/packages/ui/shadcn/src/__tests__/calendar.spec.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Calendar } from '../calendar';
+
+const DECEMBER_2025 = new Date(2025, 11, 1);
+
+describe('Calendar', () => {
+  it('renders a month grid with weekday headers', () => {
+    const { container } = render(
+      <Calendar mode="single" defaultMonth={DECEMBER_2025} />,
+    );
+
+    // react-day-picker renders the month as a table with role="grid".
+    expect(screen.getByRole('grid')).toBeInTheDocument();
+    // Seven weekday headers (Sun..Sat).
+    expect(container.querySelectorAll('.rdp-weekday')).toHaveLength(7);
+  });
+
+  it('calls onSelect with the clicked day', () => {
+    const onSelect = vi.fn();
+    render(
+      <Calendar
+        mode="single"
+        defaultMonth={DECEMBER_2025}
+        onSelect={onSelect}
+      />,
+    );
+
+    const target = new Date(2025, 11, 24);
+    const dayButton = document.querySelector(
+      `[data-day="${target.toLocaleDateString()}"]`,
+    );
+    expect(dayButton).not.toBeNull();
+
+    fireEvent.click(dayButton as Element);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const selected = onSelect.mock.calls[0]?.[0] as Date;
+    expect(selected.getFullYear()).toBe(2025);
+    expect(selected.getMonth()).toBe(11);
+    expect(selected.getDate()).toBe(24);
+  });
+
+  it('marks the selected day with the single-selection data attribute', () => {
+    const selected = new Date(2025, 11, 24);
+    render(
+      <Calendar
+        mode="single"
+        defaultMonth={DECEMBER_2025}
+        selected={selected}
+      />,
+    );
+
+    const dayButton = document.querySelector(
+      `[data-day="${selected.toLocaleDateString()}"]`,
+    );
+    expect(dayButton).toHaveAttribute('data-selected-single', 'true');
+  });
+
+  it('renders month and year dropdowns when captionLayout is "dropdown"', () => {
+    render(
+      <Calendar
+        mode="single"
+        captionLayout="dropdown"
+        defaultMonth={DECEMBER_2025}
+        startMonth={new Date(2020, 0)}
+        endMonth={new Date(2030, 11)}
+      />,
+    );
+
+    // Month + year dropdowns are rendered as native <select> (role combobox).
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/ui/shadcn/src/calendar.tsx
+++ b/packages/ui/shadcn/src/calendar.tsx
@@ -1,0 +1,220 @@
+import { cn } from '@bangle.io/ui-misc';
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from 'lucide-react';
+import React from 'react';
+import {
+  type DayButton,
+  DayPicker,
+  getDefaultClassNames,
+} from 'react-day-picker';
+
+import { Button, buttonVariants } from './button';
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  captionLayout = 'label',
+  buttonVariant = 'ghost',
+  formatters,
+  components,
+  ...props
+}: React.ComponentProps<typeof DayPicker> & {
+  buttonVariant?: React.ComponentProps<typeof Button>['variant'];
+}) {
+  const defaultClassNames = getDefaultClassNames();
+
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn(
+        'group/calendar bg-background p-3 [--cell-size:--spacing(8)] [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent',
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className,
+      )}
+      captionLayout={captionLayout}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString('default', { month: 'short' }),
+        ...formatters,
+      }}
+      classNames={{
+        root: cn('w-fit', defaultClassNames.root),
+        months: cn(
+          'relative flex flex-col gap-4 md:flex-row',
+          defaultClassNames.months,
+        ),
+        month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
+        nav: cn(
+          'absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1',
+          defaultClassNames.nav,
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: buttonVariant }),
+          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+          defaultClassNames.button_previous,
+        ),
+        button_next: cn(
+          buttonVariants({ variant: buttonVariant }),
+          'size-(--cell-size) p-0 select-none aria-disabled:opacity-50',
+          defaultClassNames.button_next,
+        ),
+        month_caption: cn(
+          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
+          defaultClassNames.month_caption,
+        ),
+        dropdowns: cn(
+          'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
+          defaultClassNames.dropdowns,
+        ),
+        dropdown_root: cn(
+          'relative rounded-md border border-input shadow-xs has-focus:border-ring has-focus:ring-[3px] has-focus:ring-ring/50',
+          defaultClassNames.dropdown_root,
+        ),
+        dropdown: cn(
+          'absolute inset-0 bg-popover opacity-0',
+          defaultClassNames.dropdown,
+        ),
+        caption_label: cn(
+          'font-medium select-none',
+          captionLayout === 'label'
+            ? 'text-sm'
+            : 'flex h-8 items-center gap-1 rounded-md pr-1 pl-2 text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
+          defaultClassNames.caption_label,
+        ),
+        month_grid: cn('w-full border-collapse', defaultClassNames.month_grid),
+        weekdays: cn('flex', defaultClassNames.weekdays),
+        weekday: cn(
+          'flex-1 rounded-md text-[0.8rem] font-normal text-muted-foreground select-none',
+          defaultClassNames.weekday,
+        ),
+        week: cn('mt-2 flex w-full', defaultClassNames.week),
+        week_number_header: cn(
+          'w-(--cell-size) select-none',
+          defaultClassNames.week_number_header,
+        ),
+        week_number: cn(
+          'text-[0.8rem] text-muted-foreground select-none',
+          defaultClassNames.week_number,
+        ),
+        day: cn(
+          'group/day relative aspect-square h-full w-full p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-md',
+          props.showWeekNumber
+            ? '[&:nth-child(2)[data-selected=true]_button]:rounded-l-md'
+            : '[&:first-child[data-selected=true]_button]:rounded-l-md',
+          defaultClassNames.day,
+        ),
+        range_start: cn(
+          'rounded-l-md bg-accent',
+          defaultClassNames.range_start,
+        ),
+        range_middle: cn('rounded-none', defaultClassNames.range_middle),
+        range_end: cn('rounded-r-md bg-accent', defaultClassNames.range_end),
+        today: cn(
+          'rounded-md bg-accent text-accent-foreground data-[selected=true]:rounded-none',
+          defaultClassNames.today,
+        ),
+        outside: cn(
+          'text-muted-foreground aria-selected:text-muted-foreground',
+          defaultClassNames.outside,
+        ),
+        disabled: cn(
+          'text-muted-foreground opacity-50',
+          defaultClassNames.disabled,
+        ),
+        hidden: cn('invisible', defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          );
+        },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === 'left') {
+            return (
+              <ChevronLeftIcon className={cn('size-4', className)} {...props} />
+            );
+          }
+
+          if (orientation === 'right') {
+            return (
+              <ChevronRightIcon
+                className={cn('size-4', className)}
+                {...props}
+              />
+            );
+          }
+
+          return (
+            <ChevronDownIcon className={cn('size-4', className)} {...props} />
+          );
+        },
+        DayButton: CalendarDayButton,
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          );
+        },
+        ...components,
+      }}
+      {...props}
+    />
+  );
+}
+
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  ...props
+}: React.ComponentProps<typeof DayButton>) {
+  const defaultClassNames = getDefaultClassNames();
+
+  const ref = React.useRef<HTMLButtonElement>(null);
+  React.useEffect(() => {
+    if (modifiers.focused) {
+      ref.current?.focus();
+    }
+  }, [modifiers.focused]);
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString()}
+      data-selected-single={
+        modifiers.selected &&
+        !modifiers.range_start &&
+        !modifiers.range_end &&
+        !modifiers.range_middle
+      }
+      data-range-start={modifiers.range_start}
+      data-range-end={modifiers.range_end}
+      data-range-middle={modifiers.range_middle}
+      className={cn(
+        'flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 font-normal leading-none data-[range-end=true]:rounded-md data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-md data-[range-end=true]:rounded-r-md data-[range-start=true]:rounded-l-md data-[range-end=true]:bg-primary data-[range-middle=true]:bg-accent data-[range-start=true]:bg-primary data-[selected-single=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-middle=true]:text-accent-foreground data-[range-start=true]:text-primary-foreground data-[selected-single=true]:text-primary-foreground group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50 dark:hover:text-accent-foreground [&>span]:text-xs [&>span]:opacity-70',
+        defaultClassNames.day,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Calendar, CalendarDayButton };

--- a/packages/ui/shadcn/src/index.ts
+++ b/packages/ui/shadcn/src/index.ts
@@ -3,6 +3,7 @@ export * from '@bangle.io/ui-misc';
 export * from './accordion';
 export * from './alert-dialog';
 export * from './button';
+export * from './calendar';
 export * from './collapsible';
 export * from './command';
 export * from './dialog';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1158,6 +1158,9 @@ importers:
       react:
         specifier: 19.2.7
         version: 19.2.7
+      react-day-picker:
+        specifier: ^9.11.0
+        version: 9.14.0(react@19.2.7)
       react-dom:
         specifier: 19.2.7
         version: 19.2.7(react@19.2.7)
@@ -1165,6 +1168,12 @@ importers:
       '@storybook/react':
         specifier: ^10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(typescript@6.0.3)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
 
   packages/ui/ui-components:
     dependencies:
@@ -1866,6 +1875,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@electron-internal/extract-zip@1.0.4':
     resolution: {integrity: sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==}
@@ -4382,6 +4394,10 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
+  '@tabby_ai/hijri-converter@1.0.5':
+    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
+    engines: {node: '>=16.0.0'}
+
   '@tailwindcss/node@4.3.2':
     resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
 
@@ -5642,6 +5658,9 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -8217,6 +8236,12 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  react-day-picker@9.14.0:
+    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
+
   react-devtools-core@6.1.5:
     resolution: {integrity: sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==}
 
@@ -10287,6 +10312,8 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@date-fns/tz@1.5.0': {}
+
   '@electron-internal/extract-zip@1.0.4': {}
 
   '@electron/asar@3.4.1':
@@ -10343,7 +10370,7 @@ snapshots:
       fs-extra: 10.1.0
       isbinaryfile: 4.0.10
       minimist: 1.2.8
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -10366,7 +10393,7 @@ snapshots:
       dir-compare: 4.2.0
       fs-extra: 11.3.6
       minimatch: 9.0.7
-      plist: 3.1.0
+      plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
 
@@ -12800,6 +12827,8 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
+  '@tabby_ai/hijri-converter@1.0.5': {}
+
   '@tailwindcss/node@4.3.2':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -14112,6 +14141,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  date-fns-jalali@4.1.0-0: {}
+
   date-fns@4.4.0: {}
 
   debug@2.6.9:
@@ -15030,7 +15061,7 @@ snapshots:
       es6-error: 4.1.1
       matcher: 3.0.0
       roarr: 2.15.4
-      semver: 7.7.4
+      semver: 7.8.5
       serialize-error: 7.0.1
     optional: true
 
@@ -16530,11 +16561,11 @@ snapshots:
 
   node-abi@4.33.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-api-version@0.2.1:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   node-fetch@2.7.0:
     dependencies:
@@ -16549,7 +16580,7 @@ snapshots:
       graceful-fs: 4.2.11
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.4
+      semver: 7.8.5
       tar: 7.5.19
       tinyglobby: 0.2.17
       undici: 6.27.0
@@ -17245,6 +17276,14 @@ snapshots:
   quick-lru@5.1.1: {}
 
   range-parser@1.2.1: {}
+
+  react-day-picker@9.14.0(react@19.2.7):
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      '@tabby_ai/hijri-converter': 1.0.5
+      date-fns: 4.4.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.2.7
 
   react-devtools-core@6.1.5:
     dependencies:


### PR DESCRIPTION
## What

Adds a calendar date picker to the editor — reachable both from the slash menu (`/date`) and by typing the `$date` trigger directly — built as a first-class suggestion surface rather than a mode of the slash command.

## Architecture

The earlier revisions of this PR embedded the calendar inside `SlashCommand` behind a `commandView: 'menu' | 'date-picker'` state machine. That coupled the menu to the date picker and set a bad precedent for every future floating surface. This revision restructures it around the pattern the codebase already uses for wiki links:

- **`date_suggestion` is a real suggestion provider** registered in `extensions.ts` with a typed trigger (`$date`), exactly like `wiki_link_suggestion` (`[[`).
- **The slash menu's "Date" item is a mark swap**: it replaces the slash mark with the `$date` trigger text carrying the `date_suggestion` mark — the same document state as if the user had typed the trigger. Both entry paths converge on one surface.
- **`DatePickerMenu` is its own component** (`packages/core/editor/src/components/date-picker-menu.tsx`), mounted flatly beside the other floating menus. `slash-command.tsx` is a pure menu again and never imports the calendar.
- The recipe for future floating pickers (emoji, mentions, templates) is now: one `setupSuggestions` entry + one component file.

## Fixes found along the way

- **Multi-char trigger input rule** (`banger-editor`): a trigger arriving as a single inserted chunk (dictation, autocorrect, `insertText`) crashed with "Position -3 out of range" and could swallow the preceding boundary character. The handler now uses the `start`/`end` positions provided by the input-rules plugin.
- **Playwright port isolation**: `E2E_PORT` env override so a local run can't silently attach (via `reuseExistingServer`) to a dev server from another checkout and test the wrong code.

## Behavior notes

- Focus moves into the calendar on open; arrows/Enter navigate and commit via react-day-picker, Escape dismisses and clears the trigger text.
- An abandoned trigger (caret moved away) leaves `$date` as plain text — the same contract as an abandoned `[[` wiki trigger; covered by a reload-persistence e2e.

## Testing

- Unit: suggestion handoff contract (slash → date mark swap activates the provider), multi-char typed trigger, chunk-inserted trigger, plus the existing calendar component spec.
- E2E (7 tests in `slash-command.e2e.ts`): slash → Date → pick day (+ focus handoff), month navigation, Escape dismissal, direct `$date` trigger, abandoned-trigger persistence across reload.
- `pnpm local-ci-check` passes end to end (lint, typecheck, all Vitest, full Playwright E2E + CT, build, desktop smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)