### PR TITLE
[codex] Fix popup dialog centering

### DIFF
--- a/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
+++ b/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
@@ -1,10 +1,31 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import {
   createBrowserWorkspaceAndNote,
   EDITOR_FOCUSED_SELECTOR,
   getEditorLocator,
   pressAppShortcut,
 } from './common';
+
+async function expectDialogCentered(page: Page) {
+  const dialog = page.getByRole('dialog', { name: 'omni command bar' });
+
+  await expect(dialog).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        dialog.evaluate((element) => {
+          const rect = element.getBoundingClientRect();
+          return Math.max(
+            Math.abs(rect.left + rect.width / 2 - window.innerWidth / 2),
+            Math.abs(rect.top + rect.height / 2 - window.innerHeight / 2),
+          );
+        }),
+      {
+        message: 'Expected the omni command dialog to remain centered',
+      },
+    )
+    .toBeLessThanOrEqual(1);
+}
 
 test('command bar restores editor focus after Escape and Enter', async ({
   page,
@@ -19,9 +40,7 @@ test('command bar restores editor focus after Escape and Enter', async ({
   await expect(page.locator(EDITOR_FOCUSED_SELECTOR)).toBeVisible();
 
   await pressAppShortcut(page, 'k');
-  await expect(
-    page.getByRole('dialog', { name: 'omni command bar' }),
-  ).toBeVisible();
+  await expectDialogCentered(page);
   await expect(
     page.getByPlaceholder('Type a command or search...'),
   ).toBeFocused();
@@ -42,4 +61,30 @@ test('command bar restores editor focus after Escape and Enter', async ({
     page.getByRole('dialog', { name: 'omni command bar' }),
   ).toBeHidden();
   await expect(page.locator(EDITOR_FOCUSED_SELECTOR)).toBeVisible();
+});
+
+test('command bar and all-commands route stay centered when translate utilities are unavailable', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'omni-position-workspace',
+    noteName: 'omni-position-note',
+  });
+
+  await page.addStyleTag({
+    content: String.raw`
+      .translate-x-\[-50\%\],
+      .translate-y-\[-50\%\] {
+        transform: none;
+        translate: none;
+      }
+    `,
+  });
+
+  await pressAppShortcut(page, 'k');
+  await expectDialogCentered(page);
+
+  await page.getByPlaceholder('Type a command or search...').fill('>');
+  await expect(page.getByText('> Commands')).toBeVisible();
+  await expectDialogCentered(page);
 });

--- a/packages/ui/shadcn/src/alert-dialog.tsx
+++ b/packages/ui/shadcn/src/alert-dialog.tsx
@@ -28,15 +28,16 @@ AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <AlertDialogPortal>
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
         className,
       )}
+      style={{ translate: '-50% -50%', ...style }}
       {...props}
     />
   </AlertDialogPortal>

--- a/packages/ui/shadcn/src/dialog.tsx
+++ b/packages/ui/shadcn/src/dialog.tsx
@@ -29,15 +29,16 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+>(({ className, children, style, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
         className,
       )}
+      style={{ translate: '-50% -50%', ...style }}
       {...props}
     >
       {children}


### PR DESCRIPTION
## Project item

- Project item: https://github.com/orgs/bangle-io/projects/5/views/4?pane=issue&itemId=206873914
- Project item ID: `PVTI_lADOBGCX5c4AkHWHzgxUpTo`
- Draft content ID: `DI_lADOBGCX5c4AkHWHzgKsP1g`

## Summary

- Replaced shared dialog centering dependence on Tailwind translate utility classes with inline `translate: -50% -50%` on `DialogContent` and `AlertDialogContent`.
- Kept fixed `top: 50%` / `left: 50%` anchoring while avoiding double translation from generated utility CSS.
- Added Playwright regression coverage that verifies the omni-search and all-commands command dialog remains centered even when the old translate utility classes are unavailable/neutralized.

## Checks

- `pnpm --filter "@bangle.io/e2e-tests" run test -- omni-search-focus.e2e.ts` passed.
- `pnpm lint:ci` passed.
- `pnpm test:ci` passed.
- `pnpm e2e:ci` passed on rerun: 30 E2E tests and 5 component tests passed.
- `pnpm local-ci-check` passed on rerun, including full E2E and component Playwright suites.
- GitHub checks passed: deploy preview, lint, test, and e2e-tests.

## Failures / retries

- Initial `pnpm local-ci-check` attempt failed in `e2e:ci` after the Playwright dev server became unreachable: multiple tests reported `page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:5173/` and `page.reload: net::ERR_CONNECTION_REFUSED`; the failed script was `e2e:ci`. A standalone `pnpm e2e:ci` rerun passed, then `pnpm local-ci-check` passed.
- Existing Vite/Radix console warnings appeared during Playwright runs (`DialogContent requires a DialogTitle`, missing description, and nested `<p>` warnings); tests still passed and these warnings appear unrelated to this change.

## Thermonuclear review outcome

- Passed with no actionable findings.
- The reviewer confirmed the root-cause fix belongs in the shared Radix/shadcn wrappers rather than omni-search-specific code.
- Focused review validation reran `pnpm --filter "@bangle.io/e2e-tests" exec playwright test -c ./playwright.config.ts src/omni-search-focus.e2e.ts`; result: `2 passed (5.6s)`.
- Residual non-blocking risk: alert-dialog centering uses identical shared wrapper logic but does not have a dedicated regression test.

## Remaining risks / blockers

- No known blocker. This hardens the shared dialog centering path, but the original report says the issue reproduced only in one persistent Chrome profile, so browser-profile-specific injected CSS or stale cached assets cannot be fully ruled out locally.