### PR TITLE
[codex] Extract code block editor bundle

### DIFF
--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -79,12 +79,19 @@ jobs:
           EOF
           chmod 600 "$HOME/.wrangler/config/default.toml"
 
+          set +e
           output="$(pnpm exec wrangler pages deploy packages/tooling/browser-entry/dist \
             --project-name "$CLOUDFLARE_PAGES_PROJECT" \
             --branch "$CLOUDFLARE_PREVIEW_BRANCH" \
             --commit-dirty=true 2>&1)"
+          wrangler_status=$?
+          set -e
 
           printf '%s\n' "$output"
+
+          if [ "$wrangler_status" -ne 0 ]; then
+            exit "$wrangler_status"
+          fi
 
           preview_url="$(printf '%s\n' "$output" | sed -nE 's#.*(https://[^[:space:]]+\.pages\.dev).*#\1#p' | tail -n 1)"
 

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -6,8 +6,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
-  group: cloudflare-pr-preview-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: cloudflare-pr-preview-oauth
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -47,26 +47,36 @@ jobs:
         id: deploy
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_OAUTH_CONFIG: ${{ secrets.CLOUDFLARE_OAUTH_CONFIG }}
           CLOUDFLARE_OAUTH_EXPIRATION_TIME: ${{ secrets.CLOUDFLARE_OAUTH_EXPIRATION_TIME }}
           CLOUDFLARE_OAUTH_REFRESH_TOKEN: ${{ secrets.CLOUDFLARE_OAUTH_REFRESH_TOKEN }}
           CLOUDFLARE_OAUTH_TOKEN: ${{ secrets.CLOUDFLARE_OAUTH_TOKEN }}
         run: |
           set -euo pipefail
 
-          for secret_name in \
-            CLOUDFLARE_ACCOUNT_ID \
-            CLOUDFLARE_OAUTH_EXPIRATION_TIME \
-            CLOUDFLARE_OAUTH_REFRESH_TOKEN \
-            CLOUDFLARE_OAUTH_TOKEN
-          do
-            if [ -z "${!secret_name:-}" ]; then
-              echo "Missing ${secret_name} repository secret." >&2
-              exit 1
-            fi
-          done
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "Missing CLOUDFLARE_ACCOUNT_ID repository secret." >&2
+            exit 1
+          fi
 
           mkdir -p "$HOME/.wrangler/config"
-          cat > "$HOME/.wrangler/config/default.toml" <<EOF
+          config_file="$HOME/.wrangler/config/default.toml"
+
+          if [ -n "${CLOUDFLARE_OAUTH_CONFIG:-}" ]; then
+            printf '%s' "$CLOUDFLARE_OAUTH_CONFIG" > "$config_file"
+          else
+            for secret_name in \
+              CLOUDFLARE_OAUTH_EXPIRATION_TIME \
+              CLOUDFLARE_OAUTH_REFRESH_TOKEN \
+              CLOUDFLARE_OAUTH_TOKEN
+            do
+              if [ -z "${!secret_name:-}" ]; then
+                echo "Missing ${secret_name} repository secret." >&2
+                exit 1
+              fi
+            done
+
+            cat > "$config_file" <<EOF
           oauth_token = "$CLOUDFLARE_OAUTH_TOKEN"
           expiration_time = "$CLOUDFLARE_OAUTH_EXPIRATION_TIME"
           refresh_token = "$CLOUDFLARE_OAUTH_REFRESH_TOKEN"
@@ -77,7 +87,8 @@ jobs:
             "offline_access",
           ]
           EOF
-          chmod 600 "$HOME/.wrangler/config/default.toml"
+          fi
+          chmod 600 "$config_file"
 
           set +e
           output="$(pnpm exec wrangler pages deploy packages/tooling/browser-entry/dist \
@@ -131,19 +142,10 @@ jobs:
             exit 1
           fi
 
-          persist_secret() {
-            local name="$1"
-            local value="$2"
-
-            if ! printf '%s' "$value" | gh secret set "$name" --repo "$GITHUB_REPOSITORY"; then
-              echo "Could not persist refreshed Cloudflare OAuth credentials; continuing with the preview URL comment."
-              exit 0
-            fi
-          }
-
-          persist_secret CLOUDFLARE_OAUTH_TOKEN "$oauth_token"
-          persist_secret CLOUDFLARE_OAUTH_EXPIRATION_TIME "$expiration_time"
-          persist_secret CLOUDFLARE_OAUTH_REFRESH_TOKEN "$refresh_token"
+          if ! gh secret set CLOUDFLARE_OAUTH_CONFIG --repo "$GITHUB_REPOSITORY" < "$config_file"; then
+            echo "Could not persist refreshed Cloudflare OAuth config." >&2
+            exit 1
+          fi
 
       - name: Update PR preview comment
         uses: actions/github-script@v8

--- a/packages/core/editor/package.json
+++ b/packages/core/editor/package.json
@@ -46,6 +46,7 @@
     "jotai": "^2.20.1",
     "lucide-react": "^1.18.0",
     "prosemirror-view": "^1.41.9",
-    "react": "19.2.7"
+    "react": "19.2.7",
+    "shiki": "^3.22.0"
   }
 }

--- a/packages/core/editor/package.json
+++ b/packages/core/editor/package.json
@@ -45,6 +45,7 @@
     "github-slugger": "^2.0.0",
     "jotai": "^2.20.1",
     "lucide-react": "^1.18.0",
+    "prosemirror-highlight": "^0.15.2",
     "prosemirror-view": "^1.41.9",
     "react": "19.2.7",
     "shiki": "^3.22.0"

--- a/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
@@ -129,4 +129,17 @@ describe('code block Markdown', () => {
     expect(codeBlock?.textContent).toBe('listed();');
     expect(serialized).toBe('- item\n\n  ```js\n  listed();\n  ```');
   });
+
+  it('serializes fenced code blocks inside ordered list items with marker-width indentation', () => {
+    const { document, serialized } = expectEquivalentAfterSerialize(
+      '1. item\n\n   ```js\n   ordered();\n   ```',
+    );
+    const [list] = findNodes(document, 'list');
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(list).toBeDefined();
+    expect(codeBlock?.attrs.language).toBe('js');
+    expect(codeBlock?.textContent).toBe('ordered();');
+    expect(serialized).toBe('1. item\n\n   ```js\n   ordered();\n   ```');
+  });
 });

--- a/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
@@ -1,0 +1,132 @@
+import {
+  markdownLoader,
+  type PMNode,
+  resolve,
+  Schema,
+  setupBase,
+  setupBlockquote,
+  setupCodeBlock,
+  setupList,
+  setupParagraph,
+} from '@bangle.io/prosemirror-plugins';
+import { describe, expect, it } from 'vitest';
+
+function createMarkdown() {
+  const extensions = [
+    setupBase(),
+    setupParagraph(),
+    setupBlockquote(),
+    setupList(),
+    setupCodeBlock(),
+  ];
+  const resolved = resolve(extensions);
+  const schema = new Schema({ nodes: resolved.nodes, marks: resolved.marks });
+  return markdownLoader(extensions, schema);
+}
+
+function findNodes(document: PMNode, typeName: string): PMNode[] {
+  const nodes: PMNode[] = [];
+  document.descendants((node) => {
+    if (node.type.name === typeName) {
+      nodes.push(node);
+    }
+    return true;
+  });
+  return nodes;
+}
+
+function expectEquivalentAfterSerialize(source: string) {
+  const markdown = createMarkdown();
+  const document = markdown.parser.parse(source);
+  const serialized = markdown.serializer.serialize(document);
+  const reparsed = markdown.parser.parse(serialized);
+
+  expect(reparsed.toJSON()).toEqual(document.toJSON());
+  return { document, serialized };
+}
+
+describe('code block Markdown', () => {
+  it('round trips ordinary fenced code blocks with language info', () => {
+    const source = '```js\nconsole.log("ok");\n```';
+    const { document, serialized } = expectEquivalentAfterSerialize(source);
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(serialized).toBe(source);
+    expect(codeBlock?.attrs.language).toBe('js');
+    expect(codeBlock?.textContent).toBe('console.log("ok");');
+  });
+
+  it('parses indented code blocks as code without inventing language info', () => {
+    const { document } = expectEquivalentAfterSerialize(
+      '    indented code\n    - not a list item',
+    );
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(codeBlock?.attrs.language).toBe('');
+    expect(codeBlock?.textContent).toBe('indented code\n- not a list item');
+  });
+
+  it('serializes with a longer fence when code text contains backticks', () => {
+    const { document, serialized } = expectEquivalentAfterSerialize(
+      '~~~text\nA tilde fence can contain ``` without closing.\n~~~',
+    );
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(codeBlock?.attrs.language).toBe('text');
+    expect(serialized).toBe(
+      '````text\nA tilde fence can contain ``` without closing.\n````',
+    );
+  });
+
+  it('preserves nested-fence source as a single code block', () => {
+    const { document, serialized } = expectEquivalentAfterSerialize(
+      '````markdown\n```js\nconst nestedFence = true;\n```\n````',
+    );
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(findNodes(document, 'code_block')).toHaveLength(1);
+    expect(codeBlock?.attrs.language).toBe('markdown');
+    expect(codeBlock?.textContent).toBe(
+      '```js\nconst nestedFence = true;\n```',
+    );
+    expect(serialized).toBe(
+      '````markdown\n```js\nconst nestedFence = true;\n```\n````',
+    );
+  });
+
+  it('uses tilde fences when the info string contains a backtick', () => {
+    const { document, serialized } = expectEquivalentAfterSerialize(
+      '~~~lang`meta\nvalue\n~~~',
+    );
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(codeBlock?.attrs.language).toBe('lang`meta');
+    expect(serialized).toBe('~~~lang`meta\nvalue\n~~~');
+  });
+
+  it('parses fenced code blocks inside blockquotes', () => {
+    const { document, serialized } = expectEquivalentAfterSerialize(
+      '> ```js\n> quoted();\n> ```',
+    );
+    const [blockquote] = findNodes(document, 'blockquote');
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(blockquote).toBeDefined();
+    expect(codeBlock?.attrs.language).toBe('js');
+    expect(codeBlock?.textContent).toBe('quoted();');
+    expect(serialized).toBe('> ```js\n> quoted();\n> ```');
+  });
+
+  it('parses fenced code blocks inside list items', () => {
+    const { document, serialized } = expectEquivalentAfterSerialize(
+      '- item\n\n  ```js\n  listed();\n  ```',
+    );
+    const [list] = findNodes(document, 'list');
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(list).toBeDefined();
+    expect(codeBlock?.attrs.language).toBe('js');
+    expect(codeBlock?.textContent).toBe('listed();');
+    expect(serialized).toBe('- item\n\n  ```js\n  listed();\n  ```');
+  });
+});

--- a/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
@@ -56,6 +56,27 @@ describe('code block Markdown', () => {
     expect(codeBlock?.textContent).toBe('console.log("ok");');
   });
 
