### PR TITLE
[codex] Extract editable Markdown tables

### DIFF
--- a/packages/core/editor/src/__tests__/table-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/table-markdown.spec.ts
@@ -1,0 +1,46 @@
+import {
+  markdownLoader,
+  resolve,
+  Schema,
+  setupBase,
+  setupParagraph,
+  setupTable,
+} from '@bangle.io/prosemirror-plugins';
+import { describe, expect, test } from 'vitest';
+
+describe('table markdown', () => {
+  test('parses and serializes pipe table markdown', () => {
+    const extensions = {
+      base: setupBase(),
+      paragraph: setupParagraph(),
+      table: setupTable(),
+    };
+
+    const resolved = resolve(extensions, false, true);
+    const schema = new Schema({
+      topNode: 'doc',
+      nodes: resolved.nodes,
+      marks: resolved.marks,
+    });
+    const markdown = markdownLoader([...Object.values(extensions)], schema);
+    (
+      markdown.parser as unknown as {
+        tokenizer?: { enable: (name: string) => unknown };
+      }
+    ).tokenizer?.enable?.('table');
+
+    const source = [
+      '| sarah | key | note |',
+      '| ----- | --- | ---- |',
+      '| value | data | test |',
+    ].join('\n');
+
+    const doc = markdown.parser.parse(source);
+    const serialized = markdown.serializer.serialize(doc);
+
+    expect(doc.firstChild?.type.name).toBe('table');
+    expect(serialized).toContain('| sarah | key | note |');
+    expect(serialized).toContain('| ----- | ----- | ----- |');
+    expect(serialized).toContain('| value | data | test |');
+  });
+});

--- a/packages/core/editor/src/__tests__/table-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/table-markdown.spec.ts
@@ -1,40 +1,56 @@
 import {
+  type CollectionType,
   markdownLoader,
   resolve,
   Schema,
   setupBase,
+  setupBold,
+  setupCode,
+  setupImage,
+  setupItalic,
+  setupLink,
   setupParagraph,
   setupTable,
 } from '@bangle.io/prosemirror-plugins';
 import { describe, expect, test } from 'vitest';
 
