### PR TITLE
[codex] improve delete note dialog UX

### DIFF
--- a/.claude/skills/bangle-desktop-release
+++ b/.claude/skills/bangle-desktop-release
@@ -1,0 +1,1 @@
+../../.codex/skills/bangle-desktop-release

--- a/.claude/skills/bangle-project-task
+++ b/.claude/skills/bangle-project-task
@@ -1,0 +1,1 @@
+../../.codex/skills/bangle-project-task

--- a/.claude/skills/thermonuclear-code-quality-review
+++ b/.claude/skills/thermonuclear-code-quality-review
@@ -1,0 +1,1 @@
+../../.codex/skills/thermonuclear-code-quality-review

--- a/.github/scripts/update-cloudflare-preview-comment.cjs
+++ b/.github/scripts/update-cloudflare-preview-comment.cjs
@@ -1,0 +1,75 @@
+const marker = '<!-- bangle-cloudflare-pr-preview -->';
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function renderCommitLine({ sha, state }) {
+  const shortSha = sha.slice(0, 7);
+
+  if (state === 'building') {
+    return `Commit: \`${shortSha}\` (building \`${shortSha}\` commit)`;
+  }
+
+  return `Commit: \`${shortSha}\``;
+}
+
+module.exports = async function updateCloudflarePreviewComment({
+  github,
+  context,
+}) {
+  const pr = context.payload.pull_request;
+  if (!pr) {
+    throw new Error('Cloudflare preview comments require a pull_request event.');
+  }
+
+  const previewUrl = requireEnv('PREVIEW_URL');
+  const previewBranch = requireEnv('PREVIEW_BRANCH');
+  const previewSha = requireEnv('PREVIEW_SHA');
+  const previewState = process.env.PREVIEW_STATE || 'deployed';
+  const runAt = new Date().toISOString();
+
+  const body = [
+    marker,
+    '## Cloudflare Pages Preview',
+    '',
+    `Preview: ${previewUrl}`,
+    '',
+    `Branch: \`${previewBranch}\``,
+    renderCommitLine({ sha: previewSha, state: previewState }),
+    `Last run: \`${runAt}\``,
+    '',
+    'This comment is updated automatically when new commits are pushed to this PR.',
+  ].join('\n');
+
+  const { owner, repo } = context.repo;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pr.number,
+    per_page: 100,
+  });
+
+  const existing = comments.find((comment) => comment.body?.includes(marker));
+
+  if (existing) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+    return;
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pr.number,
+    body,
+  });
+};

--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -6,8 +6,8 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
-  group: cloudflare-pr-preview
-  cancel-in-progress: false
+  group: cloudflare-pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -17,6 +17,8 @@ env:
   SENTRY_NO_PROGRESS_BAR: 1
   CLOUDFLARE_PAGES_PROJECT: bangle-io-2
   CLOUDFLARE_PREVIEW_BRANCH: pr-${{ github.event.pull_request.number }}
+  CLOUDFLARE_PREVIEW_URL: https://pr-${{ github.event.pull_request.number }}.bangle-io-2.pages.dev
+  PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
 jobs:
   deploy-preview:
@@ -25,6 +27,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.PR_HEAD_SHA }}
+
+      - name: Mark PR preview comment as building
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_URL: ${{ env.CLOUDFLARE_PREVIEW_URL }}
+          PREVIEW_BRANCH: ${{ env.CLOUDFLARE_PREVIEW_BRANCH }}
+          PREVIEW_SHA: ${{ env.PR_HEAD_SHA }}
+          PREVIEW_STATE: building
+        with:
+          script: |
+            const updateComment = require('./.github/scripts/update-cloudflare-preview-comment.cjs');
+            await updateComment({ github, context });
 
       - name: Install pnpm
         run: |
@@ -41,6 +57,9 @@ jobs:
         run: pnpm install
 
       - name: Build app
+        env:
+          CF_PAGES_BRANCH: ${{ env.CLOUDFLARE_PREVIEW_BRANCH }}
+          CF_PAGES_COMMIT_SHA: ${{ env.PR_HEAD_SHA }}
         run: pnpm build
 
       - name: Validate Cloudflare secrets
@@ -94,45 +113,9 @@ jobs:
         env:
           PREVIEW_URL: ${{ steps.preview.outputs.preview_url }}
           PREVIEW_BRANCH: ${{ steps.preview.outputs.preview_branch }}
+          PREVIEW_SHA: ${{ env.PR_HEAD_SHA }}
+          PREVIEW_STATE: deployed
         with:
           script: |
-            const marker = '<!-- bangle-cloudflare-pr-preview -->';
-            const pr = context.payload.pull_request;
-            const body = [
-              marker,
-              '## Cloudflare Pages Preview',
-              '',
-              `Preview: ${process.env.PREVIEW_URL}`,
-              '',
-              `Branch: \`${process.env.PREVIEW_BRANCH}\``,
-              `Commit: \`${context.sha.slice(0, 7)}\``,
-              '',
-              'This comment is updated automatically when new commits are pushed to this PR.',
-            ].join('\n');
-
-            const { owner, repo } = context.repo;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: pr.number,
-              per_page: 100,
-            });
-
-            const existing = comments.find((comment) => comment.body?.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-              return;
-            }
-
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pr.number,
-              body,
-            });
+            const updateComment = require('./.github/scripts/update-cloudflare-preview-comment.cjs');
+            await updateComment({ github, context });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+AGENTS.md

--- a/packages/core/app/src/dialogs/all-files-dialog.tsx
+++ b/packages/core/app/src/dialogs/all-files-dialog.tsx
@@ -78,8 +78,10 @@ function AllFilesContent({ search, onClose }: AllFilesContentProps) {
         fuzzySearchFunction: substringFuzzySearch,
       },
     );
-    const resultSet = new Set(results.map((r) => r.item));
-    return files.filter((file) => resultSet.has(file.title));
+    const filesByTitle = new Map(files.map((file) => [file.title, file]));
+    return results
+      .map((result) => filesByTitle.get(result.item))
+      .filter((file): file is (typeof files)[number] => Boolean(file));
   }, [files, search]);
 
   const rowVirtualizer = useVirtualizer({

--- a/packages/core/app/src/dialogs/app-dialogs.tsx
+++ b/packages/core/app/src/dialogs/app-dialogs.tsx
@@ -76,6 +76,8 @@ export function AppDialogs() {
         badgeTone={singleSelectDialog?.badgeTone}
         groupHeading={singleSelectDialog?.groupHeading}
         emptyMessage={singleSelectDialog?.emptyMessage}
+        emptyActionText={singleSelectDialog?.emptyActionText}
+        onEmptyAction={singleSelectDialog?.onEmptyAction}
         Icon={singleSelectDialog?.Icon}
         initialSearch={singleSelectDialog?.initialSearch}
         hints={singleSelectDialog?.hints}

--- a/packages/core/app/src/dialogs/app-dialogs.tsx
+++ b/packages/core/app/src/dialogs/app-dialogs.tsx
@@ -51,14 +51,13 @@ export function AppDialogs() {
           );
         }}
         onSelect={singleInputDialog?.onSelect || (() => {})}
+        title={singleInputDialog?.title}
+        description={singleInputDialog?.description}
+        inputLabel={singleInputDialog?.inputLabel}
+        submitText={singleInputDialog?.submitText}
         placeholder={singleInputDialog?.placeholder}
-        badgeText={singleInputDialog?.badgeText}
-        badgeTone={singleInputDialog?.badgeTone}
-        groupHeading={singleInputDialog?.groupHeading}
         Icon={singleInputDialog?.Icon}
-        option={singleInputDialog?.option || { id: '' }}
         initialSearch={singleInputDialog?.initialSearch}
-        hints={singleInputDialog?.hints}
       />
 
       <DialogSingleSelect

--- a/packages/core/app/src/dialogs/app-dialogs.tsx
+++ b/packages/core/app/src/dialogs/app-dialogs.tsx
@@ -70,10 +70,11 @@ export function AppDialogs() {
         }}
         options={singleSelectDialog?.options || []}
         onSelect={singleSelectDialog?.onSelect || (() => {})}
-        placeholder={singleSelectDialog?.placeholder}
-        badgeText={singleSelectDialog?.badgeText}
-        badgeTone={singleSelectDialog?.badgeTone}
-        groupHeading={singleSelectDialog?.groupHeading}
+        title={singleSelectDialog?.title}
+        description={singleSelectDialog?.description}
+        searchPlaceholder={singleSelectDialog?.searchPlaceholder}
+        tone={singleSelectDialog?.tone}
+        groupLabel={singleSelectDialog?.groupLabel}
         emptyMessage={singleSelectDialog?.emptyMessage}
         emptyActionText={singleSelectDialog?.emptyActionText}
         onEmptyAction={singleSelectDialog?.onEmptyAction}

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -64,7 +64,9 @@ describe('UI command handlers', () => {
       );
       expect(dialog).toBeDefined();
       expect(dialog?.dialogId).toBe('dialog::change-theme-pref-dialog');
-      expect(dialog?.placeholder).toBe(t.app.dialogs.changeTheme.placeholder);
+      expect(dialog?.searchPlaceholder).toBe(
+        t.app.dialogs.changeTheme.searchPlaceholder,
+      );
       //  since we mock the theme preference, not needed to check for theme change
     });
   });