+  it('preserves trailing blank lines inside fenced code blocks', () => {
+    const source = '```js\nconsole.log("ok");\n\n\n```';
+    const markdown = createMarkdown();
+    const document = markdown.parser.parse(source);
+    const serialized = markdown.serializer.serialize(document);
+    const reparsed = markdown.parser.parse(serialized);
+    const [codeBlock] = findNodes(document, 'code_block');
+
+    expect(codeBlock?.textContent).toBe('console.log("ok");\n\n');
+    expect(serialized).toBe(source);
+    expect(reparsed.toJSON()).toEqual(document.toJSON());
+  });
+
+  it('keeps empty fenced code blocks compact', () => {
+    const source = '```js\n```';
+    const markdown = createMarkdown();
+    const document = markdown.parser.parse(source);
+
+    expect(markdown.serializer.serialize(document)).toBe(source);
+  });
+
   it('parses indented code blocks as code without inventing language info', () => {
     const { document } = expectEquivalentAfterSerialize(
       '    indented code\n    - not a list item',

--- a/packages/core/editor/src/__tests__/code-highlight.spec.ts
+++ b/packages/core/editor/src/__tests__/code-highlight.spec.ts
@@ -1,5 +1,24 @@
-import { describe, expect, test, vi } from 'vitest';
-import { copyTextToClipboard } from '../code-highlight';
+// @vitest-environment jsdom
+
+import {
+  EditorState,
+  EditorView,
+  type PMNode,
+  resolve,
+  Schema,
+  setupBase,
+  setupCodeBlock,
+  setupParagraph,
+} from '@bangle.io/prosemirror-plugins';
+import type { Parser, ParserOptions } from 'prosemirror-highlight';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { copyTextToClipboard, setupCodeHighlight } from '../code-highlight';
+import { normalizeCodeBlockLanguage } from '../code-highlight-languages';
+import { createCodeHighlightParser } from '../code-highlight-shiki';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 function createFakeTextArea() {
   return {
@@ -73,3 +92,183 @@ describe('copyTextToClipboard', () => {
     expect(result).toBe(false);
   });
 });
+
+describe('normalizeCodeBlockLanguage', () => {
+  test.each([
+    ['js', 'javascript'],
+    ['TS', 'typescript'],
+    ['pwsh', 'powershell'],
+    ['console', 'bash'],
+    ['unknown-lang', 'text'],
+    ['', 'text'],
+  ])('normalizes %s to %s', (input, expected) => {
+    expect(normalizeCodeBlockLanguage(input)).toBe(expected);
+  });
+});
+
+describe('createCodeHighlightParser', () => {
+  test('loads Shiki lazily for supported languages', async () => {
+    const parser = createCodeHighlightParser();
+    const decorations = await parseWhenReady(parser, {
+      content: 'const answer = 42;',
+      language: 'js',
+      pos: 0,
+      size: 20,
+    });
+
+    expect(decorations.length).toBeGreaterThan(0);
+  });
+
+  test('skips plaintext languages', () => {
+    const parser = createCodeHighlightParser();
+
+    expect(
+      parser({
+        content: 'plain text',
+        language: 'text',
+        pos: 0,
+        size: 12,
+      }),
+    ).toEqual([]);
+  });
+
+  test('rejects Shiki load failures so the highlighter plugin does not spin', async () => {
+    vi.resetModules();
+    vi.doMock('shiki/core', () => ({
+      createHighlighterCore: () => {
+        throw new Error('offline');
+      },
+    }));
+
+    try {
+      const { createCodeHighlightParser } = await import(
+        '../code-highlight-shiki'
+      );
+      const parser = createCodeHighlightParser();
+
+      await expect(
+        parser({
+          content: 'const answer = 42;',
+          language: 'js',
+          pos: 0,
+          size: 20,
+        }),
+      ).rejects.toThrow('offline');
+    } finally {
+      vi.doUnmock('shiki/core');
+      vi.resetModules();
+    }
+  });
+});
+
+describe('setupCodeHighlight', () => {
+  test('commits language edits to a code block after its widget position is remapped', () => {
+    vi.stubGlobal('t', {
+      app: {
+        editor: {
+          codeBlock: {
+            copy: 'Copy',
+            copied: 'Copied',
+            editLanguage: 'Edit language',
+          },
+        },
+      },
+    });
+
+    const extensions = [
+      setupBase(),
+      setupParagraph(),
+      setupCodeBlock({ keyToCodeBlock: false }),
+      setupCodeHighlight(),
+    ];
+    const resolved = resolve(extensions);
+    const schema = new Schema({ nodes: resolved.nodes, marks: resolved.marks });
+    const mount = document.createElement('div');
+    document.body.append(mount);
+    const view = new EditorView(
+      { mount },
+      {
+        state: EditorState.create({
+          doc: schema.node('doc', null, [
+            schema.node('paragraph', null, schema.text('before')),
+            schema.node(
+              'code_block',
+              { language: 'js' },
+              schema.text('console.log("hi");'),
+            ),
+          ]),
+          schema,
+          plugins: resolved.resolvePlugins({ schema }),
+        }),
+      },
+    );
+
+    try {
+      const languageButton = getRequiredElement<HTMLButtonElement>(
+        mount,
+        '.prosemirror-code-language-button',
+      );
+      languageButton.click();
+
+      view.dispatch(
+        view.state.tr.insert(
+          0,
+          schema.node('paragraph', null, schema.text('inserted')),
+        ),
+      );
+
+      const input = getRequiredElement<HTMLInputElement>(
+        mount,
+        '.prosemirror-code-language-input',
+      );
+      input.value = 'ts';
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      const [codeBlock] = findNodes(view.state.doc, 'code_block');
+      expect(codeBlock?.attrs.language).toBe('ts');
+    } finally {
+      view.destroy();
+      mount.remove();
+    }
+  });
+});
+
+async function parseWhenReady(parser: Parser, options: ParserOptions) {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const result = parser(options);
+    if (Array.isArray(result)) {
+      return result;
+    }
+    await result;
+  }
+
+  throw new Error('Highlight parser did not produce decorations');
+}
+
+function getRequiredElement<T extends Element>(
+  root: ParentNode,
+  selector: string,
+): T {
+  const element = root.querySelector(selector);
+  if (!element) {
+    throw new Error(`Unable to find ${selector}`);
+  }
+  return element as T;
+}
+
+function findNodes(document: PMNode, typeName: string): PMNode[] {
+  const nodes: PMNode[] = [];
+  document.descendants((node) => {
+    if (node.type.name === typeName) {
+      nodes.push(node);
+    }
+    return true;
+  });
+  return nodes;
+}

--- a/packages/core/editor/src/__tests__/code-highlight.spec.ts
+++ b/packages/core/editor/src/__tests__/code-highlight.spec.ts
@@ -1,5 +1,5 @@
+import { describe, expect, test, vi } from 'vitest';
 import { copyTextToClipboard } from '../code-highlight';
-import { vi } from 'vitest';
 
 function createFakeTextArea() {
   return {

--- a/packages/core/editor/src/__tests__/code-highlight.spec.ts
+++ b/packages/core/editor/src/__tests__/code-highlight.spec.ts
@@ -1,0 +1,75 @@
+import { copyTextToClipboard } from '../code-highlight';
+import { vi } from 'vitest';
+
+function createFakeTextArea() {
+  return {
+    value: '',
+    setAttribute: vi.fn(),
+    style: {
+      position: '',
+      left: '',
+      top: '',
+      opacity: '',
+      pointerEvents: '',
+    },
+    focus: vi.fn(),
+    select: vi.fn(),
+    remove: vi.fn(),
+  };
+}
+
+describe('copyTextToClipboard', () => {
+  test('uses clipboard api when available', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const createElement = vi.fn(() => createFakeTextArea());
+
+    const result = await copyTextToClipboard('console.log(1);', {
+      clipboard: { writeText: writeText },
+      document: {
+        createElement: createElement,
+        body: {
+          appendChild: vi.fn(),
+        },
+        execCommand: vi.fn(() => true),
+      },
+    });
+
+    expect(result).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('console.log(1);');
+    expect(createElement).not.toHaveBeenCalled();
+  });
+
+  test('falls back to document copy command when clipboard fails', async () => {
+    const textarea = createFakeTextArea();
+    const appendChild = vi.fn();
+    const execCommand = vi.fn(() => true);
+
+    const result = await copyTextToClipboard('line 1\nline 2', {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('blocked')),
+      },
+      document: {
+        createElement: vi.fn(() => textarea),
+        body: { appendChild: appendChild },
+        execCommand: execCommand,
+      },
+    });
+
+    expect(result).toBe(true);
+    expect(textarea.value).toBe('line 1\nline 2');
+    expect(appendChild).toHaveBeenCalledWith(textarea);
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(textarea.remove).toHaveBeenCalled();
+  });
+
+  test('returns false when fallback cannot execute copy command', async () => {
+    const result = await copyTextToClipboard('x', {
+      document: {
+        createElement: vi.fn(() => createFakeTextArea()),
+        body: { appendChild: vi.fn() },
+      },
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/packages/core/editor/src/code-highlight-languages.ts
+++ b/packages/core/editor/src/code-highlight-languages.ts
@@ -1,0 +1,58 @@
+export const CODE_THEME = 'github-dark';
+
+const SUPPORTED_LANGS = [
+  'text',
+  'plaintext',
+  'bash',
+  'shell',
+  'sh',
+  'zsh',
+  'powershell',
+  'javascript',
+  'typescript',
+  'json',
+  'yaml',
+  'python',
+] as const;
+
+export type SupportedCodeBlockLanguage = (typeof SUPPORTED_LANGS)[number];
+
+export const DEFAULT_CODE_BLOCK_LANGUAGE: SupportedCodeBlockLanguage = 'text';
+
+export function getRawCodeBlockLanguage(language: unknown): string {
+  if (typeof language !== 'string') {
+    return '';
+  }
+  return language.trim().toLowerCase();
+}
+
+export function normalizeCodeBlockLanguage(
+  language: unknown,
+): SupportedCodeBlockLanguage {
+  const normalized = getRawCodeBlockLanguage(language);
+  if (!normalized) {
+    return DEFAULT_CODE_BLOCK_LANGUAGE;
+  }
+
+  if (normalized === 'ps1' || normalized === 'pwsh') {
+    return 'powershell';
+  }
+  if (normalized === 'js') {
+    return 'javascript';
+  }
+  if (normalized === 'ts') {
+    return 'typescript';
+  }
+  if (normalized === 'yml') {
+    return 'yaml';
+  }
+  if (normalized === 'console') {
+    return 'bash';
+  }
+
+  if ((SUPPORTED_LANGS as readonly string[]).includes(normalized)) {
+    return normalized as SupportedCodeBlockLanguage;
+  }
+
+  return DEFAULT_CODE_BLOCK_LANGUAGE;
+}

--- a/packages/core/editor/src/code-highlight-shiki.ts
+++ b/packages/core/editor/src/code-highlight-shiki.ts
@@ -1,0 +1,169 @@
+import type { Parser } from 'prosemirror-highlight';
+import { createParser } from 'prosemirror-highlight/shiki';
+import type { HighlighterCore, LanguageRegistration } from 'shiki/core';
+import {
+  CODE_THEME,
+  normalizeCodeBlockLanguage,
+} from './code-highlight-languages';
+
+type HighlightLanguage =
+  | 'bash'
+  | 'shellscript'
+  | 'powershell'
+  | 'javascript'
+  | 'typescript'
+  | 'json'
+  | 'yaml'
+  | 'python';
+
+type LanguageModule = {
+  default: LanguageRegistration[];
+};
+
+const LANGUAGE_LOADERS = {
+  bash: () => import('shiki/langs/bash.mjs'),
+  shellscript: () => import('shiki/langs/shellscript.mjs'),
+  powershell: () => import('shiki/langs/powershell.mjs'),
+  javascript: () => import('shiki/langs/javascript.mjs'),
+  typescript: () => import('shiki/langs/typescript.mjs'),
+  json: () => import('shiki/langs/json.mjs'),
+  yaml: () => import('shiki/langs/yaml.mjs'),
+  python: () => import('shiki/langs/python.mjs'),
+} satisfies Record<HighlightLanguage, () => Promise<LanguageModule>>;
+
+let highlighterPromise: Promise<HighlighterCore> | undefined;
+let highlighterInstance: HighlighterCore | undefined;
+let shikiParser: Parser | undefined;
+const languageModulePromises = new Map<
+  HighlightLanguage,
+  Promise<LanguageModule>
+>();
+const languagePromises = new Map<HighlightLanguage, Promise<void>>();
+
+export function createCodeHighlightParser(): Parser {
+  return (options) => {
+    const language = toHighlightLanguage(options.language);
+    if (!language || !options.content) {
+      return [];
+    }
+
+    const highlighter = highlighterInstance;
+    if (!highlighter) {
+      return loadHighlighterAndLanguage(language);
+    }
+
+    if (!highlighter.getLoadedLanguages().includes(language)) {
+      return loadLanguage(highlighter, language);
+    }
+
+    shikiParser ??= createParser(highlighter, { theme: CODE_THEME });
+
+    try {
+      return shikiParser({
+        ...options,
+        language,
+      });
+    } catch {
+      return [];
+    }
+  };
+}
+
+function loadHighlighterAndLanguage(
+  language: HighlightLanguage,
+): Promise<void> {
+  const highlighter = loadHighlighter();
+  const languageModule = loadLanguageModule(language);
+
+  return Promise.all([highlighter, languageModule]).then(
+    ([loadedHighlighter]) => loadLanguage(loadedHighlighter, language),
+  );
+}
+
+function loadHighlighter(): Promise<HighlighterCore> {
+  highlighterPromise ??= Promise.all([
+    import('shiki/core'),
+    import('shiki/engine/javascript'),
+    import('shiki/themes/github-dark.mjs'),
+  ])
+    .then(
+      async ([
+        { createHighlighterCore },
+        { createJavaScriptRegexEngine },
+        theme,
+      ]) => {
+        const highlighter = await createHighlighterCore({
+          themes: [theme.default],
+          langs: [],
+          engine: createJavaScriptRegexEngine({ forgiving: true }),
+          warnings: false,
+        });
+        highlighterInstance = highlighter;
+        return highlighter;
+      },
+    )
+    .catch((error: unknown) => {
+      highlighterPromise = undefined;
+      throw error;
+    });
+
+  return highlighterPromise;
+}
+
+function loadLanguageModule(
+  language: HighlightLanguage,
+): Promise<LanguageModule> {
+  let promise = languageModulePromises.get(language);
+  if (!promise) {
+    promise = LANGUAGE_LOADERS[language]().catch((error: unknown) => {
+      languageModulePromises.delete(language);
+      throw error;
+    });
+    languageModulePromises.set(language, promise);
+  }
+
+  return promise;
+}
+
+function loadLanguage(
+  highlighter: HighlighterCore,
+  language: HighlightLanguage,
+): Promise<void> {
+  let promise = languagePromises.get(language);
+  if (!promise) {
+    promise = loadLanguageModule(language)
+      .then((module) => highlighter.loadLanguage(...module.default))
+      .catch((error: unknown) => {
+        languagePromises.delete(language);
+        throw error;
+      });
+    languagePromises.set(language, promise);
+  }
+
+  return promise;
+}
+
+function toHighlightLanguage(
+  language: string | undefined,
+): HighlightLanguage | undefined {
+  const normalized = normalizeCodeBlockLanguage(language);
+  if (normalized === 'text' || normalized === 'plaintext') {
+    return undefined;
+  }
+  if (normalized === 'shell' || normalized === 'sh' || normalized === 'zsh') {
+    return 'shellscript';
+  }
+
+  switch (normalized) {
+    case 'bash':
+    case 'powershell':
+    case 'javascript':
+    case 'typescript':
+    case 'json':
+    case 'yaml':
+    case 'python':
+      return normalized;
+    default:
+      return undefined;
+  }
+}

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -1,0 +1,199 @@
+import {
+  collection,
+  Decoration,
+  DecorationSet,
+  Plugin,
+  PluginKey,
+  type PMNode,
+} from '@bangle.io/prosemirror-plugins';
+import { createHighlighter } from 'shiki';
+
+const CODE_HIGHLIGHT_PLUGIN_KEY = new PluginKey('code-highlight');
+const CODE_THEME = 'github-dark';
+const SUPPORTED_LANGS = [
+  'text',
+  'plaintext',
+  'bash',
+  'shell',
+  'sh',
+  'zsh',
+  'powershell',
+  'javascript',
+  'typescript',
+  'json',
+  'yaml',
+  'python',
+] as const;
+type SupportedLang = (typeof SUPPORTED_LANGS)[number];
+const DEFAULT_LANG: SupportedLang = 'text';
+
+let highlighterPromise: ReturnType<typeof createHighlighter> | undefined;
+let highlighterInstance:
+  | Awaited<ReturnType<typeof createHighlighter>>
+  | undefined;
+type LoadedHighlighter = Awaited<ReturnType<typeof createHighlighter>>;
+
+function getHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: [CODE_THEME],
+      langs: [...SUPPORTED_LANGS],
+    });
+    void highlighterPromise.then((highlighter: LoadedHighlighter) => {
+      highlighterInstance = highlighter;
+    });
+  }
+
+  return highlighterPromise;
+}
+
+export function setupCodeHighlight() {
+  return collection({
+    id: 'code-highlight',
+    plugin: {
+      codeHighlight: new Plugin({
+        key: CODE_HIGHLIGHT_PLUGIN_KEY,
+        state: {
+          init: (_, state) => createDecorations(state.doc),
+          apply(tr, old) {
+            if (!tr.docChanged && !tr.getMeta(CODE_HIGHLIGHT_PLUGIN_KEY)) {
+              return old.map(tr.mapping, tr.doc);
+            }
+            return createDecorations(tr.doc);
+          },
+        },
+        props: {
+          decorations(state) {
+            return CODE_HIGHLIGHT_PLUGIN_KEY.getState(state);
+          },
+        },
+        view(view) {
+          void getHighlighter()
+            .then(() => {
+              view.dispatch(
+                view.state.tr.setMeta(CODE_HIGHLIGHT_PLUGIN_KEY, true),
+              );
+            })
+            .catch(() => {
+              // Fallback: plain code styling.
+            });
+
+          return {};
+        },
+      }),
+    },
+  });
+}
+
+function createDecorations(doc: PMNode): DecorationSet {
+  const highlighter = highlighterInstance;
+  if (!highlighter) {
+    return DecorationSet.empty;
+  }
+
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, pos) => {
+    if (node.type.name !== 'code_block') {
+      return true;
+    }
+
+    const language = normalizeLanguage(node.attrs.language);
+    const text = node.textContent || '';
+    if (!text) {
+      return true;
+    }
+
+    const lines = text.split('\n');
+    let charPos = pos + 1;
+    let shikiLineIndex = 0;
+
+    try {
+      const rawTokens = highlighter.codeToTokens(text, {
+        lang: language,
+        theme: CODE_THEME,
+      });
+      const tokensByLine = Array.isArray(rawTokens)
+        ? rawTokens
+        : rawTokens.tokens;
+
+      for (const line of lines) {
+        const lineTokens = tokensByLine[shikiLineIndex] || [];
+        let tokenPos = charPos;
+
+        for (const token of lineTokens) {
+          const tokenLength = token.content.length;
+          if (!tokenLength) {
+            continue;
+          }
+
+          const from = tokenPos;
+          const to = tokenPos + tokenLength;
+          const styleParts: string[] = [];
+
+          if (token.color) {
+            styleParts.push(`color:${token.color}`);
+          }
+          if (token.fontStyle & 1) {
+            styleParts.push('font-style:italic');
+          }
+          if (token.fontStyle & 2) {
+            styleParts.push('font-weight:600');
+          }
+          if (token.fontStyle & 4) {
+            styleParts.push('text-decoration:underline');
+          }
+
+          if (from < to) {
+            decorations.push(
+              Decoration.inline(from, to, {
+                class: 'prosemirror-code-token',
+                style: styleParts.join(';'),
+              }),
+            );
+          }
+
+          tokenPos = to;
+        }
+
+        charPos += line.length + 1;
+        shikiLineIndex += 1;
+      }
+    } catch {
+      // Unsupported language or tokenization error.
+    }
+
+    return true;
+  });
+
+  return DecorationSet.create(doc, decorations);
+}
+
+function normalizeLanguage(language: unknown): SupportedLang {
+  if (typeof language !== 'string' || !language.trim()) {
+    return DEFAULT_LANG;
+  }
+
+  const normalized = language.trim().toLowerCase();
+  if (normalized === 'ps1' || normalized === 'pwsh') {
+    return 'powershell';
+  }
+  if (normalized === 'js') {
+    return 'javascript';
+  }
+  if (normalized === 'ts') {
+    return 'typescript';
+  }
+  if (normalized === 'yml') {
+    return 'yaml';
+  }
+  if (normalized === 'console') {
+    return 'bash';
+  }
+
+  if ((SUPPORTED_LANGS as readonly string[]).includes(normalized)) {
+    return normalized as SupportedLang;
+  }
+
+  return DEFAULT_LANG;
+}

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -63,8 +63,6 @@ type CopyDocument = {
 };
 type MinimalEditorView = Pick<EditorView, 'state' | 'dispatch' | 'focus'>;
 
-let activeEditorView: EditorView | undefined;
-
 function getHighlighter() {
   if (!highlighterPromise) {
     highlighterPromise = createHighlighter({
@@ -100,9 +98,12 @@ export function setupCodeHighlight() {
           },
         },
         view(view) {
-          activeEditorView = view;
+          let destroyed = false;
           void getHighlighter()
             .then(() => {
+              if (destroyed || view.isDestroyed) {
+                return;
+              }
               view.dispatch(
                 view.state.tr.setMeta(CODE_HIGHLIGHT_PLUGIN_KEY, true),
               );
@@ -113,9 +114,7 @@ export function setupCodeHighlight() {
 
           return {
             destroy() {
-              if (activeEditorView === view) {
-                activeEditorView = undefined;
-              }
+              destroyed = true;
             },
           };
         },
@@ -139,7 +138,7 @@ function createDecorations(doc: PMNode): DecorationSet {
     decorations.push(
       Decoration.widget(
         pos + 1,
-        () => createLanguageBadgeWidget(rawLanguage, pos),
+        (view) => createLanguageBadgeWidget(rawLanguage, pos, view),
         {
           side: -1,
           ignoreSelection: true,
@@ -276,6 +275,7 @@ function createCopyButtonWidget(text: string): HTMLElement {
 function createLanguageBadgeWidget(
   language: string,
   codeBlockPos: number,
+  editorView: EditorView,
 ): HTMLElement {
   const wrapper = document.createElement('span');
   wrapper.className = 'prosemirror-code-language-widget';
@@ -303,7 +303,7 @@ function createLanguageBadgeWidget(
   button.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
-    showLanguageEditor(wrapper, codeBlockPos, language);
+    showLanguageEditor(wrapper, editorView, codeBlockPos, language);
   });
 
   wrapper.append(button);
@@ -312,6 +312,7 @@ function createLanguageBadgeWidget(
 
 function showLanguageEditor(
   container: HTMLElement,
+  editorView: EditorView,
   codeBlockPos: number,
   initialLanguage: string,
 ) {
@@ -324,16 +325,16 @@ function showLanguageEditor(
   input.addEventListener('keydown', (event) => {
     if (event.key === 'Enter') {
       event.preventDefault();
-      applyLanguageChange(codeBlockPos, input.value);
+      applyLanguageChange(editorView, codeBlockPos, input.value);
       return;
     }
     if (event.key === 'Escape') {
       event.preventDefault();
-      activeEditorView?.focus();
+      editorView.focus();
     }
   });
   input.addEventListener('blur', () => {
-    applyLanguageChange(codeBlockPos, input.value);
+    applyLanguageChange(editorView, codeBlockPos, input.value);
   });
 
   container.replaceChildren(input);
@@ -341,8 +342,11 @@ function showLanguageEditor(
   input.select();
 }
 
-function applyLanguageChange(codeBlockPos: number, value: string) {
-  const editorView = activeEditorView;
+function applyLanguageChange(
+  editorView: EditorView,
+  codeBlockPos: number,
+  value: string,
+) {
   if (!editorView || editorView.isDestroyed) {
     return;
   }
@@ -358,7 +362,7 @@ function setCodeBlockLanguage(
   language: string,
 ): boolean {
   const node = editorView.state.doc.nodeAt(codeBlockPos);
-  if (!node || node.type.name !== 'code_block') {
+  if (node?.type.name !== 'code_block') {
     return false;
   }
 
@@ -394,7 +398,7 @@ export async function copyTextToClipboard(
   }
 
   const doc = options?.document ?? getCopyDocument(globalThis.document);
-  if (!doc || !doc.body) {
+  if (!doc?.body) {
     return false;
   }
 

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -6,37 +6,18 @@ import {
   PluginKey,
   type PMNode,
 } from '@bangle.io/prosemirror-plugins';
+import { createHighlightPlugin, type Parser } from 'prosemirror-highlight';
 import type { EditorView } from 'prosemirror-view';
-import { createHighlighter } from 'shiki';
+import {
+  DEFAULT_CODE_BLOCK_LANGUAGE,
+  getRawCodeBlockLanguage,
+  normalizeCodeBlockLanguage,
+} from './code-highlight-languages';
 
-const CODE_HIGHLIGHT_PLUGIN_KEY = new PluginKey('code-highlight');
-const CODE_THEME = 'github-dark';
-const COPY_LABEL = 'Copy';
-const COPIED_LABEL = 'Copied';
-const EDIT_LANGUAGE_LABEL = 'Edit language';
+const CODE_ACTIONS_PLUGIN_KEY = new PluginKey('code-actions');
 const COPY_FEEDBACK_TIMEOUT_MS = 1200;
-const SUPPORTED_LANGS = [
-  'text',
-  'plaintext',
-  'bash',
-  'shell',
-  'sh',
-  'zsh',
-  'powershell',
-  'javascript',
-  'typescript',
-  'json',
-  'yaml',
-  'python',
-] as const;
-type SupportedLang = (typeof SUPPORTED_LANGS)[number];
-const DEFAULT_LANG: SupportedLang = 'text';
+const copiedFeedbackUntilByPos = new Map<number, number>();
 
-let highlighterPromise: ReturnType<typeof createHighlighter> | undefined;
-let highlighterInstance:
-  | Awaited<ReturnType<typeof createHighlighter>>
-  | undefined;
-type LoadedHighlighter = Awaited<ReturnType<typeof createHighlighter>>;
 type ClipboardApi = {
   writeText: (text: string) => Promise<void>;
 };
@@ -62,69 +43,128 @@ type CopyDocument = {
   execCommand?: (command: string) => boolean;
 };
 type MinimalEditorView = Pick<EditorView, 'state' | 'dispatch' | 'focus'>;
+type CodeBlockPosResolver = () => number | undefined;
+type CodeActionsState = {
+  decorations: DecorationSet;
+  signature: string;
+};
 
-function getHighlighter() {
-  if (!highlighterPromise) {
-    highlighterPromise = createHighlighter({
-      themes: [CODE_THEME],
-      langs: [...SUPPORTED_LANGS],
-    });
-    void highlighterPromise.then((highlighter: LoadedHighlighter) => {
-      highlighterInstance = highlighter;
-    });
-  }
-
-  return highlighterPromise;
-}
+let loadedHighlightParser: Parser | undefined;
+let highlightParserPromise: Promise<void> | undefined;
 
 export function setupCodeHighlight() {
   return collection({
     id: 'code-highlight',
     plugin: {
-      codeHighlight: new Plugin({
-        key: CODE_HIGHLIGHT_PLUGIN_KEY,
+      codeHighlight: createHighlightPlugin({
+        parser: lazyCodeHighlightParser,
+        nodeTypes: ['code_block'],
+        languageExtractor: (node) =>
+          normalizeCodeBlockLanguage(node.attrs.language),
+      }),
+      codeBlockActions: new Plugin({
+        key: CODE_ACTIONS_PLUGIN_KEY,
         state: {
-          init: (_, state) => createDecorations(state.doc),
-          apply(tr, old) {
-            if (!tr.docChanged && !tr.getMeta(CODE_HIGHLIGHT_PLUGIN_KEY)) {
-              return old.map(tr.mapping, tr.doc);
+          init: (_, state) => createActionState(state.doc),
+          apply(tr, old: CodeActionsState) {
+            const mappedDecorations = old.decorations.map(tr.mapping, tr.doc);
+            if (!tr.docChanged && !tr.getMeta(CODE_ACTIONS_PLUGIN_KEY)) {
+              return {
+                ...old,
+                decorations: mappedDecorations,
+              };
             }
-            return createDecorations(tr.doc);
+
+            const signature = createActionSignature(tr.doc);
+            const expectedDecorationCount = countCodeActionDecorations(tr.doc);
+            if (
+              !tr.getMeta(CODE_ACTIONS_PLUGIN_KEY) &&
+              signature === old.signature &&
+              mappedDecorations.find().length === expectedDecorationCount
+            ) {
+              return {
+                decorations: mappedDecorations,
+                signature,
+              };
+            }
+            return createActionState(tr.doc, signature);
           },
         },
         props: {
           decorations(state) {
-            return CODE_HIGHLIGHT_PLUGIN_KEY.getState(state);
+            return CODE_ACTIONS_PLUGIN_KEY.getState(state)?.decorations;
           },
-        },
-        view(view) {
-          let destroyed = false;
-          void getHighlighter()
-            .then(() => {
-              if (destroyed || view.isDestroyed) {
-                return;
-              }
-              view.dispatch(
-                view.state.tr.setMeta(CODE_HIGHLIGHT_PLUGIN_KEY, true),
-              );
-            })
-            .catch(() => {
-              // Fallback: plain code styling.
-            });
-
-          return {
-            destroy() {
-              destroyed = true;
-            },
-          };
         },
       }),
     },
   });
 }
 
-function createDecorations(doc: PMNode): DecorationSet {
-  const highlighter = highlighterInstance;
+const lazyCodeHighlightParser: Parser = (options) => {
+  const language = normalizeCodeBlockLanguage(options.language);
+  if (!options.content || language === 'text' || language === 'plaintext') {
+    return [];
+  }
+
+  if (!loadedHighlightParser) {
+    highlightParserPromise ??= import('./code-highlight-shiki')
+      .then(({ createCodeHighlightParser }) => {
+        const parser = createCodeHighlightParser();
+        loadedHighlightParser = parser;
+        const result = parser({
+          ...options,
+          language,
+        });
+        return Array.isArray(result) ? undefined : result;
+      })
+      .catch((error: unknown) => {
+        highlightParserPromise = undefined;
+        throw error;
+      });
+    return highlightParserPromise;
+  }
+
+  return loadedHighlightParser({
+    ...options,
+    language,
+  });
+};
+
+function createActionState(
+  doc: PMNode,
+  signature = createActionSignature(doc),
+): CodeActionsState {
+  return {
+    decorations: createActionDecorations(doc),
+    signature,
+  };
+}
+
+function createActionSignature(doc: PMNode): string {
+  const languages: string[] = [];
+  doc.descendants((node) => {
+    if (node.type.name === 'code_block') {
+      languages.push(getRawCodeBlockLanguage(node.attrs.language));
+      return false;
+    }
+    return true;
+  });
+  return languages.join('\0');
+}
+
+function countCodeActionDecorations(doc: PMNode): number {
+  let codeBlockCount = 0;
+  doc.descendants((node) => {
+    if (node.type.name === 'code_block') {
+      codeBlockCount += 1;
+      return false;
+    }
+    return true;
+  });
+  return codeBlockCount * 2;
+}
+
+function createActionDecorations(doc: PMNode): DecorationSet {
   const decorations: Decoration[] = [];
 
   doc.descendants((node, pos) => {
@@ -132,98 +172,37 @@ function createDecorations(doc: PMNode): DecorationSet {
       return true;
     }
 
-    const rawLanguage = getRawLanguage(node.attrs.language);
-    const language = normalizeLanguage(rawLanguage);
-    const text = node.textContent || '';
+    const rawLanguage = getRawCodeBlockLanguage(node.attrs.language);
     decorations.push(
       Decoration.widget(
         pos + 1,
-        (view) => createLanguageBadgeWidget(rawLanguage, pos, view),
+        (view, getPos) =>
+          createLanguageBadgeWidget(
+            rawLanguage,
+            codeBlockPosFromWidget(getPos),
+            view,
+          ),
         {
+          key: `code-language:${pos}:${rawLanguage}`,
           side: -1,
           ignoreSelection: true,
-          stopEvent: (event) =>
-            event.type === 'mousedown' ||
-            event.type === 'pointerdown' ||
-            event.type === 'touchstart' ||
-            event.type === 'click',
+          stopEvent: isCodeActionEvent,
         },
       ),
     );
     decorations.push(
-      Decoration.widget(pos + 1, () => createCopyButtonWidget(text), {
-        side: -1,
-        ignoreSelection: true,
-        stopEvent: (event) =>
-          event.type === 'mousedown' ||
-          event.type === 'pointerdown' ||
-          event.type === 'touchstart' ||
-          event.type === 'click',
-      }),
+      Decoration.widget(
+        pos + 1,
+        (view, getPos) =>
+          createCopyButtonWidget(codeBlockPosFromWidget(getPos), view),
+        {
+          key: `code-copy:${pos}`,
+          side: -1,
+          ignoreSelection: true,
+          stopEvent: isCodeActionEvent,
+        },
+      ),
     );
-
-    if (!highlighter || !text) {
-      return true;
-    }
-
-    const lines = text.split('\n');
-    let charPos = pos + 1;
-    let shikiLineIndex = 0;
-
-    try {
-      const rawTokens = highlighter.codeToTokens(text, {
-        lang: language,
-        theme: CODE_THEME,
-      });
-      const tokensByLine = Array.isArray(rawTokens)
-        ? rawTokens
-        : rawTokens.tokens;
-
-      for (const line of lines) {
-        const lineTokens = tokensByLine[shikiLineIndex] || [];
-        let tokenPos = charPos;
-
-        for (const token of lineTokens) {
-          const tokenLength = token.content.length;
-          if (!tokenLength) {
-            continue;
-          }
-
-          const from = tokenPos;
-          const to = tokenPos + tokenLength;
-          const styleParts: string[] = [];
-
-          if (token.color) {
-            styleParts.push(`color:${token.color}`);
-          }
-          if (token.fontStyle & 1) {
-            styleParts.push('font-style:italic');
-          }
-          if (token.fontStyle & 2) {
-            styleParts.push('font-weight:600');
-          }
-          if (token.fontStyle & 4) {
-            styleParts.push('text-decoration:underline');
-          }
-
-          if (from < to) {
-            decorations.push(
-              Decoration.inline(from, to, {
-                class: 'prosemirror-code-token',
-                style: styleParts.join(';'),
-              }),
-            );
-          }
-
-          tokenPos = to;
-        }
-
-        charPos += line.length + 1;
-        shikiLineIndex += 1;
-      }
-    } catch {
-      // Unsupported language or tokenization error.
-    }
 
     return true;
   });
@@ -231,7 +210,27 @@ function createDecorations(doc: PMNode): DecorationSet {
   return DecorationSet.create(doc, decorations);
 }
 
-function createCopyButtonWidget(text: string): HTMLElement {
+function codeBlockPosFromWidget(getWidgetPos: CodeBlockPosResolver) {
+  return () => {
+    const widgetPos = getWidgetPos();
+    return widgetPos === undefined ? undefined : widgetPos - 1;
+  };
+}
+
+function isCodeActionEvent(event: Event): boolean {
+  return (
+    event.type === 'mousedown' ||
+    event.type === 'pointerdown' ||
+    event.type === 'touchstart' ||
+    event.type === 'click'
+  );
+}
+
+function createCopyButtonWidget(
+  getCodeBlockPos: CodeBlockPosResolver,
+  editorView: EditorView,
+): HTMLElement {
+  const copyLabel = t.app.editor.codeBlock.copy;
   const wrapper = document.createElement('span');
   wrapper.className = 'prosemirror-code-copy-widget';
   wrapper.contentEditable = 'false';
@@ -239,10 +238,10 @@ function createCopyButtonWidget(text: string): HTMLElement {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'prosemirror-code-copy-button';
-  button.textContent = COPY_LABEL;
-  button.setAttribute('aria-label', COPY_LABEL);
-  button.setAttribute('title', COPY_LABEL);
+  button.setAttribute('aria-label', copyLabel);
+  button.setAttribute('title', copyLabel);
   button.tabIndex = -1;
+  updateCopyButtonText(button, getCodeBlockPos());
   button.addEventListener('mousedown', (event) => {
     event.preventDefault();
     event.stopPropagation();
@@ -258,30 +257,94 @@ function createCopyButtonWidget(text: string): HTMLElement {
   button.addEventListener('click', async (event) => {
     event.preventDefault();
     event.stopPropagation();
-    const copied = await copyTextToClipboard(text);
+    const codeBlockPos = getCodeBlockPos();
+    if (codeBlockPos === undefined) {
+      return;
+    }
+
+    const copied = await copyTextToClipboard(
+      getCodeBlockText(editorView, codeBlockPos),
+    );
     if (!copied) {
       return;
     }
-    button.textContent = COPIED_LABEL;
-    globalThis.setTimeout(() => {
-      button.textContent = COPY_LABEL;
-    }, COPY_FEEDBACK_TIMEOUT_MS);
+    showCopyFeedback(button, codeBlockPos);
+    editorView.focus();
   });
 
   wrapper.append(button);
   return wrapper;
 }
 
+function showCopyFeedback(button: HTMLButtonElement, codeBlockPos: number) {
+  const until = Date.now() + COPY_FEEDBACK_TIMEOUT_MS;
+  copiedFeedbackUntilByPos.set(codeBlockPos, until);
+  button.textContent = t.app.editor.codeBlock.copied;
+  scheduleCopyFeedbackReset(button, codeBlockPos, until);
+}
+
+function updateCopyButtonText(
+  button: HTMLButtonElement,
+  codeBlockPos: number | undefined,
+) {
+  if (codeBlockPos === undefined) {
+    button.textContent = t.app.editor.codeBlock.copy;
+    return;
+  }
+
+  const until = copiedFeedbackUntilByPos.get(codeBlockPos);
+  if (!until || until <= Date.now()) {
+    copiedFeedbackUntilByPos.delete(codeBlockPos);
+    button.textContent = t.app.editor.codeBlock.copy;
+    return;
+  }
+
+  button.textContent = t.app.editor.codeBlock.copied;
+  scheduleCopyFeedbackReset(button, codeBlockPos, until);
+}
+
+function scheduleCopyFeedbackReset(
+  button: HTMLButtonElement,
+  codeBlockPos: number,
+  until: number,
+) {
+  globalThis.setTimeout(
+    () => {
+      const activeUntil = copiedFeedbackUntilByPos.get(codeBlockPos);
+      if (activeUntil !== undefined && activeUntil > until) {
+        return;
+      }
+      copiedFeedbackUntilByPos.delete(codeBlockPos);
+      button.textContent = t.app.editor.codeBlock.copy;
+    },
+    Math.max(0, until - Date.now()),
+  );
+}
+
+function getCodeBlockText(
+  editorView: EditorView,
+  codeBlockPos: number | undefined,
+): string {
+  if (editorView.isDestroyed || codeBlockPos === undefined) {
+    return '';
+  }
+  const node = editorView.state.doc.nodeAt(codeBlockPos);
+  if (node?.type.name !== 'code_block') {
+    return '';
+  }
+  return node.textContent || '';
+}
+
 function createLanguageBadgeWidget(
   language: string,
-  codeBlockPos: number,
+  getCodeBlockPos: CodeBlockPosResolver,
   editorView: EditorView,
 ): HTMLElement {
   const wrapper = document.createElement('span');
   wrapper.className = 'prosemirror-code-language-widget';
   wrapper.contentEditable = 'false';
   wrapper.append(
-    createLanguageButton(wrapper, language, codeBlockPos, editorView),
+    createLanguageButton(wrapper, language, getCodeBlockPos, editorView),
   );
 
   return wrapper;
@@ -290,15 +353,16 @@ function createLanguageBadgeWidget(
 function createLanguageButton(
   container: HTMLElement,
   language: string,
-  codeBlockPos: number,
+  getCodeBlockPos: CodeBlockPosResolver,
   editorView: EditorView,
 ): HTMLButtonElement {
+  const editLanguageLabel = t.app.editor.codeBlock.editLanguage;
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'prosemirror-code-language-button';
-  button.textContent = (language || DEFAULT_LANG).toUpperCase();
-  button.setAttribute('aria-label', EDIT_LANGUAGE_LABEL);
-  button.setAttribute('title', EDIT_LANGUAGE_LABEL);
+  button.textContent = (language || DEFAULT_CODE_BLOCK_LANGUAGE).toUpperCase();
+  button.setAttribute('aria-label', editLanguageLabel);
+  button.setAttribute('title', editLanguageLabel);
   button.tabIndex = -1;
   button.addEventListener('mousedown', (event) => {
     event.preventDefault();
@@ -315,7 +379,7 @@ function createLanguageButton(
   button.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
-    showLanguageEditor(container, editorView, codeBlockPos, language);
+    showLanguageEditor(container, editorView, getCodeBlockPos, language);
   });
 
   return button;
@@ -324,35 +388,43 @@ function createLanguageButton(
 function showLanguageEditor(
   container: HTMLElement,
   editorView: EditorView,
-  codeBlockPos: number,
+  getCodeBlockPos: CodeBlockPosResolver,
   initialLanguage: string,
 ) {
   let finished = false;
   const input = document.createElement('input');
+  const ownerDocument = input.ownerDocument;
   input.type = 'text';
   input.className = 'prosemirror-code-language-input';
   input.value = initialLanguage || '';
-  input.placeholder = DEFAULT_LANG;
-  input.setAttribute('aria-label', EDIT_LANGUAGE_LABEL);
+  input.placeholder = DEFAULT_CODE_BLOCK_LANGUAGE;
+  input.setAttribute('aria-label', t.app.editor.codeBlock.editLanguage);
 
   const restoreButton = () => {
     container.replaceChildren(
       createLanguageButton(
         container,
         initialLanguage,
-        codeBlockPos,
+        getCodeBlockPos,
         editorView,
       ),
     );
   };
-  const commit = () => {
+  const finish = () => {
     if (finished) {
-      return;
+      return false;
     }
     finished = true;
+    ownerDocument.removeEventListener('pointerdown', handlePointerDown, true);
+    return true;
+  };
+  const commit = () => {
+    if (!finish()) {
+      return;
+    }
     const changed = applyLanguageChange(
       editorView,
-      codeBlockPos,
+      getCodeBlockPos(),
       input.value,
       initialLanguage,
     );
@@ -361,12 +433,17 @@ function showLanguageEditor(
     }
   };
   const cancel = () => {
-    if (finished) {
+    if (!finish()) {
       return;
     }
-    finished = true;
     restoreButton();
     editorView.focus();
+  };
+  const handlePointerDown = (event: PointerEvent) => {
+    if (event.target instanceof Node && container.contains(event.target)) {
+      return;
+    }
+    commit();
   };
 
   input.addEventListener('keydown', (event) => {
@@ -383,6 +460,7 @@ function showLanguageEditor(
   input.addEventListener('blur', () => {
     commit();
   });
+  ownerDocument.addEventListener('pointerdown', handlePointerDown, true);
 
   container.replaceChildren(input);
   input.focus();
@@ -391,11 +469,11 @@ function showLanguageEditor(
 
 function applyLanguageChange(
   editorView: EditorView,
-  codeBlockPos: number,
+  codeBlockPos: number | undefined,
   value: string,
   previousValue: string,
 ): boolean {
-  if (!editorView || editorView.isDestroyed) {
+  if (!editorView || editorView.isDestroyed || codeBlockPos === undefined) {
     return false;
   }
 
@@ -430,7 +508,7 @@ function setCodeBlockLanguage(
   editorView.dispatch(
     editorView.state.tr
       .setNodeMarkup(codeBlockPos, undefined, nextAttrs)
-      .setMeta(CODE_HIGHLIGHT_PLUGIN_KEY, true),
+      .setMeta(CODE_ACTIONS_PLUGIN_KEY, true),
   );
   return true;
 }
@@ -483,13 +561,6 @@ export async function copyTextToClipboard(
   }
 }
 
-function getRawLanguage(language: unknown): string {
-  if (typeof language !== 'string') {
-    return '';
-  }
-  return language.trim().toLowerCase();
-}
-
 function getCopyDocument(value: unknown): CopyDocument | undefined {
   if (!isCopyDocument(value)) {
     return undefined;
@@ -505,33 +576,4 @@ function isCopyDocument(value: unknown): value is CopyDocument {
     'createElement' in value &&
     'body' in value
   );
-}
-
-function normalizeLanguage(language: unknown): SupportedLang {
-  if (typeof language !== 'string' || !language.trim()) {
-    return DEFAULT_LANG;
-  }
-
-  const normalized = language.trim().toLowerCase();
-  if (normalized === 'ps1' || normalized === 'pwsh') {
-    return 'powershell';
-  }
-  if (normalized === 'js') {
-    return 'javascript';
-  }
-  if (normalized === 'ts') {
-    return 'typescript';
-  }
-  if (normalized === 'yml') {
-    return 'yaml';
-  }
-  if (normalized === 'console') {
-    return 'bash';
-  }
-
-  if ((SUPPORTED_LANGS as readonly string[]).includes(normalized)) {
-    return normalized as SupportedLang;
-  }
-
-  return DEFAULT_LANG;
 }

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -280,7 +280,19 @@ function createLanguageBadgeWidget(
   const wrapper = document.createElement('span');
   wrapper.className = 'prosemirror-code-language-widget';
   wrapper.contentEditable = 'false';
+  wrapper.append(
+    createLanguageButton(wrapper, language, codeBlockPos, editorView),
+  );
 
+  return wrapper;
+}
+
+function createLanguageButton(
+  container: HTMLElement,
+  language: string,
+  codeBlockPos: number,
+  editorView: EditorView,
+): HTMLButtonElement {
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'prosemirror-code-language-button';
@@ -303,11 +315,10 @@ function createLanguageBadgeWidget(
   button.addEventListener('click', (event) => {
     event.preventDefault();
     event.stopPropagation();
-    showLanguageEditor(wrapper, editorView, codeBlockPos, language);
+    showLanguageEditor(container, editorView, codeBlockPos, language);
   });
 
-  wrapper.append(button);
-  return wrapper;
+  return button;
 }
 
 function showLanguageEditor(
@@ -316,25 +327,61 @@ function showLanguageEditor(
   codeBlockPos: number,
   initialLanguage: string,
 ) {
+  let finished = false;
   const input = document.createElement('input');
   input.type = 'text';
   input.className = 'prosemirror-code-language-input';
   input.value = initialLanguage || '';
   input.placeholder = DEFAULT_LANG;
   input.setAttribute('aria-label', EDIT_LANGUAGE_LABEL);
+
+  const restoreButton = () => {
+    container.replaceChildren(
+      createLanguageButton(
+        container,
+        initialLanguage,
+        codeBlockPos,
+        editorView,
+      ),
+    );
+  };
+  const commit = () => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    const changed = applyLanguageChange(
+      editorView,
+      codeBlockPos,
+      input.value,
+      initialLanguage,
+    );
+    if (!changed) {
+      restoreButton();
+    }
+  };
+  const cancel = () => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    restoreButton();
+    editorView.focus();
+  };
+
   input.addEventListener('keydown', (event) => {
     if (event.key === 'Enter') {
       event.preventDefault();
-      applyLanguageChange(editorView, codeBlockPos, input.value);
+      commit();
       return;
     }
     if (event.key === 'Escape') {
       event.preventDefault();
-      editorView.focus();
+      cancel();
     }
   });
   input.addEventListener('blur', () => {
-    applyLanguageChange(editorView, codeBlockPos, input.value);
+    commit();
   });
 
   container.replaceChildren(input);
@@ -346,14 +393,21 @@ function applyLanguageChange(
   editorView: EditorView,
   codeBlockPos: number,
   value: string,
-) {
+  previousValue: string,
+): boolean {
   if (!editorView || editorView.isDestroyed) {
-    return;
+    return false;
   }
 
   const nextLanguage = value.trim().toLowerCase();
-  setCodeBlockLanguage(editorView, codeBlockPos, nextLanguage || DEFAULT_LANG);
+  if (nextLanguage === previousValue) {
+    editorView.focus();
+    return false;
+  }
+
+  const changed = setCodeBlockLanguage(editorView, codeBlockPos, nextLanguage);
   editorView.focus();
+  return changed;
 }
 
 function setCodeBlockLanguage(
@@ -363,6 +417,9 @@ function setCodeBlockLanguage(
 ): boolean {
   const node = editorView.state.doc.nodeAt(codeBlockPos);
   if (node?.type.name !== 'code_block') {
+    return false;
+  }
+  if (node.attrs.language === language) {
     return false;
   }
 

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -6,12 +6,14 @@ import {
   PluginKey,
   type PMNode,
 } from '@bangle.io/prosemirror-plugins';
+import type { EditorView } from 'prosemirror-view';
 import { createHighlighter } from 'shiki';
 
 const CODE_HIGHLIGHT_PLUGIN_KEY = new PluginKey('code-highlight');
 const CODE_THEME = 'github-dark';
 const COPY_LABEL = 'Copy';
 const COPIED_LABEL = 'Copied';
+const EDIT_LANGUAGE_LABEL = 'Edit language';
 const COPY_FEEDBACK_TIMEOUT_MS = 1200;
 const SUPPORTED_LANGS = [
   'text',
@@ -59,6 +61,9 @@ type CopyDocument = {
   } | null;
   execCommand?: (command: string) => boolean;
 };
+type MinimalEditorView = Pick<EditorView, 'state' | 'dispatch' | 'focus'>;
+
+let activeEditorView: EditorView | undefined;
 
 function getHighlighter() {
   if (!highlighterPromise) {
@@ -95,6 +100,7 @@ export function setupCodeHighlight() {
           },
         },
         view(view) {
+          activeEditorView = view;
           void getHighlighter()
             .then(() => {
               view.dispatch(
@@ -105,7 +111,13 @@ export function setupCodeHighlight() {
               // Fallback: plain code styling.
             });
 
-          return {};
+          return {
+            destroy() {
+              if (activeEditorView === view) {
+                activeEditorView = undefined;
+              }
+            },
+          };
         },
       }),
     },
@@ -121,8 +133,24 @@ function createDecorations(doc: PMNode): DecorationSet {
       return true;
     }
 
-    const language = normalizeLanguage(node.attrs.language);
+    const rawLanguage = getRawLanguage(node.attrs.language);
+    const language = normalizeLanguage(rawLanguage);
     const text = node.textContent || '';
+    decorations.push(
+      Decoration.widget(
+        pos + 1,
+        () => createLanguageBadgeWidget(rawLanguage, pos),
+        {
+          side: -1,
+          ignoreSelection: true,
+          stopEvent: (event) =>
+            event.type === 'mousedown' ||
+            event.type === 'pointerdown' ||
+            event.type === 'touchstart' ||
+            event.type === 'click',
+        },
+      ),
+    );
     decorations.push(
       Decoration.widget(pos + 1, () => createCopyButtonWidget(text), {
         side: -1,
@@ -245,6 +273,111 @@ function createCopyButtonWidget(text: string): HTMLElement {
   return wrapper;
 }
 
+function createLanguageBadgeWidget(
+  language: string,
+  codeBlockPos: number,
+): HTMLElement {
+  const wrapper = document.createElement('span');
+  wrapper.className = 'prosemirror-code-language-widget';
+  wrapper.contentEditable = 'false';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'prosemirror-code-language-button';
+  button.textContent = (language || DEFAULT_LANG).toUpperCase();
+  button.setAttribute('aria-label', EDIT_LANGUAGE_LABEL);
+  button.setAttribute('title', EDIT_LANGUAGE_LABEL);
+  button.tabIndex = -1;
+  button.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  button.addEventListener('pointerdown', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  button.addEventListener('touchstart', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    showLanguageEditor(wrapper, codeBlockPos, language);
+  });
+
+  wrapper.append(button);
+  return wrapper;
+}
+
+function showLanguageEditor(
+  container: HTMLElement,
+  codeBlockPos: number,
+  initialLanguage: string,
+) {
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'prosemirror-code-language-input';
+  input.value = initialLanguage || '';
+  input.placeholder = DEFAULT_LANG;
+  input.setAttribute('aria-label', EDIT_LANGUAGE_LABEL);
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      applyLanguageChange(codeBlockPos, input.value);
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      activeEditorView?.focus();
+    }
+  });
+  input.addEventListener('blur', () => {
+    applyLanguageChange(codeBlockPos, input.value);
+  });
+
+  container.replaceChildren(input);
+  input.focus();
+  input.select();
+}
+
+function applyLanguageChange(codeBlockPos: number, value: string) {
+  const editorView = activeEditorView;
+  if (!editorView || editorView.isDestroyed) {
+    return;
+  }
+
+  const nextLanguage = value.trim().toLowerCase();
+  setCodeBlockLanguage(
+    editorView,
+    codeBlockPos,
+    nextLanguage || DEFAULT_LANG,
+  );
+  editorView.focus();
+}
+
+function setCodeBlockLanguage(
+  editorView: MinimalEditorView,
+  codeBlockPos: number,
+  language: string,
+): boolean {
+  const node = editorView.state.doc.nodeAt(codeBlockPos);
+  if (!node || node.type.name !== 'code_block') {
+    return false;
+  }
+
+  const nextAttrs = {
+    ...node.attrs,
+    language,
+  };
+  editorView.dispatch(
+    editorView.state.tr
+      .setNodeMarkup(codeBlockPos, undefined, nextAttrs)
+      .setMeta(CODE_HIGHLIGHT_PLUGIN_KEY, true),
+  );
+  return true;
+}
+
 export async function copyTextToClipboard(
   text: string,
   options?: {
@@ -291,6 +424,13 @@ export async function copyTextToClipboard(
   } finally {
     textarea.remove();
   }
+}
+
+function getRawLanguage(language: unknown): string {
+  if (typeof language !== 'string') {
+    return '';
+  }
+  return language.trim().toLowerCase();
 }
 
 function getCopyDocument(value: unknown): CopyDocument | undefined {

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -10,6 +10,9 @@ import { createHighlighter } from 'shiki';
 
 const CODE_HIGHLIGHT_PLUGIN_KEY = new PluginKey('code-highlight');
 const CODE_THEME = 'github-dark';
+const COPY_LABEL = 'Copy';
+const COPIED_LABEL = 'Copied';
+const COPY_FEEDBACK_TIMEOUT_MS = 1200;
 const SUPPORTED_LANGS = [
   'text',
   'plaintext',
@@ -32,6 +35,30 @@ let highlighterInstance:
   | Awaited<ReturnType<typeof createHighlighter>>
   | undefined;
 type LoadedHighlighter = Awaited<ReturnType<typeof createHighlighter>>;
+type ClipboardApi = {
+  writeText: (text: string) => Promise<void>;
+};
+type CopyTextarea = {
+  value: string;
+  setAttribute: (name: string, value: string) => void;
+  style: {
+    position: string;
+    left: string;
+    top: string;
+    opacity: string;
+    pointerEvents: string;
+  };
+  focus: () => void;
+  select: () => void;
+  remove: () => void;
+};
+type CopyDocument = {
+  createElement: (tagName: 'textarea') => CopyTextarea;
+  body: {
+    appendChild: (node: CopyTextarea) => void;
+  } | null;
+  execCommand?: (command: string) => boolean;
+};
 
 function getHighlighter() {
   if (!highlighterPromise) {
@@ -87,10 +114,6 @@ export function setupCodeHighlight() {
 
 function createDecorations(doc: PMNode): DecorationSet {
   const highlighter = highlighterInstance;
-  if (!highlighter) {
-    return DecorationSet.empty;
-  }
-
   const decorations: Decoration[] = [];
 
   doc.descendants((node, pos) => {
@@ -100,7 +123,19 @@ function createDecorations(doc: PMNode): DecorationSet {
 
     const language = normalizeLanguage(node.attrs.language);
     const text = node.textContent || '';
-    if (!text) {
+    decorations.push(
+      Decoration.widget(pos + 1, () => createCopyButtonWidget(text), {
+        side: -1,
+        ignoreSelection: true,
+        stopEvent: (event) =>
+          event.type === 'mousedown' ||
+          event.type === 'pointerdown' ||
+          event.type === 'touchstart' ||
+          event.type === 'click',
+      }),
+    );
+
+    if (!highlighter || !text) {
       return true;
     }
 
@@ -167,6 +202,112 @@ function createDecorations(doc: PMNode): DecorationSet {
   });
 
   return DecorationSet.create(doc, decorations);
+}
+
+function createCopyButtonWidget(text: string): HTMLElement {
+  const wrapper = document.createElement('span');
+  wrapper.className = 'prosemirror-code-copy-widget';
+  wrapper.contentEditable = 'false';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'prosemirror-code-copy-button';
+  button.textContent = COPY_LABEL;
+  button.setAttribute('aria-label', COPY_LABEL);
+  button.setAttribute('title', COPY_LABEL);
+  button.tabIndex = -1;
+  button.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  button.addEventListener('pointerdown', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  button.addEventListener('touchstart', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  });
+  button.addEventListener('click', async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const copied = await copyTextToClipboard(text);
+    if (!copied) {
+      return;
+    }
+    button.textContent = COPIED_LABEL;
+    globalThis.setTimeout(() => {
+      button.textContent = COPY_LABEL;
+    }, COPY_FEEDBACK_TIMEOUT_MS);
+  });
+
+  wrapper.append(button);
+  return wrapper;
+}
+
+export async function copyTextToClipboard(
+  text: string,
+  options?: {
+    clipboard?: ClipboardApi;
+    document?: CopyDocument;
+  },
+): Promise<boolean> {
+  const clipboard =
+    options?.clipboard ?? globalThis.navigator?.clipboard ?? undefined;
+
+  if (clipboard?.writeText) {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the document fallback.
+    }
+  }
+
+  const doc = options?.document ?? getCopyDocument(globalThis.document);
+  if (!doc || !doc.body) {
+    return false;
+  }
+
+  const textarea = doc.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', 'readonly');
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  textarea.style.top = '0';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+  doc.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  try {
+    if (typeof doc.execCommand !== 'function') {
+      return false;
+    }
+    return doc.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}
+
+function getCopyDocument(value: unknown): CopyDocument | undefined {
+  if (!isCopyDocument(value)) {
+    return undefined;
+  }
+
+  return value;
+}
+
+function isCopyDocument(value: unknown): value is CopyDocument {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'createElement' in value &&
+    'body' in value
+  );
 }
 
 function normalizeLanguage(language: unknown): SupportedLang {

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -348,11 +348,7 @@ function applyLanguageChange(codeBlockPos: number, value: string) {
   }
 
   const nextLanguage = value.trim().toLowerCase();
-  setCodeBlockLanguage(
-    editorView,
-    codeBlockPos,
-    nextLanguage || DEFAULT_LANG,
-  );
+  setCodeBlockLanguage(editorView, codeBlockPos, nextLanguage || DEFAULT_LANG);
   editorView.focus();
 }
 

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -200,6 +200,19 @@ export function SlashCommand({
             >
               Heading 3
             </CommandItem>
+            <CommandItem
+              value="code-block code fenced-code snippet"
+              onSelect={() => {
+                dismissCommandUi();
+                ext.codeBlock.command.toggleCodeBlock(
+                  editorView.state,
+                  editorView.dispatch,
+                  editorView,
+                );
+              }}
+            >
+              Code block
+            </CommandItem>
           </CommandGroup>
 
           <CommandSeparator />

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -87,9 +87,7 @@ export function setupExtensions(
       placeholder: funPlaceholder(),
     }),
     code: setupCode(),
-    codeBlock: setupCodeBlock({
-      keyExit: false,
-    }),
+    codeBlock: setupCodeBlock(),
     codeHighlight: setupCodeHighlight(),
     italic: setupItalic(),
     link,

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -27,6 +27,7 @@ import {
   setupWikiLink,
   type WikiLinkConfig,
 } from '@bangle.io/prosemirror-plugins';
+import { setupCodeHighlight } from './code-highlight';
 import { funPlaceholder } from './utils';
 
 export function setupExtensions(
@@ -86,7 +87,10 @@ export function setupExtensions(
       placeholder: funPlaceholder(),
     }),
     code: setupCode(),
-    codeBlock: setupCodeBlock(),
+    codeBlock: setupCodeBlock({
+      keyExit: false,
+    }),
+    codeHighlight: setupCodeHighlight(),
     italic: setupItalic(),
     link,
     linkMenu: setupLinkMenu({ link }),

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -23,6 +23,7 @@ import {
   setupSelectionMenu,
   setupStrike,
   setupSuggestions,
+  setupTrailingNode,
   setupUnderline,
   setupWikiLink,
   type WikiLinkConfig,
@@ -71,6 +72,7 @@ export function setupExtensions(
       markClassName: 'text-pop',
       logger: logger.child('suggestions'),
     }),
+    trailingNode: setupTrailingNode(),
     wikiSuggestions: setupSuggestions({
       providerId: 'wiki-link',
       markName: 'wiki_link_suggestion',

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -263,10 +263,6 @@ div.ProseMirror {
   & .prosemirror-horizontal-rule {
     padding: 1em 0;
     margin: 1em 0;
-
-    & hr {
-      margin: 0;
-    }
   }
 
   & .prosemirror-flat-list {

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -164,11 +164,23 @@ div.ProseMirror {
 
   & pre {
     margin: 0.5rem 0;
-    padding: 0.95rem 1rem;
+    padding: 2.55rem 1rem 0.95rem;
     overflow-x: auto;
-    border-radius: 0.375rem;
-    border: 1px solid hsl(var(--BV-border) / 0.7);
+    border-radius: 0.5rem;
+    border: 1px solid hsl(var(--BV-border) / 0.65);
     position: relative;
+  }
+
+  & pre::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    height: 2.05rem;
+    border-bottom: 1px solid hsl(var(--BV-border) / 0.45);
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+    background-color: hsl(var(--BV-muted) / 0.18);
+    pointer-events: none;
   }
 
   & pre,
@@ -188,34 +200,33 @@ div.ProseMirror {
     display: block;
     line-height: 1.35;
     font-size: 0.95rem;
-    padding-top: 1.7rem;
-    padding-right: 3.6rem;
+    padding: 0;
   }
 
   & .prosemirror-code-copy-widget {
     position: absolute;
-    top: 0.55rem;
-    right: 0.75rem;
+    top: 0.42rem;
+    right: 0.65rem;
     z-index: 1;
   }
 
   & .prosemirror-code-language-widget {
     position: absolute;
-    top: 0.55rem;
+    top: 0.42rem;
     left: 0.75rem;
     z-index: 1;
   }
 
   & .prosemirror-code-language-button {
-    border: 1px solid hsl(var(--BV-border) / 0.8);
-    border-radius: 9999px;
-    padding: 0.1rem 0.5rem;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    padding: 0.12rem 0.35rem;
     color: hsl(var(--BV-muted-foreground));
     font-size: 0.68rem;
-    line-height: 1.1;
+    line-height: 1.25;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    background-color: hsl(var(--BV-background) / 0.92);
+    background-color: transparent;
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
@@ -223,29 +234,29 @@ div.ProseMirror {
 
   & .prosemirror-code-language-button:hover {
     color: hsl(var(--BV-foreground));
-    background-color: hsl(var(--BV-background));
+    background-color: hsl(var(--BV-background) / 0.5);
   }
 
   & .prosemirror-code-language-input {
     width: 7.5rem;
-    border: 1px solid hsl(var(--BV-border) / 0.8);
-    border-radius: 9999px;
-    padding: 0.12rem 0.55rem;
+    border: 1px solid hsl(var(--BV-border) / 0.7);
+    border-radius: 0.25rem;
+    padding: 0.12rem 0.35rem;
     font-size: 0.68rem;
-    line-height: 1.1;
+    line-height: 1.25;
     color: hsl(var(--BV-foreground));
-    background-color: hsl(var(--BV-background));
+    background-color: hsl(var(--BV-background) / 0.7);
     text-transform: lowercase;
   }
 
   & .prosemirror-code-copy-button {
-    border: 1px solid hsl(var(--BV-border) / 0.75);
-    border-radius: 9999px;
-    padding: 0.12rem 0.5rem;
-    font-size: 0.68rem;
-    line-height: 1.1;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    padding: 0.12rem 0.35rem;
+    font-size: 0.75rem;
+    line-height: 1.25;
     color: hsl(var(--BV-muted-foreground));
-    background-color: hsl(var(--BV-background) / 0.92);
+    background-color: transparent;
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
@@ -253,7 +264,7 @@ div.ProseMirror {
 
   & .prosemirror-code-copy-button:hover {
     color: hsl(var(--BV-foreground));
-    background-color: hsl(var(--BV-background));
+    background-color: hsl(var(--BV-background) / 0.5);
   }
 
   & hr {

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -192,13 +192,21 @@ div.ProseMirror {
     padding-right: 3.6rem;
   }
 
-  & pre[data-language]:not([data-language=""])::before {
-    content: attr(data-language);
-    display: inline-flex;
-    align-items: center;
+  & .prosemirror-code-copy-widget {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.75rem;
+    z-index: 1;
+  }
+
+  & .prosemirror-code-language-widget {
     position: absolute;
     top: 0.55rem;
     left: 0.75rem;
+    z-index: 1;
+  }
+
+  & .prosemirror-code-language-button {
     border: 1px solid hsl(var(--BV-border) / 0.8);
     border-radius: 9999px;
     padding: 0.1rem 0.5rem;
@@ -207,14 +215,27 @@ div.ProseMirror {
     line-height: 1.1;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    z-index: 1;
+    background-color: hsl(var(--BV-background) / 0.92);
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
-  & .prosemirror-code-copy-widget {
-    position: absolute;
-    top: 0.55rem;
-    right: 0.75rem;
-    z-index: 1;
+  & .prosemirror-code-language-button:hover {
+    color: hsl(var(--BV-foreground));
+    background-color: hsl(var(--BV-background));
+  }
+
+  & .prosemirror-code-language-input {
+    width: 7.5rem;
+    border: 1px solid hsl(var(--BV-border) / 0.8);
+    border-radius: 9999px;
+    padding: 0.12rem 0.55rem;
+    font-size: 0.68rem;
+    line-height: 1.1;
+    color: hsl(var(--BV-foreground));
+    background-color: hsl(var(--BV-background));
+    text-transform: lowercase;
   }
 
   & .prosemirror-code-copy-button {

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -164,9 +164,11 @@ div.ProseMirror {
 
   & pre {
     margin: 0.5rem 0;
-    padding: 1.2rem 1.2rem;
+    padding: 0.95rem 1rem;
     overflow-x: auto;
     border-radius: 0.375rem;
+    border: 1px solid hsl(var(--BV-border) / 0.7);
+    position: relative;
   }
 
   & pre,
@@ -183,6 +185,31 @@ div.ProseMirror {
 
   & pre code {
     font-weight: inherit;
+    display: block;
+    line-height: 1.35;
+    font-size: 0.95rem;
+  }
+
+  & pre[data-language]:not([data-language=""])::before {
+    content: attr(data-language);
+    display: inline-flex;
+    align-items: center;
+    position: absolute;
+    top: 0.55rem;
+    left: 0.75rem;
+    border: 1px solid hsl(var(--BV-border) / 0.8);
+    border-radius: 9999px;
+    padding: 0.1rem 0.5rem;
+    color: hsl(var(--BV-muted-foreground));
+    font-size: 0.68rem;
+    line-height: 1.1;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    z-index: 1;
+  }
+
+  & pre[data-language]:not([data-language=""]) code {
+    padding-top: 1.7rem;
   }
 
   & hr {

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -263,6 +263,10 @@ div.ProseMirror {
   & .prosemirror-horizontal-rule {
     padding: 1em 0;
     margin: 1em 0;
+
+    & hr {
+      margin: 0;
+    }
   }
 
   & .prosemirror-flat-list {

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -191,11 +191,21 @@ div.ProseMirror {
     word-wrap: normal;
     tab-size: 4;
     hyphens: none;
+  }
+
+  & pre {
+    background-color: var(--prosemirror-highlight-bg, hsl(var(--BV-accent)));
+    color: var(--prosemirror-highlight, hsl(var(--BV-accent-foreground)));
+  }
+
+  & code {
     background-color: hsl(var(--BV-accent));
     color: hsl(var(--BV-accent-foreground));
   }
 
   & pre code {
+    background-color: transparent;
+    color: inherit;
     font-weight: inherit;
     display: block;
     line-height: 1.35;

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -188,6 +188,8 @@ div.ProseMirror {
     display: block;
     line-height: 1.35;
     font-size: 0.95rem;
+    padding-top: 1.7rem;
+    padding-right: 3.6rem;
   }
 
   & pre[data-language]:not([data-language=""])::before {
@@ -208,8 +210,29 @@ div.ProseMirror {
     z-index: 1;
   }
 
-  & pre[data-language]:not([data-language=""]) code {
-    padding-top: 1.7rem;
+  & .prosemirror-code-copy-widget {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.75rem;
+    z-index: 1;
+  }
+
+  & .prosemirror-code-copy-button {
+    border: 1px solid hsl(var(--BV-border) / 0.75);
+    border-radius: 9999px;
+    padding: 0.12rem 0.5rem;
+    font-size: 0.68rem;
+    line-height: 1.1;
+    color: hsl(var(--BV-muted-foreground));
+    background-color: hsl(var(--BV-background) / 0.92);
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  & .prosemirror-code-copy-button:hover {
+    color: hsl(var(--BV-foreground));
+    background-color: hsl(var(--BV-background));
   }
 
   & hr {

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -139,6 +139,7 @@ export function initializeServices(
             );
           },
           options: {
+            ...(command.allowShortcutInInputs ? { allowInInput: true } : {}),
             unique: true,
           },
         };

--- a/packages/core/service-core/src/shortcut-service.ts
+++ b/packages/core/service-core/src/shortcut-service.ts
@@ -26,6 +26,7 @@ export class ShortcutService extends BaseService {
   private shortcutManager = new ShortcutManager({
     isDarwin: isDarwin,
   });
+  // App shortcuts must see keydown before editor keymaps can claim it.
   private readonly eventListenerOptions = { capture: true };
 
   eventHandler = (event: KeyboardEvent) => {

--- a/packages/core/service-core/src/shortcut-service.ts
+++ b/packages/core/service-core/src/shortcut-service.ts
@@ -26,6 +26,7 @@ export class ShortcutService extends BaseService {
   private shortcutManager = new ShortcutManager({
     isDarwin: isDarwin,
   });
+  private readonly eventListenerOptions = { capture: true };
 
   eventHandler = (event: KeyboardEvent) => {
     if (!this.mounted) {
@@ -53,9 +54,17 @@ export class ShortcutService extends BaseService {
   }
 
   hookMount() {
-    this.config.target.addEventListener('keydown', this.eventHandler);
+    this.config.target.addEventListener(
+      'keydown',
+      this.eventHandler,
+      this.eventListenerOptions,
+    );
     this.addCleanup(() => {
-      this.config.target.removeEventListener('keydown', this.eventHandler);
+      this.config.target.removeEventListener(
+        'keydown',
+        this.eventHandler,
+        this.eventListenerOptions,
+      );
       this.shortcutManager.deregisterAll();
     });
   }

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -5,6 +5,7 @@ import { setupBase } from '../base';
 import { setupBlockquote } from '../blockquote';
 import { setupCodeBlock } from '../code-block';
 import { collection } from '../common';
+import { setupHeading } from '../heading';
 import { setupList } from '../list';
 import { setupParagraph } from '../paragraph';
 import { createBangerEditorTestSetup } from '../test-helpers';
@@ -25,6 +26,23 @@ const macShortcutEditorTest = createBangerEditorTestSetup({
 const appKeymapOrderEditorTest = createBangerEditorTestSetup({
   extensions: [setupBase(), setupList(), setupParagraph(), setupCodeBlock()],
 });
+const blockBoundaryEditorTest = createBangerEditorTestSetup({
+  extensions: [
+    setupBase(),
+    setupParagraph(),
+    setupHeading(),
+    setupCodeBlock({
+      keyMoveToPreviousBlock: 'Alt-ArrowLeft',
+      keyMoveToNextBlock: 'Alt-ArrowRight',
+    }),
+  ],
+  builderAliases: {
+    codeBlock: { nodeType: 'code_block', language: '' },
+    doc: { nodeType: 'doc' },
+    heading: { nodeType: 'heading', level: 1 },
+    p: { nodeType: 'paragraph' },
+  },
+});
 const nestedEditorTest = createBangerEditorTestSetup({
   extensions: [
     setupBase(),
@@ -35,6 +53,12 @@ const nestedEditorTest = createBangerEditorTestSetup({
     collection({
       id: 'restricted-test-container',
       nodes: {
+        codeOnly: {
+          content: 'code_block+',
+          group: 'block',
+          parseDOM: [{ tag: 'section[data-code-only]' }],
+          toDOM: () => ['section', { 'data-code-only': 'true' }, 0],
+        },
         restricted: {
           content: 'paragraph+',
           group: 'block',
@@ -47,6 +71,7 @@ const nestedEditorTest = createBangerEditorTestSetup({
   builderAliases: {
     bq: { nodeType: 'blockquote' },
     codeBlock: { nodeType: 'code_block', language: '' },
+    codeOnly: { nodeType: 'codeOnly' },
     doc: { nodeType: 'doc' },
     list: { nodeType: 'list', kind: 'bullet' },
     p: { nodeType: 'paragraph' },
@@ -58,6 +83,7 @@ afterEach(() => {
   editorTest.cleanup();
   macShortcutEditorTest.cleanup();
   appKeymapOrderEditorTest.cleanup();
+  blockBoundaryEditorTest.cleanup();
   nestedEditorTest.cleanup();
 });
 
@@ -70,6 +96,26 @@ describe('code block keymap', () => {
     expect(editor.pressKey('Enter')).toBe(true);
 
     editor.expectDoc(doc(codeBlock('const done = true;'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
+  });
+
+  it('schema-safely exits repeated Enter when the parent cannot contain paragraphs', () => {
+    const codeOnly = nestedEditorTest.nodeBuilder('codeOnly');
+    const nestedCodeBlock = nestedEditorTest.nodeBuilder('codeBlock');
+    const nestedDoc = nestedEditorTest.nodeBuilder('doc');
+    const nestedParagraph = nestedEditorTest.nodeBuilder('p');
+    const editor = nestedEditorTest.createEditor(
+      nestedDoc(codeOnly(nestedCodeBlock('const done = true;\n\n<cursor>'))),
+    );
+
+    expect(editor.pressKey('Enter')).toBe(true);
+
+    editor.expectDoc(
+      nestedDoc(
+        codeOnly(nestedCodeBlock('const done = true;')),
+        nestedParagraph(),
+      ),
+    );
     expect(editor.selectionParentType()).toBe('paragraph');
   });
 
@@ -120,6 +166,19 @@ describe('code block keymap', () => {
     editor.setSelection(1);
     expect(editor.pressKey('ArrowUp')).toBe(true);
     editor.expectDoc(doc(p(), codeBlock('line'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
+  });
+
+  it('uses configurable keys for moving out of code block boundaries', () => {
+    const { codeBlock, doc, p } = blockBoundaryEditorTest.builders;
+    const editor = blockBoundaryEditorTest.createEditor(
+      doc(codeBlock('line<cursor>')),
+    );
+
+    expect(editor.pressKey('ArrowDown')).toBe(false);
+    expect(editor.pressKey('ArrowRight', { altKey: true })).toBe(true);
+
+    editor.expectDoc(doc(codeBlock('line'), p()));
     expect(editor.selectionParentType()).toBe('paragraph');
   });
 
@@ -204,6 +263,16 @@ describe('code block keymap', () => {
     expect(multiWordEditor.pressKey('Backspace', { altKey: true })).toBe(true);
     multiWordEditor.expectDoc(doc(codeBlock('two ')));
     expect(multiWordEditor.selectionParentType()).toBe('code_block');
+
+    const trailingWhitespaceEditor = macShortcutEditorTest.createEditor(
+      doc(codeBlock('two words   <cursor>')),
+    );
+
+    expect(
+      trailingWhitespaceEditor.pressKey('Backspace', { altKey: true }),
+    ).toBe(true);
+    trailingWhitespaceEditor.expectDoc(doc(codeBlock('two ')));
+    expect(trailingWhitespaceEditor.selectionParentType()).toBe('code_block');
   });
 
   it('jumps to code line boundaries with Ctrl-a and Ctrl-e', () => {
@@ -275,6 +344,20 @@ describe('code block keymap', () => {
     emptyCodeEditor.expectDoc(doc(codeBlock()));
     expect(emptyCodeEditor.selectionParentType()).toBe('code_block');
     expect(emptyCodeEditor.selectionParentOffset()).toBe(0);
+  });
+
+  it('deletes an empty paragraph before non-paragraph text blocks with forward Delete', () => {
+    const heading = blockBoundaryEditorTest.nodeBuilder('heading');
+    const { doc, p } = blockBoundaryEditorTest.builders;
+    const editor = blockBoundaryEditorTest.createEditor(
+      doc(p('<cursor>'), heading('Next section')),
+    );
+
+    expect(editor.pressKey('Delete')).toBe(true);
+
+    editor.expectDoc(doc(heading('Next section')));
+    expect(editor.selectionParentType()).toBe('heading');
+    expect(editor.selectionParentOffset()).toBe(0);
   });
 
   it('does not claim the sidebar shortcut as a code block toggle', () => {

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -1,0 +1,286 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { setupBase } from '../base';
+import { setupCodeBlock } from '../code-block';
+import { resolve } from '../common';
+import { setupParagraph } from '../paragraph';
+import { EditorState, EditorView, Schema, TextSelection } from '../pm';
+
+const resolved = resolve([setupBase(), setupParagraph(), setupCodeBlock()]);
+const schema = new Schema({
+  nodes: resolved.nodes,
+  marks: resolved.marks,
+});
+
+const editors: EditorView[] = [];
+
+afterEach(() => {
+  for (const view of editors.splice(0)) {
+    if (!view.isDestroyed) {
+      view.destroy();
+    }
+  }
+  document.body.replaceChildren();
+});
+
+function paragraph(text = '') {
+  return schema.node('paragraph', null, text ? [schema.text(text)] : undefined);
+}
+
+function codeBlock(text = '', attrs?: { language?: string }) {
+  return schema.node(
+    'code_block',
+    { language: attrs?.language ?? '' },
+    text ? [schema.text(text)] : undefined,
+  );
+}
+
+function createEditor({
+  doc,
+  selectionPos,
+}: {
+  doc: ReturnType<typeof schema.node>;
+  selectionPos: number;
+}) {
+  const mount = document.createElement('div');
+  document.body.append(mount);
+
+  const state = EditorState.create({
+    doc,
+    schema,
+    selection: TextSelection.create(doc, selectionPos),
+    plugins: resolved.resolvePlugins({ schema }),
+  });
+  const view = new EditorView({ mount }, { state });
+  editors.push(view);
+  return view;
+}
+
+function pressKey(
+  view: EditorView,
+  key: string,
+  modifiers: {
+    altKey?: boolean;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
+  } = {},
+) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...modifiers,
+  });
+  let handled = false;
+  view.someProp('handleKeyDown', (handler) => {
+    if (handler(view, event)) {
+      handled = true;
+      return true;
+    }
+    return undefined;
+  });
+  return handled;
+}
+
+function docJson(view: EditorView) {
+  return view.state.doc.toJSON();
+}
+
+function selectionParentType(view: EditorView) {
+  return view.state.selection.$from.parent.type.name;
+}
+
+function codeTextPos(text: string, offset = text.length) {
+  return 1 + offset;
+}
+
+describe('code block keymap', () => {
+  it('exits a code block after repeated Enter at the end', () => {
+    const code = 'const done = true;\n\n';
+    const doc = schema.node('doc', null, [codeBlock(code)]);
+    const view = createEditor({ doc, selectionPos: codeTextPos(code) });
+
+    expect(pressKey(view, 'Enter')).toBe(true);
+
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'const done = true;' }],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    expect(selectionParentType(view)).toBe('paragraph');
+  });
+
+  it('lets normal Enter insert a newline inside code blocks', () => {
+    const code = 'const done = true;';
+    const doc = schema.node('doc', null, [codeBlock(code)]);
+    const view = createEditor({ doc, selectionPos: codeTextPos(code) });
+
+    expect(pressKey(view, 'Enter')).toBe(true);
+
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'const done = true;\n' }],
+        },
+      ],
+    });
+    expect(selectionParentType(view)).toBe('code_block');
+  });
+
+  it('exits an empty code block on Enter so it does not trap the cursor', () => {
+    const doc = schema.node('doc', null, [codeBlock()]);
+    const view = createEditor({ doc, selectionPos: 1 });
+
+    expect(pressKey(view, 'Enter')).toBe(true);
+
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'code_block', attrs: { language: '' } },
+        { type: 'paragraph' },
+      ],
+    });
+    expect(selectionParentType(view)).toBe('paragraph');
+  });
+
+  it('inserts paragraphs below and above with primary Enter shortcuts', () => {
+    const code = 'const below = true;';
+    const doc = schema.node('doc', null, [codeBlock(code)]);
+    const view = createEditor({ doc, selectionPos: codeTextPos(code) });
+
+    expect(pressKey(view, 'Enter', { ctrlKey: true })).toBe(true);
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'const below = true;' }],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    expect(selectionParentType(view)).toBe('paragraph');
+
+    view.dispatch(
+      view.state.tr.setSelection(
+        TextSelection.create(view.state.doc, codeTextPos(code)),
+      ),
+    );
+    expect(pressKey(view, 'Enter', { ctrlKey: true, shiftKey: true })).toBe(
+      true,
+    );
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'const below = true;' }],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    expect(selectionParentType(view)).toBe('paragraph');
+  });
+
+  it('inserts boundary paragraphs with ArrowUp and ArrowDown at code block edges', () => {
+    const doc = schema.node('doc', null, [codeBlock('line')]);
+    const view = createEditor({ doc, selectionPos: 5 });
+
+    expect(pressKey(view, 'ArrowDown')).toBe(true);
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'line' }],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    expect(selectionParentType(view)).toBe('paragraph');
+
+    view.dispatch(
+      view.state.tr.setSelection(TextSelection.create(view.state.doc, 1)),
+    );
+    expect(pressKey(view, 'ArrowUp')).toBe(true);
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'line' }],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    expect(selectionParentType(view)).toBe('paragraph');
+  });
+
+  it('treats single-line code blocks as vertical ArrowUp and ArrowDown boundaries', () => {
+    const doc = schema.node('doc', null, [codeBlock('line')]);
+    const downView = createEditor({ doc, selectionPos: 3 });
+
+    expect(pressKey(downView, 'ArrowDown')).toBe(true);
+    expect(docJson(downView)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'line' }],
+        },
+        { type: 'paragraph' },
+      ],
+    });
+    expect(selectionParentType(downView)).toBe('paragraph');
+
+    const upView = createEditor({ doc, selectionPos: 3 });
+
+    expect(pressKey(upView, 'ArrowUp')).toBe(true);
+    expect(docJson(upView)).toEqual({
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        {
+          type: 'code_block',
+          attrs: { language: '' },
+          content: [{ type: 'text', text: 'line' }],
+        },
+      ],
+    });
+    expect(selectionParentType(upView)).toBe('paragraph');
+  });
+
+  it('does not claim the sidebar shortcut as a code block toggle', () => {
+    const doc = schema.node('doc', null, [paragraph('plain text')]);
+    const view = createEditor({ doc, selectionPos: 5 });
+
+    expect(pressKey(view, '\\', { ctrlKey: true })).toBe(false);
+    expect(docJson(view)).toEqual({
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'plain text' }],
+        },
+      ],
+    });
+  });
+});

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -1,12 +1,49 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it } from 'vitest';
+import { setupBase } from '../base';
+import { setupBlockquote } from '../blockquote';
+import { setupCodeBlock } from '../code-block';
+import { collection } from '../common';
+import { setupList } from '../list';
+import { setupParagraph } from '../paragraph';
 import { createBangerEditorTestSetup } from '../test-helpers';
 
 const editorTest = createBangerEditorTestSetup();
 const { codeBlock, doc, p } = editorTest.builders;
+const nestedEditorTest = createBangerEditorTestSetup({
+  extensions: [
+    setupBase(),
+    setupParagraph(),
+    setupBlockquote(),
+    setupList(),
+    setupCodeBlock(),
+    collection({
+      id: 'restricted-test-container',
+      nodes: {
+        restricted: {
+          content: 'paragraph+',
+          group: 'block',
+          parseDOM: [{ tag: 'section[data-restricted]' }],
+          toDOM: () => ['section', { 'data-restricted': 'true' }, 0],
+        },
+      },
+    }),
+  ],
+  builderAliases: {
+    bq: { nodeType: 'blockquote' },
+    codeBlock: { nodeType: 'code_block', language: '' },
+    doc: { nodeType: 'doc' },
+    list: { nodeType: 'list', kind: 'bullet' },
+    p: { nodeType: 'paragraph' },
+    restricted: { nodeType: 'restricted' },
+  },
+});
 
-afterEach(editorTest.cleanup);
+afterEach(() => {
+  editorTest.cleanup();
+  nestedEditorTest.cleanup();
+});
 
 describe('code block keymap', () => {
   it('exits a code block after repeated Enter at the end', () => {
@@ -112,5 +149,45 @@ describe('code block keymap', () => {
 
     expect(editor.runKeyDownHandlers('\\', { ctrlKey: true })).toBe(false);
     editor.expectDoc(doc(p('plain text')));
+  });
+
+  it('converts typed fences inside schema-valid block containers', () => {
+    const blockquote = nestedEditorTest.nodeBuilder('bq');
+    const list = nestedEditorTest.nodeBuilder('list');
+    const nestedDoc = nestedEditorTest.nodeBuilder('doc');
+    const nestedCodeBlock = nestedEditorTest.nodeBuilder('codeBlock');
+    const nestedParagraph = nestedEditorTest.nodeBuilder('p');
+    const blockquoteEditor = nestedEditorTest.createEditor(
+      nestedDoc(blockquote(nestedParagraph('```js<cursor>'))),
+    );
+
+    expect(blockquoteEditor.pressKey('Enter')).toBe(true);
+    blockquoteEditor.expectDoc(
+      nestedDoc(blockquote(nestedCodeBlock({ language: 'js' }))),
+    );
+    expect(blockquoteEditor.selectionParentType()).toBe('code_block');
+
+    const listEditor = nestedEditorTest.createEditor(
+      nestedDoc(list(nestedParagraph('```ts<cursor>'))),
+    );
+
+    expect(listEditor.pressKey('Enter')).toBe(true);
+    listEditor.expectDoc(nestedDoc(list(nestedCodeBlock({ language: 'ts' }))));
+    expect(listEditor.selectionParentType()).toBe('code_block');
+  });
+
+  it('does not convert typed fences when the parent schema forbids code blocks', () => {
+    const restricted = nestedEditorTest.nodeBuilder('restricted');
+    const nestedDoc = nestedEditorTest.nodeBuilder('doc');
+    const nestedParagraph = nestedEditorTest.nodeBuilder('p');
+    const editor = nestedEditorTest.createEditor(
+      nestedDoc(restricted(nestedParagraph('```<cursor>'))),
+    );
+
+    expect(editor.pressKey('Enter')).toBe(true);
+    editor.expectDoc(
+      nestedDoc(restricted(nestedParagraph('```'), nestedParagraph())),
+    );
+    expect(editor.selectionParentType()).toBe('paragraph');
   });
 });

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -1,17 +1,42 @@
 // @vitest-environment jsdom
 
+import type { NodeBuilder } from 'prosemirror-test-builder';
 import { afterEach, describe, expect, it } from 'vitest';
 import { setupBase } from '../base';
 import { setupCodeBlock } from '../code-block';
 import { resolve } from '../common';
 import { setupParagraph } from '../paragraph';
-import { EditorState, EditorView, Schema, TextSelection } from '../pm';
+import {
+  builders,
+  EditorState,
+  EditorView,
+  type PMNode,
+  Schema,
+  TextSelection,
+} from '../pm';
 
 const resolved = resolve([setupBase(), setupParagraph(), setupCodeBlock()]);
 const schema = new Schema({
   nodes: resolved.nodes,
   marks: resolved.marks,
 });
+
+const testBuilders = builders(schema, {
+  doc: { nodeType: 'doc' },
+  p: { nodeType: 'paragraph' },
+  code_block: { nodeType: 'code_block', language: '' },
+});
+const doc = requiredNodeBuilder('doc');
+const p = requiredNodeBuilder('p');
+const codeBlock = requiredNodeBuilder('code_block');
+
+function requiredNodeBuilder(name: string): NodeBuilder {
+  const builder = testBuilders[name];
+  if (!builder) {
+    throw new Error(`Missing ProseMirror test builder: ${name}`);
+  }
+  return builder as NodeBuilder;
+}
 
 const editors: EditorView[] = [];
 
@@ -24,32 +49,19 @@ afterEach(() => {
   document.body.replaceChildren();
 });
 
-function paragraph(text = '') {
-  return schema.node('paragraph', null, text ? [schema.text(text)] : undefined);
-}
-
-function codeBlock(text = '', attrs?: { language?: string }) {
-  return schema.node(
-    'code_block',
-    { language: attrs?.language ?? '' },
-    text ? [schema.text(text)] : undefined,
-  );
-}
-
 function createEditor({
-  doc,
-  selectionPos,
+  initialDoc,
 }: {
-  doc: ReturnType<typeof schema.node>;
-  selectionPos: number;
+  initialDoc: PMNode & { tag?: Record<string, number> };
 }) {
   const mount = document.createElement('div');
   document.body.append(mount);
+  const selectionPos = initialDoc.tag?.cursor ?? 1;
 
   const state = EditorState.create({
-    doc,
+    doc: initialDoc,
     schema,
-    selection: TextSelection.create(doc, selectionPos),
+    selection: TextSelection.create(initialDoc, selectionPos),
     plugins: resolved.resolvePlugins({ schema }),
   });
   const view = new EditorView({ mount }, { state });
@@ -58,6 +70,26 @@ function createEditor({
 }
 
 function pressKey(
+  view: EditorView,
+  key: string,
+  modifiers: {
+    altKey?: boolean;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    shiftKey?: boolean;
+  } = {},
+) {
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...modifiers,
+  });
+  view.dispatchEvent(event);
+  return event.defaultPrevented;
+}
+
+function canHandleKey(
   view: EditorView,
   key: string,
   modifiers: {
@@ -84,203 +116,136 @@ function pressKey(
   return handled;
 }
 
-function docJson(view: EditorView) {
-  return view.state.doc.toJSON();
+function expectDoc(view: EditorView, expectedDoc: PMNode) {
+  expect(view.state.doc.toJSON()).toEqual(expectedDoc.toJSON());
 }
 
 function selectionParentType(view: EditorView) {
   return view.state.selection.$from.parent.type.name;
 }
 
-function codeTextPos(text: string, offset = text.length) {
-  return 1 + offset;
+function selectionParentText(view: EditorView) {
+  return view.state.selection.$from.parent.textContent;
+}
+
+function setSelection(view: EditorView, pos: number) {
+  view.dispatch(
+    view.state.tr.setSelection(TextSelection.create(view.state.doc, pos)),
+  );
+}
+
+function setSelectionAtFirstBlockEnd(view: EditorView) {
+  const firstBlock = view.state.doc.firstChild;
+  if (!firstBlock) {
+    throw new Error('Expected a first block in the test document');
+  }
+
+  setSelection(view, 1 + firstBlock.content.size);
 }
 
 describe('code block keymap', () => {
   it('exits a code block after repeated Enter at the end', () => {
-    const code = 'const done = true;\n\n';
-    const doc = schema.node('doc', null, [codeBlock(code)]);
-    const view = createEditor({ doc, selectionPos: codeTextPos(code) });
+    const view = createEditor({
+      initialDoc: doc(codeBlock('const done = true;\n\n<cursor>')),
+    });
 
     expect(pressKey(view, 'Enter')).toBe(true);
 
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'const done = true;' }],
-        },
-        { type: 'paragraph' },
-      ],
-    });
+    expectDoc(view, doc(codeBlock('const done = true;'), p()));
     expect(selectionParentType(view)).toBe('paragraph');
   });
 
   it('lets normal Enter insert a newline inside code blocks', () => {
-    const code = 'const done = true;';
-    const doc = schema.node('doc', null, [codeBlock(code)]);
-    const view = createEditor({ doc, selectionPos: codeTextPos(code) });
+    const view = createEditor({
+      initialDoc: doc(codeBlock('const done = true;<cursor>')),
+    });
 
     expect(pressKey(view, 'Enter')).toBe(true);
 
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'const done = true;\n' }],
-        },
-      ],
-    });
+    expectDoc(view, doc(codeBlock('const done = true;\n')));
     expect(selectionParentType(view)).toBe('code_block');
   });
 
   it('exits an empty code block on Enter so it does not trap the cursor', () => {
-    const doc = schema.node('doc', null, [codeBlock()]);
-    const view = createEditor({ doc, selectionPos: 1 });
+    const view = createEditor({ initialDoc: doc(codeBlock('<cursor>')) });
 
     expect(pressKey(view, 'Enter')).toBe(true);
 
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        { type: 'code_block', attrs: { language: '' } },
-        { type: 'paragraph' },
-      ],
-    });
+    expectDoc(view, doc(codeBlock(), p()));
     expect(selectionParentType(view)).toBe('paragraph');
   });
 
   it('inserts paragraphs below and above with primary Enter shortcuts', () => {
-    const code = 'const below = true;';
-    const doc = schema.node('doc', null, [codeBlock(code)]);
-    const view = createEditor({ doc, selectionPos: codeTextPos(code) });
+    const view = createEditor({
+      initialDoc: doc(codeBlock('const below = true;<cursor>')),
+    });
 
     expect(pressKey(view, 'Enter', { ctrlKey: true })).toBe(true);
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'const below = true;' }],
-        },
-        { type: 'paragraph' },
-      ],
-    });
+    expectDoc(view, doc(codeBlock('const below = true;'), p()));
     expect(selectionParentType(view)).toBe('paragraph');
 
-    view.dispatch(
-      view.state.tr.setSelection(
-        TextSelection.create(view.state.doc, codeTextPos(code)),
-      ),
-    );
+    setSelectionAtFirstBlockEnd(view);
     expect(pressKey(view, 'Enter', { ctrlKey: true, shiftKey: true })).toBe(
       true,
     );
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        { type: 'paragraph' },
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'const below = true;' }],
-        },
-        { type: 'paragraph' },
-      ],
-    });
+    expectDoc(view, doc(p(), codeBlock('const below = true;'), p()));
     expect(selectionParentType(view)).toBe('paragraph');
   });
 
   it('inserts boundary paragraphs with ArrowUp and ArrowDown at code block edges', () => {
-    const doc = schema.node('doc', null, [codeBlock('line')]);
-    const view = createEditor({ doc, selectionPos: 5 });
+    const view = createEditor({ initialDoc: doc(codeBlock('line<cursor>')) });
 
     expect(pressKey(view, 'ArrowDown')).toBe(true);
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'line' }],
-        },
-        { type: 'paragraph' },
-      ],
-    });
+    expectDoc(view, doc(codeBlock('line'), p()));
     expect(selectionParentType(view)).toBe('paragraph');
 
-    view.dispatch(
-      view.state.tr.setSelection(TextSelection.create(view.state.doc, 1)),
-    );
+    setSelection(view, 1);
     expect(pressKey(view, 'ArrowUp')).toBe(true);
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        { type: 'paragraph' },
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'line' }],
-        },
-        { type: 'paragraph' },
-      ],
-    });
+    expectDoc(view, doc(p(), codeBlock('line'), p()));
     expect(selectionParentType(view)).toBe('paragraph');
   });
 
-  it('treats single-line code blocks as vertical ArrowUp and ArrowDown boundaries', () => {
-    const doc = schema.node('doc', null, [codeBlock('line')]);
-    const downView = createEditor({ doc, selectionPos: 3 });
-
-    expect(pressKey(downView, 'ArrowDown')).toBe(true);
-    expect(docJson(downView)).toEqual({
-      type: 'doc',
-      content: [
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'line' }],
-        },
-        { type: 'paragraph' },
-      ],
+  it('moves into existing adjacent paragraphs with ArrowUp and ArrowDown', () => {
+    const upView = createEditor({
+      initialDoc: doc(p('before'), codeBlock('<cursor>line')),
     });
-    expect(selectionParentType(downView)).toBe('paragraph');
-
-    const upView = createEditor({ doc, selectionPos: 3 });
 
     expect(pressKey(upView, 'ArrowUp')).toBe(true);
-    expect(docJson(upView)).toEqual({
-      type: 'doc',
-      content: [
-        { type: 'paragraph' },
-        {
-          type: 'code_block',
-          attrs: { language: '' },
-          content: [{ type: 'text', text: 'line' }],
-        },
-      ],
+    expectDoc(upView, doc(p('before'), codeBlock('line')));
+    expect(selectionParentType(upView)).toBe('paragraph');
+    expect(selectionParentText(upView)).toBe('before');
+    expect(upView.state.selection.$from.parentOffset).toBe('before'.length);
+
+    const downView = createEditor({
+      initialDoc: doc(codeBlock('line<cursor>'), p('after')),
     });
+
+    expect(pressKey(downView, 'ArrowDown')).toBe(true);
+    expectDoc(downView, doc(codeBlock('line'), p('after')));
+    expect(selectionParentType(downView)).toBe('paragraph');
+    expect(selectionParentText(downView)).toBe('after');
+    expect(downView.state.selection.$from.parentOffset).toBe(0);
+  });
+
+  it('treats single-line code blocks as vertical ArrowUp and ArrowDown boundaries', () => {
+    const initialDoc = doc(codeBlock('li<cursor>ne'));
+    const downView = createEditor({ initialDoc });
+
+    expect(pressKey(downView, 'ArrowDown')).toBe(true);
+    expectDoc(downView, doc(codeBlock('line'), p()));
+    expect(selectionParentType(downView)).toBe('paragraph');
+
+    const upView = createEditor({ initialDoc });
+
+    expect(pressKey(upView, 'ArrowUp')).toBe(true);
+    expectDoc(upView, doc(p(), codeBlock('line')));
     expect(selectionParentType(upView)).toBe('paragraph');
   });
 
   it('does not claim the sidebar shortcut as a code block toggle', () => {
-    const doc = schema.node('doc', null, [paragraph('plain text')]);
-    const view = createEditor({ doc, selectionPos: 5 });
+    const view = createEditor({ initialDoc: doc(p('plai<cursor>n text')) });
 
-    expect(pressKey(view, '\\', { ctrlKey: true })).toBe(false);
-    expect(docJson(view)).toEqual({
-      type: 'doc',
-      content: [
-        {
-          type: 'paragraph',
-          content: [{ type: 'text', text: 'plain text' }],
-        },
-      ],
-    });
+    expect(canHandleKey(view, '\\', { ctrlKey: true })).toBe(false);
+    expectDoc(view, doc(p('plain text')));
   });
 });

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -222,6 +222,38 @@ describe('code block keymap', () => {
     expect(lineEditor.selectionParentOffset()).toBe('one\ntwo'.length);
   });
 
+  it('indents and outdents code lines with Tab and Shift-Tab', () => {
+    const emptySelectionEditor = editorTest.createEditor(
+      doc(codeBlock('const<cursor> value = true;')),
+    );
+
+    expect(emptySelectionEditor.pressKey('Tab')).toBe(true);
+    emptySelectionEditor.expectDoc(doc(codeBlock('const   value = true;')));
+    expect(emptySelectionEditor.selectionParentOffset()).toBe('const  '.length);
+
+    const currentLineEditor = editorTest.createEditor(
+      doc(codeBlock('  first\n  sec<cursor>ond')),
+    );
+
+    expect(currentLineEditor.pressKey('Tab', { shiftKey: true })).toBe(true);
+    currentLineEditor.expectDoc(doc(codeBlock('  first\nsecond')));
+    expect(currentLineEditor.selectionParentOffset()).toBe(
+      '  first\nsec'.length,
+    );
+  });
+
+  it('indents and outdents selected code lines with Tab and Shift-Tab', () => {
+    const editor = editorTest.createEditor(
+      doc(codeBlock('<start>first\nsecond<end>\nthird')),
+    );
+
+    expect(editor.pressKey('Tab')).toBe(true);
+    editor.expectDoc(doc(codeBlock('  first\n  second\nthird')));
+
+    expect(editor.pressKey('Tab', { shiftKey: true })).toBe(true);
+    editor.expectDoc(doc(codeBlock('first\nsecond\nthird')));
+  });
+
   it('deletes an empty paragraph before a code block with forward Delete', () => {
     const { codeBlock, doc, p } = appKeymapOrderEditorTest.builders;
     const editor = appKeymapOrderEditorTest.createEditor(

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -43,6 +43,13 @@ const blockBoundaryEditorTest = createBangerEditorTestSetup({
     p: { nodeType: 'paragraph' },
   },
 });
+const noTabTrapEditorTest = createBangerEditorTestSetup({
+  extensions: [
+    setupBase({ trapTabKey: false }),
+    setupParagraph(),
+    setupCodeBlock(),
+  ],
+});
 const nestedEditorTest = createBangerEditorTestSetup({
   extensions: [
     setupBase(),
@@ -84,6 +91,7 @@ afterEach(() => {
   macShortcutEditorTest.cleanup();
   appKeymapOrderEditorTest.cleanup();
   blockBoundaryEditorTest.cleanup();
+  noTabTrapEditorTest.cleanup();
   nestedEditorTest.cleanup();
 });
 
@@ -95,7 +103,7 @@ describe('code block keymap', () => {
 
     expect(editor.pressKey('Enter')).toBe(true);
 
-    editor.expectDoc(doc(codeBlock('const done = true;'), p()));
+    editor.expectDoc(doc(codeBlock('const done = true;\n\n'), p()));
     expect(editor.selectionParentType()).toBe('paragraph');
   });
 
@@ -112,7 +120,7 @@ describe('code block keymap', () => {
 
     editor.expectDoc(
       nestedDoc(
-        codeOnly(nestedCodeBlock('const done = true;')),
+        codeOnly(nestedCodeBlock('const done = true;\n\n')),
         nestedParagraph(),
       ),
     );
@@ -309,6 +317,15 @@ describe('code block keymap', () => {
     expect(currentLineEditor.selectionParentOffset()).toBe(
       '  first\nsec'.length,
     );
+
+    const noTrapCodeBlock = noTabTrapEditorTest.builders.codeBlock;
+    const noTrapDoc = noTabTrapEditorTest.builders.doc;
+    const plainLineEditor = noTabTrapEditorTest.createEditor(
+      noTrapDoc(noTrapCodeBlock('plain<cursor>')),
+    );
+
+    expect(plainLineEditor.pressKey('Tab', { shiftKey: true })).toBe(false);
+    plainLineEditor.expectDoc(noTrapDoc(noTrapCodeBlock('plain')));
   });
 
   it('indents and outdents selected code lines with Tab and Shift-Tab', () => {
@@ -321,6 +338,16 @@ describe('code block keymap', () => {
 
     expect(editor.pressKey('Tab', { shiftKey: true })).toBe(true);
     editor.expectDoc(doc(codeBlock('first\nsecond\nthird')));
+  });
+
+  it('includes a leading empty code line when indenting a selection from the start', () => {
+    const editor = editorTest.createEditor(
+      doc(codeBlock('<start>\nsecond<end>')),
+    );
+
+    expect(editor.pressKey('Tab')).toBe(true);
+
+    editor.expectDoc(doc(codeBlock('  \n  second')));
   });
 
   it('deletes an empty paragraph before a code block with forward Delete', () => {

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -11,6 +11,13 @@ import { createBangerEditorTestSetup } from '../test-helpers';
 
 const editorTest = createBangerEditorTestSetup();
 const { codeBlock, doc, p } = editorTest.builders;
+const macShortcutEditorTest = createBangerEditorTestSetup({
+  extensions: [
+    setupBase(),
+    setupParagraph(),
+    setupCodeBlock({ keyDeleteWordBackward: 'Alt-Backspace' }),
+  ],
+});
 const nestedEditorTest = createBangerEditorTestSetup({
   extensions: [
     setupBase(),
@@ -42,6 +49,7 @@ const nestedEditorTest = createBangerEditorTestSetup({
 
 afterEach(() => {
   editorTest.cleanup();
+  macShortcutEditorTest.cleanup();
   nestedEditorTest.cleanup();
 });
 
@@ -142,6 +150,52 @@ describe('code block keymap', () => {
     expect(upEditor.pressKey('ArrowUp')).toBe(true);
     upEditor.expectDoc(doc(p(), codeBlock('line')));
     expect(upEditor.selectionParentType()).toBe('paragraph');
+  });
+
+  it('moves code blocks with Alt ArrowUp and ArrowDown', () => {
+    const upEditor = editorTest.createEditor(
+      doc(p('before'), codeBlock('line<cursor>'), p('after')),
+    );
+
+    expect(upEditor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    upEditor.expectDoc(doc(codeBlock('line'), p('before'), p('after')));
+    expect(upEditor.selectionParentType()).toBe('code_block');
+
+    const downEditor = editorTest.createEditor(
+      doc(p('before'), codeBlock('line<cursor>'), p('after')),
+    );
+
+    expect(downEditor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    downEditor.expectDoc(doc(p('before'), p('after'), codeBlock('line')));
+    expect(downEditor.selectionParentType()).toBe('code_block');
+  });
+
+  it('turns an empty leading code block into a paragraph on Backspace', () => {
+    const editor = editorTest.createEditor(doc(codeBlock('<cursor>')));
+
+    expect(editor.pressKey('Backspace')).toBe(true);
+
+    editor.expectDoc(doc(p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
+  });
+
+  it('deletes the previous code word with Alt Backspace', () => {
+    const { codeBlock, doc } = macShortcutEditorTest.builders;
+    const longWordEditor = macShortcutEditorTest.createEditor(
+      doc(codeBlock('singlelongword<cursor>')),
+    );
+
+    expect(longWordEditor.pressKey('Backspace', { altKey: true })).toBe(true);
+    longWordEditor.expectDoc(doc(codeBlock()));
+    expect(longWordEditor.selectionParentType()).toBe('code_block');
+
+    const multiWordEditor = macShortcutEditorTest.createEditor(
+      doc(codeBlock('two words<cursor>')),
+    );
+
+    expect(multiWordEditor.pressKey('Backspace', { altKey: true })).toBe(true);
+    multiWordEditor.expectDoc(doc(codeBlock('two ')));
+    expect(multiWordEditor.selectionParentType()).toBe('code_block');
   });
 
   it('does not claim the sidebar shortcut as a code block toggle', () => {

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -1,251 +1,116 @@
 // @vitest-environment jsdom
 
-import type { NodeBuilder } from 'prosemirror-test-builder';
 import { afterEach, describe, expect, it } from 'vitest';
-import { setupBase } from '../base';
-import { setupCodeBlock } from '../code-block';
-import { resolve } from '../common';
-import { setupParagraph } from '../paragraph';
-import {
-  builders,
-  EditorState,
-  EditorView,
-  type PMNode,
-  Schema,
-  TextSelection,
-} from '../pm';
+import { createBangerEditorTestSetup } from '../test-helpers';
 
-const resolved = resolve([setupBase(), setupParagraph(), setupCodeBlock()]);
-const schema = new Schema({
-  nodes: resolved.nodes,
-  marks: resolved.marks,
-});
+const editorTest = createBangerEditorTestSetup();
+const { codeBlock, doc, p } = editorTest.builders;
 
-const testBuilders = builders(schema, {
-  doc: { nodeType: 'doc' },
-  p: { nodeType: 'paragraph' },
-  code_block: { nodeType: 'code_block', language: '' },
-});
-const doc = requiredNodeBuilder('doc');
-const p = requiredNodeBuilder('p');
-const codeBlock = requiredNodeBuilder('code_block');
-
-function requiredNodeBuilder(name: string): NodeBuilder {
-  const builder = testBuilders[name];
-  if (!builder) {
-    throw new Error(`Missing ProseMirror test builder: ${name}`);
-  }
-  return builder as NodeBuilder;
-}
-
-const editors: EditorView[] = [];
-
-afterEach(() => {
-  for (const view of editors.splice(0)) {
-    if (!view.isDestroyed) {
-      view.destroy();
-    }
-  }
-  document.body.replaceChildren();
-});
-
-function createEditor({
-  initialDoc,
-}: {
-  initialDoc: PMNode & { tag?: Record<string, number> };
-}) {
-  const mount = document.createElement('div');
-  document.body.append(mount);
-  const selectionPos = initialDoc.tag?.cursor ?? 1;
-
-  const state = EditorState.create({
-    doc: initialDoc,
-    schema,
-    selection: TextSelection.create(initialDoc, selectionPos),
-    plugins: resolved.resolvePlugins({ schema }),
-  });
-  const view = new EditorView({ mount }, { state });
-  editors.push(view);
-  return view;
-}
-
-function pressKey(
-  view: EditorView,
-  key: string,
-  modifiers: {
-    altKey?: boolean;
-    ctrlKey?: boolean;
-    metaKey?: boolean;
-    shiftKey?: boolean;
-  } = {},
-) {
-  const event = new KeyboardEvent('keydown', {
-    key,
-    bubbles: true,
-    cancelable: true,
-    ...modifiers,
-  });
-  view.dispatchEvent(event);
-  return event.defaultPrevented;
-}
-
-function canHandleKey(
-  view: EditorView,
-  key: string,
-  modifiers: {
-    altKey?: boolean;
-    ctrlKey?: boolean;
-    metaKey?: boolean;
-    shiftKey?: boolean;
-  } = {},
-) {
-  const event = new KeyboardEvent('keydown', {
-    key,
-    bubbles: true,
-    cancelable: true,
-    ...modifiers,
-  });
-  let handled = false;
-  view.someProp('handleKeyDown', (handler) => {
-    if (handler(view, event)) {
-      handled = true;
-      return true;
-    }
-    return undefined;
-  });
-  return handled;
-}
-
-function expectDoc(view: EditorView, expectedDoc: PMNode) {
-  expect(view.state.doc.toJSON()).toEqual(expectedDoc.toJSON());
-}
-
-function selectionParentType(view: EditorView) {
-  return view.state.selection.$from.parent.type.name;
-}
-
-function selectionParentText(view: EditorView) {
-  return view.state.selection.$from.parent.textContent;
-}
-
-function setSelection(view: EditorView, pos: number) {
-  view.dispatch(
-    view.state.tr.setSelection(TextSelection.create(view.state.doc, pos)),
-  );
-}
-
-function setSelectionAtFirstBlockEnd(view: EditorView) {
-  const firstBlock = view.state.doc.firstChild;
-  if (!firstBlock) {
-    throw new Error('Expected a first block in the test document');
-  }
-
-  setSelection(view, 1 + firstBlock.content.size);
-}
+afterEach(editorTest.cleanup);
 
 describe('code block keymap', () => {
   it('exits a code block after repeated Enter at the end', () => {
-    const view = createEditor({
-      initialDoc: doc(codeBlock('const done = true;\n\n<cursor>')),
-    });
+    const editor = editorTest.createEditor(
+      doc(codeBlock('const done = true;\n\n<cursor>')),
+    );
 
-    expect(pressKey(view, 'Enter')).toBe(true);
+    expect(editor.pressKey('Enter')).toBe(true);
 
-    expectDoc(view, doc(codeBlock('const done = true;'), p()));
-    expect(selectionParentType(view)).toBe('paragraph');
+    editor.expectDoc(doc(codeBlock('const done = true;'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
   });
 
   it('lets normal Enter insert a newline inside code blocks', () => {
-    const view = createEditor({
-      initialDoc: doc(codeBlock('const done = true;<cursor>')),
-    });
+    const editor = editorTest.createEditor(
+      doc(codeBlock('const done = true;<cursor>')),
+    );
 
-    expect(pressKey(view, 'Enter')).toBe(true);
+    expect(editor.pressKey('Enter')).toBe(true);
 
-    expectDoc(view, doc(codeBlock('const done = true;\n')));
-    expect(selectionParentType(view)).toBe('code_block');
+    editor.expectDoc(doc(codeBlock('const done = true;\n')));
+    expect(editor.selectionParentType()).toBe('code_block');
   });
 
   it('exits an empty code block on Enter so it does not trap the cursor', () => {
-    const view = createEditor({ initialDoc: doc(codeBlock('<cursor>')) });
+    const editor = editorTest.createEditor(doc(codeBlock('<cursor>')));
 
-    expect(pressKey(view, 'Enter')).toBe(true);
+    expect(editor.pressKey('Enter')).toBe(true);
 
-    expectDoc(view, doc(codeBlock(), p()));
-    expect(selectionParentType(view)).toBe('paragraph');
+    editor.expectDoc(doc(codeBlock(), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
   });
 
   it('inserts paragraphs below and above with primary Enter shortcuts', () => {
-    const view = createEditor({
-      initialDoc: doc(codeBlock('const below = true;<cursor>')),
-    });
+    const editor = editorTest.createEditor(
+      doc(codeBlock('const below = true;<cursor>')),
+    );
 
-    expect(pressKey(view, 'Enter', { ctrlKey: true })).toBe(true);
-    expectDoc(view, doc(codeBlock('const below = true;'), p()));
-    expect(selectionParentType(view)).toBe('paragraph');
+    expect(editor.pressKey('Enter', { ctrlKey: true })).toBe(true);
+    editor.expectDoc(doc(codeBlock('const below = true;'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
 
-    setSelectionAtFirstBlockEnd(view);
-    expect(pressKey(view, 'Enter', { ctrlKey: true, shiftKey: true })).toBe(
+    editor.setSelectionAtFirstBlockEnd();
+    expect(editor.pressKey('Enter', { ctrlKey: true, shiftKey: true })).toBe(
       true,
     );
-    expectDoc(view, doc(p(), codeBlock('const below = true;'), p()));
-    expect(selectionParentType(view)).toBe('paragraph');
+    editor.expectDoc(doc(p(), codeBlock('const below = true;'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
   });
 
   it('inserts boundary paragraphs with ArrowUp and ArrowDown at code block edges', () => {
-    const view = createEditor({ initialDoc: doc(codeBlock('line<cursor>')) });
+    const editor = editorTest.createEditor(doc(codeBlock('line<cursor>')));
 
-    expect(pressKey(view, 'ArrowDown')).toBe(true);
-    expectDoc(view, doc(codeBlock('line'), p()));
-    expect(selectionParentType(view)).toBe('paragraph');
+    expect(editor.pressKey('ArrowDown')).toBe(true);
+    editor.expectDoc(doc(codeBlock('line'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
 
-    setSelection(view, 1);
-    expect(pressKey(view, 'ArrowUp')).toBe(true);
-    expectDoc(view, doc(p(), codeBlock('line'), p()));
-    expect(selectionParentType(view)).toBe('paragraph');
+    editor.setSelection(1);
+    expect(editor.pressKey('ArrowUp')).toBe(true);
+    editor.expectDoc(doc(p(), codeBlock('line'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
   });
 
   it('moves into existing adjacent paragraphs with ArrowUp and ArrowDown', () => {
-    const upView = createEditor({
-      initialDoc: doc(p('before'), codeBlock('<cursor>line')),
-    });
+    const upEditor = editorTest.createEditor(
+      doc(p('before'), codeBlock('<cursor>line')),
+    );
 
-    expect(pressKey(upView, 'ArrowUp')).toBe(true);
-    expectDoc(upView, doc(p('before'), codeBlock('line')));
-    expect(selectionParentType(upView)).toBe('paragraph');
-    expect(selectionParentText(upView)).toBe('before');
-    expect(upView.state.selection.$from.parentOffset).toBe('before'.length);
+    expect(upEditor.pressKey('ArrowUp')).toBe(true);
+    upEditor.expectDoc(doc(p('before'), codeBlock('line')));
+    expect(upEditor.selectionParentType()).toBe('paragraph');
+    expect(upEditor.selectionParentText()).toBe('before');
+    expect(upEditor.selectionParentOffset()).toBe('before'.length);
 
-    const downView = createEditor({
-      initialDoc: doc(codeBlock('line<cursor>'), p('after')),
-    });
+    const downEditor = editorTest.createEditor(
+      doc(codeBlock('line<cursor>'), p('after')),
+    );
 
-    expect(pressKey(downView, 'ArrowDown')).toBe(true);
-    expectDoc(downView, doc(codeBlock('line'), p('after')));
-    expect(selectionParentType(downView)).toBe('paragraph');
-    expect(selectionParentText(downView)).toBe('after');
-    expect(downView.state.selection.$from.parentOffset).toBe(0);
+    expect(downEditor.pressKey('ArrowDown')).toBe(true);
+    downEditor.expectDoc(doc(codeBlock('line'), p('after')));
+    expect(downEditor.selectionParentType()).toBe('paragraph');
+    expect(downEditor.selectionParentText()).toBe('after');
+    expect(downEditor.selectionParentOffset()).toBe(0);
   });
 
   it('treats single-line code blocks as vertical ArrowUp and ArrowDown boundaries', () => {
     const initialDoc = doc(codeBlock('li<cursor>ne'));
-    const downView = createEditor({ initialDoc });
+    const downEditor = editorTest.createEditor(initialDoc);
 
-    expect(pressKey(downView, 'ArrowDown')).toBe(true);
-    expectDoc(downView, doc(codeBlock('line'), p()));
-    expect(selectionParentType(downView)).toBe('paragraph');
+    expect(downEditor.pressKey('ArrowDown')).toBe(true);
+    downEditor.expectDoc(doc(codeBlock('line'), p()));
+    expect(downEditor.selectionParentType()).toBe('paragraph');
 
-    const upView = createEditor({ initialDoc });
+    const upEditor = editorTest.createEditor(initialDoc);
 
-    expect(pressKey(upView, 'ArrowUp')).toBe(true);
-    expectDoc(upView, doc(p(), codeBlock('line')));
-    expect(selectionParentType(upView)).toBe('paragraph');
+    expect(upEditor.pressKey('ArrowUp')).toBe(true);
+    upEditor.expectDoc(doc(p(), codeBlock('line')));
+    expect(upEditor.selectionParentType()).toBe('paragraph');
   });
 
   it('does not claim the sidebar shortcut as a code block toggle', () => {
-    const view = createEditor({ initialDoc: doc(p('plai<cursor>n text')) });
+    const editor = editorTest.createEditor(doc(p('plai<cursor>n text')));
 
-    expect(canHandleKey(view, '\\', { ctrlKey: true })).toBe(false);
-    expectDoc(view, doc(p('plain text')));
+    expect(editor.runKeyDownHandlers('\\', { ctrlKey: true })).toBe(false);
+    editor.expectDoc(doc(p('plain text')));
   });
 });

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -15,8 +15,15 @@ const macShortcutEditorTest = createBangerEditorTestSetup({
   extensions: [
     setupBase(),
     setupParagraph(),
-    setupCodeBlock({ keyDeleteWordBackward: 'Alt-Backspace' }),
+    setupCodeBlock({
+      keyDeleteWordBackward: 'Alt-Backspace',
+      keyJumpToLineStart: 'Ctrl-a',
+      keyJumpToLineEnd: 'Ctrl-e',
+    }),
   ],
+});
+const appKeymapOrderEditorTest = createBangerEditorTestSetup({
+  extensions: [setupBase(), setupList(), setupParagraph(), setupCodeBlock()],
 });
 const nestedEditorTest = createBangerEditorTestSetup({
   extensions: [
@@ -50,6 +57,7 @@ const nestedEditorTest = createBangerEditorTestSetup({
 afterEach(() => {
   editorTest.cleanup();
   macShortcutEditorTest.cleanup();
+  appKeymapOrderEditorTest.cleanup();
   nestedEditorTest.cleanup();
 });
 
@@ -196,6 +204,45 @@ describe('code block keymap', () => {
     expect(multiWordEditor.pressKey('Backspace', { altKey: true })).toBe(true);
     multiWordEditor.expectDoc(doc(codeBlock('two ')));
     expect(multiWordEditor.selectionParentType()).toBe('code_block');
+  });
+
+  it('jumps to code line boundaries with Ctrl-a and Ctrl-e', () => {
+    const { codeBlock, doc } = macShortcutEditorTest.builders;
+    const lineEditor = macShortcutEditorTest.createEditor(
+      doc(codeBlock('one\ntw<cursor>o\nthree')),
+    );
+
+    expect(lineEditor.pressKey('a', { ctrlKey: true })).toBe(true);
+    expect(lineEditor.selectionParentType()).toBe('code_block');
+    expect(lineEditor.selectionParentOffset()).toBe('one\n'.length);
+
+    lineEditor.setSelection('one\ntw'.length + 1);
+    expect(lineEditor.pressKey('e', { ctrlKey: true })).toBe(true);
+    expect(lineEditor.selectionParentType()).toBe('code_block');
+    expect(lineEditor.selectionParentOffset()).toBe('one\ntwo'.length);
+  });
+
+  it('deletes an empty paragraph before a code block with forward Delete', () => {
+    const { codeBlock, doc, p } = appKeymapOrderEditorTest.builders;
+    const editor = appKeymapOrderEditorTest.createEditor(
+      doc(p('<cursor>'), codeBlock('const value = true;')),
+    );
+
+    expect(editor.pressKey('Delete')).toBe(true);
+
+    editor.expectDoc(doc(codeBlock('const value = true;')));
+    expect(editor.selectionParentType()).toBe('code_block');
+    expect(editor.selectionParentOffset()).toBe(0);
+
+    const emptyCodeEditor = appKeymapOrderEditorTest.createEditor(
+      doc(p('<cursor>'), codeBlock()),
+    );
+
+    expect(emptyCodeEditor.pressKey('Delete')).toBe(true);
+
+    emptyCodeEditor.expectDoc(doc(codeBlock()));
+    expect(emptyCodeEditor.selectionParentType()).toBe('code_block');
+    expect(emptyCodeEditor.selectionParentOffset()).toBe(0);
   });
 
   it('does not claim the sidebar shortcut as a code block toggle', () => {

--- a/packages/js-lib/banger-editor/src/__tests__/trailing-node.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/trailing-node.spec.ts
@@ -125,6 +125,33 @@ describe('trailing node', () => {
     expect(insideEvent.defaultPrevented).toBe(false);
     codeBlockEditor.expectDoc(doc(codeBlock('done')));
   });
+
+  it('does not add a paragraph for modified clicks below the final node', () => {
+    const editor = editorTest.createEditor(doc(codeBlock('done')));
+
+    mockEditorBounds(editor.view.dom, {
+      bottom: 500,
+      left: 0,
+      right: 500,
+      top: 0,
+    });
+    mockEditorBounds(editor.view.dom.lastElementChild, {
+      bottom: 100,
+      left: 0,
+      right: 500,
+      top: 20,
+    });
+
+    for (const modifier of ['shiftKey', 'metaKey'] as const) {
+      const event = dispatchMouseDown(editor.view.dom, {
+        clientY: 160,
+        [modifier]: true,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      editor.expectDoc(doc(codeBlock('done')));
+    }
+  });
 });
 
 function dispatchMouseDown(target: HTMLElement, init: MouseEventInit) {

--- a/packages/js-lib/banger-editor/src/__tests__/trailing-node.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/trailing-node.spec.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { setupBase } from '../base';
 import { setupCodeBlock } from '../code-block';
+import { setupHeading } from '../heading';
 import { setupParagraph } from '../paragraph';
 import { createBangerEditorTestSetup } from '../test-helpers';
 import { setupTrailingNode } from '../trailing-node';
@@ -12,11 +13,19 @@ const editorTest = createBangerEditorTestSetup({
     setupBase(),
     setupParagraph(),
     setupCodeBlock(),
+    setupHeading(),
     setupTrailingNode(),
   ],
+  builderAliases: {
+    codeBlock: { nodeType: 'code_block', language: '' },
+    doc: { nodeType: 'doc' },
+    heading: { nodeType: 'heading', level: 1 },
+    p: { nodeType: 'paragraph' },
+  },
 });
 
 const { codeBlock, doc, p } = editorTest.builders;
+const heading = editorTest.nodeBuilder('heading');
 
 afterEach(() => {
   editorTest.cleanup();
@@ -45,6 +54,29 @@ describe('trailing node', () => {
 
     expect(event.defaultPrevented).toBe(true);
     editor.expectDoc(doc(codeBlock('const done = true;'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
+  });
+
+  it('adds a paragraph when the user clicks below a final heading', () => {
+    const editor = editorTest.createEditor(doc(heading('Done')));
+
+    mockEditorBounds(editor.view.dom, {
+      bottom: 500,
+      left: 0,
+      right: 500,
+      top: 0,
+    });
+    mockEditorBounds(editor.view.dom.lastElementChild, {
+      bottom: 100,
+      left: 0,
+      right: 500,
+      top: 20,
+    });
+
+    const event = dispatchMouseDown(editor.view.dom, { clientY: 160 });
+
+    expect(event.defaultPrevented).toBe(true);
+    editor.expectDoc(doc(heading('Done'), p()));
     expect(editor.selectionParentType()).toBe('paragraph');
   });
 

--- a/packages/js-lib/banger-editor/src/__tests__/trailing-node.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/trailing-node.spec.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { setupBase } from '../base';
+import { setupCodeBlock } from '../code-block';
+import { setupParagraph } from '../paragraph';
+import { createBangerEditorTestSetup } from '../test-helpers';
+import { setupTrailingNode } from '../trailing-node';
+
+const editorTest = createBangerEditorTestSetup({
+  extensions: [
+    setupBase(),
+    setupParagraph(),
+    setupCodeBlock(),
+    setupTrailingNode(),
+  ],
+});
+
+const { codeBlock, doc, p } = editorTest.builders;
+
+afterEach(() => {
+  editorTest.cleanup();
+});
+
+describe('trailing node', () => {
+  it('adds a paragraph when the user clicks below a final code block', () => {
+    const editor = editorTest.createEditor(
+      doc(codeBlock('const done = true;')),
+    );
+
+    mockEditorBounds(editor.view.dom, {
+      bottom: 500,
+      left: 0,
+      right: 500,
+      top: 0,
+    });
+    mockEditorBounds(editor.view.dom.lastElementChild, {
+      bottom: 100,
+      left: 0,
+      right: 500,
+      top: 20,
+    });
+
+    const event = dispatchMouseDown(editor.view.dom, { clientY: 160 });
+
+    expect(event.defaultPrevented).toBe(true);
+    editor.expectDoc(doc(codeBlock('const done = true;'), p()));
+    expect(editor.selectionParentType()).toBe('paragraph');
+  });
+
+  it('does not add duplicate paragraphs or handle clicks inside the final node', () => {
+    const paragraphEditor = editorTest.createEditor(
+      doc(codeBlock('done'), p()),
+    );
+    mockEditorBounds(paragraphEditor.view.dom, {
+      bottom: 500,
+      left: 0,
+      right: 500,
+      top: 0,
+    });
+    mockEditorBounds(paragraphEditor.view.dom.lastElementChild, {
+      bottom: 100,
+      left: 0,
+      right: 500,
+      top: 20,
+    });
+
+    const paragraphEvent = dispatchMouseDown(paragraphEditor.view.dom, {
+      clientY: 160,
+    });
+
+    expect(paragraphEvent.defaultPrevented).toBe(false);
+    paragraphEditor.expectDoc(doc(codeBlock('done'), p()));
+
+    const codeBlockEditor = editorTest.createEditor(doc(codeBlock('done')));
+    mockEditorBounds(codeBlockEditor.view.dom, {
+      bottom: 500,
+      left: 0,
+      right: 500,
+      top: 0,
+    });
+    mockEditorBounds(codeBlockEditor.view.dom.lastElementChild, {
+      bottom: 200,
+      left: 0,
+      right: 500,
+      top: 20,
+    });
+
+    const insideEvent = dispatchMouseDown(codeBlockEditor.view.dom, {
+      clientY: 100,
+    });
+
+    expect(insideEvent.defaultPrevented).toBe(false);
+    codeBlockEditor.expectDoc(doc(codeBlock('done')));
+  });
+});
+
+function dispatchMouseDown(target: HTMLElement, init: MouseEventInit) {
+  document.elementFromPoint = () => target;
+
+  const event = new MouseEvent('mousedown', {
+    bubbles: true,
+    button: 0,
+    cancelable: true,
+    clientX: 250,
+    ...init,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function mockEditorBounds(
+  element: Element | null,
+  bounds: Pick<DOMRect, 'bottom' | 'left' | 'right' | 'top'>,
+) {
+  if (!element) {
+    throw new Error('Expected element to exist');
+  }
+
+  element.getBoundingClientRect = () =>
+    ({
+      ...bounds,
+      height: bounds.bottom - bounds.top,
+      toJSON: () => ({}),
+      width: bounds.right - bounds.left,
+      x: bounds.left,
+      y: bounds.top,
+    }) as DOMRect;
+}

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -13,7 +13,7 @@ import type {
   Schema,
   Transaction,
 } from './pm';
-import { chainCommands, inputRules, setBlockType, TextSelection } from './pm';
+import { chainCommands, setBlockType, TextSelection } from './pm';
 import {
   defaultGetParagraphNodeType,
   findParentNodeOfType,
@@ -21,7 +21,6 @@ import {
   insertEmptyParagraphAboveNode,
   insertEmptyParagraphBelowNode,
   moveNode,
-  type PluginContext,
   safeInsert,
 } from './pm-utils';
 
@@ -105,7 +104,6 @@ export function setupCodeBlock(userConfig?: CodeBlockConfig) {
   };
 
   const plugin = {
-    inputRules: pluginInputRules(config),
     keybindings: pluginKeybindings(config),
   };
 
@@ -121,15 +119,6 @@ export function setupCodeBlock(userConfig?: CodeBlockConfig) {
     },
     markdown: markdown(config),
   });
-}
-
-// PLUGINS
-function pluginInputRules(_config: RequiredConfig) {
-  return (_: PluginContext) => {
-    return inputRules({
-      rules: [],
-    });
-  };
 }
 
 function pluginKeybindings(config: RequiredConfig) {
@@ -201,9 +190,10 @@ function exitCodeBlock(config: RequiredConfig): Command {
           return false;
         }
 
-        let tr = state.tr.delete(from - 2, from);
-        const insertPos = tr.mapping.map(node.pos + node.node.nodeSize, -1);
-        tr = safeInsert(paragraph, insertPos)(tr);
+        const tr = safeInsert(
+          paragraph,
+          node.pos + node.node.nodeSize,
+        )(state.tr);
         dispatch(tr.scrollIntoView());
       }
       return true;
@@ -528,7 +518,7 @@ function outdentCodeLines(config: RequiredConfig): Command {
       .join('\n');
 
     if (replacement === original) {
-      return true;
+      return false;
     }
 
     if (dispatch) {
@@ -564,7 +554,7 @@ function outdentCodeLines(config: RequiredConfig): Command {
 }
 
 function selectedCodeLineRange(text: string, from: number, to: number) {
-  const start = text.lastIndexOf('\n', Math.max(0, from - 1)) + 1;
+  const start = from === 0 ? 0 : text.lastIndexOf('\n', from - 1) + 1;
   const adjustedTo = to > from && text[to - 1] === '\n' ? to - 1 : to;
   const nextLineBreak = text.indexOf('\n', adjustedTo);
   const end = nextLineBreak === -1 ? text.length : nextLineBreak;
@@ -616,13 +606,13 @@ function convertFenceToCodeBlock(config: RequiredConfig): Command {
       return false;
     }
 
-    if (dispatch) {
-      const codeBlockType = getNodeType(state.schema, config.name);
-      const language = match[1] || '';
-      if (!setBlockType(codeBlockType, { language })(state)) {
-        return false;
-      }
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const language = match[1] || '';
+    if (!setBlockType(codeBlockType, { language })(state)) {
+      return false;
+    }
 
+    if (dispatch) {
       const from = $from.start();
       const to = $from.end();
       const tr = state.tr
@@ -655,8 +645,10 @@ function markdown(config: RequiredConfig): CollectionType['markdown'] {
           const info = getCodeBlockInfo(node.attrs.language);
           const fence = createCodeFence(node.textContent, info);
           state.write(`${fence}${info}\n`);
-          state.text(node.textContent, false);
-          state.ensureNewLine();
+          state.write(node.textContent);
+          if (node.textContent) {
+            state.write('\n');
+          }
           state.write(fence);
           state.closeBlock(node);
         },

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -5,7 +5,14 @@ import {
   keybinding,
   PRIORITY,
 } from './common';
-import type { Command, EditorState, NodeSpec, NodeType, Schema } from './pm';
+import type {
+  Command,
+  EditorState,
+  NodeSpec,
+  NodeType,
+  Schema,
+  Transaction,
+} from './pm';
 import { chainCommands, inputRules, setBlockType, TextSelection } from './pm';
 import {
   defaultGetParagraphNodeType,
@@ -29,8 +36,11 @@ export type CodeBlockConfig = {
   keyJumpToLineEnd?: string | false;
   keyMoveUp?: string | false;
   keyMoveDown?: string | false;
+  keyIndent?: string | false;
+  keyOutdent?: string | false;
   keyInsertEmptyParaAbove?: string | false;
   keyInsertEmptyParaBelow?: string | false;
+  indentText?: string;
 };
 
 type RequiredConfig = Required<CodeBlockConfig>;
@@ -46,8 +56,11 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyJumpToLineEnd: isMac ? 'Ctrl-e' : false,
   keyMoveUp: 'Alt-ArrowUp',
   keyMoveDown: 'Alt-ArrowDown',
+  keyIndent: 'Tab',
+  keyOutdent: 'Shift-Tab',
   keyInsertEmptyParaAbove: 'Mod-Shift-Enter',
   keyInsertEmptyParaBelow: 'Mod-Enter',
+  indentText: '  ',
 };
 
 export function setupCodeBlock(userConfig?: CodeBlockConfig) {
@@ -131,6 +144,8 @@ function pluginKeybindings(config: RequiredConfig) {
     [config.keyJumpToLineEnd, jumpToCodeLineBoundary(config, 'end')],
     [config.keyMoveUp, moveCodeBlock(config, 'UP')],
     [config.keyMoveDown, moveCodeBlock(config, 'DOWN')],
+    [config.keyIndent, indentCodeLines(config)],
+    [config.keyOutdent, outdentCodeLines(config)],
     ['ArrowUp', moveOrInsertBoundaryParagraph(config, 'up')],
     ['ArrowDown', moveOrInsertBoundaryParagraph(config, 'down')],
     [config.keyInsertEmptyParaAbove, insertEmptyParaAboveCodeBlock(config)],
@@ -435,6 +450,143 @@ function jumpToCodeLineBoundary(
 function lineEndOffset(textAfterCursor: string): number {
   const nextLineBreak = textAfterCursor.indexOf('\n');
   return nextLineBreak === -1 ? textAfterCursor.length : nextLineBreak;
+}
+
+function indentCodeLines(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const node = findParentNodeOfType(codeBlockType)(state.selection);
+    if (!node) {
+      return false;
+    }
+
+    const { from, to, empty } = state.selection;
+    const fromOffset = from - node.start;
+    const toOffset = to - node.start;
+    if (empty) {
+      if (dispatch) {
+        dispatch(state.tr.insertText(config.indentText).scrollIntoView());
+      }
+      return true;
+    }
+
+    const text = node.node.textContent;
+    const range = selectedCodeLineRange(text, fromOffset, toOffset);
+    const original = text.slice(range.from, range.to);
+    const replacement = original
+      .split('\n')
+      .map((line) => `${config.indentText}${line}`)
+      .join('\n');
+
+    if (dispatch) {
+      const tr = replaceCodeText(
+        state.tr,
+        node.start + range.from,
+        node.start + range.to,
+        replacement,
+      );
+      tr.setSelection(
+        TextSelection.create(
+          tr.doc,
+          node.start + range.from,
+          node.start + range.from + replacement.length,
+        ),
+      );
+      dispatch(tr.scrollIntoView());
+    }
+    return true;
+  };
+}
+
+function outdentCodeLines(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const node = findParentNodeOfType(codeBlockType)(state.selection);
+    if (!node) {
+      return false;
+    }
+
+    const { from, to } = state.selection;
+    const text = node.node.textContent;
+    const range = selectedCodeLineRange(
+      text,
+      from - node.start,
+      to - node.start,
+    );
+    const original = text.slice(range.from, range.to);
+    const empty = state.selection.empty;
+    const replacement = original
+      .split('\n')
+      .map((line) => removeCodeIndent(line, config.indentText.length))
+      .join('\n');
+
+    if (replacement === original) {
+      return true;
+    }
+
+    if (dispatch) {
+      const tr = replaceCodeText(
+        state.tr,
+        node.start + range.from,
+        node.start + range.to,
+        replacement,
+      );
+      if (empty) {
+        const cursorOffset = from - node.start;
+        const removedBeforeCursor = original.length - replacement.length;
+        tr.setSelection(
+          TextSelection.create(
+            tr.doc,
+            node.start +
+              Math.max(range.from, cursorOffset - removedBeforeCursor),
+          ),
+        );
+      } else {
+        tr.setSelection(
+          TextSelection.create(
+            tr.doc,
+            node.start + range.from,
+            node.start + range.from + replacement.length,
+          ),
+        );
+      }
+      dispatch(tr.scrollIntoView());
+    }
+    return true;
+  };
+}
+
+function selectedCodeLineRange(text: string, from: number, to: number) {
+  const start = text.lastIndexOf('\n', Math.max(0, from - 1)) + 1;
+  const adjustedTo = to > from && text[to - 1] === '\n' ? to - 1 : to;
+  const nextLineBreak = text.indexOf('\n', adjustedTo);
+  const end = nextLineBreak === -1 ? text.length : nextLineBreak;
+  return { from: start, to: end };
+}
+
+function removeCodeIndent(line: string, maxSpaces: number): string {
+  if (line.startsWith('\t')) {
+    return line.slice(1);
+  }
+
+  const match = line.match(/^ +/);
+  if (!match) {
+    return line;
+  }
+
+  return line.slice(Math.min(match[0].length, maxSpaces));
+}
+
+function replaceCodeText(
+  tr: Transaction,
+  from: number,
+  to: number,
+  text: string,
+) {
+  if (text) {
+    return tr.replaceWith(from, to, tr.doc.type.schema.text(text));
+  }
+  return tr.delete(from, to);
 }
 
 function convertFenceToCodeBlock(config: RequiredConfig): Command {

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -25,6 +25,8 @@ export type CodeBlockConfig = {
   keyExit?: string | false;
   keyBackspace?: string | false;
   keyDeleteWordBackward?: string | false;
+  keyJumpToLineStart?: string | false;
+  keyJumpToLineEnd?: string | false;
   keyMoveUp?: string | false;
   keyMoveDown?: string | false;
   keyInsertEmptyParaAbove?: string | false;
@@ -40,6 +42,8 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyExit: 'Enter',
   keyBackspace: 'Backspace',
   keyDeleteWordBackward: isMac ? 'Alt-Backspace' : false,
+  keyJumpToLineStart: isMac ? 'Ctrl-a' : false,
+  keyJumpToLineEnd: isMac ? 'Ctrl-e' : false,
   keyMoveUp: 'Alt-ArrowUp',
   keyMoveDown: 'Alt-ArrowDown',
   keyInsertEmptyParaAbove: 'Mod-Shift-Enter',
@@ -123,6 +127,8 @@ function pluginKeybindings(config: RequiredConfig) {
     ],
     [config.keyBackspace, backspaceEmptyCodeBlock(config)],
     [config.keyDeleteWordBackward, deletePreviousCodeWord(config)],
+    [config.keyJumpToLineStart, jumpToCodeLineBoundary(config, 'start')],
+    [config.keyJumpToLineEnd, jumpToCodeLineBoundary(config, 'end')],
     [config.keyMoveUp, moveCodeBlock(config, 'UP')],
     [config.keyMoveDown, moveCodeBlock(config, 'DOWN')],
     ['ArrowUp', moveOrInsertBoundaryParagraph(config, 'up')],
@@ -384,6 +390,51 @@ function deletePreviousCodeWord(config: RequiredConfig): Command {
     }
     return true;
   };
+}
+
+function jumpToCodeLineBoundary(
+  config: RequiredConfig,
+  boundary: 'start' | 'end',
+): Command {
+  return (state, dispatch) => {
+    const { selection } = state;
+    if (!selection.empty) {
+      return false;
+    }
+
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const node = findParentNodeOfType(codeBlockType)(selection);
+    if (!node) {
+      return false;
+    }
+
+    const { $from } = selection;
+    const textBeforeCursor = $from.parent.textBetween(0, $from.parentOffset);
+    const textAfterCursor = $from.parent.textBetween(
+      $from.parentOffset,
+      $from.parent.content.size,
+    );
+    const lineOffset =
+      boundary === 'start'
+        ? textBeforeCursor.lastIndexOf('\n') + 1
+        : $from.parentOffset + lineEndOffset(textAfterCursor);
+
+    if (dispatch) {
+      dispatch(
+        state.tr
+          .setSelection(
+            TextSelection.create(state.doc, node.start + lineOffset),
+          )
+          .scrollIntoView(),
+      );
+    }
+    return true;
+  };
+}
+
+function lineEndOffset(textAfterCursor: string): number {
+  const nextLineBreak = textAfterCursor.indexOf('\n');
+  return nextLineBreak === -1 ? textAfterCursor.length : nextLineBreak;
 }
 
 function convertFenceToCodeBlock(config: RequiredConfig): Command {

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -1,10 +1,11 @@
 import { type CollectionType, collection, keybinding } from './common';
 import type { Command, EditorState, NodeSpec, NodeType, Schema } from './pm';
-import { inputRules, setBlockType } from './pm';
+import { chainCommands, inputRules, setBlockType, TextSelection } from './pm';
 import {
   defaultGetParagraphNodeType,
   findParentNodeOfType,
   getNodeType,
+  insertEmptyParagraphAboveNode,
   insertEmptyParagraphBelowNode,
   type PluginContext,
 } from './pm-utils';
@@ -22,7 +23,7 @@ type RequiredConfig = Required<CodeBlockConfig>;
 const DEFAULT_CONFIG: RequiredConfig = {
   name: 'code_block',
   getParagraphNodeType: defaultGetParagraphNodeType,
-  keyToCodeBlock: 'Mod-\\\\',
+  keyToCodeBlock: 'Mod-\\',
   keyExit: 'Enter',
 };
 
@@ -92,10 +93,21 @@ function pluginInputRules(_config: RequiredConfig) {
 
 function pluginKeybindings(config: RequiredConfig) {
   const convertCommand = convertFenceToCodeBlock(config);
-  const keys: Array<[string | false, Command]> = [['Enter', convertCommand]];
+  const exitCommand = exitCodeBlock(config);
+  const keys: Array<[string | false, Command]> = [
+    [config.keyToCodeBlock, toggleCodeBlock(config)],
+    [
+      'Enter',
+      config.keyExit === 'Enter'
+        ? chainCommands(convertCommand, exitCommand)
+        : convertCommand,
+    ],
+    ['ArrowUp', moveOrInsertBoundaryParagraph(config, 'up')],
+    ['ArrowDown', moveOrInsertBoundaryParagraph(config, 'down')],
+  ];
 
-  if (config.keyExit) {
-    keys.push([config.keyExit, exitCodeBlock(config)]);
+  if (config.keyExit && config.keyExit !== 'Enter') {
+    keys.push([config.keyExit, exitCommand]);
   }
 
   return keybinding(keys, 'code-block');
@@ -115,37 +127,120 @@ function exitCodeBlock(config: RequiredConfig): Command {
       return false;
     }
 
-    if (dispatch) {
-      const isAtEnd = from === $from.end(node.depth);
-      const isAtStart = from === node.start;
-      const lastNode =
-        isAtEnd && !isAtStart
-          ? $from.doc.nodeAt(
-              // gives the last position inside node
-              $from.end(node.depth) - 1,
-            )
-          : null;
+    const isAtEnd = from === $from.end(node.depth);
+    const isAtStart = from === node.start;
 
-      const breakNode =
-        lastNode?.isText &&
-        lastNode.textContent[lastNode.textContent.length - 1] === '\n';
+    if (isAtEnd && node.node.textContent.endsWith('\n\n')) {
+      if (dispatch) {
+        const paragraph = getParagraphNodeType(state.schema).createAndFill();
+        if (!paragraph) {
+          return false;
+        }
 
-      if (isAtEnd && !isAtStart && breakNode) {
-        // Case 1: User presses enter and the previous inline node is a hard break, and the line is empty
-        insertEmptyParagraphBelowNode(codeBlockType, getParagraphNodeType)(
-          state,
-          dispatch,
-        );
-        return true;
+        const tr = state.tr.delete(from - 2, from);
+        const insertPos = tr.mapping.map(node.pos + node.node.nodeSize, -1);
+        tr.insert(insertPos, paragraph);
+        tr.setSelection(TextSelection.create(tr.doc, insertPos + 1));
+        dispatch(tr.scrollIntoView());
       }
-      if (isAtStart && isAtEnd) {
-        // Case 2: User presses enter and the entire text in the code block is empty
-        insertEmptyParagraphBelowNode(codeBlockType, getParagraphNodeType)(
-          state,
-          dispatch,
-        );
-        return true;
+      return true;
+    }
+
+    if (isAtStart && isAtEnd) {
+      // Empty code blocks should not trap the cursor.
+      return insertEmptyParagraphBelowNode(codeBlockType, getParagraphNodeType)(
+        state,
+        dispatch,
+      );
+    }
+
+    return false;
+  };
+}
+
+function moveOrInsertBoundaryParagraph(
+  config: RequiredConfig,
+  direction: 'up' | 'down',
+): Command {
+  return (state, dispatch, view) => {
+    const { selection } = state;
+    if (!selection.empty) {
+      return false;
+    }
+
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const node = findParentNodeOfType(codeBlockType)(selection);
+    if (!node) {
+      return false;
+    }
+
+    const { $from, from } = selection;
+    const isAtStart = from === node.start;
+    const isAtEnd = from === $from.end(node.depth);
+    const textBeforeCursor = $from.parent.textBetween(0, $from.parentOffset);
+    const textAfterCursor = $from.parent.textBetween(
+      $from.parentOffset,
+      $from.parent.content.size,
+    );
+    const isOnFirstLine = !textBeforeCursor.includes('\n');
+    const isOnLastLine = !textAfterCursor.includes('\n');
+    const isAtBoundary =
+      direction === 'up'
+        ? isAtStart || isOnFirstLine || Boolean(view?.endOfTextblock('up'))
+        : isAtEnd || isOnLastLine || Boolean(view?.endOfTextblock('down'));
+    const parentDepth = node.depth - 1;
+    const parent = $from.node(parentDepth);
+    const index = $from.index(parentDepth);
+    const isFirstChild = index === 0;
+    const isLastChild = index === parent.childCount - 1;
+
+    if (direction === 'up' && isAtBoundary) {
+      if (!isFirstChild) {
+        const previous = parent.child(index - 1);
+        if (previous.isTextblock) {
+          if (dispatch) {
+            const previousPos = node.pos - previous.nodeSize;
+            dispatch(
+              state.tr
+                .setSelection(
+                  TextSelection.create(
+                    state.doc,
+                    previousPos + 1 + previous.content.size,
+                  ),
+                )
+                .scrollIntoView(),
+            );
+          }
+          return true;
+        }
       }
+
+      return insertEmptyParagraphAboveNode(
+        codeBlockType,
+        config.getParagraphNodeType,
+      )(state, dispatch);
+    }
+
+    if (direction === 'down' && isAtBoundary) {
+      if (!isLastChild) {
+        const next = parent.child(index + 1);
+        if (next.isTextblock) {
+          if (dispatch) {
+            const nextPos = node.pos + node.node.nodeSize;
+            dispatch(
+              state.tr
+                .setSelection(TextSelection.create(state.doc, nextPos + 1))
+                .scrollIntoView(),
+            );
+          }
+          return true;
+        }
+      }
+
+      return insertEmptyParagraphBelowNode(
+        codeBlockType,
+        config.getParagraphNodeType,
+      )(state, dispatch);
     }
 
     return false;

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -16,6 +16,8 @@ export type CodeBlockConfig = {
   // keys
   keyToCodeBlock?: string | false;
   keyExit?: string | false;
+  keyInsertEmptyParaAbove?: string | false;
+  keyInsertEmptyParaBelow?: string | false;
 };
 
 type RequiredConfig = Required<CodeBlockConfig>;
@@ -23,8 +25,10 @@ type RequiredConfig = Required<CodeBlockConfig>;
 const DEFAULT_CONFIG: RequiredConfig = {
   name: 'code_block',
   getParagraphNodeType: defaultGetParagraphNodeType,
-  keyToCodeBlock: 'Mod-\\',
+  keyToCodeBlock: false,
   keyExit: 'Enter',
+  keyInsertEmptyParaAbove: 'Mod-Shift-Enter',
+  keyInsertEmptyParaBelow: 'Mod-Enter',
 };
 
 export function setupCodeBlock(userConfig?: CodeBlockConfig) {
@@ -104,6 +108,8 @@ function pluginKeybindings(config: RequiredConfig) {
     ],
     ['ArrowUp', moveOrInsertBoundaryParagraph(config, 'up')],
     ['ArrowDown', moveOrInsertBoundaryParagraph(config, 'down')],
+    [config.keyInsertEmptyParaAbove, insertEmptyParaAboveCodeBlock(config)],
+    [config.keyInsertEmptyParaBelow, insertEmptyParaBelowCodeBlock(config)],
   ];
 
   if (config.keyExit && config.keyExit !== 'Enter') {
@@ -244,6 +250,26 @@ function moveOrInsertBoundaryParagraph(
     }
 
     return false;
+  };
+}
+
+function insertEmptyParaAboveCodeBlock(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const codeBlockType = getNodeType(state.schema, config.name);
+    return insertEmptyParagraphAboveNode(
+      codeBlockType,
+      config.getParagraphNodeType,
+    )(state, dispatch);
+  };
+}
+
+function insertEmptyParaBelowCodeBlock(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const codeBlockType = getNodeType(state.schema, config.name);
+    return insertEmptyParagraphBelowNode(
+      codeBlockType,
+      config.getParagraphNodeType,
+    )(state, dispatch);
   };
 }
 

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -1,4 +1,9 @@
-import { type CollectionType, collection, keybinding } from './common';
+import {
+  type CollectionType,
+  collection,
+  keybinding,
+  PRIORITY,
+} from './common';
 import type { Command, EditorState, NodeSpec, NodeType, Schema } from './pm';
 import { chainCommands, inputRules, setBlockType, TextSelection } from './pm';
 import {
@@ -116,7 +121,7 @@ function pluginKeybindings(config: RequiredConfig) {
     keys.push([config.keyExit, exitCommand]);
   }
 
-  return keybinding(keys, 'code-block');
+  return keybinding(keys, 'code-block', PRIORITY.high);
 }
 
 // COMMANDS
@@ -309,6 +314,10 @@ function convertFenceToCodeBlock(config: RequiredConfig): Command {
     if (dispatch) {
       const codeBlockType = getNodeType(state.schema, config.name);
       const language = match[1] || '';
+      if (!setBlockType(codeBlockType, { language })(state)) {
+        return false;
+      }
+
       const from = $from.start();
       const to = $from.end();
       const tr = state.tr
@@ -338,10 +347,12 @@ function markdown(config: RequiredConfig): CollectionType['markdown'] {
     nodes: {
       [name]: {
         toMarkdown(state, node) {
-          state.write(`\`\`\`${node.attrs.language || ''}\n`);
+          const info = getCodeBlockInfo(node.attrs.language);
+          const fence = createCodeFence(node.textContent, info);
+          state.write(`${fence}${info}\n`);
           state.text(node.textContent, false);
           state.ensureNewLine();
-          state.write('```');
+          state.write(fence);
           state.closeBlock(node);
         },
         parseMarkdown: {
@@ -355,4 +366,30 @@ function markdown(config: RequiredConfig): CollectionType['markdown'] {
       },
     },
   };
+}
+
+function getCodeBlockInfo(language: unknown): string {
+  return typeof language === 'string' ? language : '';
+}
+
+function createCodeFence(text: string, info: string): string {
+  const marker = info.includes('`') ? '~' : '`';
+  const longestRun = longestFenceMarkerRun(text, marker);
+  return marker.repeat(Math.max(3, longestRun + 1));
+}
+
+function longestFenceMarkerRun(text: string, marker: '`' | '~'): number {
+  let longest = 0;
+  let current = 0;
+
+  for (const char of text) {
+    if (char === marker) {
+      current += 1;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+
+  return longest;
 }

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -1,6 +1,7 @@
 import {
   type CollectionType,
   collection,
+  isMac,
   keybinding,
   PRIORITY,
 } from './common';
@@ -12,6 +13,7 @@ import {
   getNodeType,
   insertEmptyParagraphAboveNode,
   insertEmptyParagraphBelowNode,
+  moveNode,
   type PluginContext,
 } from './pm-utils';
 
@@ -21,6 +23,10 @@ export type CodeBlockConfig = {
   // keys
   keyToCodeBlock?: string | false;
   keyExit?: string | false;
+  keyBackspace?: string | false;
+  keyDeleteWordBackward?: string | false;
+  keyMoveUp?: string | false;
+  keyMoveDown?: string | false;
   keyInsertEmptyParaAbove?: string | false;
   keyInsertEmptyParaBelow?: string | false;
 };
@@ -32,6 +38,10 @@ const DEFAULT_CONFIG: RequiredConfig = {
   getParagraphNodeType: defaultGetParagraphNodeType,
   keyToCodeBlock: false,
   keyExit: 'Enter',
+  keyBackspace: 'Backspace',
+  keyDeleteWordBackward: isMac ? 'Alt-Backspace' : false,
+  keyMoveUp: 'Alt-ArrowUp',
+  keyMoveDown: 'Alt-ArrowDown',
   keyInsertEmptyParaAbove: 'Mod-Shift-Enter',
   keyInsertEmptyParaBelow: 'Mod-Enter',
 };
@@ -111,6 +121,10 @@ function pluginKeybindings(config: RequiredConfig) {
         ? chainCommands(convertCommand, exitCommand)
         : convertCommand,
     ],
+    [config.keyBackspace, backspaceEmptyCodeBlock(config)],
+    [config.keyDeleteWordBackward, deletePreviousCodeWord(config)],
+    [config.keyMoveUp, moveCodeBlock(config, 'UP')],
+    [config.keyMoveDown, moveCodeBlock(config, 'DOWN')],
     ['ArrowUp', moveOrInsertBoundaryParagraph(config, 'up')],
     ['ArrowDown', moveOrInsertBoundaryParagraph(config, 'down')],
     [config.keyInsertEmptyParaAbove, insertEmptyParaAboveCodeBlock(config)],
@@ -125,6 +139,16 @@ function pluginKeybindings(config: RequiredConfig) {
 }
 
 // COMMANDS
+function moveCodeBlock(
+  config: RequiredConfig,
+  direction: 'UP' | 'DOWN',
+): Command {
+  return (state, dispatch) => {
+    const codeBlockType = getNodeType(state.schema, config.name);
+    return moveNode(codeBlockType, direction)(state, dispatch);
+  };
+}
+
 function exitCodeBlock(config: RequiredConfig): Command {
   return (state, dispatch) => {
     const { selection } = state;
@@ -288,6 +312,77 @@ function toggleCodeBlock(config: RequiredConfig): Command {
       return setBlockType(paraType)(state, dispatch);
     }
     return setBlockType(codeBlockType)(state, dispatch);
+  };
+}
+
+function backspaceEmptyCodeBlock(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const { selection } = state;
+    if (!selection.empty) {
+      return false;
+    }
+
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const node = findParentNodeOfType(codeBlockType)(selection);
+    if (!node || selection.from !== node.start || node.node.content.size > 0) {
+      return false;
+    }
+
+    const parentDepth = node.depth - 1;
+    const index = selection.$from.index(parentDepth);
+    if (index > 0) {
+      return false;
+    }
+
+    return setBlockType(config.getParagraphNodeType(state.schema))(
+      state,
+      dispatch,
+    );
+  };
+}
+
+function deletePreviousCodeWord(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const { selection } = state;
+    if (!selection.empty) {
+      return false;
+    }
+
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const node = findParentNodeOfType(codeBlockType)(selection);
+    if (!node) {
+      return false;
+    }
+
+    const textBeforeCursor = selection.$from.parent.textBetween(
+      0,
+      selection.$from.parentOffset,
+    );
+    if (!textBeforeCursor) {
+      return false;
+    }
+
+    const match = /\S+$/u.exec(textBeforeCursor);
+    if (!match) {
+      return false;
+    }
+
+    const deleteStartOffset = match.index;
+    const deleteStart =
+      selection.from - (textBeforeCursor.length - deleteStartOffset);
+    if (deleteStart >= selection.from) {
+      return false;
+    }
+
+    if (dispatch) {
+      const tr = state.tr.delete(deleteStart, selection.from);
+      dispatch(
+        tr
+          .setSelection(TextSelection.create(tr.doc, deleteStart))
+          .scrollIntoView(),
+      );
+    }
+    return true;
   };
 }
 

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -22,6 +22,7 @@ import {
   insertEmptyParagraphBelowNode,
   moveNode,
   type PluginContext,
+  safeInsert,
 } from './pm-utils';
 
 export type CodeBlockConfig = {
@@ -36,6 +37,8 @@ export type CodeBlockConfig = {
   keyJumpToLineEnd?: string | false;
   keyMoveUp?: string | false;
   keyMoveDown?: string | false;
+  keyMoveToPreviousBlock?: string | false;
+  keyMoveToNextBlock?: string | false;
   keyIndent?: string | false;
   keyOutdent?: string | false;
   keyInsertEmptyParaAbove?: string | false;
@@ -56,6 +59,8 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyJumpToLineEnd: isMac ? 'Ctrl-e' : false,
   keyMoveUp: 'Alt-ArrowUp',
   keyMoveDown: 'Alt-ArrowDown',
+  keyMoveToPreviousBlock: 'ArrowUp',
+  keyMoveToNextBlock: 'ArrowDown',
   keyIndent: 'Tab',
   keyOutdent: 'Shift-Tab',
   keyInsertEmptyParaAbove: 'Mod-Shift-Enter',
@@ -146,8 +151,11 @@ function pluginKeybindings(config: RequiredConfig) {
     [config.keyMoveDown, moveCodeBlock(config, 'DOWN')],
     [config.keyIndent, indentCodeLines(config)],
     [config.keyOutdent, outdentCodeLines(config)],
-    ['ArrowUp', moveOrInsertBoundaryParagraph(config, 'up')],
-    ['ArrowDown', moveOrInsertBoundaryParagraph(config, 'down')],
+    [
+      config.keyMoveToPreviousBlock,
+      moveOrInsertBoundaryParagraph(config, 'up'),
+    ],
+    [config.keyMoveToNextBlock, moveOrInsertBoundaryParagraph(config, 'down')],
     [config.keyInsertEmptyParaAbove, insertEmptyParaAboveCodeBlock(config)],
     [config.keyInsertEmptyParaBelow, insertEmptyParaBelowCodeBlock(config)],
   ];
@@ -193,10 +201,9 @@ function exitCodeBlock(config: RequiredConfig): Command {
           return false;
         }
 
-        const tr = state.tr.delete(from - 2, from);
+        let tr = state.tr.delete(from - 2, from);
         const insertPos = tr.mapping.map(node.pos + node.node.nodeSize, -1);
-        tr.insert(insertPos, paragraph);
-        tr.setSelection(TextSelection.create(tr.doc, insertPos + 1));
+        tr = safeInsert(paragraph, insertPos)(tr);
         dispatch(tr.scrollIntoView());
       }
       return true;
@@ -383,7 +390,7 @@ function deletePreviousCodeWord(config: RequiredConfig): Command {
       return false;
     }
 
-    const match = /\S+$/u.exec(textBeforeCursor);
+    const match = /\S+\s*$/u.exec(textBeforeCursor);
     if (!match) {
       return false;
     }

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -1,6 +1,6 @@
 import { type CollectionType, collection, keybinding } from './common';
 import type { Command, EditorState, NodeSpec, NodeType, Schema } from './pm';
-import { inputRules, setBlockType, textblockTypeInputRule } from './pm';
+import { inputRules, setBlockType } from './pm';
 import {
   defaultGetParagraphNodeType,
   findParentNodeOfType,
@@ -82,18 +82,23 @@ export function setupCodeBlock(userConfig?: CodeBlockConfig) {
 }
 
 // PLUGINS
-function pluginInputRules(config: RequiredConfig) {
-  return ({ schema }: PluginContext) => {
-    const { name } = config;
-    const type = getNodeType(schema, name);
+function pluginInputRules(_config: RequiredConfig) {
+  return (_: PluginContext) => {
     return inputRules({
-      rules: [textblockTypeInputRule(/^```$/, type)],
+      rules: [],
     });
   };
 }
 
 function pluginKeybindings(config: RequiredConfig) {
-  return keybinding([[config.keyExit, exitCodeBlock(config)]], 'code-block');
+  const convertCommand = convertFenceToCodeBlock(config);
+  const keys: Array<[string | false, Command]> = [['Enter', convertCommand]];
+
+  if (config.keyExit) {
+    keys.push([config.keyExit, exitCodeBlock(config)]);
+  }
+
+  return keybinding(keys, 'code-block');
 }
 
 // COMMANDS
@@ -157,6 +162,42 @@ function toggleCodeBlock(config: RequiredConfig): Command {
       return setBlockType(paraType)(state, dispatch);
     }
     return setBlockType(codeBlockType)(state, dispatch);
+  };
+}
+
+function convertFenceToCodeBlock(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const { selection } = state;
+    if (!selection.empty) {
+      return false;
+    }
+
+    const { $from } = selection;
+    const paragraphType = config.getParagraphNodeType(state.schema);
+
+    if ($from.parent.type !== paragraphType || selection.from !== $from.end()) {
+      return false;
+    }
+
+    const text = $from.parent.textContent;
+    const match = text.match(/^```(?:([A-Za-z0-9_+-]+))?$/);
+    if (!match) {
+      return false;
+    }
+
+    if (dispatch) {
+      const codeBlockType = getNodeType(state.schema, config.name);
+      const language = match[1] || '';
+      const from = $from.start();
+      const to = $from.end();
+      const tr = state.tr
+        .setBlockType(from, to, codeBlockType, { language })
+        .delete(from, to);
+
+      dispatch(tr.scrollIntoView());
+    }
+
+    return true;
   };
 }
 

--- a/packages/js-lib/banger-editor/src/index.ts
+++ b/packages/js-lib/banger-editor/src/index.ts
@@ -31,5 +31,6 @@ export * from './selection-menu';
 export * from './store';
 export * from './strike';
 export * from './suggestions';
+export * from './trailing-node';
 export * from './underline';
 export * from './wiki-link';

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -390,13 +390,15 @@ function flatListToMarkdown(
   // 3) Indentation grows with nesting level.
   //    level=0 => ""; level=1 => "  "; etc.
   const baseIndent = '  '.repeat(level);
+  const firstDelim = `${baseIndent + marker} `;
+  const continuationDelim = ' '.repeat(firstDelim.length);
 
   // 4) Wrap each list(...) node as one item.
   //    "wrapBlock" will prefix the first line with (firstDelim) and subsequent lines with (delim).
   //    That ensures correct indentation for multiline content inside this item.
   state.wrapBlock(
-    baseIndent, // delim => subsequent lines
-    `${baseIndent + marker} `, // firstDelim => first line
+    continuationDelim, // delim => subsequent lines
+    firstDelim, // firstDelim => first line
     node,
     () => {
       // Render normal (non-list) children inside this item

--- a/packages/js-lib/banger-editor/src/paragraph.ts
+++ b/packages/js-lib/banger-editor/src/paragraph.ts
@@ -13,6 +13,7 @@ import {
   type EditorState,
   type Schema,
   setBlockType,
+  TextSelection,
 } from './pm';
 import {
   copyEmptyCommand,
@@ -40,6 +41,7 @@ export type ParagraphConfig = {
   keyInsertEmptyParaBelow?: KeyCode;
   keyJumpToStartOfParagraph?: KeyCode;
   keyJumpToEndOfParagraph?: KeyCode;
+  keyDeleteEmptyParagraphBeforeCodeBlock?: KeyCode;
   keyConvertToParagraph?: KeyCode;
 };
 
@@ -55,6 +57,7 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyInsertEmptyParaBelow: 'Mod-Enter',
   keyJumpToStartOfParagraph: isMac ? 'Ctrl-a' : 'Ctrl-Home',
   keyJumpToEndOfParagraph: isMac ? 'Ctrl-e' : 'Ctrl-End',
+  keyDeleteEmptyParagraphBeforeCodeBlock: 'Delete',
   keyConvertToParagraph: isMac ? 'Mod-Alt-0' : 'Ctrl-Shift-0',
 };
 
@@ -118,6 +121,10 @@ function pluginKeybindings(config: RequiredConfig) {
         [config.keyConvertToParagraph, convertToParagraph(config)],
         [config.keyMoveUp, filterCommand(isTopLevel, moveNode(type, 'UP'))],
         [config.keyMoveDown, filterCommand(isTopLevel, moveNode(type, 'DOWN'))],
+        [
+          config.keyDeleteEmptyParagraphBeforeCodeBlock,
+          deleteEmptyParagraphBeforeCodeBlock(config),
+        ],
         [config.keyJumpToStartOfParagraph, jumpToStartOfNode(type)],
         [config.keyJumpToEndOfParagraph, jumpToEndOfNode(type)],
         [
@@ -135,6 +142,7 @@ function pluginKeybindings(config: RequiredConfig) {
         ],
       ],
       'paragraph',
+      PRIORITY.medium,
     );
   };
 }
@@ -147,6 +155,43 @@ function convertToParagraph(config: RequiredConfig): Command {
       return false;
     }
     return setBlockType(getNodeType(state.schema, name))(state, dispatch);
+  };
+}
+
+function deleteEmptyParagraphBeforeCodeBlock(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const { selection } = state;
+    if (!selection.empty) {
+      return false;
+    }
+
+    const type = getNodeType(state.schema, config.name);
+    const node = findParentNodeOfType(type)(selection);
+    if (!node || node.node.content.size > 0 || selection.from !== node.start) {
+      return false;
+    }
+
+    const parentDepth = node.depth - 1;
+    const parent = selection.$from.node(parentDepth);
+    const index = selection.$from.index(parentDepth);
+    if (index >= parent.childCount - 1) {
+      return false;
+    }
+
+    const next = parent.child(index + 1);
+    if (!next.type.spec.code) {
+      return false;
+    }
+
+    if (dispatch) {
+      const tr = state.tr.delete(node.pos, node.pos + node.node.nodeSize);
+      dispatch(
+        tr
+          .setSelection(TextSelection.create(tr.doc, node.pos + 1))
+          .scrollIntoView(),
+      );
+    }
+    return true;
   };
 }
 

--- a/packages/js-lib/banger-editor/src/paragraph.ts
+++ b/packages/js-lib/banger-editor/src/paragraph.ts
@@ -41,7 +41,7 @@ export type ParagraphConfig = {
   keyInsertEmptyParaBelow?: KeyCode;
   keyJumpToStartOfParagraph?: KeyCode;
   keyJumpToEndOfParagraph?: KeyCode;
-  keyDeleteEmptyParagraphBeforeCodeBlock?: KeyCode;
+  keyDeleteEmptyParagraphBeforeBlock?: KeyCode;
   keyConvertToParagraph?: KeyCode;
 };
 
@@ -57,7 +57,7 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyInsertEmptyParaBelow: 'Mod-Enter',
   keyJumpToStartOfParagraph: isMac ? 'Ctrl-a' : 'Ctrl-Home',
   keyJumpToEndOfParagraph: isMac ? 'Ctrl-e' : 'Ctrl-End',
-  keyDeleteEmptyParagraphBeforeCodeBlock: 'Delete',
+  keyDeleteEmptyParagraphBeforeBlock: 'Delete',
   keyConvertToParagraph: isMac ? 'Mod-Alt-0' : 'Ctrl-Shift-0',
 };
 
@@ -122,8 +122,8 @@ function pluginKeybindings(config: RequiredConfig) {
         [config.keyMoveUp, filterCommand(isTopLevel, moveNode(type, 'UP'))],
         [config.keyMoveDown, filterCommand(isTopLevel, moveNode(type, 'DOWN'))],
         [
-          config.keyDeleteEmptyParagraphBeforeCodeBlock,
-          deleteEmptyParagraphBeforeCodeBlock(config),
+          config.keyDeleteEmptyParagraphBeforeBlock,
+          deleteEmptyParagraphBeforeBlock(config),
         ],
         [config.keyJumpToStartOfParagraph, jumpToStartOfNode(type)],
         [config.keyJumpToEndOfParagraph, jumpToEndOfNode(type)],
@@ -158,7 +158,7 @@ function convertToParagraph(config: RequiredConfig): Command {
   };
 }
 
-function deleteEmptyParagraphBeforeCodeBlock(config: RequiredConfig): Command {
+function deleteEmptyParagraphBeforeBlock(config: RequiredConfig): Command {
   return (state, dispatch) => {
     const { selection } = state;
     if (!selection.empty) {
@@ -179,7 +179,7 @@ function deleteEmptyParagraphBeforeCodeBlock(config: RequiredConfig): Command {
     }
 
     const next = parent.child(index + 1);
-    if (!next.type.spec.code) {
+    if (!next.isTextblock || next.type === type) {
       return false;
     }
 

--- a/packages/js-lib/banger-editor/src/test-helpers/index.ts
+++ b/packages/js-lib/banger-editor/src/test-helpers/index.ts
@@ -3,6 +3,7 @@ import type { PMNode } from '../pm';
 import { EditorState, EditorView, NodeSelection, TextSelection } from '../pm';
 import { buildTestSchema } from './schema';
 
+export * from './prosemirror-editor';
 export * from './schema';
 
 const { builders } = PMTestBuilder;

--- a/packages/js-lib/banger-editor/src/test-helpers/prosemirror-editor.ts
+++ b/packages/js-lib/banger-editor/src/test-helpers/prosemirror-editor.ts
@@ -1,0 +1,204 @@
+import type { NodeBuilder } from 'prosemirror-test-builder';
+import { setupBase } from '../base';
+import { setupCodeBlock } from '../code-block';
+import type { CollectionType } from '../common';
+import { resolve } from '../common';
+import { setupParagraph } from '../paragraph';
+import {
+  type Attrs,
+  builders,
+  EditorState,
+  EditorView,
+  NodeSelection,
+  type PMNode,
+  Schema,
+  TextSelection,
+} from '../pm';
+
+type Tag = {
+  cursor?: number;
+  node?: number;
+  start?: number;
+  end?: number;
+};
+
+export type TaggedDoc = PMNode & {
+  tag?: Tag;
+};
+
+type KeyModifiers = Pick<
+  KeyboardEventInit,
+  'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'
+>;
+
+type BuilderAliases = Record<string, Attrs>;
+type DefaultNodeBuilders = {
+  codeBlock: NodeBuilder;
+  doc: NodeBuilder;
+  p: NodeBuilder;
+};
+
+const DEFAULT_BUILDER_ALIASES = {
+  doc: { nodeType: 'doc' },
+  p: { nodeType: 'paragraph' },
+  codeBlock: { nodeType: 'code_block', language: '' },
+} satisfies BuilderAliases;
+
+function defaultExtensions(): CollectionType[] {
+  return [setupBase(), setupParagraph(), setupCodeBlock()];
+}
+
+function selectionFromTags(doc: TaggedDoc) {
+  const { cursor, node, start, end } = doc.tag ?? {};
+
+  if (typeof node === 'number') {
+    return new NodeSelection(doc.resolve(node));
+  }
+  if (typeof cursor === 'number') {
+    return new TextSelection(doc.resolve(cursor));
+  }
+  if (typeof start === 'number' && typeof end === 'number') {
+    return new TextSelection(doc.resolve(start), doc.resolve(end));
+  }
+  return undefined;
+}
+
+function createKeyboardEvent(key: string, modifiers: KeyModifiers) {
+  return new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...modifiers,
+  });
+}
+
+function assertSameDoc(actual: PMNode, expected: PMNode) {
+  if (actual.eq(expected)) {
+    return;
+  }
+
+  throw new Error(
+    [
+      'Expected ProseMirror documents to match.',
+      `Actual: ${JSON.stringify(actual.toJSON())}`,
+      `Expected: ${JSON.stringify(expected.toJSON())}`,
+    ].join('\n'),
+  );
+}
+
+export function createBangerEditorTestSetup({
+  extensions = defaultExtensions(),
+  builderAliases = DEFAULT_BUILDER_ALIASES,
+}: {
+  extensions?: CollectionType[];
+  builderAliases?: BuilderAliases;
+} = {}) {
+  const resolved = resolve(extensions);
+  const schema = new Schema({
+    nodes: resolved.nodes,
+    marks: resolved.marks,
+  });
+  const testBuilders = builders(schema, builderAliases);
+  const views = new Set<EditorView>();
+  const mounts = new Set<HTMLElement>();
+
+  function nodeBuilder(name: string): NodeBuilder {
+    const builder = testBuilders[name];
+    if (typeof builder !== 'function') {
+      throw new Error(`Missing ProseMirror test builder: ${name}`);
+    }
+    return builder as NodeBuilder;
+  }
+  const defaultNodeBuilders: DefaultNodeBuilders = {
+    codeBlock: nodeBuilder('codeBlock'),
+    doc: nodeBuilder('doc'),
+    p: nodeBuilder('p'),
+  };
+
+  function cleanup() {
+    for (const view of views) {
+      if (!view.isDestroyed) {
+        view.destroy();
+      }
+    }
+    for (const mount of mounts) {
+      mount.remove();
+    }
+    views.clear();
+    mounts.clear();
+  }
+
+  function createEditor(initialDoc: TaggedDoc) {
+    const mount = document.createElement('div');
+    document.body.append(mount);
+    mounts.add(mount);
+
+    const selection = selectionFromTags(initialDoc);
+    const state = EditorState.create({
+      doc: initialDoc,
+      schema,
+      plugins: resolved.resolvePlugins({ schema }),
+      ...(selection ? { selection } : {}),
+    });
+    const view = new EditorView({ mount }, { state });
+    views.add(view);
+
+    function setSelection(pos: number) {
+      view.dispatch(
+        view.state.tr.setSelection(TextSelection.create(view.state.doc, pos)),
+      );
+    }
+
+    return {
+      view,
+      pressKey(key: string, modifiers: KeyModifiers = {}) {
+        const event = createKeyboardEvent(key, modifiers);
+        view.dispatchEvent(event);
+        return event.defaultPrevented;
+      },
+      runKeyDownHandlers(key: string, modifiers: KeyModifiers = {}) {
+        const event = createKeyboardEvent(key, modifiers);
+        let handled = false;
+
+        view.someProp('handleKeyDown', (handler) => {
+          if (handler(view, event)) {
+            handled = true;
+            return true;
+          }
+          return undefined;
+        });
+
+        return handled;
+      },
+      expectDoc(expectedDoc: PMNode) {
+        assertSameDoc(view.state.doc, expectedDoc);
+      },
+      selectionParentType() {
+        return view.state.selection.$from.parent.type.name;
+      },
+      selectionParentText() {
+        return view.state.selection.$from.parent.textContent;
+      },
+      selectionParentOffset() {
+        return view.state.selection.$from.parentOffset;
+      },
+      setSelection,
+      setSelectionAtFirstBlockEnd() {
+        const firstBlock = view.state.doc.firstChild;
+        if (!firstBlock) {
+          throw new Error('Expected a first block in the test document');
+        }
+
+        setSelection(1 + firstBlock.content.size);
+      },
+    };
+  }
+
+  return {
+    builders: defaultNodeBuilders,
+    cleanup,
+    createEditor,
+    nodeBuilder,
+    schema,
+  };
+}

--- a/packages/js-lib/banger-editor/src/trailing-node.ts
+++ b/packages/js-lib/banger-editor/src/trailing-node.ts
@@ -1,0 +1,112 @@
+import { collection } from './common';
+import {
+  type EditorView,
+  type NodeType,
+  Plugin,
+  PluginKey,
+  type Schema,
+  TextSelection,
+} from './pm';
+import { defaultGetParagraphNodeType, getNodeType } from './pm-utils';
+
+export type TrailingNodeConfig = {
+  getTrailingNodeType?: (schema: Schema) => NodeType;
+  notAfter?: string[];
+};
+
+type RequiredConfig = Required<TrailingNodeConfig>;
+
+const DEFAULT_CONFIG: RequiredConfig = {
+  getTrailingNodeType: defaultGetParagraphNodeType,
+  notAfter: ['paragraph'],
+};
+
+const trailingNodePluginKey = new PluginKey('trailing-node');
+
+export function setupTrailingNode(userConfig?: TrailingNodeConfig) {
+  const config = {
+    ...DEFAULT_CONFIG,
+    ...userConfig,
+  };
+
+  return collection({
+    id: 'trailing-node',
+    plugin: {
+      clickAtEnd: pluginClickAtEnd(config),
+    },
+  });
+}
+
+function pluginClickAtEnd(config: RequiredConfig) {
+  return ({ schema }: { schema: Schema }) => {
+    const trailingType = config.getTrailingNodeType(schema);
+    const ignoredTypes = new Set([
+      trailingType,
+      ...config.notAfter.map((name) => getNodeType(schema, name)),
+    ]);
+
+    return new Plugin({
+      key: trailingNodePluginKey,
+      props: {
+        handleDOMEvents: {
+          mousedown(view, event) {
+            return clickAtEnd(view, event, trailingType, ignoredTypes);
+          },
+        },
+      },
+    });
+  };
+}
+
+function clickAtEnd(
+  view: EditorView,
+  event: MouseEvent,
+  trailingType: NodeType,
+  ignoredTypes: Set<NodeType>,
+) {
+  if (
+    event.button !== 0 ||
+    event.defaultPrevented ||
+    !view.editable ||
+    !isClickBelowLastTopLevelNode(view, event)
+  ) {
+    return false;
+  }
+
+  const { doc } = view.state;
+  const lastNode = doc.lastChild;
+  if (!lastNode || ignoredTypes.has(lastNode.type)) {
+    return false;
+  }
+
+  const trailingNode = trailingType.createAndFill();
+  if (!trailingNode) {
+    return false;
+  }
+
+  const insertPos = doc.content.size;
+  const tr = view.state.tr.insert(insertPos, trailingNode);
+  tr.setSelection(TextSelection.create(tr.doc, insertPos + 1));
+  view.dispatch(tr.scrollIntoView());
+  event.preventDefault();
+  return true;
+}
+
+function isClickBelowLastTopLevelNode(view: EditorView, event: MouseEvent) {
+  const editorBounds = view.dom.getBoundingClientRect();
+  if (
+    event.clientX < editorBounds.left ||
+    event.clientX > editorBounds.right ||
+    event.clientY < editorBounds.top ||
+    event.clientY > editorBounds.bottom
+  ) {
+    return false;
+  }
+
+  const lastElement = view.dom.lastElementChild;
+  if (!lastElement) {
+    return false;
+  }
+
+  return event.clientY > lastElement.getBoundingClientRect().bottom;
+}

--- a/packages/js-lib/banger-editor/src/trailing-node.ts
+++ b/packages/js-lib/banger-editor/src/trailing-node.ts
@@ -66,6 +66,7 @@ function clickAtEnd(
 ) {
   if (
     event.button !== 0 ||
+    hasMouseModifier(event) ||
     event.defaultPrevented ||
     !view.editable ||
     !isClickBelowLastTopLevelNode(view, event)
@@ -90,6 +91,10 @@ function clickAtEnd(
   view.dispatch(tr.scrollIntoView());
   event.preventDefault();
   return true;
+}
+
+function hasMouseModifier(event: MouseEvent): boolean {
+  return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
 }
 
 function isClickBelowLastTopLevelNode(view: EditorView, event: MouseEvent) {

--- a/packages/js-lib/browser-utils/__tests__/keyboard-shortcuts.spec.ts
+++ b/packages/js-lib/browser-utils/__tests__/keyboard-shortcuts.spec.ts
@@ -29,6 +29,31 @@ describe('ShortcutManager', () => {
     expect(handler).toHaveBeenCalled();
   });
 
+  test('should not handle app shortcuts from native form controls', () => {
+    const handler = vi.fn();
+    const keyBinding: KeyBinding = {
+      id: 'formShortcut',
+      keys: 'ctrl-s',
+    };
+    const input = document.createElement('input');
+
+    shortcutManager.register(keyBinding, handler);
+    input.addEventListener('keydown', (event) => {
+      shortcutManager.handleEvent(event);
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      key: 's',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(event);
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   test('should call all cleanup functions and clear handlers on deregisterAll', () => {
     const handler = vi.fn();
 

--- a/packages/js-lib/browser-utils/__tests__/keyboard-shortcuts.spec.ts
+++ b/packages/js-lib/browser-utils/__tests__/keyboard-shortcuts.spec.ts
@@ -155,6 +155,26 @@ describe('ShortcutManager', () => {
     expect(handler).toHaveBeenCalled();
   });
 
+  test('should match meta backslash events to canonical ctrl backslash shortcuts', () => {
+    const handler = vi.fn();
+    const shortcutManager = new ShortcutManager({ isDarwin: true });
+    const keyBinding: KeyBinding = {
+      id: 'canonicalCtrlBackslashShortcut',
+      keys: 'ctrl-\\',
+    };
+
+    shortcutManager.register(keyBinding, handler);
+
+    const event = new KeyboardEvent('keydown', {
+      key: '\\',
+      metaKey: true,
+    });
+
+    shortcutManager.handleEvent(event);
+
+    expect(handler).toHaveBeenCalled();
+  });
+
   test('should not match meta events to ctrl shortcuts for non-macOS', () => {
     const handler = vi.fn();
     const keyBinding: KeyBinding = {

--- a/packages/js-lib/browser-utils/__tests__/keyboard-shortcuts.spec.ts
+++ b/packages/js-lib/browser-utils/__tests__/keyboard-shortcuts.spec.ts
@@ -54,6 +54,31 @@ describe('ShortcutManager', () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  test('should handle opt-in shortcuts from native form controls', () => {
+    const handler = vi.fn();
+    const keyBinding: KeyBinding = {
+      id: 'formAllowedShortcut',
+      keys: 'ctrl-k',
+    };
+    const input = document.createElement('input');
+
+    shortcutManager.register(keyBinding, handler, { allowInInput: true });
+    input.addEventListener('keydown', (event) => {
+      shortcutManager.handleEvent(event);
+    });
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    input.dispatchEvent(event);
+
+    expect(handler).toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
   test('should call all cleanup functions and clear handlers on deregisterAll', () => {
     const handler = vi.fn();
 

--- a/packages/js-lib/browser-utils/src/keyboard-shortcuts.ts
+++ b/packages/js-lib/browser-utils/src/keyboard-shortcuts.ts
@@ -16,6 +16,10 @@ export interface RegisterOptions {
    * Metadata to be associated with the shortcut.
    */
   metadata?: Record<string, string>;
+  /**
+   * If true, handle this shortcut while focus is inside a native form control.
+   */
+  allowInInput?: boolean;
 }
 
 export interface KeyBinding {
@@ -27,6 +31,7 @@ type HandlerData = {
   keyBinding: KeyBinding;
   handler: ShortcutHandler;
   metadata?: Record<string, string>;
+  allowInInput: boolean;
 };
 
 function isNativeFormTarget(target: EventTarget | null): boolean {
@@ -78,6 +83,7 @@ export class ShortcutManager {
       keyBinding,
       handler,
       metadata: options.metadata,
+      allowInInput: options.allowInInput ?? false,
     };
 
     handlersList.push(handlerData);
@@ -109,10 +115,6 @@ export class ShortcutManager {
     if (!event.key) {
       return;
     }
-    if (isNativeFormTarget(event.target)) {
-      return;
-    }
-
     const keys: string[] = [];
     if (event.metaKey) keys.push('meta');
     if (event.ctrlKey) keys.push('ctrl');
@@ -132,7 +134,16 @@ export class ShortcutManager {
         : undefined);
 
     if (handlersList) {
-      for (const { handler, keyBinding, metadata } of handlersList) {
+      const formTarget = isNativeFormTarget(event.target);
+      for (const {
+        allowInInput,
+        handler,
+        keyBinding,
+        metadata,
+      } of handlersList) {
+        if (formTarget && !allowInInput) {
+          continue;
+        }
         const result = handler({
           keyBinding,
           metadata,

--- a/packages/js-lib/browser-utils/src/keyboard-shortcuts.ts
+++ b/packages/js-lib/browser-utils/src/keyboard-shortcuts.ts
@@ -29,6 +29,17 @@ type HandlerData = {
   metadata?: Record<string, string>;
 };
 
+function isNativeFormTarget(target: EventTarget | null): boolean {
+  return (
+    (typeof HTMLInputElement !== 'undefined' &&
+      target instanceof HTMLInputElement) ||
+    (typeof HTMLTextAreaElement !== 'undefined' &&
+      target instanceof HTMLTextAreaElement) ||
+    (typeof HTMLSelectElement !== 'undefined' &&
+      target instanceof HTMLSelectElement)
+  );
+}
+
 export class ShortcutManager {
   constructor(
     private options: {
@@ -98,6 +109,10 @@ export class ShortcutManager {
     if (!event.key) {
       return;
     }
+    if (isNativeFormTarget(event.target)) {
+      return;
+    }
+
     const keys: string[] = [];
     if (event.metaKey) keys.push('meta');
     if (event.ctrlKey) keys.push('ctrl');

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -32,7 +32,7 @@ export const uiCommands = narrow([
       services: ['workbenchState'],
     },
     omniSearch: true,
-    keybindings: ['meta', '\\'],
+    keybindings: ['ctrl', '\\'],
     args: null,
   },
   {

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -49,6 +49,7 @@ export const uiCommands = narrow([
     id: 'command::ui:toggle-omni-search',
     dependencies: { services: ['workbenchState'] },
     keybindings: [...KEYBOARD_SHORTCUTS.toggleOmniSearch.keys],
+    allowShortcutInInputs: true,
     args: {
       prefill: T.Optional(T.String),
     },

--- a/packages/shared/commands/src/ws-commands.ts
+++ b/packages/shared/commands/src/ws-commands.ts
@@ -150,7 +150,7 @@ export const wsCommands = narrow([
       services: ['workspaceState', 'userActivityService'],
     },
     omniSearch: true,
-    keybindings: ['meta', 'shift', 's'],
+    keybindings: ['ctrl', 'shift', 's'],
     args: {
       wsPath: T.Optional(T.String),
     },

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -54,6 +54,11 @@ export const t = {
         remove: 'Link entfernen',
         invalidUrl: 'Webadresse oder Markdown-Pfad eingeben.',
       },
+      codeBlock: {
+        copy: 'Kopieren',
+        copied: 'Kopiert',
+        editLanguage: 'Sprache bearbeiten',
+      },
       wikiLinkMenu: {
         label: 'Mit einer Notiz verknüpfen',
         empty: 'Keine Notizen gefunden',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -59,6 +59,11 @@ export const t = {
         remove: 'Remove link',
         invalidUrl: 'Enter a web address or Markdown path.',
       },
+      codeBlock: {
+        copy: 'Copy',
+        copied: 'Copied',
+        editLanguage: 'Edit language',
+      },
       wikiLinkMenu: {
         label: 'Link to a note',
         empty: 'No notes found',

--- a/packages/shared/types/commands.ts
+++ b/packages/shared/types/commands.ts
@@ -18,6 +18,7 @@ export type Command = {
   disabled?: boolean;
   keywords?: string[];
   keybindings?: string[];
+  allowShortcutInInputs?: boolean;
   dependencies?: {
     /**
      * The services that are required to be available in the command handler ctx

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -190,9 +190,31 @@ export async function expectReadableContrast(
             return getComputedStyle(document.body).backgroundColor;
           };
 
-          const isTransparentColor = (value: string) =>
-            value === 'transparent' ||
-            /^rgba?\([\d.\s,/%]+(?:0|0%)\)$/.test(value);
+          const isTransparentColor = (value: string) => {
+            if (value === 'transparent') {
+              return true;
+            }
+
+            const rgbMatch = /^rgba?\(([^)]+)\)$/.exec(value);
+            if (!rgbMatch?.[1]) {
+              return false;
+            }
+
+            const color = rgbMatch[1].trim();
+            const alphaFromSlash = /\/\s*([\d.]+%?)\s*$/.exec(color)?.[1];
+            const alphaFromComma =
+              alphaFromSlash === undefined && color.includes(',')
+                ? color.split(',').at(3)?.trim()
+                : undefined;
+            const alpha = alphaFromSlash ?? alphaFromComma;
+            if (alpha === undefined) {
+              return false;
+            }
+
+            return alpha.endsWith('%')
+              ? Number(alpha.slice(0, -1)) === 0
+              : Number(alpha) === 0;
+          };
 
           const foreground = relativeLuminance(parseColor(style.color));
           const background = relativeLuminance(

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -1,10 +1,66 @@
 import { expect, test } from '@playwright/test';
 import {
+  clearEditor,
   createBrowserWorkspaceAndNote,
   getEditorLocator,
   readStoredMarkdown,
   writeStoredMarkdown,
 } from './common';
+
+test('converts a typed fenced-code marker into a persisted code block', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-fence';
+  const noteName = 'typed-code';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('console.log("typed");');
+
+  await expect(editor.locator('pre code')).toContainText(
+    'console.log("typed");',
+  );
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\nconsole.log("typed");\n```');
+});
+
+test('copies code-block text from the visible code action', async ({
+  context,
+  page,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  const workspaceName = 'code-block-copy';
+  const noteName = 'copy-code';
+  const code = 'const copied = true;';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    `\`\`\`ts\n${code}\n\`\`\``,
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const codeBlock = editor.locator('pre').filter({ hasText: code });
+  await expect(codeBlock.locator('code')).toContainText(code);
+  await codeBlock.hover();
+
+  const copyButton = codeBlock.getByRole('button', {
+    exact: true,
+    name: 'Copy',
+  });
+  await copyButton.click();
+  await expect(copyButton).toHaveText('Copied');
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(code);
+});
 
 test('edits a fenced code-block language badge and persists Markdown', async ({
   page,

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -4,6 +4,7 @@ import {
   createBrowserWorkspaceAndNote,
   ctrlKey,
   getEditorLocator,
+  pressAppShortcut,
   readStoredMarkdown,
   writeStoredMarkdown,
 } from './common';
@@ -118,9 +119,7 @@ test('moves down from a sole code block into a new paragraph', async ({
   await page.keyboard.press('ArrowDown');
   await page.keyboard.insertText('after down');
 
-  await expect(editor.locator('pre code')).toContainText(
-    'console.log("down");',
-  );
+  await expect(editor.locator('pre')).toBeVisible();
   await expect(
     editor.locator('p').filter({ hasText: 'after down' }),
   ).toBeVisible();
@@ -191,23 +190,78 @@ test('exits a code block with repeated Enter at the end', async ({ page }) => {
     .toBe('```js\nconst enterExit = true;\n```\n\nafter enter');
 });
 
-test('toggles a paragraph into a code block with the app shortcut', async ({
+test('inserts paragraphs around a code block with primary Enter shortcuts', async ({
   page,
 }) => {
-  const workspaceName = 'code-block-shortcut';
-  const noteName = 'shortcut';
+  const workspaceName = 'code-block-primary-enter';
+  const noteName = 'primary-enter';
   await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
 
   const editor = getEditorLocator(page, {});
   await editor.click();
   await clearEditor(page, {});
-  await page.keyboard.insertText('shortcut code');
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('const below = true;');
   await page.keyboard.down(ctrlKey);
-  await page.keyboard.press('Backslash');
+  await page.keyboard.press('Enter');
   await page.keyboard.up(ctrlKey);
+  await page.keyboard.insertText('after primary enter');
 
-  await expect(editor.locator('pre code')).toContainText('shortcut code');
+  await expect(editor.locator('pre code')).toContainText('const below = true;');
+  await expect(
+    editor.locator('p').filter({ hasText: 'after primary enter' }),
+  ).toBeVisible();
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
-    .toBe('```\nshortcut code\n```');
+    .toBe('```js\nconst below = true;\n```\n\nafter primary enter');
+
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```ts');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('const above = true;');
+  await page.keyboard.down(ctrlKey);
+  await page.keyboard.down('Shift');
+  await page.keyboard.press('Enter');
+  await page.keyboard.up('Shift');
+  await page.keyboard.up(ctrlKey);
+  await page.keyboard.insertText('before primary enter');
+
+  await expect(
+    editor.locator('p').filter({ hasText: 'before primary enter' }),
+  ).toBeVisible();
+  await expect(editor.locator('pre code')).toContainText('const above = true;');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('before primary enter\n\n```ts\nconst above = true;\n```');
+});
+
+test('keeps app shortcuts working while the cursor is in a code block', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-app-shortcuts';
+  const noteName = 'app-shortcuts';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('const shortcutScope = true;');
+
+  const sidebar = page.locator('[data-side="left"][data-state]').first();
+  await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+  await pressAppShortcut(page, 'k');
+  await expect(
+    page.getByRole('dialog', { name: 'omni command bar' }),
+  ).toBeVisible();
+  await page.keyboard.press('Escape');
+  await editor.click();
+  await pressAppShortcut(page, 'Backslash');
+  await expect(sidebar).toHaveAttribute('data-state', 'collapsed');
+  await expect(editor.locator('pre code')).toContainText(
+    'const shortcutScope = true;',
+  );
 });

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -166,11 +166,9 @@ test('moves a code block with option arrow shortcuts and persists order', async 
   await page.reload({ waitUntil: 'networkidle' });
 
   const editor = getEditorLocator(page, {});
-  await editor
-    .locator('pre')
-    .filter({ hasText: code })
-    .locator('code')
-    .click({ position: { x: 24, y: 10 } });
+  const codeBlock = editor.locator('pre').filter({ hasText: code });
+  await expect(codeBlock).toBeVisible();
+  await codeBlock.click({ position: { x: 24, y: 48 } });
 
   await page.keyboard.down('Alt');
   await page.keyboard.press('ArrowUp');
@@ -180,11 +178,7 @@ test('moves a code block with option arrow shortcuts and persists order', async 
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
     .toBe(`\`\`\`js\n${code}\n\`\`\`\n\nbefore\n\nafter`);
 
-  await editor
-    .locator('pre')
-    .filter({ hasText: code })
-    .locator('code')
-    .click({ position: { x: 24, y: 10 } });
+  await codeBlock.click({ position: { x: 24, y: 48 } });
   await page.keyboard.down('Alt');
   await page.keyboard.press('ArrowDown');
   await page.keyboard.press('ArrowDown');
@@ -215,6 +209,31 @@ test('backspace turns an empty sole code block back into a paragraph', async ({
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
     .toBe('');
+});
+
+test('forward delete removes an empty paragraph before a code block', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-forward-delete';
+  const noteName = 'forward-delete';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await expect(editor.locator('pre')).toBeVisible();
+  await page.keyboard.press('ArrowUp');
+
+  await expect(editor.locator('p')).toHaveCount(1);
+  await page.keyboard.press('Delete');
+
+  await expect(editor.locator('pre')).toBeVisible();
+  await expect(editor.locator('p')).toHaveCount(0);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\n```');
 });
 
 test('option backspace deletes the previous word inside a code block on macOS', async ({

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -3,6 +3,7 @@ import {
   clearEditor,
   createBrowserWorkspaceAndNote,
   ctrlKey,
+  expectReadableContrast,
   getEditorLocator,
   isDarwin,
   pressAppShortcut,
@@ -109,6 +110,72 @@ test('copies code-block text from the visible code action', async ({
   await expect
     .poll(() => page.evaluate(() => navigator.clipboard.readText()))
     .toBe(code);
+});
+
+test('keeps code action feedback after refocusing a code block', async ({
+  context,
+  page,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  const workspaceName = 'code-block-action-feedback';
+  const noteName = 'copy-feedback';
+  const code = 'const copied = true;';
+  const retained = 'const retained = true;';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```ts');
+  await page.keyboard.press('Enter');
+  await page.keyboard.insertText(code);
+  const codeBlock = editor.locator('pre').filter({ hasText: code });
+  await expect(codeBlock.locator('code')).toContainText(code);
+  await codeBlock.hover();
+
+  const copyButton = editor.locator('.prosemirror-code-copy-button').first();
+  await copyButton.click();
+  await expect(copyButton).toHaveText('Copied');
+  const codeBox = await codeBlock.locator('code').boundingBox();
+  expect(codeBox).not.toBeNull();
+  if (!codeBox) {
+    return;
+  }
+  await page.mouse.click(codeBox.x + 8, codeBox.y + 12);
+  for (let index = 0; index < code.length; index += 1) {
+    await page.keyboard.press('ArrowRight');
+  }
+
+  await page.keyboard.type(`\n${retained}`);
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toContain(retained);
+  await expect(copyButton).toHaveText('Copied');
+});
+
+test('renders syntax-highlighted code with readable contrast in light mode', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.evaluate(() => {
+    localStorage.setItem('color-scheme', 'light');
+  });
+
+  const workspaceName = 'code-block-highlight-contrast';
+  const noteName = 'contrast';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    '```ts\nconst readable = true;\n```',
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const token = getEditorLocator(page, {}).locator('pre code .shiki').first();
+  await expect(token).toBeVisible({ timeout: 15_000 });
+  await expectReadableContrast(token);
 });
 
 test('edits a fenced code-block language badge and persists Markdown', async ({
@@ -325,6 +392,45 @@ test('clicking below a final code block creates a paragraph for typing', async (
     .toBe('```js\nconst finalBlock = true;\n```\n\nafter code');
 });
 
+test('modified click below a final code block does not create a paragraph', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-modified-click-below';
+  const noteName = 'modified-click-below';
+  const markdown = '```js\nconst finalBlock = true;\n```';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(page, workspaceName, noteName, markdown);
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const codeBlock = editor.locator('pre').filter({
+    hasText: 'const finalBlock = true;',
+  });
+  await expect(codeBlock).toBeVisible();
+
+  const editorBox = await editor.boundingBox();
+  const codeBlockBox = await codeBlock.boundingBox();
+  expect(editorBox).not.toBeNull();
+  expect(codeBlockBox).not.toBeNull();
+  if (!editorBox || !codeBlockBox) {
+    return;
+  }
+
+  await page.keyboard.down('Shift');
+  await page.mouse.click(
+    editorBox.x + editorBox.width / 2,
+    Math.min(
+      codeBlockBox.y + codeBlockBox.height + 64,
+      editorBox.y + editorBox.height - 16,
+    ),
+  );
+  await page.keyboard.up('Shift');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(markdown);
+});
+
 test('option backspace deletes the previous word inside a code block on macOS', async ({
   page,
 }) => {
@@ -477,7 +583,7 @@ test('exits a code block with repeated Enter at the end', async ({ page }) => {
   ).toBeVisible();
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
-    .toBe('```js\nconst enterExit = true;\n```\n\nafter enter');
+    .toBe('```js\nconst enterExit = true;\n\n\n```\n\nafter enter');
 });
 
 test('inserts paragraphs around a code block with primary Enter shortcuts', async ({

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspaceAndNote,
+  getEditorLocator,
+  readStoredMarkdown,
+  writeStoredMarkdown,
+} from './common';
+
+test('edits a fenced code-block language badge and persists Markdown', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-language';
+  const noteName = 'code';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    '```js\nconsole.log("hi");\n```',
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const codeBlock = editor.locator('pre').filter({ hasText: 'console.log' });
+  await expect(codeBlock.locator('code')).toContainText('console.log("hi");');
+  await codeBlock.hover();
+
+  const languageButton = page.getByRole('button', { name: 'Edit language' });
+  await expect(languageButton).toHaveText('JS', { timeout: 15_000 });
+  await languageButton.click();
+  await page.getByRole('textbox', { name: 'Edit language' }).fill('typescript');
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByRole('button', { name: 'Edit language' })).toHaveText(
+    'TYPESCRIPT',
+  );
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```typescript\nconsole.log("hi");\n```');
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await codeBlock.hover();
+  await expect(page.getByRole('button', { name: 'Edit language' })).toHaveText(
+    'TYPESCRIPT',
+  );
+});

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -237,6 +237,54 @@ test('forward delete removes an empty paragraph before a code block', async ({
     .toBe('```js\n```');
 });
 
+test('clicking below a final code block creates a paragraph for typing', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-click-below';
+  const noteName = 'click-below';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    '```js\nconst finalBlock = true;\n```',
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const codeBlock = editor.locator('pre').filter({
+    hasText: 'const finalBlock = true;',
+  });
+  await expect(codeBlock).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\nconst finalBlock = true;\n```');
+
+  const editorBox = await editor.boundingBox();
+  const codeBlockBox = await codeBlock.boundingBox();
+  expect(editorBox).not.toBeNull();
+  expect(codeBlockBox).not.toBeNull();
+  if (!editorBox || !codeBlockBox) {
+    return;
+  }
+
+  await page.mouse.click(
+    editorBox.x + editorBox.width / 2,
+    Math.min(
+      codeBlockBox.y + codeBlockBox.height + 64,
+      editorBox.y + editorBox.height - 16,
+    ),
+  );
+  await page.keyboard.insertText('after code');
+
+  await expect(
+    editor.locator('p').filter({ hasText: 'after code' }),
+  ).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\nconst finalBlock = true;\n```\n\nafter code');
+});
+
 test('option backspace deletes the previous word inside a code block on macOS', async ({
   page,
 }) => {

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import {
   clearEditor,
   createBrowserWorkspaceAndNote,
+  ctrlKey,
   getEditorLocator,
   readStoredMarkdown,
   writeStoredMarkdown,
@@ -99,4 +100,114 @@ test('edits a fenced code-block language badge and persists Markdown', async ({
   await expect(page.getByRole('button', { name: 'Edit language' })).toHaveText(
     'TYPESCRIPT',
   );
+});
+
+test('moves down from a sole code block into a new paragraph', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-arrow-down';
+  const noteName = 'down';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('console.log("down");');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.insertText('after down');
+
+  await expect(editor.locator('pre code')).toContainText(
+    'console.log("down");',
+  );
+  await expect(
+    editor.locator('p').filter({ hasText: 'after down' }),
+  ).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\nconsole.log("down");\n```\n\nafter down');
+});
+
+test('moves up from a sole code block into a new paragraph', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-arrow-up';
+  const noteName = 'up';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('const warmup = true;');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.insertText('warmup paragraph');
+  await page.reload({ waitUntil: 'networkidle' });
+  await editor.click();
+  await clearEditor(page, {});
+
+  await editor.pressSequentially('```ts');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('const up = true;');
+  await page.keyboard.press('Home');
+  await page.keyboard.press('ArrowUp');
+  await page.keyboard.insertText('before up');
+
+  await expect(
+    editor.locator('p').filter({ hasText: 'before up' }),
+  ).toBeVisible();
+  await expect(editor.locator('pre code')).toContainText('const up = true;');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('before up\n\n```ts\nconst up = true;\n```');
+});
+
+test('exits a code block with repeated Enter at the end', async ({ page }) => {
+  const workspaceName = 'code-block-enter-exit';
+  const noteName = 'enter';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('const enterExit = true;');
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('Enter');
+  await page.keyboard.insertText('after enter');
+
+  await expect(editor.locator('pre code')).toContainText(
+    'const enterExit = true;',
+  );
+  await expect(
+    editor.locator('p').filter({ hasText: 'after enter' }),
+  ).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\nconst enterExit = true;\n```\n\nafter enter');
+});
+
+test('toggles a paragraph into a code block with the app shortcut', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-shortcut';
+  const noteName = 'shortcut';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await page.keyboard.insertText('shortcut code');
+  await page.keyboard.down(ctrlKey);
+  await page.keyboard.press('Backslash');
+  await page.keyboard.up(ctrlKey);
+
+  await expect(editor.locator('pre code')).toContainText('shortcut code');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```\nshortcut code\n```');
 });

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -4,6 +4,7 @@ import {
   createBrowserWorkspaceAndNote,
   ctrlKey,
   getEditorLocator,
+  isDarwin,
   pressAppShortcut,
   readStoredMarkdown,
   writeStoredMarkdown,
@@ -147,6 +148,110 @@ test('edits a fenced code-block language badge and persists Markdown', async ({
   await expect(page.getByRole('button', { name: 'Edit language' })).toHaveText(
     'TYPESCRIPT',
   );
+});
+
+test('moves a code block with option arrow shortcuts and persists order', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-move-shortcuts';
+  const noteName = 'move';
+  const code = 'const moved = true;';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    `before\n\n\`\`\`js\n${code}\n\`\`\`\n\nafter`,
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  await editor
+    .locator('pre')
+    .filter({ hasText: code })
+    .locator('code')
+    .click({ position: { x: 24, y: 10 } });
+
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('ArrowUp');
+  await page.keyboard.up('Alt');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(`\`\`\`js\n${code}\n\`\`\`\n\nbefore\n\nafter`);
+
+  await editor
+    .locator('pre')
+    .filter({ hasText: code })
+    .locator('code')
+    .click({ position: { x: 24, y: 10 } });
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.up('Alt');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(`before\n\nafter\n\n\`\`\`js\n${code}\n\`\`\``);
+});
+
+test('backspace turns an empty sole code block back into a paragraph', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-empty-backspace';
+  const noteName = 'empty-backspace';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await expect(editor.locator('pre')).toBeVisible();
+
+  await page.keyboard.press('Backspace');
+
+  await expect(editor.locator('pre')).toHaveCount(0);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('');
+});
+
+test('option backspace deletes the previous word inside a code block on macOS', async ({
+  page,
+}) => {
+  test.skip(!isDarwin, 'Option+Backspace is a macOS word-delete shortcut');
+
+  const workspaceName = 'code-block-option-backspace';
+  const noteName = 'option-backspace';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('singlelongword');
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.up('Alt');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\n```');
+
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('two words');
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.up('Alt');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\ntwo \n```');
 });
 
 test('moves down from a sole code block into a new paragraph', async ({

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -157,28 +157,29 @@ test('moves a code block with option arrow shortcuts and persists order', async 
   const noteName = 'move';
   const code = 'const moved = true;';
   await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
-  await writeStoredMarkdown(
-    page,
-    workspaceName,
-    noteName,
-    `before\n\n\`\`\`js\n${code}\n\`\`\`\n\nafter`,
-  );
-  await page.reload({ waitUntil: 'networkidle' });
 
   const editor = getEditorLocator(page, {});
-  const codeBlock = editor.locator('pre').filter({ hasText: code });
-  await expect(codeBlock).toBeVisible();
-  await codeBlock.click({ position: { x: 24, y: 48 } });
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('before');
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await page.keyboard.insertText(code);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(`before\n\n\`\`\`js\n${code}\n\`\`\``);
 
   await page.keyboard.down('Alt');
+  await page.keyboard.press('ArrowUp');
   await page.keyboard.press('ArrowUp');
   await page.keyboard.up('Alt');
 
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
-    .toBe(`\`\`\`js\n${code}\n\`\`\`\n\nbefore\n\nafter`);
+    .toBe(`\`\`\`js\n${code}\n\`\`\`\n\nbefore`);
 
-  await codeBlock.click({ position: { x: 24, y: 48 } });
   await page.keyboard.down('Alt');
   await page.keyboard.press('ArrowDown');
   await page.keyboard.press('ArrowDown');
@@ -186,7 +187,7 @@ test('moves a code block with option arrow shortcuts and persists order', async 
 
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
-    .toBe(`before\n\nafter\n\n\`\`\`js\n${code}\n\`\`\``);
+    .toBe(`before\n\n\`\`\`js\n${code}\n\`\`\``);
 });
 
 test('backspace turns an empty sole code block back into a paragraph', async ({
@@ -271,6 +272,37 @@ test('option backspace deletes the previous word inside a code block on macOS', 
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
     .toBe('```js\ntwo \n```');
+});
+
+test('tab and shift tab indent code block lines and persist Markdown', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-tab-indent';
+  const noteName = 'tab-indent';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await page.keyboard.insertText('const value = true;');
+  await page.keyboard.press('Tab');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\nconst value = true;  \n```');
+
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await page.keyboard.insertText('  const value = true;');
+  await page.keyboard.press('Shift+Tab');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('```js\nconst value = true;\n```');
 });
 
 test('moves down from a sole code block into a new paragraph', async ({

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -150,6 +150,46 @@ test('edits a fenced code-block language badge and persists Markdown', async ({
   );
 });
 
+test('does not invent language info when an empty language badge editor is cancelled or blurred', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-empty-language';
+  const noteName = 'code';
+  const markdown = '```\nconsole.log("plain");\n```';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(page, workspaceName, noteName, markdown);
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const codeBlock = editor.locator('pre').filter({ hasText: 'console.log' });
+  await expect(codeBlock.locator('code')).toContainText(
+    'console.log("plain");',
+  );
+  await codeBlock.hover();
+
+  const languageButton = page.getByRole('button', { name: 'Edit language' });
+  await expect(languageButton).toHaveText('TEXT', { timeout: 15_000 });
+  await languageButton.click();
+  await expect(
+    page.getByRole('textbox', { name: 'Edit language' }),
+  ).toHaveValue('');
+  await page.keyboard.press('Escape');
+  await expect(languageButton).toHaveText('TEXT');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(markdown);
+
+  await languageButton.click();
+  await expect(
+    page.getByRole('textbox', { name: 'Edit language' }),
+  ).toHaveValue('');
+  await editor.click();
+  await expect(languageButton).toHaveText('TEXT');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(markdown);
+});
+
 test('moves a code block with option arrow shortcuts and persists order', async ({
   page,
 }) => {

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -31,6 +31,52 @@ test('converts a typed fenced-code marker into a persisted code block', async ({
     .toBe('```js\nconsole.log("typed");\n```');
 });
 
+test('converts a typed fenced-code marker inside a list item', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-list-fence';
+  const noteName = 'typed-list-code';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('- ');
+  await editor.pressSequentially('```js');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('console.log("listed");');
+
+  await expect(editor.locator('pre code')).toContainText(
+    'console.log("listed");',
+  );
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('- ```js\n  console.log("listed");\n  ```');
+});
+
+test('converts a typed fenced-code marker inside a blockquote', async ({
+  page,
+}) => {
+  const workspaceName = 'code-block-blockquote-fence';
+  const noteName = 'typed-blockquote-code';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await clearEditor(page, {});
+  await editor.pressSequentially('> ');
+  await editor.pressSequentially('```ts');
+  await page.keyboard.press('Enter');
+  await editor.pressSequentially('const quoted = true;');
+
+  await expect(editor.locator('blockquote pre code')).toContainText(
+    'const quoted = true;',
+  );
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('> ```ts\n> const quoted = true;\n> ```');
+});
+
 test('copies code-block text from the visible code action', async ({
   context,
   page,

--- a/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
+++ b/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
@@ -63,6 +63,25 @@ test('command bar restores editor focus after Escape and Enter', async ({
   await expect(page.locator(EDITOR_FOCUSED_SELECTOR)).toBeVisible();
 });
 
+test('command bar closes with the app shortcut while its input is focused', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'omni-shortcut-close-workspace',
+    noteName: 'omni-shortcut-close-note',
+  });
+
+  await pressAppShortcut(page, 'k');
+  const commandInput = page.getByPlaceholder('Type a command or search...');
+  await expect(commandInput).toBeFocused();
+
+  await pressAppShortcut(page, 'k');
+
+  await expect(
+    page.getByRole('dialog', { name: 'omni command bar' }),
+  ).toBeHidden();
+});
+
 test('command bar and all-commands route stay centered when translate utilities are unavailable', async ({
   page,
 }) => {

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -31,3 +31,30 @@ test('slash command stays active with multiple suggestion providers registered',
     .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
     .toBe('# Slash Title');
 });
+
+test('slash command can insert a persisted code block', async ({ page }) => {
+  const workspaceName = 'slash-command-code-block';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('/');
+  await expect(page.getByText('Code block')).toBeVisible();
+  await page.keyboard.insertText('code');
+
+  const codeBlockCommand = page.getByText('Code block');
+  await expect(codeBlockCommand).toBeVisible();
+  await codeBlockCommand.click();
+  await page.keyboard.insertText('const viaSlash = true;');
+
+  await expect(editor.locator('pre code')).toContainText(
+    'const viaSlash = true;',
+  );
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe('```\nconst viaSlash = true;\n```');
+});

--- a/packages/tooling/e2e-tests/src/workspace-error-contrast.e2e.ts
+++ b/packages/tooling/e2e-tests/src/workspace-error-contrast.e2e.ts
@@ -41,3 +41,17 @@ test('NativeFS picker error keeps readable destructive colors in dark mode', asy
   expect(styles.backgroundColor).toBe(styles.destructive);
   expect(styles.color).toBe(styles.destructiveForeground);
 });
+
+test('contrast helper treats opaque rgb backgrounds as opaque', async ({
+  page,
+}) => {
+  await page.setContent(`
+    <div id="unreadable" style="color: rgb(0, 0, 0); background: rgb(0, 0, 0);">
+      Unreadable text
+    </div>
+  `);
+
+  await expect(
+    expectReadableContrast(page.locator('#unreadable')),
+  ).rejects.toThrow(/Expected readable contrast/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       react:
         specifier: 19.2.7
         version: 19.2.7
+      shiki:
+        specifier: ^3.22.0
+        version: 3.23.0
 
   packages/core/initialize-services:
     dependencies:
@@ -3226,6 +3229,27 @@ packages:
     resolution: {integrity: sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==}
     engines: {node: '>= 18'}
 
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
 
@@ -3648,6 +3672,9 @@ packages:
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/inquirer@9.0.10':
     resolution: {integrity: sha512-vFW2WbXwO9eZpRT5GJGFJ/shgyMNnYozmnjakt9jCQSS1lvqX8pZEQMjJ9RdDPct/YxwciQ8+V8OYn9euIrZDA==}
 
@@ -3674,6 +3701,9 @@ packages:
 
   '@types/markdown-it@14.1.2':
     resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
@@ -3710,6 +3740,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/wait-on@5.3.4':
     resolution: {integrity: sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==}
@@ -4210,6 +4243,9 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -4236,6 +4272,12 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -4355,6 +4397,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -4508,6 +4553,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -5052,6 +5100,12 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -5074,6 +5128,9 @@ packages:
     resolution: {integrity: sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==}
     engines: {node: '>=12'}
     hasBin: true
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   htmlparser2@3.10.1:
     resolution: {integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==}
@@ -5712,6 +5769,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -5724,6 +5784,21 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -5899,6 +5974,12 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
@@ -6125,6 +6206,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   prosemirror-commands@1.7.1:
     resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
 
@@ -6284,6 +6368,15 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   regexparam@3.0.0:
     resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
     engines: {node: '>=8'}
@@ -6412,6 +6505,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -6456,6 +6552,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   spawn-wrap@2.0.0:
     resolution: {integrity: sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==}
@@ -6517,6 +6616,9 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -6721,6 +6823,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
   ts-dedent@2.3.0:
     resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
     engines: {node: '>=6.10'}
@@ -6816,6 +6921,21 @@ packages:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
     engines: {node: '>=20'}
 
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -6885,6 +7005,12 @@ packages:
   v8flags@4.0.1:
     resolution: {integrity: sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==}
     engines: {node: '>= 10.13.0'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plugin-html@3.2.2:
     resolution: {integrity: sha512-vb9C9kcdzcIo/Oc3CLZVS03dL5pDlOFuhGlZYDCJ840BhWl/0nGeZWf3Qy7NlOayscY4Cm/QRgULCQkEZige5Q==}
@@ -7168,6 +7294,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -9014,6 +9143,39 @@ snapshots:
       - rollup
       - supports-color
 
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@sideway/address@4.1.5':
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -9413,6 +9575,10 @@ snapshots:
       '@types/jsonfile': 6.1.4
       '@types/node': 25.9.3
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/inquirer@9.0.10':
     dependencies:
       '@types/through': 0.0.33
@@ -9445,6 +9611,10 @@ snapshots:
     dependencies:
       '@types/linkify-it': 5.0.0
       '@types/mdurl': 2.0.0
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/mdurl@2.0.0': {}
 
@@ -9479,6 +9649,8 @@ snapshots:
 
   '@types/tough-cookie@4.0.5':
     optional: true
+
+  '@types/unist@3.0.3': {}
 
   '@types/wait-on@5.3.4':
     dependencies:
@@ -9972,6 +10144,8 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  ccount@2.0.1: {}
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -9998,6 +10172,10 @@ snapshots:
   change-case@5.4.4: {}
 
   char-regex@1.0.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   chardet@2.1.1: {}
 
@@ -10084,6 +10262,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0: {}
 
@@ -10195,6 +10375,10 @@ snapshots:
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diff@4.0.4: {}
 
@@ -10806,6 +10990,24 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   he@1.2.0: {}
 
   headers-polyfill@4.0.3:
@@ -10832,6 +11034,8 @@ snapshots:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.48.0
+
+  html-void-elements@3.0.0: {}
 
   htmlparser2@3.10.1:
     dependencies:
@@ -11643,6 +11847,18 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.1
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
@@ -11650,6 +11866,23 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -11859,6 +12092,14 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   open@10.2.0:
     dependencies:
@@ -12126,6 +12367,8 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-information@7.2.0: {}
+
   prosemirror-commands@1.7.1:
     dependencies:
       prosemirror-model: 1.25.8
@@ -12337,6 +12580,16 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   regexparam@3.0.0: {}
 
   relateurl@0.2.7: {}
@@ -12510,6 +12763,17 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -12546,6 +12810,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  space-separated-tokens@2.0.2: {}
 
   spawn-wrap@2.0.0:
     dependencies:
@@ -12632,6 +12898,11 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -12794,6 +13065,8 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trim-lines@3.0.1: {}
+
   ts-dedent@2.3.0: {}
 
   ts-node@10.9.2(@swc/core@1.15.41)(@types/node@25.9.3)(typescript@6.0.3):
@@ -12871,6 +13144,29 @@ snapshots:
   unicorn-magic@0.3.0: {}
 
   unicorn-magic@0.4.0: {}
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universalify@0.2.0:
     optional: true
@@ -12959,6 +13255,16 @@ snapshots:
       convert-source-map: 2.0.0
 
   v8flags@4.0.1: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-plugin-html@3.2.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)):
     dependencies:
@@ -13232,3 +13538,5 @@ snapshots:
       youch-core: 0.3.3
 
   zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       lucide-react:
         specifier: ^1.18.0
         version: 1.18.0(react@19.2.7)
+      prosemirror-highlight:
+        specifier: ^0.15.2
+        version: 0.15.2(@shikijs/types@3.23.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9)
       prosemirror-view:
         specifier: ^1.41.9
         version: 1.41.9
@@ -6223,6 +6226,47 @@ packages:
 
   prosemirror-gapcursor@1.4.1:
     resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-highlight@0.15.2:
+    resolution: {integrity: sha512-G5Wn4kn+MZMus/7vSh4ZNsC+3yrMpjKsgV6QKKYfwKOPMknRX+3H6FWr+E+Qji4xhmkqdXiToG1VTQ2bZn5b0w==}
+    peerDependencies:
+      '@lezer/common': ^1.0.0
+      '@lezer/highlight': ^1.0.0
+      '@shikijs/types': ^1.29.2 || ^2.0.0 || ^3.0.0 || ^4.0.0
+      '@types/hast': ^3.0.0
+      highlight.js: ^11.9.0
+      lowlight: ^3.1.0
+      prosemirror-model: ^1.19.3
+      prosemirror-state: ^1.4.3
+      prosemirror-transform: ^1.8.0
+      prosemirror-view: ^1.32.4
+      refractor: ^5.0.0
+      sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^1.0.0
+    peerDependenciesMeta:
+      '@lezer/common':
+        optional: true
+      '@lezer/highlight':
+        optional: true
+      '@shikijs/types':
+        optional: true
+      '@types/hast':
+        optional: true
+      highlight.js:
+        optional: true
+      lowlight:
+        optional: true
+      prosemirror-model:
+        optional: true
+      prosemirror-state:
+        optional: true
+      prosemirror-transform:
+        optional: true
+      prosemirror-view:
+        optional: true
+      refractor:
+        optional: true
+      sugar-high:
+        optional: true
 
   prosemirror-history@1.5.0:
     resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
@@ -12406,6 +12450,15 @@ snapshots:
       prosemirror-keymap: 1.2.3
       prosemirror-model: 1.25.8
       prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.9
+
+  prosemirror-highlight@0.15.2(@shikijs/types@3.23.0)(@types/hast@3.0.4)(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.9):
+    optionalDependencies:
+      '@shikijs/types': 3.23.0
+      '@types/hast': 3.0.4
+      prosemirror-model: 1.25.8
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.9
 
   prosemirror-history@1.5.0:


### PR DESCRIPTION
## Summary

Extracts the code-block bundle from the consolidated stack onto current `origin/main` while excluding unrelated ServerFS, folder actions, tables, attachments, internal links, and sidebar changes.

This PR preserves the contributor commits for:

- safe Shiki highlighting and fenced code-block Enter workflow
- code-block copy button
- editable code-block language badge
- badge style lint cleanup

It adds one follow-up commit that applies code-block-specific review hardening and committed Playwright coverage for editing the language badge and verifying persisted Markdown across reload.

## Validation

- `pnpm vitest packages/core/editor/src/__tests__/code-highlight.spec.ts` passed
- `pnpm --filter "@bangle.io/e2e-tests" run test -- src/editor-code-blocks.e2e.ts` passed
- `pnpm lint:ci` passed
- `pnpm test:ci` passed
- `pnpm build` passed
- `pnpm local-ci-check` passed

Notes: build emitted expected local Sentry auth-token warnings and Vite chunk-size warnings. Playwright emitted existing app console warnings around dialog accessibility/nested paragraph markup, but the test suites passed.
