### PR TITLE
[codex] handle expected app errors outside sentry

### DIFF
--- a/.claude/skills/bangle-followup-operator
+++ b/.claude/skills/bangle-followup-operator
@@ -1,0 +1,1 @@
+../../.codex/skills/bangle-followup-operator

--- a/.codex/skills/bangle-followup-operator/SKILL.md
+++ b/.codex/skills/bangle-followup-operator/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: bangle-followup-operator
+description: Operate recurring Bangle.io agent follow-ups after a thread has already started. Use when the user asks to continue, check status, decide what is next, push, create or update a PR, poll CI, rebase, merge, release, run Playwright/manual UX checks, spawn or aggregate code-review subagents, run thermonuclear review, address review findings, make a plan, add a project task, or asks "we good?", "pushed?", "PR?", "did you test?", "what should I test?", or similar follow-up prompts in the Bangle repo.
+---
+
+# Bangle Follow-up Operator
+
+## Overview
+
+Use this skill to convert short Bangle follow-ups into the next concrete action. Keep repository-wide engineering policy in `AGENTS.md`/`CLAUDE.md`; keep plan-specific policy in `plans/AGENTS.md`.
+
+## Reconstruct State
+
+1. Read the latest prompt and recent conversation turns using the thread/history tools available in the current agent environment.
+2. Check repository state from the root: branch, dirty files, remotes, active PR, recent commits, and any generated worktree context.
+3. Infer terse prompts like `continue`, `what next`, `we good`, `pushed?`, or `PR?` from the immediately previous work before asking for clarification.
+
+## Route the Follow-up
+
+### Continue or status
+
+- Inspect unfinished commands, partial edits, unpushed commits, failed checks, and PR/CI state.
+- Report exact current state, then continue the next unfinished step.
+
+### Review or subagent request
+
+- For `thermonuclear review`, use the `thermonuclear-code-quality-review` skill.
+- For normal review or subagent review, pass raw scope: repo path, branch/PR, diff target, constraints, and whether the agent may edit.
+- Aggregate findings into `must fix`, `worth fixing`, and `defer/track`.
+
+### Address findings or "do it"
+
+- Re-read the cited code and tests before editing.
+- Implement only fixes that match the user's scope and improve the branch.
+- After edits, run focused checks first, then the required `AGENTS.md` gates for the changed surface.
+
+### UI, UX, or Playwright follow-up
+
+- Use `playwright-cli`, browser, or Chrome tools when the user asks for manual UX validation, screenshots, authenticated Chrome, or visual comparison.
+- If the user points at production, t3code, prosekit, or another local reference, inspect that reference before claiming parity.
+
+### PR, git, CI, and deploy follow-up
+
+- Before push/PR/merge/release, verify branch, remote, dirty state, and target PR.
+- After push, provide the PR URL or branch and poll relevant GitHub checks when requested.
+- For Cloudflare preview or GitHub Action comments, verify whether displayed commit hashes are PR head SHAs, merge SHAs, or deployment branch SHAs before patching.
+- For releases, use the applicable Bangle release skill and `AGENTS.md` release gates.
+
+### Planning or project task
+
+- For durable plans under `plans/`, read `plans/AGENTS.md` first.
+- For "add a task", "track this", or Bangle project board requests, use `bangle-project-task`.
+- When a plan is fully done, move it to `plans/archived/`, set `status: completed`, set `archived: true`, set `archived_on: YYYY-MM-DD` in the YAML frontmatter, update `updated`, and include the DONE note required by `plans/AGENTS.md`.
+
+## Close Out
+
+- State what changed or what was found.
+- Include branch/PR/push/CI status when relevant.
+- Include checks run and any checks intentionally not run.

--- a/.codex/skills/bangle-followup-operator/agents/openai.yaml
+++ b/.codex/skills/bangle-followup-operator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Bangle Follow-up Operator"
+  short_description: "Handle recurring Bangle thread follow-ups"
+  default_prompt: "Use $bangle-followup-operator to continue this Bangle agent thread with the right review, test, PR, or release workflow."

