### PR TITLE
[codex] add general settings page

### DIFF
--- a/packages/core/app/src/index.tsx
+++ b/packages/core/app/src/index.tsx
@@ -20,6 +20,7 @@ import {
   PageNativeFsAuthFailed,
   PageNativeFsAuthReq,
   PageNotFound,
+  PageSettings,
   PageWelcome,
   PageWorkspaceNotFound,
   PageWsHome,
@@ -83,6 +84,8 @@ function AppRoutes() {
       return <PageFatalError />;
     case 'not-found':
       return <PageNotFound />;
+    case 'settings-general':
+      return <PageSettings />;
 
     default: {
       // Use assertion for exhaustiveness check

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -19,10 +19,10 @@ import {
   Folder,
   MessageCircle,
   Move,
-  Paintbrush2,
   Pencil,
   PlusIcon,
   Search,
+  Settings2,
   Trash2,
 } from 'lucide-react';
 import React, { useMemo } from 'react';
@@ -241,14 +241,15 @@ export const AppSidebar = ({ children }: SidebarProps) => {
               <Command className="mr-2 h-4 w-4" />
               <span>{t.app.sidebar.allCommands}</span>
             </DropdownMenu.DropdownMenuItem>
-            <DropdownMenu.DropdownMenuItem
-              onClick={() =>
-                commandDispatcher.dispatch('command::ui:switch-theme', {}, 'ui')
+            <SettingsMenuItem
+              onOpenSettings={() =>
+                commandDispatcher.dispatch(
+                  'command::ui:open-settings',
+                  null,
+                  'ui',
+                )
               }
-            >
-              <Paintbrush2 className="mr-2 h-4 w-4" />
-              <span>{t.app.sidebar.changeTheme}</span>
-            </DropdownMenu.DropdownMenuItem>
+            />
 
             <DropdownMenu.DropdownMenuSeparator />
             <DropdownMenu.DropdownMenuLabel className="text-muted-foreground text-xs">
@@ -306,3 +307,21 @@ export const AppSidebar = ({ children }: SidebarProps) => {
     </Sidebar.SidebarProvider>
   );
 };
+
+function SettingsMenuItem({ onOpenSettings }: { onOpenSettings: () => void }) {
+  const { isMobile, setOpenMobile } = Sidebar.useSidebar();
+
+  return (
+    <DropdownMenu.DropdownMenuItem
+      onClick={() => {
+        if (isMobile) {
+          setOpenMobile(false);
+        }
+        onOpenSettings();
+      }}
+    >
+      <Settings2 className="mr-2 h-4 w-4" />
+      <span>{t.app.sidebar.settings}</span>
+    </DropdownMenu.DropdownMenuItem>
+  );
+}

--- a/packages/core/app/src/layout/main-content-container.tsx
+++ b/packages/core/app/src/layout/main-content-container.tsx
@@ -12,6 +12,12 @@ export interface PageContentContainerProps {
    * @default true
    */
   applyPadding?: boolean;
+  /**
+   * If true, constrain content based on the editor width preference.
+   * Non-editor pages with their own layout should opt out.
+   * @default true
+   */
+  respectEditorWidthPreference?: boolean;
 }
 
 /**
@@ -20,6 +26,7 @@ export interface PageContentContainerProps {
 export function PageContentContainer({
   children,
   applyPadding = true,
+  respectEditorWidthPreference = true,
 }: PageContentContainerProps) {
   const coreServices = useCoreServices();
   const wideEditor = useAtomValue(coreServices.workbenchState.$wideEditor);
@@ -28,7 +35,9 @@ export function PageContentContainer({
     <main
       className={cx(
         'B-app-page-content flex min-w-0 flex-1 flex-col gap-4',
-        !wideEditor && 'mx-auto w-full max-w-(--breakpoint-md)',
+        respectEditorWidthPreference &&
+          !wideEditor &&
+          'mx-auto w-full max-w-(--breakpoint-md)',
         applyPadding && APP_MAIN_CONTENT_PADDING,
       )}
     >

--- a/packages/core/app/src/pages/index.ts
+++ b/packages/core/app/src/pages/index.ts
@@ -3,6 +3,7 @@ export { PageFatalError } from './page-fatal-error';
 export { PageNativeFsAuthFailed } from './page-native-fs-auth-failed';
 export { PageNativeFsAuthReq } from './page-native-fs-auth-req';
 export { PageNotFound } from './page-not-found';
+export { PageSettings } from './page-settings';
 export { PageWelcome } from './page-welcome';
 export { PageWorkspaceNotFound } from './page-workspace-not-found';
 export { PageWsHome } from './page-ws-home';

--- a/packages/core/app/src/pages/page-settings.tsx
+++ b/packages/core/app/src/pages/page-settings.tsx
@@ -1,15 +1,18 @@
 import { useCoreServices } from '@bangle.io/context';
 import type { AppRouteInfo, ThemePreference } from '@bangle.io/types';
 import {
-  Button,
   cn,
-  DropdownMenu,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   SettingsPage,
   ToggleGroup,
   ToggleGroupItem,
 } from '@bangle.io/ui-components';
 import { useAtom, useAtomValue } from 'jotai';
-import { ArrowLeft, ChevronDown, Settings2 } from 'lucide-react';
+import { ArrowLeft, Settings2 } from 'lucide-react';
 import React from 'react';
 import { AppHeader } from '../layout/app-header';
 import { PageContentContainer } from '../layout/main-content-container';
@@ -172,42 +175,29 @@ function ThemePreferenceSelect({
   value: ThemePreference;
   onValueChange: (value: ThemePreference) => void;
 }) {
-  const selectedLabel =
-    THEME_OPTIONS.find((option) => option.value === value)?.label ??
-    t.app.dialogs.changeTheme.options.system;
-
   return (
-    <DropdownMenu.DropdownMenu>
-      <DropdownMenu.DropdownMenuTrigger asChild>
-        <Button
-          aria-label={t.app.settings.general.themeLabel}
-          className="h-9 w-full justify-between rounded-lg bg-muted/60 px-3 text-sm shadow-none sm:w-48"
-          variant="outline"
-        >
-          <span>{selectedLabel}</span>
-          <ChevronDown className="h-4 w-4 text-muted-foreground" />
-        </Button>
-      </DropdownMenu.DropdownMenuTrigger>
-      <DropdownMenu.DropdownMenuContent align="end" className="min-w-40">
-        <DropdownMenu.DropdownMenuRadioGroup
-          onValueChange={(nextValue) => {
-            if (isThemePreference(nextValue)) {
-              onValueChange(nextValue);
-            }
-          }}
-          value={value}
-        >
-          {THEME_OPTIONS.map((option) => (
-            <DropdownMenu.DropdownMenuRadioItem
-              key={option.value}
-              value={option.value}
-            >
-              {option.label}
-            </DropdownMenu.DropdownMenuRadioItem>
-          ))}
-        </DropdownMenu.DropdownMenuRadioGroup>
-      </DropdownMenu.DropdownMenuContent>
-    </DropdownMenu.DropdownMenu>
+    <Select
+      onValueChange={(nextValue) => {
+        if (isThemePreference(nextValue)) {
+          onValueChange(nextValue);
+        }
+      }}
+      value={value}
+    >
+      <SelectTrigger
+        aria-label={t.app.settings.general.themeLabel}
+        className="w-full sm:w-48"
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end" className="min-w-40">
+        {THEME_OPTIONS.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/packages/core/app/src/pages/page-settings.tsx
+++ b/packages/core/app/src/pages/page-settings.tsx
@@ -1,0 +1,234 @@
+import { useCoreServices } from '@bangle.io/context';
+import type { AppRouteInfo, ThemePreference } from '@bangle.io/types';
+import {
+  Button,
+  cn,
+  DropdownMenu,
+  SettingsPage,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@bangle.io/ui-components';
+import { useAtom, useAtomValue } from 'jotai';
+import { ArrowLeft, ChevronDown, Settings2 } from 'lucide-react';
+import React from 'react';
+import { AppHeader } from '../layout/app-header';
+import { PageContentContainer } from '../layout/main-content-container';
+
+const THEME_VALUES = [
+  'system',
+  'light',
+  'dark',
+] as const satisfies readonly ThemePreference[];
+
+const THEME_OPTIONS: Array<{ value: ThemePreference; label: string }> = [
+  { value: 'system', label: t.app.dialogs.changeTheme.options.system },
+  { value: 'light', label: t.app.dialogs.changeTheme.options.light },
+  { value: 'dark', label: t.app.dialogs.changeTheme.options.dark },
+];
+
+const SETTINGS_PAGES = [
+  {
+    id: 'general',
+    label: t.app.settings.nav.general,
+    route: 'settings-general' as const,
+    icon: Settings2,
+  },
+] as const;
+
+type SettingsPageId = (typeof SETTINGS_PAGES)[number]['id'];
+
+function isThemePreference(value: string): value is ThemePreference {
+  return THEME_VALUES.some((theme) => theme === value);
+}
+
+function getSettingsReturnTo(routeInfo: AppRouteInfo) {
+  if (routeInfo.route !== 'settings-general') {
+    return undefined;
+  }
+
+  return routeInfo.payload.returnTo;
+}
+
+function safeAppHref(href: string | undefined) {
+  if (!href || !href.startsWith('/') || href.startsWith('//')) {
+    return undefined;
+  }
+
+  return href;
+}
+
+export function PageSettings() {
+  return <SettingsLayout activePage="general" />;
+}
+
+function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
+  const { navigation, workbenchState } = useCoreServices();
+  const routeInfo = useAtomValue(navigation.$routeInfo);
+  const themePref = useAtomValue(workbenchState.$themePref);
+  const [wideEditor, setWideEditor] = useAtom(workbenchState.$wideEditor);
+  const returnTo = safeAppHref(getSettingsReturnTo(routeInfo));
+
+  const backHref =
+    returnTo ??
+    navigation.toUri({
+      route: 'welcome',
+      payload: {},
+    });
+  const navItems = SETTINGS_PAGES.map((page) => ({
+    id: page.id,
+    label: page.label,
+    href: navigation.toUri({
+      route: page.route,
+      payload: { returnTo },
+    }),
+    icon: page.icon,
+  }));
+
+  return (
+    <>
+      <AppHeader />
+      <PageContentContainer respectEditorWidthPreference={false}>
+        <SettingsPage.SettingsPageLayout>
+          <SettingsPage.SettingsPageHeader
+            backHref={backHref}
+            backIcon={<ArrowLeft className="h-4 w-4 shrink-0" />}
+            backLabel={t.app.settings.backToApp}
+            eyebrow={t.app.settings.title}
+            nav={
+              <SettingsPage.SettingsPageNav
+                activeId={activePage}
+                ariaLabel={t.app.settings.title}
+                items={navItems}
+              />
+            }
+            title={t.app.settings.general.title}
+          />
+
+          <SettingsPage.SettingsPageContent>
+            <SettingsPage.SettingsSection
+              title={t.app.settings.general.appearanceSection}
+            >
+              <SettingsPage.SettingsRow
+                control={
+                  <ThemePreferenceSelect
+                    onValueChange={(preference) => {
+                      workbenchState.changeThemePreference(preference);
+                    }}
+                    value={themePref}
+                  />
+                }
+                description={t.app.settings.general.themeDescription}
+                title={t.app.settings.general.themeTitle}
+              />
+            </SettingsPage.SettingsSection>
+
+            <SettingsPage.SettingsSection
+              title={t.app.settings.general.editorSection}
+            >
+              <SettingsPage.SettingsRow
+                control={
+                  <SegmentedControl
+                    aria-label={t.app.settings.general.wideEditorToggle}
+                    onValueChange={(value) => {
+                      if (value === 'default') {
+                        setWideEditor(false);
+                      }
+                      if (value === 'wide') {
+                        setWideEditor(true);
+                      }
+                    }}
+                    type="single"
+                    value={wideEditor ? 'wide' : 'default'}
+                  >
+                    <ToggleGroupItem
+                      className={SEGMENTED_ITEM_CLASS}
+                      value="default"
+                    >
+                      {t.app.settings.general.defaultWidth}
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      className={SEGMENTED_ITEM_CLASS}
+                      value="wide"
+                    >
+                      {t.app.settings.general.wideWidth}
+                    </ToggleGroupItem>
+                  </SegmentedControl>
+                }
+                description={t.app.settings.general.wideEditorDescription}
+                title={t.app.settings.general.wideEditorTitle}
+              />
+            </SettingsPage.SettingsSection>
+          </SettingsPage.SettingsPageContent>
+        </SettingsPage.SettingsPageLayout>
+      </PageContentContainer>
+    </>
+  );
+}
+
+function ThemePreferenceSelect({
+  value,
+  onValueChange,
+}: {
+  value: ThemePreference;
+  onValueChange: (value: ThemePreference) => void;
+}) {
+  const selectedLabel =
+    THEME_OPTIONS.find((option) => option.value === value)?.label ??
+    t.app.dialogs.changeTheme.options.system;
+
+  return (
+    <DropdownMenu.DropdownMenu>
+      <DropdownMenu.DropdownMenuTrigger asChild>
+        <Button
+          aria-label={t.app.settings.general.themeLabel}
+          className="h-9 w-full justify-between rounded-lg bg-muted/60 px-3 text-sm shadow-none sm:w-48"
+          variant="outline"
+        >
+          <span>{selectedLabel}</span>
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      </DropdownMenu.DropdownMenuTrigger>
+      <DropdownMenu.DropdownMenuContent align="end" className="min-w-40">
+        <DropdownMenu.DropdownMenuRadioGroup
+          onValueChange={(nextValue) => {
+            if (isThemePreference(nextValue)) {
+              onValueChange(nextValue);
+            }
+          }}
+          value={value}
+        >
+          {THEME_OPTIONS.map((option) => (
+            <DropdownMenu.DropdownMenuRadioItem
+              key={option.value}
+              value={option.value}
+            >
+              {option.label}
+            </DropdownMenu.DropdownMenuRadioItem>
+          ))}
+        </DropdownMenu.DropdownMenuRadioGroup>
+      </DropdownMenu.DropdownMenuContent>
+    </DropdownMenu.DropdownMenu>
+  );
+}
+
+const SEGMENTED_ITEM_CLASS =
+  'h-8 min-w-16 rounded-md px-3 text-xs data-[state=on]:bg-background data-[state=on]:shadow-xs';
+
+function SegmentedControl({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<typeof ToggleGroup>) {
+  return (
+    <ToggleGroup
+      className={cn(
+        'inline-flex rounded-lg bg-muted/60 p-1 shadow-inner',
+        className,
+      )}
+      variant="default"
+      {...props}
+    >
+      {children}
+    </ToggleGroup>
+  );
+}

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -31,6 +31,28 @@ describe('UI command handlers', () => {
     });
   });
 
+  describe('command::ui:open-settings', () => {
+    it('should navigate to general settings', async () => {
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ui:open-settings',
+      });
+
+      dispatch('command::ui:open-settings', null);
+
+      await vi.waitFor(() => {
+        expect(services.navigation.resolveAtoms().routeInfo).toEqual({
+          route: 'settings-general',
+          payload: {
+            returnTo: services.navigation.toUri({
+              route: 'welcome',
+              payload: {},
+            }),
+          },
+        });
+      });
+    });
+  });
+
   describe('command::ui:toggle-omni-search', () => {
     it('should toggle omni-search and prefill input if provided', async () => {
       const { dispatch, testEnv, services } = await setupTest({

--- a/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
+++ b/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
@@ -69,6 +69,10 @@ export const basicOperationsHandlers = [
     workbenchState.reloadUi();
   }),
 
+  c('command::ui:open-settings', ({ navigation }) => {
+    navigation.goSettingsGeneral();
+  }),
+
   c(
     'command::ui:toggle-all-files',
     ({ workbenchState }, { prefillInput }, key) => {

--- a/packages/core/service-core/src/navigation-service.ts
+++ b/packages/core/service-core/src/navigation-service.ts
@@ -178,6 +178,19 @@ export class NavigationService extends BaseService {
     });
   }
 
+  public goSettingsGeneral() {
+    const currentRoute = this.store.get(this.$routeInfo);
+    const returnTo =
+      currentRoute.route === 'settings-general'
+        ? currentRoute.payload.returnTo
+        : this.toUri(currentRoute);
+
+    this.go({
+      route: 'settings-general',
+      payload: returnTo ? { returnTo } : {},
+    });
+  }
+
   private get routerService() {
     return this.dep.router;
   }

--- a/packages/platform/service-platform/src/router/__tests__/hash-strategy.spec.ts
+++ b/packages/platform/service-platform/src/router/__tests__/hash-strategy.spec.ts
@@ -79,6 +79,35 @@ describe('HashStrategy', () => {
       expect(result.search).toBe('');
       expect(result.hash).toMatch(/#route=editor(&wsPath=)?/);
     });
+
+    it('should encode settings general route', () => {
+      const routeInfo: AppRouteInfo = {
+        route: 'settings-general',
+        payload: {},
+      };
+
+      const result = strategy.encodeRouteInfo(routeInfo, basePath);
+      expect(result).toEqual({
+        pathname: '/app',
+        search: '',
+        hash: '#route=settings-general',
+      });
+    });
+
+    it('should encode settings general return target', () => {
+      const routeInfo: AppRouteInfo = {
+        route: 'settings-general',
+        payload: {
+          returnTo: '/ws#route=editor&wsPath=notes%3Aindex.md',
+        },
+      };
+
+      expect(strategy.encodeRouteInfo(routeInfo, basePath)).toEqual({
+        pathname: '/app',
+        search: '',
+        hash: '#route=settings-general&returnTo=%2Fws%23route%3Deditor%26wsPath%3Dnotes%253Aindex.md',
+      });
+    });
   });
 
   describe('decodeRouteInfo', () => {
@@ -132,6 +161,34 @@ describe('HashStrategy', () => {
       expect(result.route).toBe('fatal-error');
       expect((result.payload as { error: Error }).error.message).toBe('OMG');
     });
+
+    it('should decode settings general route', () => {
+      const encoded: EncodedRoute = {
+        pathname: '/app',
+        search: '',
+        hash: '#route=settings-general',
+      };
+
+      expect(strategy.decodeRouteInfo(encoded, basePath)).toEqual({
+        route: 'settings-general',
+        payload: {},
+      });
+    });
+
+    it('should decode settings general return target', () => {
+      const encoded: EncodedRoute = {
+        pathname: '/app',
+        search: '',
+        hash: '#route=settings-general&returnTo=%2Fws%23route%3Deditor%26wsPath%3Dnotes%253Aindex.md',
+      };
+
+      expect(strategy.decodeRouteInfo(encoded, basePath)).toEqual({
+        route: 'settings-general',
+        payload: {
+          returnTo: '/ws#route=editor&wsPath=notes%3Aindex.md',
+        },
+      });
+    });
   });
 
   describe('bidirectional conversion', () => {
@@ -163,6 +220,14 @@ describe('HashStrategy', () => {
           payload: { error: new Error('Test error') },
         },
         basePath: '/someBase',
+      },
+      {
+        name: 'settings general route with basePath',
+        routeInfo: {
+          route: 'settings-general',
+          payload: {},
+        },
+        basePath: '/app',
       },
     ];
 

--- a/packages/platform/service-platform/src/router/__tests__/path-based-strategy.spec.ts
+++ b/packages/platform/service-platform/src/router/__tests__/path-based-strategy.spec.ts
@@ -165,6 +165,35 @@ describe('PathBasedStrategy', () => {
         hash: '',
       });
     });
+
+    it('should encode settings general route', () => {
+      const routeInfo: AppRouteInfo = {
+        route: 'settings-general',
+        payload: {},
+      };
+
+      expect(strategy.encodeRouteInfo(routeInfo, basePath)).toEqual({
+        pathname: '/app/settings-general',
+        search: '',
+        hash: '',
+      });
+    });
+
+    it('should encode settings general return target', () => {
+      const routeInfo: AppRouteInfo = {
+        route: 'settings-general',
+        payload: {
+          returnTo: '/ws#route=editor&wsPath=notes%3Aindex.md',
+        },
+      };
+
+      expect(strategy.encodeRouteInfo(routeInfo, basePath)).toEqual({
+        pathname: '/app/settings-general',
+        search:
+          '?returnTo=%2Fws%23route%3Deditor%26wsPath%3Dnotes%253Aindex.md',
+        hash: '',
+      });
+    });
   });
 
   describe('decodeRouteInfo', () => {
@@ -257,6 +286,33 @@ describe('PathBasedStrategy', () => {
         payload: { wsName: 'test' },
       });
     });
+
+    it('should decode settings general route', () => {
+      const encoded: EncodedRoute = {
+        pathname: '/settings-general',
+        search: '',
+      };
+
+      expect(strategy.decodeRouteInfo(encoded, basePath)).toEqual({
+        route: 'settings-general',
+        payload: {},
+      });
+    });
+
+    it('should decode settings general return target', () => {
+      const encoded: EncodedRoute = {
+        pathname: '/settings-general',
+        search:
+          '?returnTo=%2Fws%23route%3Deditor%26wsPath%3Dnotes%253Aindex.md',
+      };
+
+      expect(strategy.decodeRouteInfo(encoded, basePath)).toEqual({
+        route: 'settings-general',
+        payload: {
+          returnTo: '/ws#route=editor&wsPath=notes%3Aindex.md',
+        },
+      });
+    });
   });
 
   describe('bidirectional conversion', () => {
@@ -288,6 +344,14 @@ describe('PathBasedStrategy', () => {
           payload: { wsPath: 'test:file.md' },
         },
         basePath: '',
+      },
+      {
+        name: 'settings general route with basePath',
+        routeInfo: {
+          route: 'settings-general',
+          payload: {},
+        },
+        basePath: '/app',
       },
     ];
 

--- a/packages/platform/service-platform/src/router/common.ts
+++ b/packages/platform/service-platform/src/router/common.ts
@@ -144,6 +144,13 @@ export function handleRouteInfo(
       };
     }
 
+    case 'settings-general': {
+      return {
+        route: 'settings-general',
+        payload: params.returnTo ? { returnTo: params.returnTo } : {},
+      };
+    }
+
     default:
       return { route: 'not-found', payload: { path: route } };
   }

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -66,6 +66,17 @@ export const uiCommands = narrow([
     autoFocusEditor: false,
     args: {},
   },
+  {
+    id: 'command::ui:open-settings',
+    title: 'Open Settings',
+    omniSearch: true,
+    keywords: ['settings', 'preferences', 'general'],
+    dependencies: {
+      services: ['navigation'],
+    },
+    autoFocusEditor: false,
+    args: null,
+  },
 
   // GROUP: NOTES MANAGEMENT
   {

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -100,7 +100,7 @@ export const t = {
       appActionsLabel: 'App-Aktionen',
       omniSearch: 'Omni-Suche',
       allCommands: 'Alle Befehle',
-      changeTheme: 'Theme ändern',
+      settings: 'Einstellungen',
       linksLabel: 'Links',
       homepage: 'Startseite',
       githubProject: 'GitHub-Projekt',
@@ -110,6 +110,29 @@ export const t = {
       footerTitle: 'Bangle.io',
       toggleSidebarSr: 'Seitenleiste umschalten',
       toggleSidebarRailTitle: 'Seitenleiste umschalten',
+    },
+    settings: {
+      title: 'Einstellungen',
+      backToApp: 'Zurück zur App',
+      general: {
+        title: 'Allgemein',
+        appearanceSection: 'Darstellung',
+        themeTitle: 'Theme',
+        themeDescription: 'Wählen Sie, wie Bangle auf diesem Gerät aussieht.',
+        themeLabel: 'Theme-Einstellung',
+        editorSection: 'Editor',
+        wideEditorTitle: 'Editorbreite',
+        wideEditorDescription:
+          'Verfügbare Fensterbreite zum Bearbeiten von Notizen nutzen.',
+        wideEditorToggle: 'Breiten Editor verwenden',
+        defaultWidth: 'Standard',
+        wideWidth: 'Breit',
+        enabled: 'Aktiviert',
+        disabled: 'Deaktiviert',
+      },
+      nav: {
+        general: 'Allgemein',
+      },
     },
     dialogs: {
       changeTheme: {

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -105,7 +105,7 @@ export const t = {
       appActionsLabel: 'App Actions',
       omniSearch: 'Omni Search',
       allCommands: 'All Commands',
-      changeTheme: 'Change Theme',
+      settings: 'Settings',
       linksLabel: 'Links',
       homepage: 'Homepage',
       githubProject: 'GitHub Project',
@@ -115,6 +115,29 @@ export const t = {
       footerTitle: 'Bangle.io',
       toggleSidebarSr: 'Toggle Sidebar',
       toggleSidebarRailTitle: 'Toggle Sidebar',
+    },
+    settings: {
+      title: 'Settings',
+      backToApp: 'Back to app',
+      general: {
+        title: 'General',
+        appearanceSection: 'Appearance',
+        themeTitle: 'Theme',
+        themeDescription: 'Choose how Bangle looks on this device.',
+        themeLabel: 'Theme preference',
+        editorSection: 'Editor',
+        wideEditorTitle: 'Editor width',
+        wideEditorDescription:
+          'Use the available window width for note editing.',
+        wideEditorToggle: 'Use wide editor',
+        defaultWidth: 'Default',
+        wideWidth: 'Wide',
+        enabled: 'Enabled',
+        disabled: 'Disabled',
+      },
+      nav: {
+        general: 'General',
+      },
     },
     dialogs: {
       changeTheme: {

--- a/packages/shared/types/base-router.ts
+++ b/packages/shared/types/base-router.ts
@@ -45,6 +45,13 @@ export type AppRouteInfo =
       };
     }
   | {
+      route: 'settings-general';
+      metadata?: Record<string, string>;
+      payload: {
+        returnTo?: string;
+      };
+    }
+  | {
       route: 'welcome';
       metadata?: Record<string, string>;
       payload: Record<string, never>;

--- a/packages/tooling/e2e-tests/src/settings-general.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-general.e2e.ts
@@ -15,8 +15,8 @@ test('general settings update and persist user preferences', async ({
   await expect(page.getByRole('link', { name: 'Back to app' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
 
-  await page.getByRole('button', { name: 'Theme preference' }).click();
-  await page.getByRole('menuitemradio', { name: 'Dark' }).click();
+  await page.getByRole('combobox', { name: 'Theme preference' }).click();
+  await page.getByRole('option', { name: 'Dark' }).click();
   await expect(page.locator('html')).toHaveAttribute(
     'data-theme',
     'BU_dark-scheme',
@@ -36,6 +36,9 @@ test('general settings update and persist user preferences', async ({
     'data-theme',
     'BU_dark-scheme',
   );
+  await expect(
+    page.getByRole('combobox', { name: 'Theme preference' }),
+  ).toContainText('Dark');
   await expect(page.getByRole('radio', { name: 'Default' })).toBeChecked();
 });
 

--- a/packages/tooling/e2e-tests/src/settings-general.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-general.e2e.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+import { createBrowserWorkspaceAndNote } from './common';
+
+test('general settings update and persist user preferences', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: /Bangle\.io/ }).click();
+  await expect(
+    page.getByRole('menuitem', { name: 'Change Theme' }),
+  ).toHaveCount(0);
+  await page.getByRole('menuitem', { name: 'Settings' }).click();
+
+  await expect(page.getByRole('link', { name: 'Back to app' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Theme preference' }).click();
+  await page.getByRole('menuitemradio', { name: 'Dark' }).click();
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-theme',
+    'BU_dark-scheme',
+  );
+
+  const defaultWidth = page.getByRole('radio', { name: 'Default' });
+  const wideWidth = page.getByRole('radio', { name: 'Wide' });
+  await expect(wideWidth).toBeChecked();
+  await defaultWidth.click();
+  await expect(defaultWidth).toBeChecked();
+  await expect(wideWidth).not.toBeChecked();
+
+  await page.reload({ waitUntil: 'networkidle' });
+
+  await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute(
+    'data-theme',
+    'BU_dark-scheme',
+  );
+  await expect(page.getByRole('radio', { name: 'Default' })).toBeChecked();
+});
+
+test('general settings returns to the route it was opened from', async ({
+  page,
+}) => {
+  const workspaceName = 'settings-return-workspace';
+  const noteName = 'settings-return-note';
+
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  await expect(
+    page
+      .getByLabel('breadcrumb')
+      .getByRole('button', { name: `${noteName}.md` }),
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: /Bangle\.io/ }).click();
+  await page.getByRole('menuitem', { name: 'Settings' }).click();
+
+  await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Back to app' }).click();
+
+  await expect(
+    page
+      .getByLabel('breadcrumb')
+      .getByRole('button', { name: `${noteName}.md` }),
+  ).toBeVisible();
+});

--- a/packages/ui/shadcn/package.json
+++ b/packages/ui/shadcn/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@radix-ui/react-label": "^2.1.9",
     "@radix-ui/react-menubar": "^1.1.17",
+    "@radix-ui/react-select": "^2.3.2",
     "@radix-ui/react-separator": "^1.1.9",
     "@radix-ui/react-slot": "^1.2.5",
     "@radix-ui/react-toggle": "^1.1.11",

--- a/packages/ui/shadcn/src/index.ts
+++ b/packages/ui/shadcn/src/index.ts
@@ -10,6 +10,7 @@ export * from './dropdown-menu';
 export * from './input';
 export * from './label';
 export * from './menubar';
+export * from './select';
 export * from './separator';
 export * from './sheet';
 export * from './skeleton';

--- a/packages/ui/shadcn/src/select.stories.tsx
+++ b/packages/ui/shadcn/src/select.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from './select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Select',
+  component: Select,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+export const ThemePreference: Story = {
+  render: () => {
+    const [value, setValue] = React.useState('system');
+    return (
+      <Select onValueChange={setValue} value={value}>
+        <SelectTrigger aria-label="Theme preference" className="w-48">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent align="end">
+          <SelectItem value="system">System</SelectItem>
+          <SelectItem value="light">Light</SelectItem>
+          <SelectItem value="dark">Dark</SelectItem>
+        </SelectContent>
+      </Select>
+    );
+  },
+};
+
+export const Placeholder: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-56">
+        <SelectValue placeholder="Select a workspace" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="notes">Notes</SelectItem>
+        <SelectItem value="journal">Journal</SelectItem>
+        <SelectItem value="scratchpad">Scratchpad</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const Grouped: Story = {
+  render: () => (
+    <Select defaultValue="markdown">
+      <SelectTrigger className="w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Text</SelectLabel>
+          <SelectItem value="markdown">Markdown</SelectItem>
+          <SelectItem value="plain">Plain text</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Rich</SelectLabel>
+          <SelectItem value="wysiwyg">WYSIWYG</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+};

--- a/packages/ui/shadcn/src/select.tsx
+++ b/packages/ui/shadcn/src/select.tsx
@@ -1,0 +1,156 @@
+import { cn } from '@bangle.io/ui-misc';
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import React from 'react';
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'flex h-9 w-full items-center justify-between gap-2 whitespace-nowrap rounded-lg border border-input bg-background px-3 py-2 text-sm shadow-xs ring-offset-background transition-colors hover:bg-accent/40 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[placeholder]:text-muted-foreground [&>span]:line-clamp-1 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="size-4 text-muted-foreground opacity-70" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      'flex cursor-default items-center justify-center py-1 text-muted-foreground',
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = 'popper', ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-32 overflow-hidden rounded-lg border bg-popover text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in',
+        position === 'popper' &&
+          'data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1',
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          'p-1',
+          position === 'popper' &&
+            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn('px-2 py-1.5 font-semibold text-sm', className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/packages/ui/ui-components/src/index.ts
+++ b/packages/ui/ui-components/src/index.ts
@@ -14,6 +14,7 @@ export * from './dialog-single-input';
 export * from './dialog-single-select';
 export * from './fun-missing';
 export * from './kbd';
+export * as SettingsPage from './settings-page';
 export * as Sidebar from './sidebar';
 export * from './star-button';
 export * from './toaster';

--- a/packages/ui/ui-components/src/settings-page.tsx
+++ b/packages/ui/ui-components/src/settings-page.tsx
@@ -1,0 +1,135 @@
+import { cn } from '@bangle.io/shadcn';
+import type { ComponentType, ReactNode } from 'react';
+import * as React from 'react';
+
+export type SettingsNavItem = {
+  id: string;
+  label: string;
+  href: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+export function SettingsPageLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8">
+      {children}
+    </div>
+  );
+}
+
+export function SettingsPageHeader({
+  backHref,
+  backLabel,
+  backIcon,
+  eyebrow,
+  title,
+  nav,
+}: {
+  backHref: string;
+  backLabel: string;
+  backIcon: ReactNode;
+  eyebrow: string;
+  title: string;
+  nav: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-5">
+      <a
+        className="inline-flex w-fit items-center gap-2 rounded-md px-2 py-1 font-medium text-muted-foreground text-sm hover:bg-accent hover:text-accent-foreground"
+        href={backHref}
+      >
+        {backIcon}
+        <span>{backLabel}</span>
+      </a>
+
+      <div className="flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-medium text-muted-foreground text-sm">{eyebrow}</p>
+          <h1 className="font-semibold text-3xl tracking-normal">{title}</h1>
+        </div>
+        {nav}
+      </div>
+    </div>
+  );
+}
+
+export function SettingsPageNav({
+  activeId,
+  ariaLabel,
+  items,
+}: {
+  activeId: string;
+  ariaLabel: string;
+  items: readonly SettingsNavItem[];
+}) {
+  return (
+    <nav aria-label={ariaLabel} className="flex flex-wrap gap-1">
+      {items.map((item) => {
+        const Icon = item.icon;
+        const isActive = item.id === activeId;
+
+        return (
+          <a
+            aria-current={isActive ? 'page' : undefined}
+            className={cn(
+              'inline-flex h-9 items-center gap-2 rounded-md px-3 text-sm',
+              isActive
+                ? 'bg-accent font-medium text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent/70 hover:text-foreground',
+            )}
+            href={item.href}
+            key={item.id}
+          >
+            <Icon className="h-4 w-4 shrink-0" />
+            <span>{item.label}</span>
+          </a>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function SettingsPageContent({ children }: { children: ReactNode }) {
+  return <div className="flex flex-col gap-9">{children}</div>;
+}
+
+export function SettingsSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="font-semibold text-base">{title}</h2>
+      <div className="overflow-hidden rounded-lg border bg-card/80 text-card-foreground">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export function SettingsRow({
+  title,
+  description,
+  control,
+}: {
+  title: string;
+  description: string;
+  control: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-20 flex-col gap-4 border-border/70 border-t px-4 py-4 first:border-t-0 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+      <div className="min-w-0 space-y-1">
+        <h3 className="font-medium text-sm leading-5">{title}</h3>
+        <p className="max-w-2xl text-muted-foreground text-sm leading-5">
+          {description}
+        </p>
+      </div>
+      <div className="flex w-full shrink-0 items-center sm:w-auto sm:justify-end">
+        {control}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/ui-components/src/sidebar.tsx
+++ b/packages/ui/ui-components/src/sidebar.tsx
@@ -23,7 +23,9 @@ const SIDEBAR_WIDTH_ICON = '3rem';
 type SidebarContext = {
   state: 'expanded' | 'collapsed';
   open: boolean;
+  openMobile: boolean;
   setOpen: (open: boolean | ((currentOpen: boolean) => boolean)) => void;
+  setOpenMobile: (open: boolean | ((currentOpen: boolean) => boolean)) => void;
   isMobile: boolean;
   toggleSidebar: () => void;
 };
@@ -50,8 +52,8 @@ const SidebarProvider = React.forwardRef<
   const [openMobile, setOpenMobile] = React.useState(false);
 
   const toggleSidebar = React.useCallback(() => {
-    return setOpen((open) => !open);
-  }, [setOpen]);
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen]);
 
   const state = open ? 'expanded' : 'collapsed';
 
@@ -113,7 +115,7 @@ const Sidebar = React.forwardRef<
     },
     ref,
   ) => {
-    const { isMobile, open, setOpen, state } = useSidebar();
+    const { isMobile, openMobile, setOpenMobile, state } = useSidebar();
 
     if (collapsible === 'none') {
       return (
@@ -132,7 +134,7 @@ const Sidebar = React.forwardRef<
 
     if (isMobile) {
       return (
-        <Sheet open={open} onOpenChange={setOpen} {...props}>
+        <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
           <SheetContent
             data-sidebar="sidebar"
             data-mobile="true"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1097,6 +1097,9 @@ importers:
       '@radix-ui/react-menubar':
         specifier: ^1.1.17
         version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select':
+        specifier: ^2.3.2
+        version: 2.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-separator':
         specifier: ^1.1.9
         version: 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2561,6 +2564,9 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@radix-ui/number@1.1.2':
+    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
+
   '@radix-ui/primitive@1.1.4':
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
 
@@ -2590,6 +2596,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-arrow@1.1.11':
+    resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.9':
     resolution: {integrity: sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==}
     peerDependencies:
@@ -2605,6 +2624,19 @@ packages:
 
   '@radix-ui/react-collapsible@1.1.13':
     resolution: {integrity: sha512-F0s8+p2XNpfc3k02zBfB0jPWbkHVG162+p7BdUMyJ2308QMqZ+oaclX+FAzKFovgL5OqRU+Rvy6f/vbdlJVaqA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.11':
+    resolution: {integrity: sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2682,6 +2714,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.14':
+    resolution: {integrity: sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.1.17':
     resolution: {integrity: sha512-S6b3Jm57sY5EdDyOMLkacbB0qMnKhy1RCKZCt795ZkmtUOAvojYIZ5p7dXHIh5Cyr3jCLLI5/g64V3FKLudZmw==}
     peerDependencies:
@@ -2702,6 +2747,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.11':
+    resolution: {integrity: sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-focus-scope@1.1.9':
@@ -2778,8 +2836,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.3.2':
+    resolution: {integrity: sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.11':
     resolution: {integrity: sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.13':
+    resolution: {integrity: sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2817,8 +2901,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.7':
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.12':
     resolution: {integrity: sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.3.2':
+    resolution: {integrity: sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2845,6 +2955,15 @@ packages:
 
   '@radix-ui/react-slot@1.2.5':
     resolution: {integrity: sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2936,6 +3055,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.2':
     resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
     peerDependencies:
@@ -2956,6 +3084,19 @@ packages:
 
   '@radix-ui/react-visually-hidden@1.2.5':
     resolution: {integrity: sha512-tPcHNI3FajdDBFpl/Ez1m2WL0ufJqBKyHxMDBvKitopamK36WwBGOMicuMEZKkM5Wce41QxUyv6BsiqfrWBiGg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.7':
+    resolution: {integrity: sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -9320,6 +9461,8 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@radix-ui/number@1.1.2': {}
+
   '@radix-ui/primitive@1.1.4': {}
 
   '@radix-ui/react-accordion@1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
@@ -9353,6 +9496,15 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-arrow@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-arrow@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9372,6 +9524,18 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-collection@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -9443,6 +9607,19 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-dropdown-menu@2.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -9463,6 +9640,17 @@ snapshots:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
+
+  '@radix-ui/react-focus-scope@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-focus-scope@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -9553,9 +9741,37 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-popper@1.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-portal@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-portal@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -9581,6 +9797,15 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-roving-focus@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -9598,6 +9823,36 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-select@2.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-separator@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9608,6 +9863,13 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-slot@1.2.5(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
@@ -9694,6 +9956,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/rect': 1.1.2
@@ -9711,6 +9979,15 @@ snapshots:
   '@radix-ui/react-visually-hidden@1.2.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:


### PR DESCRIPTION
## Summary
- add a General settings route and page using the standard app route shell
- reshape Settings into a Codex-style dedicated settings surface: left settings rail, back link, search/filter input, grouped page navigation, centered content column, and bordered row-card sections
- add a settings page registry/sidebar shape so additional settings pages can plug in without rewriting the layout
- add a shadcn `Select` primitive to `@bangle.io/shadcn` (Radix `@radix-ui/react-select`, styled with Bangle tokens and the T3Code compact selector look) and use it for the theme preference selector, with a Storybook story documenting it
- keep Settings layout independent of the editor-width preference
- expose Settings from the sidebar and command layer
- fix mobile sidebar state so Settings opens visibly instead of behind the drawer
- persist theme and editor width preferences through the existing user preference/browser storage path
- cover route parsing, command navigation, and the user-visible settings workflow

## Validation
- pnpm lint:ci
- pnpm test:ci
- pnpm --filter "@bangle.io/e2e-tests" run test settings-general.e2e.ts
- pnpm local-ci-check
- Playwright CLI visual smoke against http://localhost:5197/ws#route=settings-general in light and dark themes
- Playwright smoke against http://localhost:5197/ for desktop width stability and mobile Settings navigation

## Notes
- T3Code uses shadcn-style primitives, including a compact Select for theme preference. Bangle now has a matching shadcn `Select` primitive: this PR adds `packages/ui/shadcn/src/select.tsx` (Radix `@radix-ui/react-select`) styled to Bangle's design tokens and the T3Code compact look, and the theme selector uses it instead of the earlier DropdownMenu radio-group stand-in. The settings E2E drives the real `combobox`/`option` roles and asserts the selected theme survives a reload; the primitive was smoke-tested via Playwright CLI in light and dark on a local dev server.
- The Codex reference is a dedicated settings window. Bangle still renders this route inside the existing app sidebar shell, so the implementation mirrors the settings rail/content treatment while preserving Bangle navigation.
- Existing full-suite console noise remains around Radix dialog titles and nested paragraph warnings in unrelated flows.
