### PR TITLE
fix: avoid full workspace rescan on note create

### DIFF
--- a/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
@@ -277,3 +277,144 @@ describe('WorkspaceStateService backlink index', () => {
     }
   });
 });
+
+describe('WorkspaceStateService file tree updates', () => {
+  let controller = new AbortController();
+
+  beforeEach(() => {
+    controller = new AbortController();
+  });
+
+  afterEach(() => {
+    controller.abort();
+  });
+
+  it('adds newly created notes to workspace state without a full rescan', async () => {
+    const { services } = await setupWorkspaceStateService({ controller });
+    const newWsPath = `${WS_NAME}:NewNote.md`;
+    const originalListFiles = services.fileSystem.listFiles.bind(
+      services.fileSystem,
+    );
+    const listFiles = vi
+      .spyOn(services.fileSystem, 'listFiles')
+      .mockImplementation(originalListFiles);
+
+    await services.fileSystem.createTextFile(newWsPath, 'Created note');
+    services.navigation.goWsPath(newWsPath);
+
+    await vi.waitUntil(() => {
+      return (
+        services.workspaceState.resolveAtoms().currentWsPath?.wsPath ===
+        newWsPath
+      );
+    });
+
+    expect(
+      services.workspaceState.resolveAtoms().wsPaths.map((path) => path.wsPath),
+    ).toContain(newWsPath);
+    expect(listFiles).not.toHaveBeenCalled();
+  });
+
+  it('keeps an incremental create when an older full rescan resolves later', async () => {
+    const { services, store } = await setupWorkspaceStateService({
+      controller,
+    });
+    const newWsPath = `${WS_NAME}:CreatedDuringScan.md`;
+    const stalePaths = services.workspaceState
+      .resolveAtoms()
+      .wsPaths.map((path) => path.wsPath);
+    const blockedScan = createDeferred<string[]>();
+    const originalListFiles = services.fileSystem.listFiles.bind(
+      services.fileSystem,
+    );
+    let listFilesCalls = 0;
+    vi.spyOn(services.fileSystem, 'listFiles').mockImplementation(
+      (wsName, abortSignal) => {
+        listFilesCalls += 1;
+        if (listFilesCalls === 1) {
+          return blockedScan.promise;
+        }
+        return originalListFiles(wsName, abortSignal);
+      },
+    );
+
+    store.set(services.fileSystem.$fileForceUpdateCount, (count) => count + 1);
+    await vi.waitUntil(() => listFilesCalls === 1);
+
+    await services.fileSystem.createTextFile(newWsPath, 'Created note');
+    services.navigation.goWsPath(newWsPath);
+    await vi.waitUntil(() => {
+      return (
+        services.workspaceState.resolveAtoms().currentWsPath?.wsPath ===
+        newWsPath
+      );
+    });
+
+    blockedScan.resolve(stalePaths);
+    await blockedScan.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      services.workspaceState.resolveAtoms().wsPaths.map((path) => path.wsPath),
+    ).toContain(newWsPath);
+    expect(services.workspaceState.resolveAtoms().currentWsPath?.wsPath).toBe(
+      newWsPath,
+    );
+  });
+
+  it('tracks multiple created notes without a full rescan', async () => {
+    const { services } = await setupWorkspaceStateService({ controller });
+    const firstWsPath = `${WS_NAME}:BurstOne.md`;
+    const secondWsPath = `${WS_NAME}:BurstTwo.md`;
+    const originalListFiles = services.fileSystem.listFiles.bind(
+      services.fileSystem,
+    );
+    const listFiles = vi
+      .spyOn(services.fileSystem, 'listFiles')
+      .mockImplementation(originalListFiles);
+
+    await Promise.all([
+      services.fileSystem.createTextFile(firstWsPath, 'First'),
+      services.fileSystem.createTextFile(secondWsPath, 'Second'),
+    ]);
+
+    await vi.waitUntil(() => {
+      const wsPaths = services.workspaceState
+        .resolveAtoms()
+        .wsPaths.map((path) => path.wsPath);
+      return wsPaths.includes(firstWsPath) && wsPaths.includes(secondWsPath);
+    });
+
+    expect(listFiles).not.toHaveBeenCalled();
+  });
+
+  it('does not add unsupported created files to workspace note state', async () => {
+    const { services, store } = await setupWorkspaceStateService({
+      controller,
+    });
+    const unsupportedWsPath = `${WS_NAME}:asset.txt`;
+    const originalListFiles = services.fileSystem.listFiles.bind(
+      services.fileSystem,
+    );
+    const listFiles = vi
+      .spyOn(services.fileSystem, 'listFiles')
+      .mockImplementation(originalListFiles);
+
+    await services.fileSystem.createFile(
+      unsupportedWsPath,
+      new File(['not a note'], 'asset.txt', { type: 'text/plain' }),
+    );
+
+    await vi.waitUntil(() => {
+      return (
+        store.get(services.fileSystem.$fileCreateEvent)?.wsPath ===
+        unsupportedWsPath
+      );
+    });
+
+    expect(
+      services.workspaceState.resolveAtoms().wsPaths.map((path) => path.wsPath),
+    ).not.toContain(unsupportedWsPath);
+    expect(listFiles).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -29,6 +29,11 @@ export type FileContentUpdateEvent = {
   wsPath: string;
 };
 
+export type FileCreateEvent = {
+  sequence: number;
+  wsPath: string;
+};
+
 type FileReadOptions = {
   signal?: AbortSignal;
 };
@@ -53,15 +58,17 @@ export class FileSystemService extends BaseService {
   $fileDeleteCount = atom(0);
   $fileRenameCount = atom(0);
   $fileForceUpdateCount = atom(0);
+  $fileCreateEvent = atom<FileCreateEvent | undefined>(undefined);
   $fileContentUpdateEvent = atom<FileContentUpdateEvent | undefined>(undefined);
 
+  private fileCreateSequence = 0;
   private fileContentUpdateSequence = 0;
 
   $fileTreeChangeCount = atom((get) => {
     return (
-      get(this.$fileCreateCount) +
       get(this.$fileDeleteCount) +
-      get(this.$fileRenameCount)
+      get(this.$fileRenameCount) +
+      get(this.$fileForceUpdateCount)
     );
   });
 
@@ -97,6 +104,11 @@ export class FileSystemService extends BaseService {
         switch (event.type) {
           case 'file-create': {
             this.store.set(this.$fileCreateCount, (c) => c + 1);
+            this.fileCreateSequence += 1;
+            this.store.set(this.$fileCreateEvent, {
+              sequence: this.fileCreateSequence,
+              wsPath: event.wsPath,
+            });
             break;
           }
           case 'file-content-update': {

--- a/packages/core/service-core/src/workspace-state-service.ts
+++ b/packages/core/service-core/src/workspace-state-service.ts
@@ -79,6 +79,14 @@ function throwIfAborted(signal: AbortSignal): void {
   }
 }
 
+function appendSortedUniqueWsPath(paths: string[], wsPath: string): string[] {
+  if (paths.includes(wsPath)) {
+    return paths;
+  }
+
+  return [...paths, wsPath].sort((a, b) => a.localeCompare(b));
+}
+
 /**
  * Manages the state of current and available workspaces
  */
@@ -197,6 +205,9 @@ export class WorkspaceStateService extends BaseService {
     super(SERVICE_NAME.workspaceStateService, context, dep);
   }
 
+  private createdWsPathsBySequence = new Map<number, string>();
+  private handledFileCreateSequence = 0;
+
   async hookMount(): Promise<void> {
     this.addCleanup(
       this.store.sub(
@@ -204,6 +215,7 @@ export class WorkspaceStateService extends BaseService {
           const abortController = new AbortController();
           get(this.fileSystem.$fileTreeChangeCount);
           const wsName = get(this.$currentWsName);
+          const createSequenceAtScanStart = this.handledFileCreateSequence;
           if (!wsName) {
             set(this.$rawWsPaths, EMPTY_STRING_ARRAY);
             return;
@@ -214,12 +226,51 @@ export class WorkspaceStateService extends BaseService {
             this.emitAppError,
           ).then((paths) => {
             if (!abortController.signal.aborted) {
-              set(this.$rawWsPaths, paths);
+              set(
+                this.$rawWsPaths,
+                this.mergeCreatedWsPathsAfterSequence({
+                  paths,
+                  sequence: createSequenceAtScanStart,
+                  wsName,
+                }),
+              );
+              this.pruneCreatedWsPathsThrough(createSequenceAtScanStart);
             }
           });
           return () => {
             abortController.abort();
           };
+        }),
+        () => {},
+      ),
+    );
+
+    this.addCleanup(
+      this.store.sub(
+        atomEffect((get, set) => {
+          const createEvent = get(this.fileSystem.$fileCreateEvent);
+          if (
+            !createEvent ||
+            createEvent.sequence <= this.handledFileCreateSequence
+          ) {
+            return;
+          }
+          this.handledFileCreateSequence = createEvent.sequence;
+
+          const filePath = this.getSupportedFilePath(createEvent.wsPath);
+          const wsName = get(this.$currentWsName);
+          if (!wsName || !filePath || filePath.wsName !== wsName) {
+            return;
+          }
+          this.createdWsPathsBySequence.set(
+            createEvent.sequence,
+            filePath.wsPath,
+          );
+
+          set(
+            this.$rawWsPaths,
+            appendSortedUniqueWsPath(get(this.$rawWsPaths), filePath.wsPath),
+          );
         }),
         () => {},
       ),
@@ -236,6 +287,49 @@ export class WorkspaceStateService extends BaseService {
 
   private get workspaceOps() {
     return this.dep.workspaceOps;
+  }
+
+  private getSupportedFilePath(wsPath: string): WsFilePath | undefined {
+    const filePath = WsPath.safeParse(wsPath).data?.asFile();
+    const extension = filePath?.extension;
+    if (!filePath || !extension) {
+      return undefined;
+    }
+
+    return this.fileSystem.isFileTypeSupported({ extension })
+      ? filePath
+      : undefined;
+  }
+
+  private mergeCreatedWsPathsAfterSequence({
+    paths,
+    sequence,
+    wsName,
+  }: {
+    paths: string[];
+    sequence: number;
+    wsName: string;
+  }): string[] {
+    let nextPaths = paths;
+    for (const [createSequence, createdWsPath] of this
+      .createdWsPathsBySequence) {
+      if (createSequence <= sequence) {
+        continue;
+      }
+      const filePath = this.getSupportedFilePath(createdWsPath);
+      if (filePath?.wsName === wsName) {
+        nextPaths = appendSortedUniqueWsPath(nextPaths, filePath.wsPath);
+      }
+    }
+    return nextPaths;
+  }
+
+  private pruneCreatedWsPathsThrough(sequence: number): void {
+    for (const createSequence of this.createdWsPathsBySequence.keys()) {
+      if (createSequence <= sequence) {
+        this.createdWsPathsBySequence.delete(createSequence);
+      }
+    }
   }
 
   hasWorkspace(wsName: string) {


### PR DESCRIPTION
## Summary
- add sequenced file-create events so note creation can update workspace state incrementally
- keep delete/rename/force refresh on the full file-tree rescan path
- merge create events that happen while an older `listFiles()` scan is in flight so stale scans cannot drop new notes
- add service-level regression coverage for incremental create, stale scan races, burst creates, and unsupported files

## Validation
- `pnpm exec biome check --write packages/core/service-core/src/workspace-state-service.ts packages/core/service-core/src/file-system-service.ts packages/core/service-core/src/__tests__/workspace-state-service.spec.ts`
- `pnpm vitest packages/core/service-core/src/__tests__/workspace-state-service.spec.ts --run`
- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm local-ci-check`

## Review
- thermonuclear review found an initial stale-scan race; fixed with sequenced create merging
- final thermonuclear review on the exact current diff found no high-confidence findings

Note: Playwright still emits existing Radix dialog-title/description and nested `<p>` console warnings during the suite; tests pass.