--- a/packages/core/app/src/__tests__/app-error-handler.spec.ts
+++ b/packages/core/app/src/__tests__/app-error-handler.spec.ts
@@ -1,0 +1,52 @@
+import type { AppError } from '@bangle.io/types';
+import { describe, expect, test } from 'vitest';
+import { shouldReportAppError } from '../app-error-handler';
+
+describe('shouldReportAppError', () => {
+  test.each([
+    {
+      appError: {
+        name: 'error::editor:save-failed',
+        payload: { error: new Error('write failed'), wsPath: 'test:note.md' },
+      } satisfies AppError,
+      expected: true,
+    },
+    {
+      appError: {
+        name: 'error::database:unknown-error',
+        payload: { databaseName: 'test-db', error: new Error('idb failed') },
+      } satisfies AppError,
+      expected: true,
+    },
+    {
+      appError: {
+        name: 'error::workspace:no-note-opened',
+        payload: {},
+      } satisfies AppError,
+      expected: false,
+    },
+    {
+      appError: {
+        name: 'error::workspace:native-fs-auth-needed',
+        payload: { wsName: 'notes' },
+      } satisfies AppError,
+      expected: false,
+    },
+    {
+      appError: {
+        name: 'error::file:already-existing',
+        payload: { wsPath: 'notes:existing.md' },
+      } satisfies AppError,
+      expected: false,
+    },
+    {
+      appError: {
+        name: 'error::file-storage:file-does-not-exist',
+        payload: { storage: 'file-storage-nativefs', wsPath: 'notes:' },
+      } satisfies AppError,
+      expected: false,
+    },
+  ])('returns $expected for $appError.name', ({ appError, expected }) => {
+    expect(shouldReportAppError(appError)).toBe(expected);
+  });
+});