@@ -222,9 +224,11 @@ describe('UI command handlers', () => {
       );
       expect(dialog).toBeDefined();
       expect(dialog?.dialogId).toBe('dialog::move-note-dialog');
-      expect(dialog?.placeholder).toBe(t.app.dialogs.moveNote.placeholder);
-      expect(dialog?.badgeText).toBe(
-        t.app.dialogs.moveNote.badgeText({ fileNameWithoutExtension: 'test' }),
+      expect(dialog?.searchPlaceholder).toBe(
+        t.app.dialogs.moveNote.searchPlaceholder,
+      );
+      expect(dialog?.title).toBe(
+        t.app.dialogs.moveNote.title({ fileNameWithoutExtension: 'test' }),
       );
 
       dialog?.onSelect({ id: 'dir/', title: 'dir/' });
@@ -304,8 +308,8 @@ describe('UI command handlers', () => {
       );
       expect(dialog).toBeDefined();
       expect(dialog?.dialogId).toBe('dialog::switch-workspace-dialog');
-      expect(dialog?.placeholder).toBe(
-        t.app.dialogs.switchWorkspace.placeholder,
+      expect(dialog?.searchPlaceholder).toBe(
+        t.app.dialogs.switchWorkspace.searchPlaceholder,
       );
       dialog?.onSelect({ id: 'test-ws', title: 'test-ws' });
       expect(services.navigation.resolveAtoms().wsName).toBe('test-ws');
@@ -326,8 +330,8 @@ describe('UI command handlers', () => {
       );
       expect(dialog).toBeDefined();
       expect(dialog?.dialogId).toBe('dialog::delete-workspace-dialog');
-      expect(dialog?.placeholder).toBe(
-        t.app.dialogs.deleteWorkspace.placeholder,
+      expect(dialog?.searchPlaceholder).toBe(
+        t.app.dialogs.deleteWorkspace.searchPlaceholder,
       );
 
       dialog?.onSelect({ id: 'ws2', title: 'ws2' });

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -84,8 +84,10 @@ describe('UI command handlers', () => {
       );
       expect(dialog).toBeDefined();
       expect(dialog?.dialogId).toBe('dialog::new-note-dialog');
+      expect(dialog?.title).toBe(t.app.dialogs.createNote.title);
+      expect(dialog?.inputLabel).toBe(t.app.dialogs.createNote.inputLabel);
       expect(dialog?.placeholder).toBe(t.app.dialogs.createNote.placeholder);
-      expect(dialog?.badgeText).toBe(t.app.dialogs.createNote.badgeText);
+      expect(dialog?.submitText).toBe(t.app.dialogs.createNote.submitText);
 
       dialog?.onSelect('My Note');
 
@@ -177,12 +179,15 @@ describe('UI command handlers', () => {
       );
       expect(dialog).toBeDefined();
       expect(dialog?.dialogId).toBe('dialog::rename-note-dialog');
+      expect(dialog?.title).toBe(t.app.dialogs.renameNote.title);
+      expect(dialog?.inputLabel).toBe(t.app.dialogs.renameNote.inputLabel);
       expect(dialog?.placeholder).toBe(t.app.dialogs.renameNote.placeholder);
-      expect(dialog?.badgeText).toBe(
-        t.app.dialogs.renameNote.badgeText({
+      expect(dialog?.description).toBe(
+        t.app.dialogs.renameNote.description({
           fileNameWithoutExtension: 'test',
         }),
       );
+      expect(dialog?.submitText).toBe(t.app.dialogs.renameNote.submitText);
 
       dialog?.onSelect('New Name');
 
@@ -253,10 +258,12 @@ describe('UI command handlers', () => {
       );
       expect(dialog).toBeDefined();
       expect(dialog?.dialogId).toBe('dialog::new-directory-dialog');
+      expect(dialog?.title).toBe(t.app.dialogs.createDirectory.title);
+      expect(dialog?.inputLabel).toBe(t.app.dialogs.createDirectory.inputLabel);
       expect(dialog?.placeholder).toBe(
         t.app.dialogs.createDirectory.placeholder,
       );
-      expect(dialog?.badgeText).toBe(t.app.dialogs.createDirectory.badgeText);
+      expect(dialog?.submitText).toBe(t.app.dialogs.createDirectory.submitText);
 
       dialog?.onSelect('My Directory');
 

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -118,6 +118,8 @@ describe('UI command handlers', () => {
       expect(dialog?.dialogId).toBe('dialog::delete-ws-path-dialog');
       expect(dialog?.placeholder).toBe(t.app.dialogs.deleteNote.placeholder);
       expect(dialog?.badgeText).toBe(t.app.dialogs.deleteNote.badgeText);
+      expect(dialog?.badgeTone).toBeUndefined();
+      expect(dialog?.hints).toEqual([t.app.dialogs.deleteNote.hintDelete]);
 
       dialog?.onSelect({ id: 'test-ws:test.md', title: 'test.md' });
       const alertDialog = testEnv.store.get(

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -205,7 +205,7 @@ describe('UI command handlers', () => {
         t.app.dialogs.moveNote.badgeText({ fileNameWithoutExtension: 'test' }),
       );
 
-      dialog?.onSelect({ id: 'dir', title: 'dir' });
+      dialog?.onSelect({ id: 'dir/', title: 'dir/' });
 
       await vi.waitFor(() => {
         expect(
@@ -213,6 +213,11 @@ describe('UI command handlers', () => {
             .filter((result) => result.type === 'success')
             .map((result) => result.command.id),
         ).toContain('command::ws:move-ws-path');
+        expect(
+          services.workspaceState
+            .resolveAtoms()
+            .wsPaths.map((path) => path.wsPath),
+        ).toContain('test-ws:dir/test.md');
       });
     });
   });

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -100,7 +100,7 @@ describe('UI command handlers', () => {
   });
 
   describe('command::ui:delete-note-dialog', () => {
-    it('should open the delete note dialog, show alert on note selection, and dispatch ws:delete-ws-path on confirmation', async () => {
+    it('should open delete confirmation and dispatch ws:delete-ws-path on confirmation', async () => {
       const { dispatch, testEnv, services, getCommandResults } =
         await setupTest({
           targetId: 'command::ui:delete-note-dialog',
@@ -111,17 +111,9 @@ describe('UI command handlers', () => {
       dispatch('command::ui:delete-note-dialog', {
         wsPath: 'test-ws:test.md',
       });
-      const dialog = testEnv.store.get(
-        services.workbenchState.$singleSelectDialog,
-      );
-      expect(dialog).toBeDefined();
-      expect(dialog?.dialogId).toBe('dialog::delete-ws-path-dialog');
-      expect(dialog?.placeholder).toBe(t.app.dialogs.deleteNote.placeholder);
-      expect(dialog?.badgeText).toBe(t.app.dialogs.deleteNote.badgeText);
-      expect(dialog?.badgeTone).toBeUndefined();
-      expect(dialog?.hints).toEqual([t.app.dialogs.deleteNote.hintDelete]);
-
-      dialog?.onSelect({ id: 'test-ws:test.md', title: 'test.md' });
+      expect(
+        testEnv.store.get(services.workbenchState.$singleSelectDialog),
+      ).toBeUndefined();
       const alertDialog = testEnv.store.get(
         services.workbenchState.$alertDialog,
       );
@@ -141,6 +133,31 @@ describe('UI command handlers', () => {
             .map((result) => result.command.id),
         ).toContain('command::ws:delete-ws-path');
       });
+    });
+
+    it('should confirm deletion for the current note when no wsPath is provided', async () => {
+      const { dispatch, testEnv, services } = await setupTest({
+        targetId: 'command::ui:delete-note-dialog',
+        workspaces: [{ name: 'test-ws', notes: ['test-ws:current.md'] }],
+        autoNavigate: 'ws-path',
+      });
+
+      dispatch('command::ui:delete-note-dialog', {
+        wsPath: undefined,
+      });
+
+      expect(
+        testEnv.store.get(services.workbenchState.$singleSelectDialog),
+      ).toBeUndefined();
+      const alertDialog = testEnv.store.get(
+        services.workbenchState.$alertDialog,
+      );
+      expect(alertDialog).toBeDefined();
+      expect(alertDialog?.dialogId).toBe('dialog::alert');
+      expect(alertDialog?.title).toBe(t.app.dialogs.confirmDelete.title);
+      expect(alertDialog?.description).toBe(
+        t.app.dialogs.confirmDelete.description({ fileName: 'current' }),
+      );
     });
   });
 

--- a/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
+++ b/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
@@ -29,9 +29,10 @@ export const basicOperationsHandlers = [
     store.set(workbenchState.$singleSelectDialog, () => {
       return {
         dialogId: 'dialog::change-theme-pref-dialog',
-        placeholder: t.app.dialogs.changeTheme.placeholder,
-        badgeText: t.app.dialogs.changeTheme.badgeText,
-        groupHeading: t.app.dialogs.changeTheme.groupHeading,
+        title: t.app.dialogs.changeTheme.title,
+        description: t.app.dialogs.changeTheme.searchPlaceholder,
+        searchPlaceholder: t.app.dialogs.changeTheme.searchPlaceholder,
+        groupLabel: t.app.dialogs.changeTheme.groupLabel,
         emptyMessage: t.app.dialogs.changeTheme.emptyMessage,
         options: [
           {

--- a/packages/core/command-handlers/src/ui-handlers/note-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/note-management.ts
@@ -51,7 +51,6 @@ export const noteManagementHandlers = [
           dialogId: 'dialog::delete-ws-path-dialog',
           placeholder: t.app.dialogs.deleteNote.placeholder,
           badgeText: t.app.dialogs.deleteNote.badgeText,
-          badgeTone: 'destructive',
           groupHeading: t.app.dialogs.deleteNote.groupHeading,
           emptyMessage: t.app.dialogs.deleteNote.emptyMessage,
           options: wsPaths.map((path) => ({

--- a/packages/core/command-handlers/src/ui-handlers/note-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/note-management.ts
@@ -239,13 +239,20 @@ export const noteManagementHandlers = [
             fileNameWithoutExtension: filePath.fileNameWithoutExtension,
           }),
           emptyMessage: t.app.dialogs.moveNote.emptyMessage,
+          emptyActionText: t.app.dialogs.moveNote.emptyActionText,
           options,
           Icon: FilePlus,
           groupHeading: t.app.dialogs.moveNote.groupHeading,
-          hints: [
-            t.app.dialogs.moveNote.hintClick,
-            t.app.dialogs.moveNote.hintDrag,
-          ],
+          hints:
+            options.length > 0
+              ? [
+                  t.app.dialogs.moveNote.hintClick,
+                  t.app.dialogs.moveNote.hintDrag,
+                ]
+              : [t.app.dialogs.moveNote.hintCreateDirectory],
+          onEmptyAction: () => {
+            dispatch('command::ui:create-directory-dialog', null);
+          },
           onSelect: (selectedDir) => {
             let newDirPath = selectedDir.id;
             if (newDirPath === ROOT_ID) {

--- a/packages/core/command-handlers/src/ui-handlers/note-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/note-management.ts
@@ -259,7 +259,7 @@ export const noteManagementHandlers = [
             if (newDirPath === ROOT_ID) {
               newDirPath = '';
             } else {
-              validateInputPath(newDirPath);
+              newDirPath = WsPath.pathJoin(newDirPath);
             }
 
             dispatch('command::ws:move-ws-path', {

--- a/packages/core/command-handlers/src/ui-handlers/note-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/note-management.ts
@@ -230,15 +230,16 @@ export const noteManagementHandlers = [
       store.set(workbenchState.$singleSelectDialog, () => {
         return {
           dialogId: 'dialog::move-note-dialog',
-          placeholder: t.app.dialogs.moveNote.placeholder,
-          badgeText: t.app.dialogs.moveNote.badgeText({
+          title: t.app.dialogs.moveNote.title({
             fileNameWithoutExtension: filePath.fileNameWithoutExtension,
           }),
+          description: t.app.dialogs.moveNote.searchPlaceholder,
+          searchPlaceholder: t.app.dialogs.moveNote.searchPlaceholder,
           emptyMessage: t.app.dialogs.moveNote.emptyMessage,
           emptyActionText: t.app.dialogs.moveNote.emptyActionText,
           options,
           Icon: FilePlus,
-          groupHeading: t.app.dialogs.moveNote.groupHeading,
+          groupLabel: t.app.dialogs.moveNote.groupLabel,
           hints:
             options.length > 0
               ? [

--- a/packages/core/command-handlers/src/ui-handlers/note-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/note-management.ts
@@ -12,19 +12,17 @@ export const noteManagementHandlers = [
       store.set(workbenchState.$singleInputDialog, () => {
         return {
           dialogId: 'dialog::new-note-dialog',
+          title: t.app.dialogs.createNote.title,
+          description: t.app.dialogs.createNote.description,
+          inputLabel: t.app.dialogs.createNote.inputLabel,
           placeholder: t.app.dialogs.createNote.placeholder,
-          badgeText: t.app.dialogs.createNote.badgeText,
-          option: {
-            id: 'new-note-dialog',
-            title: t.app.dialogs.createNote.optionTitle,
-          },
+          submitText: t.app.dialogs.createNote.submitText,
           onSelect: (input) => {
             dispatch('command::ws:new-note-from-input', {
               inputPath: input.trim(),
             });
             dispatch('command::ui:focus-editor', null);
           },
-          Icon: FilePlus,
           initialSearch: prefillName,
         };
       });
@@ -110,16 +108,14 @@ export const noteManagementHandlers = [
       store.set(workbenchState.$singleInputDialog, () => {
         return {
           dialogId: 'dialog::rename-note-dialog',
-          placeholder: t.app.dialogs.renameNote.placeholder,
-          badgeText: t.app.dialogs.renameNote.badgeText({
+          title: t.app.dialogs.renameNote.title,
+          description: t.app.dialogs.renameNote.description({
             fileNameWithoutExtension: fileOldWsPath.fileNameWithoutExtension,
           }),
+          inputLabel: t.app.dialogs.renameNote.inputLabel,
+          placeholder: t.app.dialogs.renameNote.placeholder,
           initialSearch: fileOldWsPath.fileNameWithoutExtension,
-          Icon: FilePlus,
-          option: {
-            id: 'rename-note-dialog',
-            title: t.app.dialogs.renameNote.optionTitle,
-          },
+          submitText: t.app.dialogs.renameNote.submitText,
           onSelect: (input) => {
             const trimmedInput = input.trim();
             if (!trimmedInput) {
@@ -290,12 +286,11 @@ export const noteManagementHandlers = [
       store.set(workbenchState.$singleInputDialog, () => {
         return {
           dialogId: 'dialog::new-directory-dialog',
+          title: t.app.dialogs.createDirectory.title,
+          description: t.app.dialogs.createDirectory.description,
+          inputLabel: t.app.dialogs.createDirectory.inputLabel,
           placeholder: t.app.dialogs.createDirectory.placeholder,
-          badgeText: t.app.dialogs.createDirectory.badgeText,
-          option: {
-            id: 'new-directory-dialog',
-            title: t.app.dialogs.createDirectory.optionTitle,
-          },
+          submitText: t.app.dialogs.createDirectory.submitText,
           onSelect: (_input) => {
             const input = _input.trim();
             validateInputPath(input);
@@ -303,7 +298,6 @@ export const noteManagementHandlers = [
               dirWsPath: WsPath.fromParts(wsName, input).wsPath,
             });
           },
-          Icon: FilePlus,
         };
       });
     },

--- a/packages/core/command-handlers/src/ui-handlers/note-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/note-management.ts
@@ -1,6 +1,6 @@
 import { throwAppError } from '@bangle.io/base-utils';
 import { WsPath } from '@bangle.io/ws-path';
-import { FilePlus, Trash2 } from 'lucide-react';
+import { FilePlus } from 'lucide-react';
 import { c, getCtx } from '../helper';
 import { validateInputPath } from '../utils';
 
@@ -35,52 +35,44 @@ export const noteManagementHandlers = [
     'command::ui:delete-note-dialog',
     ({ workbenchState, workspaceState }, { wsPath }, key) => {
       const { store, dispatch } = getCtx(key);
-      const wsPaths = store.get(workspaceState.$wsPaths);
-      const wsName = store.get(workspaceState.$currentWsName);
+      const targetWsPath = wsPath || store.get(workspaceState.$currentWsPath);
 
-      if (!wsName || !wsPaths || wsPaths.length === 0) {
+      if (!targetWsPath) {
         throwAppError(
-          'error::workspace:no-notes-found',
-          t.app.errors.workspace.noNotesToDelete,
-          { wsName },
+          'error::workspace:not-opened',
+          t.app.errors.workspace.notOpened,
+          { wsPath },
         );
       }
 
-      store.set(workbenchState.$singleSelectDialog, () => {
-        return {
-          dialogId: 'dialog::delete-ws-path-dialog',
-          placeholder: t.app.dialogs.deleteNote.placeholder,
-          badgeText: t.app.dialogs.deleteNote.badgeText,
-          groupHeading: t.app.dialogs.deleteNote.groupHeading,
-          emptyMessage: t.app.dialogs.deleteNote.emptyMessage,
-          options: wsPaths.map((path) => ({
-            title: path.filePath,
-            id: path.wsPath,
-          })),
-          Icon: Trash2,
-          hints: [t.app.dialogs.deleteNote.hintDelete],
-          initialSearch: wsPath ? WsPath.fromString(wsPath).path : undefined,
-          onSelect: (option) => {
-            const wsPath = WsPath.fromString(option.id);
-            const fileName = wsPath.asFile()?.fileNameWithoutExtension;
+      const filePath = WsPath.safeParse(targetWsPath).data?.asFile();
 
-            store.set(workbenchState.$alertDialog, () => {
-              return {
-                dialogId: 'dialog::alert',
-                title: t.app.dialogs.confirmDelete.title,
-                tone: 'destructive',
-                description: t.app.dialogs.confirmDelete.description({
-                  fileName: fileName || t.app.common.unknown,
-                }),
-                continueText: t.app.dialogs.confirmDelete.continueText,
-                onContinue: () => {
-                  dispatch('command::ws:delete-ws-path', { wsPath: option.id });
-                  dispatch('command::ui:focus-editor', null);
-                },
-                onCancel: () => {},
-              };
-            });
+      if (!filePath) {
+        throwAppError(
+          'error::file:invalid-note-path',
+          t.app.errors.file.invalidNotePath,
+          {
+            invalidWsPath: targetWsPath.toString(),
           },
+        );
+      }
+
+      store.set(workbenchState.$alertDialog, () => {
+        return {
+          dialogId: 'dialog::alert',
+          title: t.app.dialogs.confirmDelete.title,
+          tone: 'destructive',
+          description: t.app.dialogs.confirmDelete.description({
+            fileName: filePath.fileNameWithoutExtension,
+          }),
+          continueText: t.app.dialogs.confirmDelete.continueText,
+          onContinue: () => {
+            dispatch('command::ws:delete-ws-path', {
+              wsPath: filePath.wsPath,
+            });
+            dispatch('command::ui:focus-editor', null);
+          },
+          onCancel: () => {},
         };
       });
     },

--- a/packages/core/command-handlers/src/ui-handlers/workspace-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/workspace-management.ts
@@ -22,9 +22,10 @@ export const workspaceManagementHandlers = [
       store.set(workbenchState.$singleSelectDialog, () => {
         return {
           dialogId: 'dialog::switch-workspace-dialog',
-          placeholder: t.app.dialogs.switchWorkspace.placeholder,
-          badgeText: t.app.dialogs.switchWorkspace.badgeText,
-          groupHeading: t.app.dialogs.switchWorkspace.groupHeading,
+          title: t.app.dialogs.switchWorkspace.title,
+          description: t.app.dialogs.switchWorkspace.searchPlaceholder,
+          searchPlaceholder: t.app.dialogs.switchWorkspace.searchPlaceholder,
+          groupLabel: t.app.dialogs.switchWorkspace.groupLabel,
           emptyMessage: t.app.dialogs.switchWorkspace.emptyMessage,
           options: (workspaces || [])
             .sort((a, b) => {
@@ -63,10 +64,11 @@ export const workspaceManagementHandlers = [
       store.set(workbenchState.$singleSelectDialog, () => {
         return {
           dialogId: 'dialog::delete-workspace-dialog',
-          placeholder: t.app.dialogs.deleteWorkspace.placeholder,
-          badgeText: t.app.dialogs.deleteWorkspace.badgeText,
-          badgeTone: 'destructive',
-          groupHeading: t.app.dialogs.deleteWorkspace.groupHeading,
+          title: t.app.dialogs.deleteWorkspace.title,
+          description: t.app.dialogs.deleteWorkspace.searchPlaceholder,
+          searchPlaceholder: t.app.dialogs.deleteWorkspace.searchPlaceholder,
+          tone: 'destructive',
+          groupLabel: t.app.dialogs.deleteWorkspace.groupLabel,
           emptyMessage: t.app.dialogs.deleteWorkspace.emptyMessage,
           options: (workspaces || []).map((ws) => ({
             title: ws.name,

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -131,7 +131,7 @@ export const uiCommands = narrow([
 
   {
     id: 'command::ui:create-directory-dialog',
-    title: 'New Directory',
+    title: 'New Folder',
     keywords: ['new', 'create', 'directory', 'folder'],
     dependencies: {
       services: ['workbenchState', 'workspaceState'],

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -116,7 +116,11 @@ export const uiCommands = narrow([
     keywords: ['move', 'note', 'relocate'],
     dependencies: {
       services: ['workbenchState', 'workspaceState'],
-      commands: ['command::ws:move-ws-path', 'command::ui:focus-editor'],
+      commands: [
+        'command::ws:move-ws-path',
+        'command::ui:focus-editor',
+        'command::ui:create-directory-dialog',
+      ],
     },
     omniSearch: true,
     autoFocusEditor: false,

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -360,9 +360,13 @@ export const t = {
         deleteAction: 'Löschen',
         moveAction: 'Verschieben',
         createNoteAction: 'Notiz erstellen',
+        moreActionsSr: ({ itemName }: { itemName: string }) =>
+          `Weitere Aktionen für ${itemName}`,
       },
       dialog: {
         closeSr: 'Schließen',
+        commandDescriptionSr:
+          'Tippen Sie, um zu suchen und ein Element auszuwählen.',
       },
       sheet: {
         closeSr: 'Schließen',

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -115,7 +115,7 @@ export const t = {
         badgeText: 'Notiz löschen',
         groupHeading: 'Notizen',
         emptyMessage: 'Keine Notizen gefunden',
-        hintDelete: 'Enter drücken oder klicken zum Löschen',
+        hintDelete: 'Wählen Sie eine Notiz aus, um das Löschen zu bestätigen',
       },
       confirmDelete: {
         title: 'Löschen bestätigen',

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -139,11 +139,15 @@ export const t = {
         }: {
           fileNameWithoutExtension: string;
         }) => `Verschieben von "${fileNameWithoutExtension}"`,
-        emptyMessage: 'Keine Verzeichnisse gefunden',
+        emptyMessage:
+          'Keine Ordner vorhanden, in die diese Notiz verschoben werden kann.',
+        emptyActionText: 'Ordner erstellen',
         groupHeading: 'Verzeichnisse',
         hintClick: 'Enter drücken oder klicken',
         hintDrag:
           'Tipp: Versuchen Sie, eine Notiz in der Seitenleiste zu ziehen',
+        hintCreateDirectory:
+          'Erstellen Sie zuerst einen Ordner und verschieben Sie dann diese Notiz.',
       },
       createDirectory: {
         placeholder: 'Verzeichnisnamen eingeben',
@@ -187,6 +191,8 @@ export const t = {
         errorTitle: 'Fehler',
         noStorageTypes: 'Keine Speicherarten verfügbar.',
         selectTypeTitle: 'Wählen Sie einen Arbeitsbereichstyp',
+        selectTypeDescription:
+          'Wählen Sie, wo dieser Arbeitsbereich seine Notizen speichert.',
         dataPrivacyLink: 'Ihre Daten bleiben bei Ihnen',
         enterNameTitle: 'Arbeitsbereichsnamen eingeben',
         enterNameDescription:
@@ -351,6 +357,9 @@ export const t = {
         noWorkspaceSelectedTitle: 'Kein Arbeitsbereich ausgewählt',
         noWorkspaceSelectedSubtitle:
           'Klicken Sie, um einen Arbeitsbereich auszuwählen',
+        mobileTitle: 'Seitenleiste',
+        mobileDescription:
+          'Arbeitsbereiche, Notizen und App-Aktionen navigieren.',
       },
       breadcrumb: {
         moreSr: 'Mehr',

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -95,9 +95,9 @@ export const t = {
     },
     dialogs: {
       changeTheme: {
-        placeholder: 'Wählen Sie eine Theme-Einstellung',
-        badgeText: 'Theme ändern',
-        groupHeading: 'Themes',
+        searchPlaceholder: 'Wählen Sie eine Theme-Einstellung',
+        title: 'Theme ändern',
+        groupLabel: 'Themes',
         emptyMessage: 'Keine Themes verfügbar',
         options: {
           system: 'System',
@@ -138,8 +138,8 @@ export const t = {
         submitText: 'Umbenennen',
       },
       moveNote: {
-        placeholder: 'Wählen Sie einen Pfad zum Verschieben der Notiz',
-        badgeText: ({
+        searchPlaceholder: 'Wählen Sie einen Pfad zum Verschieben der Notiz',
+        title: ({
           fileNameWithoutExtension,
         }: {
           fileNameWithoutExtension: string;
@@ -147,7 +147,7 @@ export const t = {
         emptyMessage:
           'Keine Ordner vorhanden, in die diese Notiz verschoben werden kann.',
         emptyActionText: 'Ordner erstellen',
-        groupHeading: 'Verzeichnisse',
+        groupLabel: 'Verzeichnisse',
         hintClick: 'Enter drücken oder klicken',
         hintDrag:
           'Tipp: Versuchen Sie, eine Notiz in der Seitenleiste zu ziehen',
@@ -163,15 +163,15 @@ export const t = {
         submitText: 'Erstellen',
       },
       switchWorkspace: {
-        placeholder: 'Wählen Sie einen Arbeitsbereich zum Wechseln',
-        badgeText: 'Arbeitsbereich wechseln',
-        groupHeading: 'Arbeitsbereiche',
+        searchPlaceholder: 'Wählen Sie einen Arbeitsbereich zum Wechseln',
+        title: 'Arbeitsbereich wechseln',
+        groupLabel: 'Arbeitsbereiche',
         emptyMessage: 'Keine Arbeitsbereiche gefunden',
       },
       deleteWorkspace: {
-        placeholder: 'Wählen Sie einen Arbeitsbereich zum Löschen',
-        badgeText: 'Arbeitsbereich löschen',
-        groupHeading: 'Arbeitsbereiche',
+        searchPlaceholder: 'Wählen Sie einen Arbeitsbereich zum Löschen',
+        title: 'Arbeitsbereich löschen',
+        groupLabel: 'Arbeitsbereiche',
         emptyMessage: 'Keine Arbeitsbereiche gefunden',
       },
       confirmDeleteWorkspace: {

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -106,9 +106,12 @@ export const t = {
         },
       },
       createNote: {
-        placeholder: 'Geben Sie einen Notiznamen ein',
-        badgeText: 'Notiz erstellen',
-        optionTitle: 'Erstellen',
+        title: 'Notiz erstellen',
+        description:
+          'Benennen Sie die Notiz, bevor sie diesem Arbeitsbereich hinzugefügt wird.',
+        inputLabel: 'Notizname',
+        placeholder: 'Unbenannte Notiz',
+        submitText: 'Erstellen',
       },
       deleteNote: {
         placeholder: 'Wählen oder tippen Sie eine Notiz zum Löschen',
@@ -124,13 +127,15 @@ export const t = {
         continueText: 'Löschen',
       },
       renameNote: {
-        placeholder: 'Geben Sie einen neuen Namen an',
-        badgeText: ({
+        title: 'Notiz umbenennen',
+        description: ({
           fileNameWithoutExtension,
         }: {
           fileNameWithoutExtension: string;
-        }) => `Umbenennen von "${fileNameWithoutExtension}"`,
-        optionTitle: 'Namensänderung bestätigen',
+        }) => `Wählen Sie einen neuen Namen für „${fileNameWithoutExtension}“.`,
+        inputLabel: 'Neuer Name',
+        placeholder: 'Neuer Notizname',
+        submitText: 'Umbenennen',
       },
       moveNote: {
         placeholder: 'Wählen Sie einen Pfad zum Verschieben der Notiz',
@@ -150,9 +155,12 @@ export const t = {
           'Erstellen Sie zuerst einen Ordner und verschieben Sie dann diese Notiz.',
       },
       createDirectory: {
-        placeholder: 'Verzeichnisnamen eingeben',
-        badgeText: 'Verzeichnis erstellen',
-        optionTitle: 'Erstellen',
+        title: 'Ordner erstellen',
+        description:
+          'Fügen Sie einen Ordner hinzu, um Notizen in diesem Arbeitsbereich zu organisieren.',
+        inputLabel: 'Ordnername',
+        placeholder: 'Ordnername',
+        submitText: 'Erstellen',
       },
       switchWorkspace: {
         placeholder: 'Wählen Sie einen Arbeitsbereich zum Wechseln',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -100,9 +100,9 @@ export const t = {
     },
     dialogs: {
       changeTheme: {
-        placeholder: 'Select a theme preference',
-        badgeText: 'Change Theme',
-        groupHeading: 'Themes',
+        searchPlaceholder: 'Select a theme preference',
+        title: 'Change Theme',
+        groupLabel: 'Themes',
         emptyMessage: 'No themes available',
         options: {
           system: 'System',
@@ -142,15 +142,15 @@ export const t = {
         submitText: 'Rename',
       },
       moveNote: {
-        placeholder: 'Select a path to move the note',
-        badgeText: ({
+        searchPlaceholder: 'Select a path to move the note',
+        title: ({
           fileNameWithoutExtension,
         }: {
           fileNameWithoutExtension: string;
         }) => `Move "${fileNameWithoutExtension}"`,
         emptyMessage: 'No folders to move this note into.',
         emptyActionText: 'Create Folder',
-        groupHeading: 'Directories',
+        groupLabel: 'Directories',
         hintClick: 'Press Enter or Click',
         hintDrag: 'Tip: Try dragging a note in the sidebar',
         hintCreateDirectory: 'Create a folder first, then move this note.',
@@ -163,15 +163,15 @@ export const t = {
         submitText: 'Create',
       },
       switchWorkspace: {
-        placeholder: 'Select a workspace to switch',
-        badgeText: 'Switch Workspace',
-        groupHeading: 'Workspaces',
+        searchPlaceholder: 'Select a workspace to switch',
+        title: 'Switch Workspace',
+        groupLabel: 'Workspaces',
         emptyMessage: 'No workspaces found',
       },
       deleteWorkspace: {
-        placeholder: 'Select a workspace to delete',
-        badgeText: 'Delete Workspace',
-        groupHeading: 'Workspaces',
+        searchPlaceholder: 'Select a workspace to delete',
+        title: 'Delete Workspace',
+        groupLabel: 'Workspaces',
         emptyMessage: 'No workspaces found',
       },
       confirmDeleteWorkspace: {

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -351,9 +351,12 @@ export const t = {
         deleteAction: 'Delete',
         moveAction: 'Move',
         createNoteAction: 'Create Note',
+        moreActionsSr: ({ itemName }: { itemName: string }) =>
+          `More actions for ${itemName}`,
       },
       dialog: {
         closeSr: 'Close',
+        commandDescriptionSr: 'Type to search and select an item.',
       },
       sheet: {
         closeSr: 'Close',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -76,7 +76,8 @@ export const t = {
       linkedMentions: {
         heading: 'Linked mentions',
         loading: 'Loading linked mentions...',
-        empty: 'No linked mentions',
+        empty:
+          'No backlinks yet. Type [[ in another note to create a backlink to this note.',
         error: 'Unable to load linked mentions',
         collapse: 'Collapse linked mentions',
         expand: 'Expand linked mentions',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -144,10 +144,12 @@ export const t = {
         }: {
           fileNameWithoutExtension: string;
         }) => `Move "${fileNameWithoutExtension}"`,
-        emptyMessage: 'No directories found',
+        emptyMessage: 'No folders to move this note into.',
+        emptyActionText: 'Create Folder',
         groupHeading: 'Directories',
         hintClick: 'Press Enter or Click',
         hintDrag: 'Tip: Try dragging a note in the sidebar',
+        hintCreateDirectory: 'Create a folder first, then move this note.',
       },
       createDirectory: {
         placeholder: 'Input directory name',
@@ -190,6 +192,7 @@ export const t = {
         errorTitle: 'Error',
         noStorageTypes: 'No storage types are available.',
         selectTypeTitle: 'Select a workspace type',
+        selectTypeDescription: 'Choose where this workspace stores its notes.',
         dataPrivacyLink: 'Your data stays with you',
         enterNameTitle: 'Enter Workspace Name',
         enterNameDescription: 'Please enter a name for your workspace.',
@@ -342,6 +345,8 @@ export const t = {
         workspacesLabel: 'Workspaces',
         noWorkspaceSelectedTitle: 'No workspace selected',
         noWorkspaceSelectedSubtitle: 'Click to select a workspace',
+        mobileTitle: 'Sidebar',
+        mobileDescription: 'Navigate workspaces, notes, and app actions.',
       },
       breadcrumb: {
         moreSr: 'More',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -120,7 +120,7 @@ export const t = {
         badgeText: 'Delete Note',
         groupHeading: 'Notes',
         emptyMessage: 'No notes found',
-        hintDelete: 'Press Enter or Click to delete',
+        hintDelete: 'Select a note to confirm deletion',
       },
       confirmDelete: {
         title: 'Confirm Delete',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -111,9 +111,11 @@ export const t = {
         },
       },
       createNote: {
-        placeholder: 'Input a note name',
-        badgeText: 'Create Note',
-        optionTitle: 'Create',
+        title: 'Create Note',
+        description: 'Name the note before adding it to this workspace.',
+        inputLabel: 'Note name',
+        placeholder: 'Untitled note',
+        submitText: 'Create',
       },
       deleteNote: {
         placeholder: 'Select or type a note to delete',
@@ -129,13 +131,15 @@ export const t = {
         continueText: 'Delete',
       },
       renameNote: {
-        placeholder: 'Provide a new name',
-        badgeText: ({
+        title: 'Rename Note',
+        description: ({
           fileNameWithoutExtension,
         }: {
           fileNameWithoutExtension: string;
-        }) => `Renaming "${fileNameWithoutExtension}"`,
-        optionTitle: 'Confirm name change',
+        }) => `Choose a new name for "${fileNameWithoutExtension}".`,
+        inputLabel: 'New name',
+        placeholder: 'New note name',
+        submitText: 'Rename',
       },
       moveNote: {
         placeholder: 'Select a path to move the note',
@@ -152,9 +156,11 @@ export const t = {
         hintCreateDirectory: 'Create a folder first, then move this note.',
       },
       createDirectory: {
-        placeholder: 'Input directory name',
-        badgeText: 'Create Directory',
-        optionTitle: 'Create',
+        title: 'Create Folder',
+        description: 'Add a folder to organize notes in this workspace.',
+        inputLabel: 'Folder name',
+        placeholder: 'Folder name',
+        submitText: 'Create',
       },
       switchWorkspace: {
         placeholder: 'Select a workspace to switch',

--- a/packages/tooling/desktop-entry/scripts/smoke-test.mjs
+++ b/packages/tooling/desktop-entry/scripts/smoke-test.mjs
@@ -99,7 +99,7 @@ async function createBrowserWorkspaceAndNote(page) {
   await page.getByRole('heading', { name: workspaceName }).waitFor();
 
   await page.getByRole('button', { name: 'New Note' }).click();
-  await page.getByPlaceholder('Input a note name').fill(noteName);
+  await page.getByLabel('Note name').fill(noteName);
   await page.getByRole('button', { name: 'Create' }).click();
   await page
     .getByLabel('breadcrumb')

--- a/packages/tooling/desktop-entry/scripts/smoke-test.mjs
+++ b/packages/tooling/desktop-entry/scripts/smoke-test.mjs
@@ -100,7 +100,7 @@ async function createBrowserWorkspaceAndNote(page) {
 
   await page.getByRole('button', { name: 'New Note' }).click();
   await page.getByPlaceholder('Input a note name').fill(noteName);
-  await page.getByRole('option', { name: 'Create' }).click();
+  await page.getByRole('button', { name: 'Create' }).click();
   await page
     .getByLabel('breadcrumb')
     .getByRole('button', { name: `${noteName}.md` })

--- a/packages/tooling/desktop-entry/scripts/smoke-test.mjs
+++ b/packages/tooling/desktop-entry/scripts/smoke-test.mjs
@@ -119,6 +119,58 @@ async function openNoteRoute(page) {
   }, noteUrl());
 }
 
+async function readStoredMarkdown(page) {
+  return page.evaluate(
+    async ({ workspace, note }) => {
+      const request = indexedDB.open('baby-idb-db-3');
+      const database = await new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      const transaction = database.transaction(
+        'baby-idb-db-store-3',
+        'readonly',
+      );
+      const getRequest = transaction
+        .objectStore('baby-idb-db-store-3')
+        .get(`${workspace}/${note}.md`);
+      const file = await new Promise((resolve, reject) => {
+        getRequest.onsuccess = () => resolve(getRequest.result);
+        getRequest.onerror = () => reject(getRequest.error);
+      });
+      database.close();
+      return file ? file.text() : undefined;
+    },
+    { workspace: workspaceName, note: noteName },
+  );
+}
+
+async function waitForStoredMarkdown(page, expected) {
+  const deadline = Date.now() + 10_000;
+  const requiredStableMs = 1_000;
+  let stableSince;
+  let lastValue;
+
+  while (Date.now() < deadline) {
+    lastValue = await readStoredMarkdown(page);
+    if (lastValue === expected) {
+      stableSince ??= Date.now();
+      if (Date.now() - stableSince >= requiredStableMs) {
+        return;
+      }
+    } else {
+      stableSince = undefined;
+    }
+    await page.waitForTimeout(100);
+  }
+
+  throw new Error(
+    `[desktop-smoke] Expected stored note content to stabilize at ${JSON.stringify(
+      expected,
+    )}, got ${JSON.stringify(lastValue)}.`,
+  );
+}
+
 let app = await launchApp();
 let page = await firstWindow(app);
 
@@ -132,6 +184,7 @@ try {
   await page.locator(editorSelector).pressSequentially(noteContent, {
     delay: 10,
   });
+  await waitForStoredMarkdown(page, noteContent);
   console.log('[desktop-smoke] Checking persistence after reload.');
   await page.reload({ waitUntil: 'domcontentloaded' });
   await openNoteRoute(page);
@@ -145,6 +198,7 @@ try {
       )}, got ${JSON.stringify(textAfterReload.trim())}.`,
     );
   }
+  await waitForStoredMarkdown(page, noteContent);
 
   console.log('[desktop-smoke] Checking persistence after restart.');
   await app.close();

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -271,7 +271,7 @@ export async function createBrowserWorkspaceAndNote(
   await createBrowserWorkspace(page, { workspaceName });
   await page.getByRole('button', { name: 'New Note' }).click();
   await page.getByPlaceholder('Input a note name').fill(noteName);
-  await page.getByRole('option', { name: 'Create' }).click();
+  await page.getByRole('button', { name: 'Create' }).click();
   await expect(getEditorLocator(page, {})).toBeVisible();
 }
 

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -270,7 +270,7 @@ export async function createBrowserWorkspaceAndNote(
 ) {
   await createBrowserWorkspace(page, { workspaceName });
   await page.getByRole('button', { name: 'New Note' }).click();
-  await page.getByPlaceholder('Input a note name').fill(noteName);
+  await page.getByLabel('Note name').fill(noteName);
   await page.getByRole('button', { name: 'Create' }).click();
   await expect(getEditorLocator(page, {})).toBeVisible();
 }

--- a/packages/tooling/e2e-tests/src/component-tests/dialog-input-and-select.ct.tsx
+++ b/packages/tooling/e2e-tests/src/component-tests/dialog-input-and-select.ct.tsx
@@ -1,0 +1,83 @@
+import stories from '@bangle.io/ui-components/src/dialog-input-and-select.stories.portable';
+import { expect, test } from '@playwright/experimental-ct-react';
+import React from 'react';
+
+test('single input dialog exposes a direct form flow', async ({
+  mount,
+  page,
+}) => {
+  await mount(<stories.CreateNoteInput />);
+
+  const dialog = page.getByRole('dialog', { name: 'Create Note' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('Name the note')).toBeVisible();
+  await expect(dialog.getByLabel('Note name')).toHaveAttribute(
+    'placeholder',
+    'Untitled note',
+  );
+  await expect(dialog.getByRole('button', { name: 'Create' })).toBeDisabled();
+
+  await dialog.getByLabel('Note name').fill('meeting-notes');
+  await dialog.getByRole('button', { name: 'Create' }).click();
+
+  await expect(page.getByLabel('Submitted note name')).toHaveText(
+    'meeting-notes',
+  );
+  await expect(dialog).toBeHidden();
+});
+
+test('single select keeps input focus model and scrolls active option', async ({
+  mount,
+  page,
+}) => {
+  await mount(<stories.LongSingleSelect />);
+
+  const dialog = page.getByRole('dialog', { name: 'Move Note' });
+  await expect(
+    dialog.getByRole('combobox', { name: 'Find a folder' }),
+  ).toBeFocused();
+
+  const cancelButton = dialog.getByRole('button', { name: 'Cancel' });
+  for (let index = 0; index < 4; index += 1) {
+    expect(
+      await page.evaluate(() => document.activeElement?.getAttribute('role')),
+    ).not.toBe('option');
+
+    if (
+      await cancelButton.evaluate(
+        (element) => element === document.activeElement,
+      )
+    ) {
+      break;
+    }
+
+    await page.keyboard.press('Tab');
+  }
+  await expect(cancelButton).toBeFocused();
+
+  await dialog.getByRole('combobox', { name: 'Find a folder' }).focus();
+
+  for (let index = 0; index < 30; index += 1) {
+    await page.keyboard.press('ArrowDown');
+  }
+
+  const listbox = dialog.getByRole('listbox', { name: 'Folders' });
+  const activeOption = dialog.getByRole('option', { name: 'Folder 31' });
+
+  await expect(activeOption).toHaveAttribute('aria-selected', 'true');
+  await expect
+    .poll(async () => {
+      const listBounds = await listbox.boundingBox();
+      const optionBounds = await activeOption.boundingBox();
+
+      if (!listBounds || !optionBounds) {
+        return false;
+      }
+
+      return (
+        optionBounds.y >= listBounds.y &&
+        optionBounds.y + optionBounds.height <= listBounds.y + listBounds.height
+      );
+    })
+    .toBe(true);
+});

--- a/packages/tooling/e2e-tests/src/component-tests/dialog-input-and-select.ct.tsx
+++ b/packages/tooling/e2e-tests/src/component-tests/dialog-input-and-select.ct.tsx
@@ -61,10 +61,10 @@ test('single select keeps input focus model and scrolls active option', async ({
     await page.keyboard.press('ArrowDown');
   }
 
-  const listbox = dialog.getByRole('listbox', { name: 'Folders' });
-  const activeOption = dialog.getByRole('option', { name: 'Folder 31' });
+  const listbox = dialog.locator('[cmdk-list]');
+  const activeOption = dialog.locator('[cmdk-item][data-selected="true"]');
 
-  await expect(activeOption).toHaveAttribute('aria-selected', 'true');
+  await expect(activeOption).toContainText('Folder');
   await expect
     .poll(async () => {
       const listBounds = await listbox.boundingBox();

--- a/packages/tooling/e2e-tests/src/component-tests/workspace-dialog.ct.tsx
+++ b/packages/tooling/e2e-tests/src/component-tests/workspace-dialog.ct.tsx
@@ -13,6 +13,10 @@ test('Default dialog shows storage options and navigates', async ({
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
   await expect(dialog).toContainText('Select a workspace type');
+  await expect(dialog).toContainText(
+    'Choose where this workspace stores its notes.',
+  );
+  await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeVisible();
 
   // Test browser storage back button
   await page.getByRole('radio', { name: /Browser Storage/i }).click();

--- a/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
+++ b/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
@@ -17,6 +17,7 @@ test('delete note command opens confirmation without an intermediate picker', as
 
   const confirmation = page.getByRole('alertdialog');
   await expect(confirmation).toBeVisible();
+  await expect(confirmation).not.toHaveClass(/slide-in-from-left/);
   await expect(confirmation).toContainText(
     'Are you sure you want to delete "delete-target"?',
   );

--- a/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
+++ b/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
@@ -37,17 +37,13 @@ test('move note dialog accepts directory destinations from the file tree', async
   });
 
   await pressAppShortcut(page, 'k');
-  await page
-    .getByPlaceholder('Type a command or search...')
-    .fill('New Directory');
-  await page.getByRole('option', { name: '> New Directory' }).click();
+  await page.getByPlaceholder('Type a command or search...').fill('New Folder');
+  await page.getByRole('option', { name: '> New Folder' }).click();
 
   const createDirectory = page.getByRole('dialog', {
-    name: 'Create Directory',
+    name: 'Create Folder',
   });
-  await createDirectory
-    .getByPlaceholder('Input directory name')
-    .fill('Projects');
+  await createDirectory.getByLabel('Folder name').fill('Projects');
   await createDirectory.getByRole('button', { name: 'Create' }).click();
   const targetTreeItem = page
     .locator('[data-sidebar="menu-button"]')
@@ -103,6 +99,6 @@ test('move note dialog offers folder creation when there is no destination', asy
 
   await expect(moveDialog).toBeHidden();
   await expect(
-    page.getByRole('dialog', { name: 'Create Directory' }),
+    page.getByRole('dialog', { name: 'Create Folder' }),
   ).toBeVisible();
 });

--- a/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
+++ b/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
@@ -15,12 +15,10 @@ test('delete note picker opens a confirmation step before deleting', async ({
     .fill('Delete Note');
   await page.getByRole('option', { name: '> Delete Note' }).click();
 
-  const picker = page.getByLabel('dialog select');
+  const picker = page.getByRole('dialog', { name: 'Delete Note' });
   const deleteBadge = picker.getByText('Delete Note', { exact: true });
   await expect(deleteBadge).toBeVisible();
-  await expect(deleteBadge.locator('xpath=parent::*')).not.toHaveClass(
-    /bg-destructive/,
-  );
+  await expect(deleteBadge).not.toHaveClass(/text-destructive/);
   await expect(
     picker.getByText('Select a note to confirm deletion'),
   ).toBeVisible();
@@ -36,4 +34,51 @@ test('delete note picker opens a confirmation step before deleting', async ({
   await expect(
     confirmation.getByRole('button', { name: 'Delete' }),
   ).toBeVisible();
+});
+
+test('move note dialog accepts directory destinations from the file tree', async ({
+  page,
+}) => {
+  const workspaceName = 'file-modal-move-workspace';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'move-target',
+  });
+
+  await pressAppShortcut(page, 'k');
+  await page
+    .getByPlaceholder('Type a command or search...')
+    .fill('New Directory');
+  await page.getByRole('option', { name: '> New Directory' }).click();
+
+  const createDirectory = page.getByRole('dialog', {
+    name: 'Create Directory',
+  });
+  await createDirectory
+    .getByPlaceholder('Input directory name')
+    .fill('Projects');
+  await createDirectory.getByRole('button', { name: 'Create' }).click();
+  const targetTreeItem = page
+    .locator('[data-sidebar="menu-button"]')
+    .filter({ hasText: 'move-target.md' })
+    .first();
+  await expect(targetTreeItem).toBeVisible();
+  await expect(page.getByRole('link', { name: 'untitled-1.md' })).toBeVisible();
+
+  await targetTreeItem.hover();
+  await page
+    .getByRole('button', { name: 'More actions for move-target.md' })
+    .click();
+  await page.getByRole('menuitem', { name: 'Move' }).click();
+
+  const moveDialog = page.getByRole('dialog', { name: 'Move "move-target"' });
+  await expect(moveDialog).toBeVisible();
+  await moveDialog.getByRole('option', { name: /Projects\/?/ }).click();
+
+  await targetTreeItem.click();
+  await expect(page).toHaveURL(
+    `/ws#route=editor&wsPath=${encodeURIComponent(
+      `${workspaceName}:Projects/move-target.md`,
+    )}`,
+  );
 });

--- a/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
+++ b/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
@@ -4,8 +4,9 @@ import { createBrowserWorkspaceAndNote, pressAppShortcut } from './common';
 test('delete note command opens confirmation without an intermediate picker', async ({
   page,
 }) => {
+  const workspaceName = 'delete-note-dialog-workspace';
   await createBrowserWorkspaceAndNote(page, {
-    workspaceName: 'delete-note-dialog-workspace',
+    workspaceName,
     noteName: 'delete-target',
   });
 
@@ -25,6 +26,19 @@ test('delete note command opens confirmation without an intermediate picker', as
   await expect(
     confirmation.getByRole('button', { name: 'Delete' }),
   ).toBeVisible();
+
+  await confirmation.getByRole('button', { name: 'Delete' }).click();
+
+  const deletedNoteTreeItem = page
+    .locator('[data-sidebar="menu-button"]')
+    .filter({ hasText: 'delete-target.md' });
+  await expect(deletedNoteTreeItem).toHaveCount(0);
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(
+    page.getByRole('heading', { name: workspaceName }),
+  ).toBeVisible();
+  await expect(deletedNoteTreeItem).toHaveCount(0);
 });
 
 test('move note dialog accepts directory destinations from the file tree', async ({

--- a/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
+++ b/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
@@ -63,6 +63,16 @@ test('move note dialog accepts directory destinations from the file tree', async
 
   const moveDialog = page.getByRole('dialog', { name: 'Move "move-target"' });
   await expect(moveDialog).toBeVisible();
+  await moveDialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(moveDialog).toBeHidden();
+  await expect(targetTreeItem).toBeVisible();
+
+  await targetTreeItem.hover();
+  await page
+    .getByRole('button', { name: 'More actions for move-target.md' })
+    .click();
+  await page.getByRole('menuitem', { name: 'Move' }).click();
+  await expect(moveDialog).toBeVisible();
   await moveDialog.getByRole('option', { name: /Projects\/?/ }).click();
 
   await targetTreeItem.click();
@@ -71,4 +81,27 @@ test('move note dialog accepts directory destinations from the file tree', async
       `${workspaceName}:Projects/move-target.md`,
     )}`,
   );
+});
+
+test('move note dialog offers folder creation when there is no destination', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'move-note-empty-destination-workspace',
+    noteName: 'root-note',
+  });
+
+  await pressAppShortcut(page, 'k');
+  await page.getByPlaceholder('Type a command or search...').fill('Move Note');
+  await page.getByRole('option', { name: '> Move Note' }).click();
+
+  const moveDialog = page.getByRole('dialog', { name: 'Move "root-note"' });
+  await expect(moveDialog).toBeVisible();
+  await expect(moveDialog).toContainText('No folders to move this note into.');
+  await moveDialog.getByRole('button', { name: 'Create Folder' }).click();
+
+  await expect(moveDialog).toBeHidden();
+  await expect(
+    page.getByRole('dialog', { name: 'Create Directory' }),
+  ).toBeVisible();
 });

--- a/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
+++ b/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { createBrowserWorkspaceAndNote, pressAppShortcut } from './common';
+
+test('delete note picker opens a confirmation step before deleting', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'delete-note-dialog-workspace',
+    noteName: 'delete-target',
+  });
+
+  await pressAppShortcut(page, 'k');
+  await page
+    .getByPlaceholder('Type a command or search...')
+    .fill('Delete Note');
+  await page.getByRole('option', { name: '> Delete Note' }).click();
+
+  const picker = page.getByLabel('dialog select');
+  const deleteBadge = picker.getByText('Delete Note', { exact: true });
+  await expect(deleteBadge).toBeVisible();
+  await expect(deleteBadge.locator('xpath=parent::*')).not.toHaveClass(
+    /bg-destructive/,
+  );
+  await expect(
+    picker.getByText('Select a note to confirm deletion'),
+  ).toBeVisible();
+  await expect(page.getByRole('alertdialog')).toBeHidden();
+
+  await page.getByRole('option', { name: 'delete-target.md' }).click();
+
+  const confirmation = page.getByRole('alertdialog');
+  await expect(confirmation).toBeVisible();
+  await expect(confirmation).toContainText(
+    'Are you sure you want to delete "delete-target"?',
+  );
+  await expect(
+    confirmation.getByRole('button', { name: 'Delete' }),
+  ).toBeVisible();
+});

--- a/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
+++ b/packages/tooling/e2e-tests/src/delete-note-dialog.e2e.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { createBrowserWorkspaceAndNote, pressAppShortcut } from './common';
 
-test('delete note picker opens a confirmation step before deleting', async ({
+test('delete note command opens confirmation without an intermediate picker', async ({
   page,
 }) => {
   await createBrowserWorkspaceAndNote(page, {
@@ -15,22 +15,12 @@ test('delete note picker opens a confirmation step before deleting', async ({
     .fill('Delete Note');
   await page.getByRole('option', { name: '> Delete Note' }).click();
 
-  const picker = page.getByRole('dialog', { name: 'Delete Note' });
-  const deleteBadge = picker.getByText('Delete Note', { exact: true });
-  await expect(deleteBadge).toBeVisible();
-  await expect(deleteBadge).not.toHaveClass(/text-destructive/);
-  await expect(
-    picker.getByText('Select a note to confirm deletion'),
-  ).toBeVisible();
-  await expect(page.getByRole('alertdialog')).toBeHidden();
-
-  await page.getByRole('option', { name: 'delete-target.md' }).click();
-
   const confirmation = page.getByRole('alertdialog');
   await expect(confirmation).toBeVisible();
   await expect(confirmation).toContainText(
     'Are you sure you want to delete "delete-target"?',
   );
+  await expect(page.getByRole('dialog', { name: 'Delete Note' })).toBeHidden();
   await expect(
     confirmation.getByRole('button', { name: 'Delete' }),
   ).toBeVisible();

--- a/packages/tooling/e2e-tests/src/selection-menu.e2e.ts
+++ b/packages/tooling/e2e-tests/src/selection-menu.e2e.ts
@@ -453,7 +453,7 @@ test('creates and modifier-opens a relative Markdown note link', async ({
   await page.getByRole('link', { name: 'Home' }).click();
   await page.getByRole('button', { name: 'New Note' }).click();
   await page.getByPlaceholder('Input a note name').fill('source');
-  await page.getByRole('option', { name: 'Create' }).click();
+  await page.getByRole('button', { name: 'Create' }).click();
   await editor.click();
   await page.keyboard.insertText('open target');
   await selectEditorText(page, 'target');

--- a/packages/tooling/e2e-tests/src/selection-menu.e2e.ts
+++ b/packages/tooling/e2e-tests/src/selection-menu.e2e.ts
@@ -452,7 +452,7 @@ test('creates and modifier-opens a relative Markdown note link', async ({
 
   await page.getByRole('link', { name: 'Home' }).click();
   await page.getByRole('button', { name: 'New Note' }).click();
-  await page.getByPlaceholder('Input a note name').fill('source');
+  await page.getByLabel('Note name').fill('source');
   await page.getByRole('button', { name: 'Create' }).click();
   await editor.click();
   await page.keyboard.insertText('open target');

--- a/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
@@ -37,7 +37,7 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
     await expect(
       page.getByRole('dialog', { name: 'Create Note' }),
     ).toBeVisible();
-    await page.getByPlaceholder('Input a note name').fill('test-note-1');
+    await page.getByLabel('Note name').fill('test-note-1');
     await page.getByRole('button', { name: 'Create' }).click();
 
     await expect(

--- a/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
@@ -34,9 +34,11 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
     await expect(page.getByRole('button', { name: 'New Note' })).toBeVisible();
     await page.getByRole('button', { name: 'New Note' }).click();
 
-    await expect(page.getByText('Create NoteCreate')).toBeVisible();
+    await expect(
+      page.getByRole('dialog', { name: 'Create Note' }),
+    ).toBeVisible();
     await page.getByPlaceholder('Input a note name').fill('test-note-1');
-    await page.getByRole('option', { name: 'Create' }).click();
+    await page.getByRole('button', { name: 'Create' }).click();
 
     await expect(
       page

--- a/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
+++ b/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
@@ -162,6 +162,23 @@ test('does not offer the note being edited as a wiki-link suggestion', async ({
   ).toHaveCount(0);
 });
 
+test('explains how to create backlinks when linked mentions are empty', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'empty-linked-mentions',
+    noteName: 'Home',
+  });
+
+  const linkedMentions = page.getByRole('region', {
+    name: 'Linked mentions',
+  });
+
+  await expect(linkedMentions).toContainText(
+    'No backlinks yet. Type [[ in another note to create a backlink to this note.',
+  );
+});
+
 test('shows exact linked mentions for the active note', async ({ page }) => {
   const workspaceName = 'linked-mentions';
   await createBrowserWorkspaceAndNote(page, {

--- a/packages/tooling/e2e-tests/src/workspace-dialog.e2e.tsx
+++ b/packages/tooling/e2e-tests/src/workspace-dialog.e2e.tsx
@@ -1,7 +1,20 @@
-import { test } from '@playwright/experimental-ct-react';
+import { expect, test } from '@playwright/experimental-ct-react';
 
 test('Submit workspace name', async ({ page }) => {
   await page.goto('/');
+
+  await page.getByRole('button', { name: 'No workspace selected' }).click();
+  await page
+    .locator('[data-radix-popper-content-wrapper]')
+    .getByText('New Workspace')
+    .click();
+  await expect(
+    page.getByText('Choose where this workspace stores its notes.'),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  await expect(
+    page.getByRole('dialog', { name: 'Select a workspace type' }),
+  ).toBeHidden();
 
   await page.getByRole('button', { name: 'No workspace selected' }).click();
   await page

--- a/packages/tooling/e2e-tests/src/workspace-dialog.e2e.tsx
+++ b/packages/tooling/e2e-tests/src/workspace-dialog.e2e.tsx
@@ -9,6 +9,9 @@ test('Submit workspace name', async ({ page }) => {
     .getByText('New Workspace')
     .click();
   await expect(
+    page.getByRole('dialog', { name: 'Select a workspace type' }),
+  ).not.toHaveClass(/slide-in-from-left/);
+  await expect(
     page.getByText('Choose where this workspace stores its notes.'),
   ).toBeVisible();
   await page.getByRole('button', { name: 'Cancel' }).click();

--- a/packages/ui/shadcn/src/alert-dialog.tsx
+++ b/packages/ui/shadcn/src/alert-dialog.tsx
@@ -3,6 +3,11 @@ import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 import type { VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 import { buttonVariants } from './button';
+import {
+  centeredModalContentClassName,
+  centeredModalContentStyle,
+  modalOverlayClassName,
+} from './modal-motion';
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -15,10 +20,7 @@ const AlertDialogOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
-    className={cn(
-      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in',
-      className,
-    )}
+    className={cn(modalOverlayClassName, className)}
     {...props}
     ref={ref}
   />
@@ -33,11 +35,8 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
       ref={ref}
-      className={cn(
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
-        className,
-      )}
-      style={{ translate: '-50% -50%', ...style }}
+      className={cn(centeredModalContentClassName, className)}
+      style={{ ...centeredModalContentStyle, ...style }}
       {...props}
     />
   </AlertDialogPortal>

--- a/packages/ui/shadcn/src/command.tsx
+++ b/packages/ui/shadcn/src/command.tsx
@@ -3,7 +3,12 @@ import type { DialogProps } from '@radix-ui/react-dialog';
 import { Command as CommandPrimitive } from 'cmdk';
 import { Search } from 'lucide-react';
 import * as React from 'react';
-import { Dialog, DialogContent, DialogTitle } from './dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from './dialog';
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -41,12 +46,15 @@ const CommandDialog = ({
 }) => {
   return (
     <Dialog {...props}>
-      <DialogTitle className="sr-only">{screenReaderTitle}</DialogTitle>
       <DialogContent
         className="overflow-hidden p-0 shadow-lg"
         onOpenAutoFocus={onOpenAutoFocus}
         onCloseAutoFocus={onCloseAutoFocus}
       >
+        <DialogTitle className="sr-only">{screenReaderTitle}</DialogTitle>
+        <DialogDescription className="sr-only">
+          {t.app.components.dialog.commandDescriptionSr}
+        </DialogDescription>
         <Command
           loop={loop}
           shouldFilter={shouldFilter}

--- a/packages/ui/shadcn/src/dialog.tsx
+++ b/packages/ui/shadcn/src/dialog.tsx
@@ -2,6 +2,11 @@ import { cn } from '@bangle.io/ui-misc';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import * as React from 'react';
+import {
+  centeredModalContentClassName,
+  centeredModalContentStyle,
+  modalOverlayClassName,
+} from './modal-motion';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -17,10 +22,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
-    className={cn(
-      'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in',
-      className,
-    )}
+    className={cn(modalOverlayClassName, className)}
     {...props}
   />
 ));
@@ -34,11 +36,8 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
-      className={cn(
-        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg',
-        className,
-      )}
-      style={{ translate: '-50% -50%', ...style }}
+      className={cn(centeredModalContentClassName, className)}
+      style={{ ...centeredModalContentStyle, ...style }}
       {...props}
     >
       {children}

--- a/packages/ui/shadcn/src/modal-motion.ts
+++ b/packages/ui/shadcn/src/modal-motion.ts
@@ -1,0 +1,11 @@
+import type React from 'react';
+
+export const modalOverlayClassName =
+  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=open]:animate-in';
+
+export const centeredModalContentClassName =
+  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-lg gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in sm:rounded-lg';
+
+export const centeredModalContentStyle = {
+  translate: '-50% -50%',
+} satisfies React.CSSProperties;

--- a/packages/ui/ui-components/src/Tree.tsx
+++ b/packages/ui/ui-components/src/Tree.tsx
@@ -155,8 +155,13 @@ const TreeNode = function TreeNode({
         {itemActions.length > 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <SidebarMenuAction showOnHover>
-                <MoreHorizontal />
+              <SidebarMenuAction
+                showOnHover
+                aria-label={t.app.components.tree.moreActionsSr({
+                  itemName: item.name,
+                })}
+              >
+                <MoreHorizontal aria-hidden="true" />
               </SidebarMenuAction>
             </DropdownMenuTrigger>
             <DropdownMenuContent side="right" align="start">
@@ -213,8 +218,13 @@ const TreeNode = function TreeNode({
         {itemActions.length > 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <SidebarMenuAction showOnHover>
-                <MoreHorizontal />
+              <SidebarMenuAction
+                showOnHover
+                aria-label={t.app.components.tree.moreActionsSr({
+                  itemName: item.name,
+                })}
+              >
+                <MoreHorizontal aria-hidden="true" />
               </SidebarMenuAction>
             </DropdownMenuTrigger>
             <DropdownMenuContent side="right" align="start">

--- a/packages/ui/ui-components/src/app-alert-dialog.tsx
+++ b/packages/ui/ui-components/src/app-alert-dialog.tsx
@@ -35,8 +35,21 @@ export function AppAlertDialog({
   onContinue,
   tone = 'default',
 }: AppAlertDialogProps) {
+  const handledActionRef = React.useRef(false);
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen && !handledActionRef.current) {
+        onCancel();
+      }
+      handledActionRef.current = false;
+      setOpen(nextOpen);
+    },
+    [onCancel, setOpen],
+  );
+
   return (
-    <AlertDialog key={dialogId} open={open} onOpenChange={setOpen}>
+    <AlertDialog key={dialogId} open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent autoFocus>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
@@ -45,13 +58,19 @@ export function AppAlertDialog({
         <AlertDialogFooter>
           <AlertDialogCancel
             autoFocus={tone === 'destructive'}
-            onClick={onCancel}
+            onClick={() => {
+              handledActionRef.current = true;
+              onCancel();
+            }}
           >
             {cancelText}
           </AlertDialogCancel>
           <AlertDialogAction
             autoFocus={tone !== 'destructive'}
-            onClick={onContinue}
+            onClick={() => {
+              handledActionRef.current = true;
+              onContinue();
+            }}
             variant={tone}
           >
             {continueText}

--- a/packages/ui/ui-components/src/dialog-input-and-select.stories.portable.tsx
+++ b/packages/ui/ui-components/src/dialog-input-and-select.stories.portable.tsx
@@ -1,0 +1,28 @@
+import { composeStory } from '@storybook/react';
+import type React from 'react';
+
+import meta, {
+  CreateNoteInput as CreateNoteInputStory,
+  LongSingleSelect as LongSingleSelectStory,
+} from './dialog-input-and-select.stories';
+
+type PortableStory = React.ComponentType;
+
+export const CreateNoteInput: PortableStory = composeStory(
+  CreateNoteInputStory,
+  meta,
+);
+export const LongSingleSelect: PortableStory = composeStory(
+  LongSingleSelectStory,
+  meta,
+);
+
+const composedStories: Record<
+  'CreateNoteInput' | 'LongSingleSelect',
+  PortableStory
+> = {
+  CreateNoteInput,
+  LongSingleSelect,
+};
+
+export default composedStories;

--- a/packages/ui/ui-components/src/dialog-input-and-select.stories.tsx
+++ b/packages/ui/ui-components/src/dialog-input-and-select.stories.tsx
@@ -46,9 +46,10 @@ export const LongSingleSelect: Story = {
       <DialogSingleSelect
         open={open}
         setOpen={setOpen}
-        badgeText="Move Note"
-        placeholder="Find a folder"
-        groupHeading="Folders"
+        title="Move Note"
+        description="Choose a destination folder."
+        searchPlaceholder="Find a folder"
+        groupLabel="Folders"
         options={options}
         onSelect={() => {}}
       />

--- a/packages/ui/ui-components/src/dialog-input-and-select.stories.tsx
+++ b/packages/ui/ui-components/src/dialog-input-and-select.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { DialogSingleInput } from './dialog-single-input';
+import { DialogSingleSelect } from './dialog-single-select';
+
+export default {
+  title: 'DialogInputAndSelect',
+  component: DialogSingleInput,
+  tags: [],
+} as Meta<typeof DialogSingleInput>;
+
+type Story = StoryObj<typeof DialogSingleInput>;
+
+export const CreateNoteInput: Story = {
+  render: function CreateNoteInputStory() {
+    const [open, setOpen] = React.useState(true);
+    const [submitted, setSubmitted] = React.useState('');
+
+    return (
+      <>
+        <DialogSingleInput
+          open={open}
+          setOpen={setOpen}
+          title="Create Note"
+          description="Name the note before adding it to this workspace."
+          inputLabel="Note name"
+          placeholder="Untitled note"
+          submitText="Create"
+          onSelect={setSubmitted}
+        />
+        <output aria-label="Submitted note name">{submitted}</output>
+      </>
+    );
+  },
+};
+
+export const LongSingleSelect: Story = {
+  render: function LongSingleSelectStory() {
+    const [open, setOpen] = React.useState(true);
+    const options = Array.from({ length: 40 }, (_, index) => ({
+      id: `folder-${index + 1}`,
+      title: `Folder ${index + 1}`,
+    }));
+
+    return (
+      <DialogSingleSelect
+        open={open}
+        setOpen={setOpen}
+        badgeText="Move Note"
+        placeholder="Find a folder"
+        groupHeading="Folders"
+        options={options}
+        onSelect={() => {}}
+      />
+    );
+  },
+};

--- a/packages/ui/ui-components/src/dialog-single-input.tsx
+++ b/packages/ui/ui-components/src/dialog-single-input.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  cn,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -8,44 +7,40 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
+  Label,
 } from '@bangle.io/shadcn';
 import React from 'react';
 
 export type DialogSingleInputProps = {
   open: boolean;
   setOpen: (open: boolean) => void;
-  option: {
-    id: string;
-    title?: string;
-  };
   onSelect: (input: string) => void;
+  title?: string;
+  description?: string;
+  inputLabel?: string;
+  submitText?: string;
   placeholder?: string;
-  groupHeading?: string;
   Icon?: React.ElementType;
-  badgeTone?: 'destructive' | 'default';
-  badgeText?: string;
   initialSearch?: string;
-  hints?: string[];
 };
 
 export function DialogSingleInput({
   open,
   setOpen,
-  option,
   onSelect,
-  groupHeading = '',
   placeholder = t.app.dialogs.singleInput.placeholderDefault,
-  badgeText,
-  badgeTone = 'default',
+  title,
+  description,
+  inputLabel = placeholder,
+  submitText = t.app.common.continueButton,
   Icon,
   initialSearch = '',
-  hints,
 }: DialogSingleInputProps) {
   const [search, setSearch] = React.useState(initialSearch);
   const inputRef = React.useRef<HTMLInputElement>(null);
-  const title = badgeText || option.title || option.id;
-  const description = hints?.join(' ') || placeholder;
-  const submitText = option.title || t.app.common.continueButton;
+  const inputId = React.useId();
+  const dialogTitle = title || inputLabel;
+  const dialogDescription = description || placeholder;
 
   React.useEffect(() => {
     setSearch(initialSearch);
@@ -63,16 +58,11 @@ export function DialogSingleInput({
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle
-            className={cn(
-              'flex items-center gap-2',
-              badgeTone === 'destructive' && 'text-destructive',
-            )}
-          >
+          <DialogTitle className="flex items-center gap-2">
             {Icon && <Icon className="h-5 w-5" aria-hidden="true" />}
-            <span>{title}</span>
+            <span>{dialogTitle}</span>
           </DialogTitle>
-          <DialogDescription>{description}</DialogDescription>
+          <DialogDescription>{dialogDescription}</DialogDescription>
         </DialogHeader>
 
         <form
@@ -87,19 +77,16 @@ export function DialogSingleInput({
             setOpen(false);
           }}
         >
-          {groupHeading && (
-            <div className="font-medium text-muted-foreground text-xs">
-              {groupHeading}
-            </div>
-          )}
-
-          <Input
-            ref={inputRef}
-            aria-label={placeholder}
-            placeholder={placeholder}
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-          />
+          <div className="grid gap-2">
+            <Label htmlFor={inputId}>{inputLabel}</Label>
+            <Input
+              id={inputId}
+              ref={inputRef}
+              placeholder={placeholder}
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </div>
 
           <DialogFooter>
             <Button

--- a/packages/ui/ui-components/src/dialog-single-input.tsx
+++ b/packages/ui/ui-components/src/dialog-single-input.tsx
@@ -1,12 +1,13 @@
-import { cx } from '@bangle.io/base-utils';
 import {
-  CommandBadge,
-  CommandDialog,
-  CommandGroup,
-  CommandHints,
-  CommandInput,
-  CommandItem,
-  CommandList,
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
 } from '@bangle.io/shadcn';
 import React from 'react';
 
@@ -27,9 +28,6 @@ export type DialogSingleInputProps = {
   hints?: string[];
 };
 
-/**
- * A simple dialog with a single option.
- */
 export function DialogSingleInput({
   open,
   setOpen,
@@ -44,48 +42,79 @@ export function DialogSingleInput({
   hints,
 }: DialogSingleInputProps) {
   const [search, setSearch] = React.useState(initialSearch);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const title = badgeText || option.title || option.id;
+  const description = hints?.join(' ') || placeholder;
+  const submitText = option.title || t.app.common.continueButton;
+
+  React.useEffect(() => {
+    setSearch(initialSearch);
+  }, [initialSearch]);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => inputRef.current?.select());
+  }, [open]);
+
   return (
-    <CommandDialog
-      open={open}
-      onOpenChange={setOpen}
-      shouldFilter={false}
-      screenReaderTitle="dialog input"
-    >
-      {badgeText && (
-        <CommandBadge
-          className={cx(badgeTone === 'destructive' && 'bg-destructive')}
-        >
-          <span
-            className={cx(
-              badgeTone === 'destructive' && 'text-destructive-foreground',
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle
+            className={cn(
+              'flex items-center gap-2',
+              badgeTone === 'destructive' && 'text-destructive',
             )}
           >
-            {badgeText}
-          </span>
-        </CommandBadge>
-      )}
-      <CommandInput
-        placeholder={placeholder}
-        value={search}
-        onValueChange={setSearch}
-        Icon={Icon}
-      />
-      <CommandList>
-        <CommandGroup heading={groupHeading}>
-          <CommandItem
-            key={option.id}
-            onSelect={() => {
-              if (search) {
-                onSelect(search);
-              }
-              setOpen(false);
-            }}
-          >
-            {option.title || option.id}
-          </CommandItem>
-        </CommandGroup>
-      </CommandList>
-      <CommandHints hints={hints} />
-    </CommandDialog>
+            {Icon && <Icon className="h-5 w-5" aria-hidden="true" />}
+            <span>{title}</span>
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!search.trim()) {
+              return;
+            }
+
+            onSelect(search);
+            setOpen(false);
+          }}
+        >
+          {groupHeading && (
+            <div className="font-medium text-muted-foreground text-xs">
+              {groupHeading}
+            </div>
+          )}
+
+          <Input
+            ref={inputRef}
+            aria-label={placeholder}
+            placeholder={placeholder}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              {t.app.common.cancelButton}
+            </Button>
+            <Button type="submit" disabled={!search.trim()}>
+              {submitText}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/ui-components/src/dialog-single-select.stories.tsx
+++ b/packages/ui/ui-components/src/dialog-single-select.stories.tsx
@@ -20,7 +20,7 @@ const Template: Story = {
       { id: 'Option 3', title: 'option3' },
     ],
     onSelect: () => {},
-    placeholder: 'Select an option',
+    searchPlaceholder: 'Select an option',
   },
 };
 
@@ -28,20 +28,20 @@ export const Default: Story = {
   ...Template,
 };
 
-export const DefaultBadge: Story = {
+export const WithTitle: Story = {
   ...Template,
   args: {
     ...Template.args,
-    badgeText: 'Issues',
+    title: 'Issues',
   },
 };
 
-export const DestructiveBadge: Story = {
+export const DestructiveTitle: Story = {
   ...Template,
   args: {
     ...Template.args,
-    badgeText: 'Issues',
-    badgeTone: 'destructive',
+    title: 'Issues',
+    tone: 'destructive',
     open: true,
   },
 };

--- a/packages/ui/ui-components/src/dialog-single-select.tsx
+++ b/packages/ui/ui-components/src/dialog-single-select.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   Input,
@@ -26,6 +27,8 @@ export type DialogSingleSelectProps = {
   badgeTone?: 'destructive' | 'default';
   badgeText?: string;
   emptyMessage?: React.ReactNode;
+  emptyActionText?: string;
+  onEmptyAction?: () => void;
   Icon?: React.ElementType;
   initialSearch?: string;
   hints?: string[];
@@ -49,21 +52,29 @@ function DialogHints({ hints }: { hints?: string[] }) {
 
 function SingleSelectItem({
   option,
+  id,
   hasAnyIcon,
+  isActive,
   onSelect,
 }: {
   option: DialogSingleSelectProps['options'][0];
+  id: string;
   hasAnyIcon: boolean;
+  isActive: boolean;
   onSelect: (option: { id: string; title?: string }) => void;
 }) {
   const OptionIcon = option.icon;
   return (
     <Button
+      id={id}
       type="button"
       role="option"
-      aria-selected={option.active ? true : undefined}
+      aria-selected={isActive || option.active}
       variant="ghost"
-      className="h-auto w-full justify-start px-2 py-2 text-left font-normal"
+      className={cn(
+        'h-auto w-full justify-start px-2 py-2 text-left font-normal',
+        isActive && 'bg-accent text-accent-foreground',
+      )}
       onClick={() => onSelect(option)}
     >
       {hasAnyIcon && (
@@ -93,12 +104,16 @@ export function DialogSingleSelect({
   badgeText,
   badgeTone = 'default',
   emptyMessage = t.app.dialogs.singleSelect.emptyMessageDefault,
+  emptyActionText,
+  onEmptyAction,
   initialSearch = '',
   Icon,
   hints,
 }: DialogSingleSelectProps) {
   const [search, setSearch] = React.useState(initialSearch);
+  const [activeIndex, setActiveIndex] = React.useState(0);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const listboxId = React.useId();
   const title = badgeText || groupHeading || placeholder;
   const description = placeholder;
 
@@ -111,6 +126,7 @@ export function DialogSingleSelect({
       return;
     }
 
+    setActiveIndex(0);
     window.requestAnimationFrame(() => inputRef.current?.select());
   }, [open]);
 
@@ -122,6 +138,18 @@ export function DialogSingleSelect({
   }, [search, options]);
 
   const hasAnyIcon = options.some((option) => option.icon);
+  const activeOption = filteredOptions[activeIndex];
+  const activeOptionId = activeOption
+    ? `${listboxId}-option-${activeIndex}`
+    : undefined;
+
+  React.useEffect(() => {
+    setActiveIndex((current) =>
+      filteredOptions.length === 0
+        ? 0
+        : Math.min(current, filteredOptions.length - 1),
+    );
+  }, [filteredOptions.length]);
 
   const selectOption = React.useCallback(
     (option: { id: string; title?: string }) => {
@@ -130,6 +158,10 @@ export function DialogSingleSelect({
     },
     [onSelect, setOpen],
   );
+  const runEmptyAction = React.useCallback(() => {
+    onEmptyAction?.();
+    setOpen(false);
+  }, [onEmptyAction, setOpen]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -151,18 +183,40 @@ export function DialogSingleSelect({
           className="grid gap-4"
           onSubmit={(event) => {
             event.preventDefault();
-            const [firstOption] = filteredOptions;
-            if (firstOption) {
-              selectOption(firstOption);
+            if (activeOption) {
+              selectOption(activeOption);
+            } else if (onEmptyAction) {
+              runEmptyAction();
             }
           }}
         >
           <Input
             ref={inputRef}
             aria-label={placeholder}
+            aria-activedescendant={activeOptionId}
+            aria-controls={listboxId}
+            aria-expanded={open}
+            role="combobox"
             placeholder={placeholder}
             value={search}
-            onChange={(event) => setSearch(event.target.value)}
+            onChange={(event) => {
+              setSearch(event.target.value);
+              setActiveIndex(0);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setActiveIndex((current) =>
+                  filteredOptions.length === 0
+                    ? 0
+                    : Math.min(current + 1, filteredOptions.length - 1),
+                );
+              }
+              if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setActiveIndex((current) => Math.max(current - 1, 0));
+              }
+            }}
           />
 
           <div className="grid gap-2">
@@ -172,28 +226,53 @@ export function DialogSingleSelect({
               </div>
             )}
             <div
+              id={listboxId}
               role="listbox"
               aria-label={groupHeading || title}
               className="max-h-72 overflow-y-auto rounded-md border p-1"
             >
               {filteredOptions.length > 0 ? (
-                filteredOptions.map((option) => (
+                filteredOptions.map((option, index) => (
                   <SingleSelectItem
                     key={option.id}
+                    id={`${listboxId}-option-${index}`}
                     option={option}
                     hasAnyIcon={hasAnyIcon}
+                    isActive={index === activeIndex}
                     onSelect={selectOption}
                   />
                 ))
               ) : (
-                <div className="px-3 py-6 text-center text-muted-foreground text-sm">
-                  {emptyMessage}
+                <div className="grid gap-3 px-3 py-6 text-center">
+                  <div className="text-muted-foreground text-sm">
+                    {emptyMessage}
+                  </div>
+                  {emptyActionText && onEmptyAction && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="justify-self-center"
+                      onClick={runEmptyAction}
+                    >
+                      {emptyActionText}
+                    </Button>
+                  )}
                 </div>
               )}
             </div>
           </div>
 
           <DialogHints hints={hints} />
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              {t.app.common.cancelButton}
+            </Button>
+          </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>

--- a/packages/ui/ui-components/src/dialog-single-select.tsx
+++ b/packages/ui/ui-components/src/dialog-single-select.tsx
@@ -1,13 +1,12 @@
-import { cx } from '@bangle.io/base-utils';
 import {
-  CommandBadge,
-  CommandDialog,
-  CommandEmpty,
-  CommandGroup,
-  CommandHints,
-  CommandInput,
-  CommandItem,
-  CommandList,
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
 } from '@bangle.io/shadcn';
 import { Check } from 'lucide-react';
 import React from 'react';
@@ -32,6 +31,22 @@ export type DialogSingleSelectProps = {
   hints?: string[];
 };
 
+function DialogHints({ hints }: { hints?: string[] }) {
+  if (!hints?.length) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-wrap justify-end gap-x-4 gap-y-1 border-border border-t pt-3">
+      {hints.map((hint) => (
+        <span key={hint} className="text-muted-foreground text-xs">
+          {hint}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function SingleSelectItem({
   option,
   hasAnyIcon,
@@ -43,24 +58,28 @@ function SingleSelectItem({
 }) {
   const OptionIcon = option.icon;
   return (
-    <CommandItem
-      key={option.id}
-      onSelect={() => {
-        onSelect(option);
-      }}
+    <Button
+      type="button"
+      role="option"
+      aria-selected={option.active ? true : undefined}
+      variant="ghost"
+      className="h-auto w-full justify-start px-2 py-2 text-left font-normal"
+      onClick={() => onSelect(option)}
     >
       {hasAnyIcon && (
-        <div className="mr-1 flex h-4 w-4 items-center">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
           {OptionIcon ? (
-            <OptionIcon className="h-4 w-4" />
-          ) : hasAnyIcon ? (
-            <div className="h-4 w-4" />
+            <OptionIcon className="h-4 w-4" aria-hidden="true" />
           ) : null}
-        </div>
+        </span>
       )}
-      <span>{option.title || option.id}</span>
-      {option.active && <Check className="h-4 w-4 shrink-0 opacity-50" />}
-    </CommandItem>
+      <span className="min-w-0 flex-1 truncate">
+        {option.title || option.id}
+      </span>
+      {option.active && (
+        <Check className="h-4 w-4 shrink-0 opacity-60" aria-hidden="true" />
+      )}
+    </Button>
   );
 }
 
@@ -79,6 +98,21 @@ export function DialogSingleSelect({
   hints,
 }: DialogSingleSelectProps) {
   const [search, setSearch] = React.useState(initialSearch);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const title = badgeText || groupHeading || placeholder;
+  const description = placeholder;
+
+  React.useEffect(() => {
+    setSearch(initialSearch);
+  }, [initialSearch]);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => inputRef.current?.select());
+  }, [open]);
 
   const filteredOptions = React.useMemo(() => {
     if (!search) return options;
@@ -89,53 +123,79 @@ export function DialogSingleSelect({
 
   const hasAnyIcon = options.some((option) => option.icon);
 
+  const selectOption = React.useCallback(
+    (option: { id: string; title?: string }) => {
+      onSelect(option);
+      setOpen(false);
+    },
+    [onSelect, setOpen],
+  );
+
   return (
-    <CommandDialog
-      open={open}
-      onOpenChange={setOpen}
-      screenReaderTitle="dialog select"
-    >
-      {badgeText && (
-        <CommandBadge
-          className={cx(badgeTone === 'destructive' && 'bg-destructive')}
-        >
-          <span
-            className={cx(
-              badgeTone === 'destructive' && 'text-destructive-foreground',
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle
+            className={cn(
+              'flex items-center gap-2',
+              badgeTone === 'destructive' && 'text-destructive',
             )}
           >
-            {badgeText}
-          </span>
-        </CommandBadge>
-      )}
-      <CommandInput
-        placeholder={placeholder}
-        value={search}
-        onValueChange={(val) => {
-          setSearch(val);
-        }}
-        Icon={Icon}
-      />
-      <CommandList>
-        <CommandGroup heading={groupHeading}>
-          {filteredOptions.length > 0 ? (
-            filteredOptions.map((option) => (
-              <SingleSelectItem
-                key={option.id}
-                option={option}
-                hasAnyIcon={hasAnyIcon}
-                onSelect={(opt) => {
-                  onSelect(opt);
-                  setOpen(false);
-                }}
-              />
-            ))
-          ) : (
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
-          )}
-        </CommandGroup>
-      </CommandList>
-      <CommandHints hints={hints} />
-    </CommandDialog>
+            {Icon && <Icon className="h-5 w-5" aria-hidden="true" />}
+            <span>{title}</span>
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <form
+          className="grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const [firstOption] = filteredOptions;
+            if (firstOption) {
+              selectOption(firstOption);
+            }
+          }}
+        >
+          <Input
+            ref={inputRef}
+            aria-label={placeholder}
+            placeholder={placeholder}
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+
+          <div className="grid gap-2">
+            {groupHeading && (
+              <div className="px-1 font-medium text-muted-foreground text-xs">
+                {groupHeading}
+              </div>
+            )}
+            <div
+              role="listbox"
+              aria-label={groupHeading || title}
+              className="max-h-72 overflow-y-auto rounded-md border p-1"
+            >
+              {filteredOptions.length > 0 ? (
+                filteredOptions.map((option) => (
+                  <SingleSelectItem
+                    key={option.id}
+                    option={option}
+                    hasAnyIcon={hasAnyIcon}
+                    onSelect={selectOption}
+                  />
+                ))
+              ) : (
+                <div className="px-3 py-6 text-center text-muted-foreground text-sm">
+                  {emptyMessage}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <DialogHints hints={hints} />
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/ui-components/src/dialog-single-select.tsx
+++ b/packages/ui/ui-components/src/dialog-single-select.tsx
@@ -55,26 +55,34 @@ function SingleSelectItem({
   id,
   hasAnyIcon,
   isActive,
+  itemRef,
+  onActive,
   onSelect,
 }: {
   option: DialogSingleSelectProps['options'][0];
   id: string;
   hasAnyIcon: boolean;
   isActive: boolean;
+  itemRef: (element: HTMLButtonElement | null) => void;
+  onActive: () => void;
   onSelect: (option: { id: string; title?: string }) => void;
 }) {
   const OptionIcon = option.icon;
   return (
     <Button
       id={id}
+      ref={itemRef}
       type="button"
       role="option"
       aria-selected={isActive || option.active}
+      tabIndex={-1}
       variant="ghost"
       className={cn(
         'h-auto w-full justify-start px-2 py-2 text-left font-normal',
         isActive && 'bg-accent text-accent-foreground',
       )}
+      onMouseDown={(event) => event.preventDefault()}
+      onMouseEnter={onActive}
       onClick={() => onSelect(option)}
     >
       {hasAnyIcon && (
@@ -113,6 +121,7 @@ export function DialogSingleSelect({
   const [search, setSearch] = React.useState(initialSearch);
   const [activeIndex, setActiveIndex] = React.useState(0);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const optionRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
   const listboxId = React.useId();
   const title = badgeText || groupHeading || placeholder;
   const description = placeholder;
@@ -150,6 +159,14 @@ export function DialogSingleSelect({
         : Math.min(current, filteredOptions.length - 1),
     );
   }, [filteredOptions.length]);
+
+  React.useEffect(() => {
+    if (!open || filteredOptions.length === 0) {
+      return;
+    }
+
+    optionRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex, filteredOptions.length, open]);
 
   const selectOption = React.useCallback(
     (option: { id: string; title?: string }) => {
@@ -239,6 +256,10 @@ export function DialogSingleSelect({
                     option={option}
                     hasAnyIcon={hasAnyIcon}
                     isActive={index === activeIndex}
+                    itemRef={(element) => {
+                      optionRefs.current[index] = element;
+                    }}
+                    onActive={() => setActiveIndex(index)}
                     onSelect={selectOption}
                   />
                 ))

--- a/packages/ui/ui-components/src/dialog-single-select.tsx
+++ b/packages/ui/ui-components/src/dialog-single-select.tsx
@@ -1,13 +1,14 @@
 import {
   Button,
+  CommandBadge,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandHints,
+  CommandInput,
+  CommandItem,
+  CommandList,
   cn,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  Input,
 } from '@bangle.io/shadcn';
 import { Check } from 'lucide-react';
 import React from 'react';
@@ -22,10 +23,11 @@ export type DialogSingleSelectProps = {
     icon?: React.ElementType;
   }[];
   onSelect: (option: { id: string; title?: string }) => void;
-  placeholder?: string;
-  groupHeading?: string;
-  badgeTone?: 'destructive' | 'default';
-  badgeText?: string;
+  title?: string;
+  description?: string;
+  searchPlaceholder?: string;
+  groupLabel?: string;
+  tone?: 'destructive' | 'default';
   emptyMessage?: React.ReactNode;
   emptyActionText?: string;
   onEmptyAction?: () => void;
@@ -34,63 +36,25 @@ export type DialogSingleSelectProps = {
   hints?: string[];
 };
 
-function DialogHints({ hints }: { hints?: string[] }) {
-  if (!hints?.length) {
-    return null;
-  }
-
-  return (
-    <div className="flex flex-wrap justify-end gap-x-4 gap-y-1 border-border border-t pt-3">
-      {hints.map((hint) => (
-        <span key={hint} className="text-muted-foreground text-xs">
-          {hint}
-        </span>
-      ))}
-    </div>
-  );
-}
-
 function SingleSelectItem({
   option,
-  id,
   hasAnyIcon,
-  isActive,
-  itemRef,
-  onActive,
   onSelect,
 }: {
   option: DialogSingleSelectProps['options'][0];
-  id: string;
   hasAnyIcon: boolean;
-  isActive: boolean;
-  itemRef: (element: HTMLButtonElement | null) => void;
-  onActive: () => void;
   onSelect: (option: { id: string; title?: string }) => void;
 }) {
   const OptionIcon = option.icon;
+
   return (
-    <Button
-      id={id}
-      ref={itemRef}
-      type="button"
-      role="option"
-      aria-selected={isActive || option.active}
-      tabIndex={-1}
-      variant="ghost"
-      className={cn(
-        'h-auto w-full justify-start px-2 py-2 text-left font-normal',
-        isActive && 'bg-accent text-accent-foreground',
-      )}
-      onMouseDown={(event) => event.preventDefault()}
-      onMouseEnter={onActive}
-      onClick={() => onSelect(option)}
-    >
+    <CommandItem onSelect={() => onSelect(option)}>
       {hasAnyIcon && (
-        <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+        <div className="flex h-4 w-4 shrink-0 items-center justify-center">
           {OptionIcon ? (
             <OptionIcon className="h-4 w-4" aria-hidden="true" />
           ) : null}
-        </span>
+        </div>
       )}
       <span className="min-w-0 flex-1 truncate">
         {option.title || option.id}
@@ -98,7 +62,7 @@ function SingleSelectItem({
       {option.active && (
         <Check className="h-4 w-4 shrink-0 opacity-60" aria-hidden="true" />
       )}
-    </Button>
+    </CommandItem>
   );
 }
 
@@ -107,10 +71,11 @@ export function DialogSingleSelect({
   setOpen,
   options,
   onSelect,
-  placeholder = t.app.dialogs.singleSelect.placeholderDefault,
-  groupHeading = '',
-  badgeText,
-  badgeTone = 'default',
+  title,
+  description,
+  searchPlaceholder = t.app.dialogs.singleSelect.placeholderDefault,
+  groupLabel = '',
+  tone = 'default',
   emptyMessage = t.app.dialogs.singleSelect.emptyMessageDefault,
   emptyActionText,
   onEmptyAction,
@@ -119,54 +84,13 @@ export function DialogSingleSelect({
   hints,
 }: DialogSingleSelectProps) {
   const [search, setSearch] = React.useState(initialSearch);
-  const [activeIndex, setActiveIndex] = React.useState(0);
-  const inputRef = React.useRef<HTMLInputElement>(null);
-  const optionRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
-  const listboxId = React.useId();
-  const title = badgeText || groupHeading || placeholder;
-  const description = placeholder;
+  const hasAnyIcon = options.some((option) => option.icon);
+  const dialogTitle = title || groupLabel || searchPlaceholder;
+  const dialogDescription = description || searchPlaceholder;
 
   React.useEffect(() => {
     setSearch(initialSearch);
   }, [initialSearch]);
-
-  React.useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    setActiveIndex(0);
-    window.requestAnimationFrame(() => inputRef.current?.select());
-  }, [open]);
-
-  const filteredOptions = React.useMemo(() => {
-    if (!search) return options;
-    return options.filter((option) =>
-      (option.title || option.id).toLowerCase().includes(search.toLowerCase()),
-    );
-  }, [search, options]);
-
-  const hasAnyIcon = options.some((option) => option.icon);
-  const activeOption = filteredOptions[activeIndex];
-  const activeOptionId = activeOption
-    ? `${listboxId}-option-${activeIndex}`
-    : undefined;
-
-  React.useEffect(() => {
-    setActiveIndex((current) =>
-      filteredOptions.length === 0
-        ? 0
-        : Math.min(current, filteredOptions.length - 1),
-    );
-  }, [filteredOptions.length]);
-
-  React.useEffect(() => {
-    if (!open || filteredOptions.length === 0) {
-      return;
-    }
-
-    optionRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' });
-  }, [activeIndex, filteredOptions.length, open]);
 
   const selectOption = React.useCallback(
     (option: { id: string; title?: string }) => {
@@ -175,127 +99,70 @@ export function DialogSingleSelect({
     },
     [onSelect, setOpen],
   );
+
   const runEmptyAction = React.useCallback(() => {
     onEmptyAction?.();
     setOpen(false);
   }, [onEmptyAction, setOpen]);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle
-            className={cn(
-              'flex items-center gap-2',
-              badgeTone === 'destructive' && 'text-destructive',
-            )}
-          >
-            {Icon && <Icon className="h-5 w-5" aria-hidden="true" />}
-            <span>{title}</span>
-          </DialogTitle>
-          <DialogDescription>{description}</DialogDescription>
-        </DialogHeader>
-
-        <form
-          className="grid gap-4"
-          onSubmit={(event) => {
-            event.preventDefault();
-            if (activeOption) {
-              selectOption(activeOption);
-            } else if (onEmptyAction) {
-              runEmptyAction();
-            }
-          }}
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      screenReaderTitle={dialogTitle}
+    >
+      <CommandBadge className={cn(tone === 'destructive' && 'bg-destructive')}>
+        <span
+          className={cn(
+            tone === 'destructive' && 'text-destructive-foreground',
+          )}
         >
-          <Input
-            ref={inputRef}
-            aria-label={placeholder}
-            aria-activedescendant={activeOptionId}
-            aria-controls={listboxId}
-            aria-expanded={open}
-            role="combobox"
-            placeholder={placeholder}
-            value={search}
-            onChange={(event) => {
-              setSearch(event.target.value);
-              setActiveIndex(0);
-            }}
-            onKeyDown={(event) => {
-              if (event.key === 'ArrowDown') {
-                event.preventDefault();
-                setActiveIndex((current) =>
-                  filteredOptions.length === 0
-                    ? 0
-                    : Math.min(current + 1, filteredOptions.length - 1),
-                );
-              }
-              if (event.key === 'ArrowUp') {
-                event.preventDefault();
-                setActiveIndex((current) => Math.max(current - 1, 0));
-              }
-            }}
-          />
-
-          <div className="grid gap-2">
-            {groupHeading && (
-              <div className="px-1 font-medium text-muted-foreground text-xs">
-                {groupHeading}
-              </div>
+          {dialogTitle}
+        </span>
+      </CommandBadge>
+      <div className="mx-4 mt-1 text-muted-foreground text-sm">
+        {dialogDescription}
+      </div>
+      <CommandInput
+        aria-label={searchPlaceholder}
+        placeholder={searchPlaceholder}
+        value={search}
+        onValueChange={setSearch}
+        Icon={Icon}
+      />
+      <CommandList>
+        <CommandGroup heading={groupLabel}>
+          {options.map((option) => (
+            <SingleSelectItem
+              key={option.id}
+              option={option}
+              hasAnyIcon={hasAnyIcon}
+              onSelect={selectOption}
+            />
+          ))}
+        </CommandGroup>
+        <CommandEmpty>
+          <div className="grid gap-3 px-3 py-6 text-center">
+            <div className="text-muted-foreground text-sm">{emptyMessage}</div>
+            {emptyActionText && onEmptyAction && (
+              <Button
+                type="button"
+                variant="outline"
+                className="justify-self-center"
+                onClick={runEmptyAction}
+              >
+                {emptyActionText}
+              </Button>
             )}
-            <div
-              id={listboxId}
-              role="listbox"
-              aria-label={groupHeading || title}
-              className="max-h-72 overflow-y-auto rounded-md border p-1"
-            >
-              {filteredOptions.length > 0 ? (
-                filteredOptions.map((option, index) => (
-                  <SingleSelectItem
-                    key={option.id}
-                    id={`${listboxId}-option-${index}`}
-                    option={option}
-                    hasAnyIcon={hasAnyIcon}
-                    isActive={index === activeIndex}
-                    itemRef={(element) => {
-                      optionRefs.current[index] = element;
-                    }}
-                    onActive={() => setActiveIndex(index)}
-                    onSelect={selectOption}
-                  />
-                ))
-              ) : (
-                <div className="grid gap-3 px-3 py-6 text-center">
-                  <div className="text-muted-foreground text-sm">
-                    {emptyMessage}
-                  </div>
-                  {emptyActionText && onEmptyAction && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="justify-self-center"
-                      onClick={runEmptyAction}
-                    >
-                      {emptyActionText}
-                    </Button>
-                  )}
-                </div>
-              )}
-            </div>
           </div>
-
-          <DialogHints hints={hints} />
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setOpen(false)}
-            >
-              {t.app.common.cancelButton}
-            </Button>
-          </DialogFooter>
-        </form>
-      </DialogContent>
-    </Dialog>
+        </CommandEmpty>
+      </CommandList>
+      <CommandHints hints={hints} />
+      <div className="flex justify-end border-border border-t p-3">
+        <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+          {t.app.common.cancelButton}
+        </Button>
+      </div>
+    </CommandDialog>
   );
 }

--- a/packages/ui/ui-components/src/sidebar.tsx
+++ b/packages/ui/ui-components/src/sidebar.tsx
@@ -5,6 +5,8 @@ import {
   Separator,
   Sheet,
   SheetContent,
+  SheetDescription,
+  SheetTitle,
   Skeleton,
   Tooltip,
   TooltipContent,
@@ -144,6 +146,12 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
+            <SheetTitle className="sr-only">
+              {t.app.components.appSidebar.mobileTitle}
+            </SheetTitle>
+            <SheetDescription className="sr-only">
+              {t.app.components.appSidebar.mobileDescription}
+            </SheetDescription>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>

--- a/packages/ui/ui-components/src/workspace-dialog.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.tsx
@@ -217,6 +217,23 @@ interface StageSelectStorageProps {
   onCancel: () => void;
 }
 
+function WorkspaceDialogFooter({
+  leadingAction,
+  children,
+}: {
+  leadingAction: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <DialogFooter className="gap-2 sm:items-center sm:justify-between sm:space-x-0">
+      {leadingAction}
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        {children}
+      </div>
+    </DialogFooter>
+  );
+}
+
 const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
   state,
   dispatch,
@@ -263,25 +280,30 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
         ))}
       </div>
       <ErrorMessage error={error} />
-      <DialogFooter className="gap-2 sm:items-center sm:justify-between sm:space-x-0">
-        <Button
-          variant="ghost"
-          className="justify-start px-0 text-primary text-sm hover:underline"
-          asChild
-        >
-          <a href="https://bangle.io/privacy" target="_blank" rel="noreferrer">
-            {t.app.dialogs.createWorkspace.dataPrivacyLink}
-          </a>
+      <WorkspaceDialogFooter
+        leadingAction={
+          <Button
+            variant="ghost"
+            className="justify-start px-0 text-primary text-sm hover:underline"
+            asChild
+          >
+            <a
+              href="https://bangle.io/privacy"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t.app.dialogs.createWorkspace.dataPrivacyLink}
+            </a>
+          </Button>
+        }
+      >
+        <Button variant="outline" onClick={onCancel}>
+          {t.app.common.cancelButton}
         </Button>
-        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <Button variant="outline" onClick={onCancel}>
-            {t.app.common.cancelButton}
-          </Button>
-          <Button onClick={handleNext} disabled={!selected}>
-            {t.app.common.nextButton}
-          </Button>
-        </div>
-      </DialogFooter>
+        <Button onClick={handleNext} disabled={!selected}>
+          {t.app.common.nextButton}
+        </Button>
+      </WorkspaceDialogFooter>
     </>
   );
 };
@@ -370,23 +392,24 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
         </div>
         <ErrorMessage error={error} />
       </div>
-      <DialogFooter className="gap-2 sm:justify-between sm:space-x-0">
-        <Button variant="outline" onClick={handleBack}>
-          {t.app.common.backButton}
+      <WorkspaceDialogFooter
+        leadingAction={
+          <Button variant="outline" onClick={handleBack}>
+            {t.app.common.backButton}
+          </Button>
+        }
+      >
+        <Button variant="outline" onClick={onCancel}>
+          {t.app.common.cancelButton}
         </Button>
-        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <Button variant="outline" onClick={onCancel}>
-            {t.app.common.cancelButton}
-          </Button>
-          <Button
-            type="submit"
-            onClick={handleSubmit}
-            disabled={Boolean(error) || !name}
-          >
-            {t.app.common.createButton}
-          </Button>
-        </div>
-      </DialogFooter>
+        <Button
+          type="submit"
+          onClick={handleSubmit}
+          disabled={Boolean(error) || !name}
+        >
+          {t.app.common.createButton}
+        </Button>
+      </WorkspaceDialogFooter>
     </>
   );
 };
@@ -495,19 +518,20 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
         <ErrorMessage error={error} />
       </div>
 
-      <DialogFooter className="gap-2 sm:justify-between sm:space-x-0">
-        <Button variant="outline" onClick={handleBack}>
-          {t.app.common.backButton}
+      <WorkspaceDialogFooter
+        leadingAction={
+          <Button variant="outline" onClick={handleBack}>
+            {t.app.common.backButton}
+          </Button>
+        }
+      >
+        <Button variant="outline" onClick={onCancel}>
+          {t.app.common.cancelButton}
         </Button>
-        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-          <Button variant="outline" onClick={onCancel}>
-            {t.app.common.cancelButton}
-          </Button>
-          <Button onClick={handleSubmit} disabled={!dirHandle}>
-            {t.app.common.createButton}
-          </Button>
-        </div>
-      </DialogFooter>
+        <Button onClick={handleSubmit} disabled={!dirHandle}>
+          {t.app.common.createButton}
+        </Button>
+      </WorkspaceDialogFooter>
     </>
   );
 };

--- a/packages/ui/ui-components/src/workspace-dialog.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.tsx
@@ -156,6 +156,9 @@ export function CreateWorkspaceDialog({
             <DialogTitle>
               {t.app.dialogs.createWorkspace.errorTitle}
             </DialogTitle>
+            <DialogDescription>
+              {t.app.dialogs.createWorkspace.noStorageTypes}
+            </DialogDescription>
           </DialogHeader>
           <div className="text-destructive">
             {t.app.dialogs.createWorkspace.noStorageTypes}
@@ -179,6 +182,7 @@ export function CreateWorkspaceDialog({
             dispatch={dispatch}
             storageTypes={storageTypes}
             defaultStorage={defaultStorage}
+            onCancel={() => onOpenChange(false)}
           />
         )}
         {state.stage === 'selected-browser' && (
@@ -187,6 +191,7 @@ export function CreateWorkspaceDialog({
             dispatch={dispatch}
             validateWorkspace={validateWorkspace}
             onDone={onDone}
+            onCancel={() => onOpenChange(false)}
           />
         )}
         {state.stage === 'selected-nativefs' && (
@@ -196,6 +201,7 @@ export function CreateWorkspaceDialog({
             onDirectoryPick={onDirectoryPick}
             validateWorkspace={validateWorkspace}
             onDone={onDone}
+            onCancel={() => onOpenChange(false)}
           />
         )}
       </DialogContent>
@@ -208,6 +214,7 @@ interface StageSelectStorageProps {
   dispatch: React.Dispatch<Action>;
   storageTypes: StorageTypeConfig[];
   defaultStorage: WorkspaceStorageType;
+  onCancel: () => void;
 }
 
 const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
@@ -215,6 +222,7 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
   dispatch,
   storageTypes,
   defaultStorage,
+  onCancel,
 }) => {
   const { selected = defaultStorage, error } = state;
   const handleSelectStorage = (storage: WorkspaceStorageType) => {
@@ -234,6 +242,9 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
         <DialogTitle className="font-semibold text-lg">
           {t.app.dialogs.createWorkspace.selectTypeTitle}
         </DialogTitle>
+        <DialogDescription>
+          {t.app.dialogs.createWorkspace.selectTypeDescription}
+        </DialogDescription>
       </DialogHeader>
       <div
         className="space-y-4"
@@ -252,19 +263,24 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
         ))}
       </div>
       <ErrorMessage error={error} />
-      <DialogFooter className="flex-col sm:justify-between">
+      <DialogFooter className="gap-2 sm:items-center sm:justify-between sm:space-x-0">
         <Button
           variant="ghost"
-          className="ml-3 text-primary text-sm hover:underline"
+          className="justify-start px-0 text-primary text-sm hover:underline"
           asChild
         >
           <a href="https://bangle.io/privacy" target="_blank" rel="noreferrer">
             {t.app.dialogs.createWorkspace.dataPrivacyLink}
           </a>
         </Button>
-        <Button onClick={handleNext} disabled={!selected}>
-          {t.app.common.nextButton}
-        </Button>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button variant="outline" onClick={onCancel}>
+            {t.app.common.cancelButton}
+          </Button>
+          <Button onClick={handleNext} disabled={!selected}>
+            {t.app.common.nextButton}
+          </Button>
+        </div>
       </DialogFooter>
     </>
   );
@@ -275,6 +291,7 @@ interface StageEnterWorkspaceNameProps {
   dispatch: React.Dispatch<Action>;
   validateWorkspace: CreateWorkspaceDialogProps['validateWorkspace'];
   onDone: CreateWorkspaceDialogProps['onDone'];
+  onCancel: () => void;
 }
 
 const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
@@ -282,6 +299,7 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
   dispatch,
   validateWorkspace,
   onDone,
+  onCancel,
 }) => {
   const { name, error } = state;
 
@@ -352,17 +370,22 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
         </div>
         <ErrorMessage error={error} />
       </div>
-      <DialogFooter className="flex justify-between">
+      <DialogFooter className="gap-2 sm:justify-between sm:space-x-0">
         <Button variant="outline" onClick={handleBack}>
           {t.app.common.backButton}
         </Button>
-        <Button
-          type="submit"
-          onClick={handleSubmit}
-          disabled={Boolean(error) || !name}
-        >
-          {t.app.common.createButton}
-        </Button>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button variant="outline" onClick={onCancel}>
+            {t.app.common.cancelButton}
+          </Button>
+          <Button
+            type="submit"
+            onClick={handleSubmit}
+            disabled={Boolean(error) || !name}
+          >
+            {t.app.common.createButton}
+          </Button>
+        </div>
       </DialogFooter>
     </>
   );
@@ -374,6 +397,7 @@ interface StagePickDirectoryProps {
   onDirectoryPick?: CreateWorkspaceDialogProps['onDirectoryPick'];
   validateWorkspace: CreateWorkspaceDialogProps['validateWorkspace'];
   onDone: CreateWorkspaceDialogProps['onDone'];
+  onCancel: () => void;
 }
 
 const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
@@ -382,6 +406,7 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
   onDirectoryPick,
   validateWorkspace,
   onDone,
+  onCancel,
 }) => {
   const { dirHandle, error } = state;
 
@@ -470,13 +495,18 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
         <ErrorMessage error={error} />
       </div>
 
-      <DialogFooter className="flex justify-between">
+      <DialogFooter className="gap-2 sm:justify-between sm:space-x-0">
         <Button variant="outline" onClick={handleBack}>
           {t.app.common.backButton}
         </Button>
-        <Button onClick={handleSubmit} disabled={!dirHandle}>
-          {t.app.common.createButton}
-        </Button>
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button variant="outline" onClick={onCancel}>
+            {t.app.common.cancelButton}
+          </Button>
+          <Button onClick={handleSubmit} disabled={!dirHandle}>
+            {t.app.common.createButton}
+          </Button>
+        </div>
       </DialogFooter>
     </>
   );

--- a/packages/ui/ui-components/src/workspace-dialog.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.tsx
@@ -217,8 +217,6 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
   defaultStorage,
 }) => {
   const { selected = defaultStorage, error } = state;
-  const titleId = useId();
-
   const handleSelectStorage = (storage: WorkspaceStorageType) => {
     dispatch({ type: 'UPDATE_SELECTED_STORAGE', storage });
   };
@@ -233,12 +231,15 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
   return (
     <>
       <DialogHeader className="mb-2">
-        <DialogTitle id={titleId} className="font-semibold text-lg">
+        <DialogTitle className="font-semibold text-lg">
           {t.app.dialogs.createWorkspace.selectTypeTitle}
         </DialogTitle>
       </DialogHeader>
-      {/* biome-ignore lint: Using ul as a container for radiogroup is a standard ARIA practice. */}
-      <ul className="space-y-4" role="radiogroup" aria-labelledby={titleId}>
+      <div
+        className="space-y-4"
+        role="radiogroup"
+        aria-label={t.app.dialogs.createWorkspace.selectTypeTitle}
+      >
         {storageTypes.map((config) => (
           <ListItem
             key={config.type}
@@ -249,7 +250,7 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
             disabled={config.disabled || false}
           />
         ))}
-      </ul>
+      </div>
       <ErrorMessage error={error} />
       <DialogFooter className="flex-col sm:justify-between">
         <Button
@@ -496,46 +497,44 @@ const ListItem: React.FC<ListItemProps> = ({
   onClick,
   disabled,
 }) => {
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if ((event.key === 'Enter' || event.key === ' ') && !disabled) {
-      event.preventDefault();
-      onClick();
-    }
-  };
-
   return (
-    <li>
-      <button
-        type="button"
-        onClick={disabled ? undefined : onClick}
-        aria-checked={isSelected}
-        onKeyDown={handleKeyDown}
-        className={cn(
-          'relative block w-full cursor-pointer select-none space-y-1 rounded-md p-3 text-left leading-none transition-colors duration-200 ease-in-out hover:bg-muted focus:bg-muted',
-          isSelected && 'bg-muted',
-          disabled && 'cursor-not-allowed opacity-50',
-        )}
+    <label
+      className={cn(
+        'relative block w-full cursor-pointer select-none space-y-1 rounded-md p-3 text-left leading-none transition-colors duration-200 ease-in-out focus-within:bg-muted focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 hover:bg-muted',
+        isSelected && 'bg-muted',
+        disabled && 'cursor-not-allowed opacity-50',
+      )}
+    >
+      <input
+        type="radio"
+        name="workspace-storage-type"
+        checked={isSelected}
+        onChange={() => {
+          if (!disabled) {
+            onClick();
+          }
+        }}
         disabled={disabled}
-        // biome-ignore lint: Using a button for custom styling and behavior while maintaining radio button semantics.
-        role="radio"
-      >
-        <div className="flex items-center justify-between space-x-1">
-          <div>
-            <h3 className="mb-1 font-semibold text-sm leading-none tracking-tight">
-              {title}
-            </h3>
-            <p className="text-foreground/80 text-sm">{description}</p>
-          </div>
-          <div className="h-4 w-4 shrink-0">
-            <Check
-              className={`h-4 w-4 transition-opacity duration-300 ${
-                isSelected ? 'opacity-100' : 'opacity-0'
-              }`}
-            />
-          </div>
+        className="absolute inset-0 h-full w-full cursor-pointer opacity-0 disabled:cursor-not-allowed"
+      />
+      <div className="flex items-center justify-between space-x-1">
+        <div>
+          <span className="mb-1 block font-semibold text-sm leading-none tracking-tight">
+            {title}
+          </span>
+          <span className="block text-foreground/80 text-sm">
+            {description}
+          </span>
         </div>
-      </button>
-    </li>
+        <div className="h-4 w-4 shrink-0">
+          <Check
+            className={`h-4 w-4 transition-opacity duration-300 ${
+              isSelected ? 'opacity-100' : 'opacity-0'
+            }`}
+          />
+        </div>
+      </div>
+    </label>
   );
 };
 


### PR DESCRIPTION
## Summary

- Replaces the delete-note picker with a direct destructive confirmation for the current note.
- Converts create/rename/folder input flows into cleaner form dialogs with explicit labels, Cancel, and primary actions.
- Fixes centered modal motion in the shared shadcn dialog primitives so dialogs fade/scale in place instead of sliding from the left.
- Keeps picker-style modals reusable by routing `DialogSingleSelect` back through the existing `CommandDialog`/cmdk primitive with a clearer title/search/group API.
- Improves related modal usability: cancel affordances, mobile sidebar dialog metadata, move-note empty state, workspace footer reuse, and stronger delete persistence coverage.

## Validation

- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm --filter "@bangle.io/e2e-tests" run test-ct -- src/component-tests/dialog-input-and-select.ct.tsx src/component-tests/workspace-dialog.ct.tsx`
- `pnpm --filter "@bangle.io/e2e-tests" run test -- src/delete-note-dialog.e2e.ts src/workspace-dialog.e2e.tsx`
- `pnpm local-ci-check`

Note: full E2E still logs existing nested `<p>` React console warnings from `WorkspaceNotFoundView` / `NoticeView`; the suite passes and this PR does not introduce those warnings.