+function createTableMarkdown() {
+  const extensions = {
+    base: setupBase(),
+    bold: setupBold(),
+    code: setupCode(),
+    image: setupImage(),
+    italic: setupItalic(),
+    link: setupLink(),
+    paragraph: setupParagraph(),
+    table: setupTable(),
+  } satisfies Record<string, CollectionType>;
+
+  const resolved = resolve(extensions, false, true);
+  const schema = new Schema({
+    topNode: 'doc',
+    nodes: resolved.nodes,
+    marks: resolved.marks,
+  });
+  const markdown = markdownLoader([...Object.values(extensions)], schema);
+  (
+    markdown.parser as unknown as {
+      tokenizer?: { enable: (name: string) => unknown };
+    }
+  ).tokenizer?.enable?.('table');
+
+  return markdown;
+}
+
 describe('table markdown', () => {
   test('parses and serializes pipe table markdown', () => {
-    const extensions = {
-      base: setupBase(),
-      paragraph: setupParagraph(),
-      table: setupTable(),
-    };
-
-    const resolved = resolve(extensions, false, true);
-    const schema = new Schema({
-      topNode: 'doc',
-      nodes: resolved.nodes,
-      marks: resolved.marks,
-    });
-    const markdown = markdownLoader([...Object.values(extensions)], schema);
-    (
-      markdown.parser as unknown as {
-        tokenizer?: { enable: (name: string) => unknown };
-      }
-    ).tokenizer?.enable?.('table');
-
     const source = [
       '| sarah | key | note |',
       '| ----- | --- | ---- |',
       '| value | data | test |',
     ].join('\n');
 
+    const markdown = createTableMarkdown();
     const doc = markdown.parser.parse(source);
     const serialized = markdown.serializer.serialize(doc);
 
@@ -42,5 +58,39 @@ describe('table markdown', () => {
     expect(serialized).toContain('| sarah | key | note |');
     expect(serialized).toContain('| ----- | ----- | ----- |');
     expect(serialized).toContain('| value | data | test |');
+  });
+
+  test('serializes inline Markdown inside table cells', () => {
+    const source = [
+      '| format | link | image |',
+      '| ------ | ---- | ----- |',
+      '| **bold** _em_ `code` a \\| b | [site](https://example.com) | ![alt](img.png) |',
+    ].join('\n');
+
+    const markdown = createTableMarkdown();
+    const doc = markdown.parser.parse(source);
+    const serialized = markdown.serializer.serialize(doc);
+
+    expect(serialized).toContain(
+      '| **bold** _em_ `code` a \\| b | [site](https://example.com) | ![alt](img.png) |',
+    );
+  });
+
+  test('escapes table delimiters without losing inline code pipes', () => {
+    const source = [
+      '| code | text |',
+      '| ---- | ---- |',
+      '| `a\\|b` | a \\| b |',
+    ].join('\n');
+
+    const markdown = createTableMarkdown();
+    const doc = markdown.parser.parse(source);
+    const serialized = markdown.serializer.serialize(doc);
+
+    expect(serialized).toContain('| `a\\|b` | a \\| b |');
+
+    const reparsed = markdown.parser.parse(serialized);
+    const codeCell = reparsed.firstChild?.child(1).child(0);
+    expect(codeCell?.textContent).toBe('a|b');
   });
 });

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -248,6 +248,80 @@ export function SlashCommand({
 
           <CommandSeparator />
 
+          <CommandGroup heading="Table">
+            <CommandItem
+              value="table-insert"
+              onSelect={() => {
+                dismissCommandUi();
+                ext.table.command.insertTable(1, 1)(
+                  editorView.state,
+                  editorView.dispatch,
+                  editorView,
+                );
+              }}
+            >
+              Insert table
+            </CommandItem>
+            {ext.table.query.isTableActive(editorView.state) && (
+              <>
+                <CommandItem
+                  value="table-add-row"
+                  onSelect={() => {
+                    dismissCommandUi();
+                    ext.table.command.addRowAfter(
+                      editorView.state,
+                      editorView.dispatch,
+                      editorView,
+                    );
+                  }}
+                >
+                  + Row below
+                </CommandItem>
+                <CommandItem
+                  value="table-add-column"
+                  onSelect={() => {
+                    dismissCommandUi();
+                    ext.table.command.addColumnAfter(
+                      editorView.state,
+                      editorView.dispatch,
+                      editorView,
+                    );
+                  }}
+                >
+                  + Column right
+                </CommandItem>
+                <CommandItem
+                  value="table-delete-row"
+                  onSelect={() => {
+                    dismissCommandUi();
+                    ext.table.command.deleteRow(
+                      editorView.state,
+                      editorView.dispatch,
+                      editorView,
+                    );
+                  }}
+                >
+                  - Row
+                </CommandItem>
+                <CommandItem
+                  value="table-delete-column"
+                  onSelect={() => {
+                    dismissCommandUi();
+                    ext.table.command.deleteColumn(
+                      editorView.state,
+                      editorView.dispatch,
+                      editorView,
+                    );
+                  }}
+                >
+                  - Column
+                </CommandItem>
+              </>
+            )}
+          </CommandGroup>
+
+          <CommandSeparator />
+
           <CommandGroup heading="Time">
             <CommandItem
               value="today"

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -23,6 +23,7 @@ import {
   setupSelectionMenu,
   setupStrike,
   setupSuggestions,
+  setupTable,
   setupUnderline,
   setupWikiLink,
   type WikiLinkConfig,
@@ -62,6 +63,7 @@ export function setupExtensions(
     heading: setupHeading(),
     history: setupHistory(),
     paragraph: setupParagraph(),
+    table: setupTable(),
     strike: setupStrike(),
     suggestions: setupSuggestions({
       providerId: 'slash-command',

--- a/packages/core/editor/src/pm-setup.ts
+++ b/packages/core/editor/src/pm-setup.ts
@@ -73,6 +73,11 @@ export function createEditor({
   });
 
   const markdown = markdownLoader([...Object.values(extensions)], schema);
+  (
+    markdown.parser as unknown as {
+      tokenizer?: { enable: (name: string) => unknown };
+    }
+  ).tokenizer?.enable?.('table');
 
   const view = new EditorView(
     { mount: domNode },

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -185,6 +185,30 @@ div.ProseMirror {
     font-weight: inherit;
   }
 
+  & table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5rem 0;
+    font-size: 0.95rem;
+  }
+
+  & th,
+  & td {
+    border: 1px solid hsl(var(--BV-border) / 0.7);
+    padding: 0.45rem 0.6rem;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  & th {
+    background-color: hsl(var(--BV-accent) / 0.55);
+    font-weight: 600;
+  }
+
+  & tr:nth-child(even) td {
+    background-color: hsl(var(--BV-accent) / 0.25);
+  }
+
   & hr {
     margin: 2em 0;
   }

--- a/packages/js-lib/banger-editor/src/index.ts
+++ b/packages/js-lib/banger-editor/src/index.ts
@@ -31,5 +31,6 @@ export * from './selection-menu';
 export * from './store';
 export * from './strike';
 export * from './suggestions';
+export * from './table';
 export * from './underline';
 export * from './wiki-link';

--- a/packages/js-lib/banger-editor/src/table.ts
+++ b/packages/js-lib/banger-editor/src/table.ts
@@ -1,0 +1,483 @@
+import { type CollectionType, collection, keybinding } from './common';
+import {
+  type Command,
+  type EditorState,
+  Fragment,
+  type NodeSpec,
+  type NodeType,
+  type PMNode,
+  TextSelection,
+} from './pm';
+import { findParentNodeOfType, getNodeType, safeInsert } from './pm-utils';
+
+export type TableConfig = {
+  tableGroup?: string;
+  cellContent?: string;
+};
+
+type RequiredConfig = Required<TableConfig>;
+
+const DEFAULT_CONFIG: RequiredConfig = {
+  tableGroup: 'block',
+  cellContent: 'inline*',
+};
+
+export function setupTable(userConfig?: TableConfig) {
+  const config: RequiredConfig = {
+    ...DEFAULT_CONFIG,
+    ...userConfig,
+  };
+
+  const nodes: Record<string, NodeSpec> = {
+    table: {
+      content: 'table_row+',
+      group: config.tableGroup,
+      parseDOM: [{ tag: 'table' }],
+      toDOM: () => ['table', ['tbody', 0]],
+    },
+    table_row: {
+      content: '(table_cell|table_header)+',
+      parseDOM: [{ tag: 'tr' }],
+      toDOM: () => ['tr', 0],
+    },
+    table_header: {
+      content: config.cellContent,
+      parseDOM: [{ tag: 'th' }],
+      toDOM: () => ['th', 0],
+    },
+    table_cell: {
+      content: config.cellContent,
+      parseDOM: [{ tag: 'td' }],
+      toDOM: () => ['td', 0],
+    },
+  };
+
+  return collection({
+    id: 'table',
+    nodes,
+    plugin: {
+      keybindings: tableKeybindings(),
+    },
+    command: {
+      insertTable: insertTable(),
+      addRowAfter: addRowAfter(),
+      deleteRow: deleteRow(),
+      addColumnAfter: addColumnAfter(),
+      deleteColumn: deleteColumn(),
+    },
+    query: {
+      isTableActive: isTableActive(),
+    },
+    markdown: markdown(),
+  });
+}
+
+function tableKeybindings() {
+  return keybinding(
+    [
+      ['Enter', insertNewLineInCell],
+      ['Backspace', preventDeleteInEmptyCell],
+      ['Delete', preventDeleteInEmptyCell],
+    ],
+    'table',
+    1000,
+  );
+}
+
+function markdown(): CollectionType['markdown'] {
+  return {
+    nodes: {
+      table: {
+        toMarkdown(state, node) {
+          writeTableToMarkdown(state, node);
+          state.closeBlock(node);
+        },
+        parseMarkdown: {
+          table: { block: 'table' },
+          thead: { ignore: true },
+          tbody: { ignore: true },
+        },
+      },
+      table_row: {
+        toMarkdown() {},
+        parseMarkdown: {
+          tr: { block: 'table_row' },
+        },
+      },
+      table_header: {
+        toMarkdown() {},
+        parseMarkdown: {
+          th: { block: 'table_header' },
+        },
+      },
+      table_cell: {
+        toMarkdown() {},
+        parseMarkdown: {
+          td: { block: 'table_cell' },
+        },
+      },
+    },
+  };
+}
+
+function writeTableToMarkdown(
+  state: {
+    write: (content: string) => void;
+    ensureNewLine: () => void;
+  },
+  tableNode: PMNode,
+) {
+  const rows: string[][] = [];
+
+  tableNode.forEach((rowNode) => {
+    const rowCells: string[] = [];
+
+    rowNode.forEach((cellNode) => {
+      rowCells.push(stringifyTableCell(cellNode));
+    });
+
+    rows.push(rowCells);
+  });
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  const columnCount = Math.max(...rows.map((row) => row.length), 0);
+  if (columnCount === 0) {
+    return;
+  }
+
+  const normalizedRows = rows.map((row) =>
+    row.length === columnCount
+      ? row
+      : [...row, ...Array(columnCount - row.length).fill('')],
+  );
+
+  const header = normalizedRows[0] || [];
+  state.write(`| ${header.join(' | ')} |`);
+  state.ensureNewLine();
+  state.write(`| ${Array(columnCount).fill('-----').join(' | ')} |`);
+  state.ensureNewLine();
+
+  for (let i = 1; i < normalizedRows.length; i++) {
+    const row = normalizedRows[i] || [];
+    state.write(`| ${row.join(' | ')} |`);
+    state.ensureNewLine();
+  }
+}
+
+function stringifyTableCell(cellNode: PMNode): string {
+  return cellNode.textContent
+    .replace(/\n+/g, '<br>')
+    .replace(/\|/g, '\\|')
+    .trim();
+}
+
+function insertTable() {
+  return (rows = 3, columns = 3): Command =>
+    (state, dispatch) => {
+      const tableType = getNodeType(state.schema, 'table');
+      const rowType = getNodeType(state.schema, 'table_row');
+      const headerType = getNodeType(state.schema, 'table_header');
+      const cellType = getNodeType(state.schema, 'table_cell');
+
+      const safeRows = Math.max(1, rows);
+      const safeColumns = Math.max(1, columns);
+      const rowNodes = Array.from({ length: safeRows }, (_, rowIndex) => {
+        const isHeader = rowIndex === 0;
+        const columnType = isHeader ? headerType : cellType;
+        const cells = Array.from({ length: safeColumns }, () =>
+          createEmptyCell(columnType),
+        );
+        return rowType.create(null, cells);
+      });
+
+      const tableNode = tableType.create(null, rowNodes);
+      if (dispatch) {
+        const tr = safeInsert(tableNode)(state.tr);
+        dispatch(tr.scrollIntoView());
+      }
+
+      return true;
+    };
+}
+
+function addRowAfter(): Command {
+  return (state, dispatch) => {
+    const resolved = resolveTableSelection(state);
+    if (!resolved) {
+      return false;
+    }
+
+    const rowType = getNodeType(state.schema, 'table_row');
+    const cellType = getNodeType(state.schema, 'table_cell');
+    const columnCount = Math.max(1, resolved.row.node.childCount);
+    const newRow = rowType.create(
+      null,
+      Array.from({ length: columnCount }, () => createEmptyCell(cellType)),
+    );
+
+    if (dispatch) {
+      const insertPos = resolved.row.pos + resolved.row.node.nodeSize;
+      const tr = state.tr.insert(insertPos, newRow);
+      const selectionPos = Math.min(insertPos + 2, tr.doc.content.size);
+      dispatch(tr.setSelection(TextSelection.create(tr.doc, selectionPos)));
+    }
+
+    return true;
+  };
+}
+
+function deleteRow(): Command {
+  return (state, dispatch) => {
+    const resolved = resolveTableSelection(state);
+    if (!resolved) {
+      return false;
+    }
+
+    if (!dispatch) {
+      return true;
+    }
+
+    if (resolved.table.node.childCount <= 1) {
+      const tr = state.tr.delete(
+        resolved.table.pos,
+        resolved.table.pos + resolved.table.node.nodeSize,
+      );
+      dispatch(tr.scrollIntoView());
+      return true;
+    }
+
+    const tr = state.tr.delete(
+      resolved.row.pos,
+      resolved.row.pos + resolved.row.node.nodeSize,
+    );
+    dispatch(tr.scrollIntoView());
+    return true;
+  };
+}
+
+function addColumnAfter(): Command {
+  return (state, dispatch) => {
+    const resolved = resolveTableSelection(state);
+    if (!resolved) {
+      return false;
+    }
+
+    if (!dispatch) {
+      return true;
+    }
+
+    const headerType = getNodeType(state.schema, 'table_header');
+    const cellType = getNodeType(state.schema, 'table_cell');
+    const rows = getTableRowsWithPositions(resolved.table);
+    const tr = state.tr;
+
+    for (let i = rows.length - 1; i >= 0; i--) {
+      const row = rows[i];
+      if (!row) {
+        continue;
+      }
+
+      const targetCol = Math.min(resolved.colIndex, row.node.childCount - 1);
+      const targetCell = row.node.child(targetCol);
+      const cellStartOffset = getChildOffsetAtIndex(row.node, targetCol);
+      if (!targetCell || cellStartOffset == null) {
+        continue;
+      }
+
+      const insertPos = row.start + cellStartOffset + targetCell.nodeSize;
+      const type = row.index === 0 ? headerType : cellType;
+      tr.insert(insertPos, createEmptyCell(type));
+    }
+
+    dispatch(tr.scrollIntoView());
+    return true;
+  };
+}
+
+function deleteColumn(): Command {
+  return (state, dispatch) => {
+    const resolved = resolveTableSelection(state);
+    if (!resolved) {
+      return false;
+    }
+
+    if (!dispatch) {
+      return true;
+    }
+
+    const rows = getTableRowsWithPositions(resolved.table);
+    const maxColumns = Math.max(...rows.map((row) => row.node.childCount), 0);
+
+    if (maxColumns <= 1) {
+      const tr = state.tr.delete(
+        resolved.table.pos,
+        resolved.table.pos + resolved.table.node.nodeSize,
+      );
+      dispatch(tr.scrollIntoView());
+      return true;
+    }
+
+    const deleteRanges: Array<{ from: number; to: number }> = [];
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      if (!row || resolved.colIndex >= row.node.childCount) {
+        continue;
+      }
+
+      const cellOffset = getChildOffsetAtIndex(row.node, resolved.colIndex);
+      const cell = row.node.child(resolved.colIndex);
+      if (cellOffset == null || !cell) {
+        continue;
+      }
+
+      const from = row.start + cellOffset;
+      const to = from + cell.nodeSize;
+      deleteRanges.push({ from, to });
+    }
+
+    if (deleteRanges.length === 0) {
+      return false;
+    }
+
+    const tr = state.tr;
+    deleteRanges
+      .sort((a, b) => b.from - a.from)
+      .forEach(({ from, to }) => tr.delete(from, to));
+
+    dispatch(tr.scrollIntoView());
+    return true;
+  };
+}
+
+function isTableActive() {
+  return (state: EditorState) => {
+    const tableType = getNodeType(state.schema, 'table');
+    return Boolean(findParentNodeOfType(tableType)(state.selection));
+  };
+}
+
+function resolveTableSelection(state: EditorState):
+  | {
+      table: NonNullable<ReturnType<ReturnType<typeof findParentNodeOfType>>>;
+      row: NonNullable<ReturnType<ReturnType<typeof findParentNodeOfType>>>;
+      cell: NonNullable<ReturnType<ReturnType<typeof findParentNodeOfType>>>;
+      rowIndex: number;
+      colIndex: number;
+    }
+  | undefined {
+  const tableType = getNodeType(state.schema, 'table');
+  const rowType = getNodeType(state.schema, 'table_row');
+  const headerType = getNodeType(state.schema, 'table_header');
+  const cellType = getNodeType(state.schema, 'table_cell');
+
+  const table = findParentNodeOfType(tableType)(state.selection);
+  const row = findParentNodeOfType(rowType)(state.selection);
+  const cell = findParentNodeOfType([headerType, cellType])(state.selection);
+
+  if (!table || !row || !cell) {
+    return;
+  }
+
+  const rowIndex = getChildIndexAtPos(table, row.pos);
+  const colIndex = getChildIndexAtPos(row, cell.pos);
+
+  if (rowIndex < 0 || colIndex < 0) {
+    return;
+  }
+
+  return { table, row, cell, rowIndex, colIndex };
+}
+
+function getChildIndexAtPos(
+  parent: { node: PMNode; start: number },
+  childPos: number,
+): number {
+  let index = -1;
+  parent.node.forEach((child, offset, i) => {
+    const start = parent.start + offset;
+    const end = start + child.nodeSize;
+    if (childPos >= start && childPos < end) {
+      index = i;
+    }
+  });
+  return index;
+}
+
+function getChildOffsetAtIndex(
+  node: PMNode,
+  index: number,
+): number | undefined {
+  let found: number | undefined;
+  node.forEach((_child, offset, i) => {
+    if (i === index) {
+      found = offset;
+    }
+  });
+  return found;
+}
+
+function getTableRowsWithPositions(table: { node: PMNode; start: number }) {
+  const rows: Array<{ node: PMNode; start: number; index: number }> = [];
+  table.node.forEach((rowNode, offset, index) => {
+    rows.push({
+      node: rowNode,
+      start: table.start + offset,
+      index,
+    });
+  });
+  return rows;
+}
+
+function createEmptyCell(type: NodeType): PMNode {
+  return type.createAndFill() ?? type.create(null, Fragment.empty);
+}
+
+const insertNewLineInCell: Command = (state, dispatch) => {
+  if (isSlashSuggestionActive(state) || !state.selection.empty) {
+    return false;
+  }
+
+  const headerType = getNodeType(state.schema, 'table_header');
+  const cellType = getNodeType(state.schema, 'table_cell');
+  const hardBreakType = state.schema.nodes.hard_break;
+  const cell = findParentNodeOfType([headerType, cellType])(state.selection);
+
+  if (!cell || !hardBreakType) {
+    return false;
+  }
+
+  if (dispatch) {
+    dispatch(
+      state.tr.replaceSelectionWith(hardBreakType.create()).scrollIntoView(),
+    );
+  }
+  return true;
+};
+
+const preventDeleteInEmptyCell: Command = (state) => {
+  if (isSlashSuggestionActive(state)) {
+    return false;
+  }
+
+  if (!state.selection.empty) {
+    return false;
+  }
+
+  const headerType = getNodeType(state.schema, 'table_header');
+  const cellType = getNodeType(state.schema, 'table_cell');
+  const cell = findParentNodeOfType([headerType, cellType])(state.selection);
+
+  if (!cell) {
+    return false;
+  }
+
+  return cell.node.content.size === 0;
+};
+
+function isSlashSuggestionActive(state: EditorState): boolean {
+  const marks = state.selection.$from.marks();
+  return marks.some((mark) => mark.type.name === 'slash_command');
+}

--- a/packages/js-lib/banger-editor/src/table.ts
+++ b/packages/js-lib/banger-editor/src/table.ts
@@ -1,3 +1,4 @@
+import type { MarkdownSerializerState } from 'prosemirror-markdown';
 import { type CollectionType, collection, keybinding } from './common';
 import {
   type Command,
@@ -121,10 +122,7 @@ function markdown(): CollectionType['markdown'] {
 }
 
 function writeTableToMarkdown(
-  state: {
-    write: (content: string) => void;
-    ensureNewLine: () => void;
-  },
+  state: MarkdownSerializerState,
   tableNode: PMNode,
 ) {
   const rows: string[][] = [];
@@ -133,7 +131,7 @@ function writeTableToMarkdown(
     const rowCells: string[] = [];
 
     rowNode.forEach((cellNode) => {
-      rowCells.push(stringifyTableCell(cellNode));
+      rowCells.push(stringifyTableCell(state, cellNode));
     });
 
     rows.push(rowCells);
@@ -167,11 +165,29 @@ function writeTableToMarkdown(
   }
 }
 
-function stringifyTableCell(cellNode: PMNode): string {
-  return cellNode.textContent
+function stringifyTableCell(
+  state: MarkdownSerializerState,
+  cellNode: PMNode,
+): string {
+  return renderInlineToString(state, cellNode)
     .replace(/\n+/g, '<br>')
     .replace(/\|/g, '\\|')
     .trim();
+}
+
+function renderInlineToString(
+  state: MarkdownSerializerState,
+  node: PMNode,
+): string {
+  const stateWithOutput = state as MarkdownSerializerState & { out: string };
+  const previousOutput = stateWithOutput.out;
+  stateWithOutput.out = '';
+  try {
+    state.renderInline(node);
+    return stateWithOutput.out;
+  } finally {
+    stateWithOutput.out = previousOutput;
+  }
 }
 
 function insertTable() {
@@ -345,7 +361,9 @@ function deleteColumn(): Command {
     const tr = state.tr;
     deleteRanges
       .sort((a, b) => b.from - a.from)
-      .forEach(({ from, to }) => tr.delete(from, to));
+      .forEach(({ from, to }) => {
+        tr.delete(from, to);
+      });
 
     dispatch(tr.scrollIntoView());
     return true;

--- a/packages/tooling/e2e-tests/src/editor-tables.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-tables.e2e.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspaceAndNote,
+  getEditorLocator,
+  readStoredMarkdown,
+  writeStoredMarkdown,
+} from './common';
+
+test('renders a Markdown table and persists table edits across reload', async ({
+  page,
+}) => {
+  const workspaceName = 'editor-tables';
+  const noteName = 'table';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    '| First |\n| --- |\n| alpha |',
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const firstCell = editor.locator('td').first();
+  await firstCell.click();
+  await page.keyboard.insertText('alpha');
+
+  await expect(editor.locator('table')).toBeVisible();
+  await expect(firstCell).toContainText('alpha');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toContain('| alphaalpha |');
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(editor.locator('table')).toBeVisible();
+  await expect(firstCell).toContainText('alphaalpha');
+});
+
+test('inserts a table from the slash command and reloads it as a table', async ({
+  page,
+}) => {
+  const workspaceName = 'editor-tables-slash';
+  const noteName = 'table';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await page.keyboard.insertText('/');
+  await page.getByText('Insert table').click();
+
+  const firstHeader = editor.locator('th').first();
+  await expect(firstHeader).toBeVisible();
+  await firstHeader.click();
+  await page.keyboard.insertText('Name');
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toContain('| Name |');
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(editor.locator('table')).toBeVisible();
+  await expect(firstHeader).toContainText('Name');
+});


### PR DESCRIPTION
## Summary

Extracts the editable Markdown tables feature from the consolidated Bangle.io stack onto current `origin/main`.

- Adds a table extension in `@bangle.io/prosemirror-plugins` with schema, commands, key handling, and Markdown parse/serialize support.
- Wires tables into the editor setup, slash command menu, and editor typography.
- Adds focused Markdown fidelity tests and Playwright coverage for loading/editing/reloading tables and inserting a table through the slash command.

## Scope control

This intentionally excludes Shiki, code highlighting, code copy controls, language badges, ServerFS, folder actions, attachments, internal-link/sidebar changes, and other consolidated branch work.

## Validation

- `pnpm lint:ci` PASS
- `pnpm test:ci` PASS
- `CI=1 pnpm --filter "@bangle.io/e2e-tests" exec playwright test -c ./playwright.config.ts src/editor-tables.e2e.ts` PASS
- `pnpm build` PASS
- `CI=1 pnpm local-ci-check` PASS

Note: Playwright runs still emit existing dialog/notice console warnings unrelated to this table extraction, but the commands exit successfully.