--- a/packages/core/app/src/__tests__/app-error-handler.spec.ts
+++ b/packages/core/app/src/__tests__/app-error-handler.spec.ts
@@ -20,6 +20,13 @@ describe('shouldReportAppError', () => {
     },
     {
       appError: {
+        name: 'error::workspace:invalid-metadata',
+        payload: { wsName: 'notes' },
+      } satisfies AppError,
+      expected: true,
+    },
+    {
+      appError: {
         name: 'error::workspace:no-note-opened',
         payload: {},
       } satisfies AppError,

--- a/packages/core/app/src/app-error-handler.tsx
+++ b/packages/core/app/src/app-error-handler.tsx
@@ -1,8 +1,21 @@
 import { getGithubUrl, handleAppError } from '@bangle.io/base-utils';
 import { useCoreServices, useLogger } from '@bangle.io/context';
-import type { RootEmitter } from '@bangle.io/types';
+import type { AppError, RootEmitter } from '@bangle.io/types';
 import { toast } from '@bangle.io/ui-components';
 import React, { useEffect } from 'react';
+
+export function shouldReportAppError(appError: AppError): boolean {
+  switch (appError.name) {
+    case 'error::database:unknown-error':
+    case 'error::editor:load-failed':
+    case 'error::editor:save-failed':
+    case 'error::main:network':
+    case 'error::main:unknown':
+      return true;
+    default:
+      return false;
+  }
+}
 
 export function AppErrorHandler({ rootEmitter }: { rootEmitter: RootEmitter }) {
   const coreServices = useCoreServices();
@@ -43,8 +56,13 @@ export function AppErrorHandler({ rootEmitter }: { rootEmitter: RootEmitter }) {
     };
 
     const handleAppLikeError = (error: Error) => {
-      logger.error(error);
       return handleAppError(error, (appError, error) => {
+        if (shouldReportAppError(appError)) {
+          logger.error(error);
+        } else {
+          logger.warn('Handled app error:', error.message);
+        }
+
         switch (appError.name) {
           case 'error::editor:save-failed': {
             const toastId = `editor-save-failed:${appError.payload.wsPath}`;

--- a/packages/core/app/src/app-error-handler.tsx
+++ b/packages/core/app/src/app-error-handler.tsx
@@ -6,14 +6,20 @@ import React, { useEffect } from 'react';
 
 export function shouldReportAppError(appError: AppError): boolean {
   switch (appError.name) {
-    case 'error::database:unknown-error':
-    case 'error::editor:load-failed':
-    case 'error::editor:save-failed':
-    case 'error::main:network':
-    case 'error::main:unknown':
-      return true;
-    default:
+    case 'error::file:already-existing':
+    case 'error::file-storage:file-does-not-exist':
+    case 'error::workspace:native-fs-auth-needed':
+    case 'error::workspace:no-note-opened':
+    case 'error::workspace:no-notes-found':
+    case 'error::workspace:not-opened':
+    case 'error::ws-path:create-new-note':
+    case 'error::ws-path:invalid-markdown-path':
+    case 'error::ws-path:invalid-note-path':
+    case 'error::ws-path:invalid-ws-name':
+    case 'error::ws-path:invalid-ws-path':
       return false;
+    default:
+      return true;
   }
 }
 

--- a/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
@@ -6,6 +6,47 @@ import { describe, expect, test, vi } from 'vitest';
 import { setupTest } from './test-utils';
 
 describe('WS command handlers', () => {
+  describe('command::ws:create-note', () => {
+    test('reports duplicate note creation as a command failure', async () => {
+      const NOTE_WS_PATH = 'test-ws:existing.md';
+      const { dispatch, services, getCommandResults, testEnv } =
+        await setupTest({
+          targetId: 'command::ws:create-note',
+          workspaces: [{ name: 'test-ws', notes: [NOTE_WS_PATH] }],
+          autoNavigate: 'workspace',
+        });
+
+      dispatch('command::ws:create-note', {
+        navigate: true,
+        wsPath: NOTE_WS_PATH,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          getCommandResults().filter((result) => result.type === 'failure'),
+        ).toEqual([
+          expect.objectContaining({
+            command: expect.objectContaining({
+              id: 'command::ws:create-note',
+            }),
+          }),
+        ]);
+        expect(testEnv.commonOpts.emitAppError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cause: expect.objectContaining({
+              name: 'error::file:already-existing',
+              payload: { wsPath: NOTE_WS_PATH },
+            }),
+          }),
+        );
+      });
+
+      expect(services.navigation.resolveAtoms().wsPath?.wsPath).not.toBe(
+        NOTE_WS_PATH,
+      );
+    });
+  });
+
   describe('command::ws:clone-note', () => {
     test.each([
       {
@@ -225,6 +266,37 @@ describe('WS command handlers', () => {
           services.userActivityService.resolveAtoms().starredWsPaths;
         // Since it was the only starred note, the list should be empty again.
         expect(starredPaths).toEqual([]);
+      });
+    });
+
+    test('reports toggle-star without an open note as a handled app error', async () => {
+      const { dispatch, getCommandResults, testEnv } = await setupTest({
+        targetId: 'command::workspace:toggle-star',
+        workspaces: [{ name: 'test-ws' }],
+        autoNavigate: 'workspace',
+      });
+
+      dispatch('command::workspace:toggle-star', {
+        wsPath: undefined,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          getCommandResults().filter((result) => result.type === 'failure'),
+        ).toEqual([
+          expect.objectContaining({
+            command: expect.objectContaining({
+              id: 'command::workspace:toggle-star',
+            }),
+          }),
+        ]);
+        expect(testEnv.commonOpts.emitAppError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cause: expect.objectContaining({
+              name: 'error::workspace:no-note-opened',
+            }),
+          }),
+        );
       });
     });
   });

--- a/packages/core/command-handlers/src/ws-command-handlers.ts
+++ b/packages/core/command-handlers/src/ws-command-handlers.ts
@@ -33,7 +33,7 @@ export const wsCommandHandlers = [
 
   c(
     'command::ws:create-note',
-    ({ fileSystem, navigation }, { wsPath, navigate }) => {
+    async ({ fileSystem, navigation }, { wsPath, navigate }) => {
       const parsedPath = WsPath.fromString(wsPath);
       const wsName = parsedPath.wsName;
 
@@ -50,18 +50,16 @@ export const wsCommandHandlers = [
       const filePath = WsPath.assertFile(wsPath);
       const fileNameWithoutExt = filePath.fileNameWithoutExtension;
 
-      void fileSystem
-        .createFile(
-          wsPath,
-          new File([''], fileNameWithoutExt, {
-            type: 'text/plain',
-          }),
-        )
-        .then(() => {
-          if (navigate) {
-            navigation.goWsPath(wsPath);
-          }
-        });
+      await fileSystem.createFile(
+        wsPath,
+        new File([''], fileNameWithoutExt, {
+          type: 'text/plain',
+        }),
+      );
+
+      if (navigate) {
+        navigation.goWsPath(wsPath);
+      }
     },
   ),
 

--- a/packages/core/service-core/src/__tests__/command-dispatch-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/command-dispatch-service.spec.ts
@@ -2,6 +2,7 @@ import {
   BaseError,
   BaseService,
   type BaseServiceContext,
+  createAppError,
 } from '@bangle.io/base-utils';
 import { commandKeyToContext } from '@bangle.io/constants';
 import { T } from '@bangle.io/mini-js-utils';
@@ -76,6 +77,7 @@ async function setup() {
 
   await dispatchService.mount();
   return {
+    commonOpts,
     logger,
     commandRegistry,
     dispatchService,
@@ -228,6 +230,40 @@ describe('CommandDispatchService', () => {
         'testSource',
       );
     };
+  });
+
+  test('should convert async app error rejections into command failures and emitted app errors', async () => {
+    const { commonOpts, commandRegistry, dispatchService, dispatchedCommands } =
+      await setup();
+    const command = {
+      id: 'command::ui:toggle-sidebar',
+      dependencies: { services: [] },
+      args: null,
+    } as const satisfies Command;
+    const error = createAppError(
+      'error::workspace:no-note-opened',
+      'No note is currently open.',
+      {},
+    );
+
+    commandRegistry.register(command);
+    commandRegistry.registerHandler({
+      id: command.id,
+      handler: async () => {
+        throw error;
+      },
+    });
+
+    dispatchService.dispatch(command.id, null, 'testSource');
+
+    await vi.waitFor(() => {
+      expect(dispatchedCommands).toContainEqual({
+        type: 'failure',
+        command,
+        from: 'testSource',
+      });
+      expect(commonOpts.emitAppError).toHaveBeenCalledWith(error);
+    });
   });
 
   test('should throw error when dispatching a non-existent command', async () => {

--- a/packages/core/service-core/src/command-dispatch-service.ts
+++ b/packages/core/service-core/src/command-dispatch-service.ts
@@ -140,7 +140,7 @@ export class CommandDispatchService extends BaseService {
               command,
               from,
             });
-            this.handleCommandError(error);
+            this.handleAsyncCommandError(error);
           },
         );
       } else {
@@ -175,18 +175,13 @@ export class CommandDispatchService extends BaseService {
     this.config.emitResult(result);
   }
 
-  private handleCommandError(error: unknown): void {
+  private handleAsyncCommandError(error: unknown): void {
     if (isAppError(error)) {
       this.emitAppError(error);
       return;
     }
 
-    if (error instanceof Error) {
-      this.logger.error(error);
-      return;
-    }
-
-    this.logger.error('Command failed with non-Error value:', error);
+    throw error;
   }
 
   private setCommandContext(command: Command, key: CommandKey<string>): void {

--- a/packages/core/service-core/src/command-dispatch-service.ts
+++ b/packages/core/service-core/src/command-dispatch-service.ts
@@ -3,6 +3,7 @@ import {
   BaseError,
   BaseService,
   type BaseServiceContext,
+  isAppError,
 } from '@bangle.io/base-utils';
 import type { BangleAppCommand } from '@bangle.io/commands';
 import {
@@ -139,7 +140,7 @@ export class CommandDispatchService extends BaseService {
               command,
               from,
             });
-            throw error;
+            this.handleCommandError(error);
           },
         );
       } else {
@@ -172,6 +173,20 @@ export class CommandDispatchService extends BaseService {
 
   private onCommandResult(result: CommandDispatchResult): void {
     this.config.emitResult(result);
+  }
+
+  private handleCommandError(error: unknown): void {
+    if (isAppError(error)) {
+      this.emitAppError(error);
+      return;
+    }
+
+    if (error instanceof Error) {
+      this.logger.error(error);
+      return;
+    }
+
+    this.logger.error('Command failed with non-Error value:', error);
   }
 
   private setCommandContext(command: Command, key: CommandKey<string>): void {

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -34,10 +34,15 @@ class FakeFileHandle {
 class FakeDirectoryHandle {
   readonly kind = 'directory';
   private entries = new Map<string, FakeDirectoryHandle | FakeFileHandle>();
+  shouldThrowNotFoundOnRead = false;
 
   constructor(readonly name: string) {}
 
   async *values(): AsyncIterableIterator<FileSystemHandle> {
+    if (this.shouldThrowNotFoundOnRead) {
+      throw new DOMException('Directory not found', 'NotFoundError');
+    }
+
     for (const entry of this.entries.values()) {
       yield entry as unknown as FileSystemHandle;
     }
@@ -127,5 +132,25 @@ describe('FileStorageNativeFs', () => {
     const readFile = await service.readFile(wsPath);
     expect(await readFile?.text()).toBe('Original');
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps missing native workspace roots during listing to a typed app error', async () => {
+    const { service } = await setup();
+    const rootDirHandle = await service.getRootDirHandle('myWorkspace');
+    (
+      rootDirHandle.handle as unknown as FakeDirectoryHandle
+    ).shouldThrowNotFoundOnRead = true;
+
+    await expect(
+      service.listAllFiles('myWorkspace', new AbortController().signal),
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        name: 'error::file-storage:file-does-not-exist',
+        payload: {
+          storage: 'file-storage-nativefs',
+          wsPath: 'myWorkspace:',
+        },
+      }),
+    });
   });
 });

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -237,7 +237,25 @@ export class FileStorageNativeFs
   ): Promise<string[]> {
     await this.mountPromise;
     const fs = await this.getFs({ wsName });
-    const rawPaths = await fs.opendirRecursive(wsName);
+    let rawPaths: string[];
+    try {
+      rawPaths = await fs.opendirRecursive(wsName);
+    } catch (error) {
+      if (
+        error instanceof BaseFileSystemError &&
+        error.code === FILE_NOT_FOUND_ERROR
+      ) {
+        throwAppError(
+          'error::file-storage:file-does-not-exist',
+          'Native workspace path was not found',
+          {
+            wsPath: `${wsName}:`,
+            storage: this.name,
+          },
+        );
+      }
+      throw error;
+    }
     abortSignal.throwIfAborted();
     return rawPaths
       .map((r) => WsPath.fromFSPath(r))

--- a/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
+++ b/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
@@ -1,5 +1,6 @@
 import { expect, type Page, test } from '@playwright/test';
 import {
+  createBrowserWorkspace,
   createBrowserWorkspaceAndNote,
   EDITOR_FOCUSED_SELECTOR,
   getEditorLocator,
@@ -106,4 +107,28 @@ test('command bar and all-commands route stay centered when translate utilities 
   await page.getByPlaceholder('Type a command or search...').fill('>');
   await expect(page.getByText('> Commands')).toBeVisible();
   await expectDialogCentered(page);
+});
+
+test('workspace-only command without an open note shows an app error and keeps the app usable', async ({
+  page,
+}) => {
+  await createBrowserWorkspace(page, {
+    workspaceName: 'omni-no-open-note',
+  });
+
+  await expect(
+    page.getByText('No notes found in this workspace.'),
+  ).toBeVisible();
+
+  await pressAppShortcut(page, 'k');
+  await page
+    .getByPlaceholder('Type a command or search...')
+    .fill('Toggle Star for Current Note');
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByText('No note is currently open.')).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'omni-no-open-note' }),
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: 'New Note' })).toBeVisible();
 });

--- a/plans/AGENTS.md
+++ b/plans/AGENTS.md
@@ -35,6 +35,7 @@ title: Human-readable title
 status: planned | active | blocked | completed | superseded
 type: plan
 archived: false
+archived_on:
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 owner: agent | human | mixed
@@ -62,8 +63,8 @@ status and final verification instead of deleting it.
 ## Archiving
 
 When a plan is fully complete, move it to `plans/archived/`, set
-`archived: true`, set `status: completed`, and prepend a DONE blockquote
-immediately after the YAML frontmatter:
+`archived: true`, set `archived_on: YYYY-MM-DD`, set `status: completed`, and
+prepend a DONE blockquote immediately after the YAML frontmatter:
 
 ```md
 ---
@@ -71,6 +72,7 @@ title: Example Plan
 status: completed
 type: plan
 archived: true
+archived_on: 2026-06-13
 created: 2026-01-01
 updated: 2026-06-13
 owner: mixed

--- a/plans/archived/001-dependency-update-modernization.md
+++ b/plans/archived/001-dependency-update-modernization.md
@@ -3,6 +3,7 @@ title: Dependency Update Modernization Plan
 status: completed
 type: plan
 archived: true
+archived_on: 2026-06-14
 created: 2026-05-25
 updated: 2026-06-14
 owner: mixed

--- a/plans/archived/002-typescript-7-tsgo-investigation.md
+++ b/plans/archived/002-typescript-7-tsgo-investigation.md
@@ -3,6 +3,7 @@ title: TypeScript 7 tsgo Investigation
 status: completed
 type: plan
 archived: true
+archived_on: 2026-06-14
 created: 2026-06-14
 updated: 2026-06-14
 owner: mixed

--- a/plans/archived/003-upgrade-wrap-up.md
+++ b/plans/archived/003-upgrade-wrap-up.md
@@ -1,8 +1,9 @@
 ---
 title: Upgrade Wrap-up
-status: complete
+status: completed
 type: plan
 archived: true
+archived_on: 2026-06-14
 created: 2026-06-14
 updated: 2026-06-14
 owner: mixed


### PR DESCRIPTION
## Summary
- Route async command AppErrors through app error handling instead of browser unhandled-rejection reporting.
- Stop expected validation, permission, duplicate-file, and missing native workspace AppErrors from being reported to Sentry.
- Keep save/load/database failures reportable, await note creation before navigation, and map native FS listing NotFound errors to a typed app error.

## Validation
- pnpm lint:ci
- pnpm test:ci
- pnpm build
- pnpm --filter "@bangle.io/e2e-tests" run test -- omni-search-focus.e2e.ts
- pnpm e2e:ci

## Notes
The full E2E run still prints existing Radix dialog and nested paragraph console warnings, but all tests passed.