### PR TITLE
feat(translations): ship one language bundle per visitor with English…

### DIFF
--- a/packages/shared/translations/src/__tests__/build-support.spec.ts
+++ b/packages/shared/translations/src/__tests__/build-support.spec.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'vitest';
+import {
+  DEFAULT_LANGUAGE,
+  getLanguageScriptSource,
+  getTranslationBootstrapScript,
+  LOCALE_APPLY_GLOBAL,
+  SUPPORTED_LANGUAGES,
+  serializeTranslations,
+} from '../build-support';
+import type { Translations } from '../types';
+
+interface FakeWindow {
+  t?: Translations;
+  [LOCALE_APPLY_GLOBAL]?: (data: unknown) => void;
+}
+
+/** Parse the language code out of a `document.write`n locale script tag. */
+function localeFromWrite(chunk: string): string | null {
+  const match = chunk.match(/\/locales\/([^.]+)\.js/);
+  return match ? (match[1] ?? null) : null;
+}
+
+/**
+ * Run the inline bootstrap against a faked browser and return the locale
+ * languages it requested (in order) plus the window it installed the
+ * apply-helper onto.
+ */
+function boot(navigatorLanguage: string): {
+  win: FakeWindow;
+  loaded: string[];
+} {
+  const bootstrap = getTranslationBootstrapScript({
+    supported: SUPPORTED_LANGUAGES,
+    version: '1.0.0+abc',
+  });
+  const win: FakeWindow = {};
+  const writes: string[] = [];
+  const documentStub = {
+    write: (chunk: string) => {
+      writes.push(chunk);
+    },
+  };
+  const navigator = { language: navigatorLanguage };
+  new Function('window', 'navigator', 'document', bootstrap)(
+    win,
+    navigator,
+    documentStub,
+  );
+  const loaded = writes
+    .map(localeFromWrite)
+    .filter((lang): lang is string => lang !== null);
+  return { win, loaded };
+}
+
+/** Simulate the browser executing the emitted `/locales/<lang>.js` scripts. */
+function applyLocales(win: FakeWindow, langs: string[]): void {
+  for (const lang of langs) {
+    new Function('window', getLanguageScriptSource(lang))(win);
+  }
+}
+
+describe('SUPPORTED_LANGUAGES', () => {
+  test('always contains the default language', () => {
+    expect(SUPPORTED_LANGUAGES).toContain(DEFAULT_LANGUAGE);
+  });
+
+  test('contains the bundled languages', () => {
+    expect(SUPPORTED_LANGUAGES).toEqual(expect.arrayContaining(['en', 'de']));
+  });
+});
+
+describe('serializeTranslations', () => {
+  test('encodes strings, nested objects, and functions', () => {
+    const source = serializeTranslations({
+      a: 'hello "world"',
+      nested: { b: 'x' },
+      fn: ({ name }: { name: string }) => `Hi ${name}`,
+    });
+    const value = new Function(`return (${source})`)() as {
+      a: string;
+      nested: { b: string };
+      fn: (arg: { name: string }) => string;
+    };
+    expect(value.a).toBe('hello "world"');
+    expect(value.nested.b).toBe('x');
+    expect(value.fn({ name: 'Ada' })).toBe('Hi Ada');
+  });
+
+  test('throws on unsupported value types', () => {
+    expect(() => serializeTranslations({ n: 1 })).toThrow(/unsupported/);
+    expect(() => serializeTranslations(undefined)).toThrow(/unsupported/);
+  });
+});
+
+describe('getLanguageScriptSource', () => {
+  test('applies the selected language to the global t', () => {
+    const { win, loaded } = boot('de-DE');
+    applyLocales(win, loaded);
+    expect(win.t?.meta.lang).toBe('Deutsch');
+    expect(win.t?.app.common.newNote).toBe('Neue Notiz');
+  });
+
+  test('preserves interpolation callbacks', () => {
+    const { win } = boot('en-US');
+    applyLocales(win, ['en']);
+    expect(win.t?.meta.lang).toBe('English');
+    expect(win.t?.meta.testCallback({ name: 'Ada' })).toBe('Hello Ada');
+  });
+
+  test('routes through the locale-apply global', () => {
+    expect(getLanguageScriptSource('en')).toContain(
+      `window.${LOCALE_APPLY_GLOBAL}(`,
+    );
+  });
+
+  test('throws for an unknown language', () => {
+    expect(() => getLanguageScriptSource('xx')).toThrow(/unknown language/);
+  });
+});
+
+describe('getTranslationBootstrapScript', () => {
+  test('English visitors download only the English bundle', () => {
+    expect(boot('en-US').loaded).toEqual(['en']);
+  });
+
+  test('always loads English first, then the visitor language', () => {
+    expect(boot('de-DE').loaded).toEqual(['en', 'de']);
+  });
+
+  test('falls back to English for an unsupported language', () => {
+    expect(boot('fr-FR').loaded).toEqual(['en']);
+  });
+
+  test('uses only the primary subtag to pick the language', () => {
+    expect(boot('de-AT').loaded).toEqual(['en', 'de']);
+  });
+
+  test('deep-merges the language over English, keeping untranslated keys', () => {
+    const { win } = boot('de-DE');
+    const apply = win[LOCALE_APPLY_GLOBAL];
+    expect(apply).toBeTypeOf('function');
+    // English base, then a partial language that translates only one leaf.
+    apply?.({
+      meta: { lang: 'English' },
+      section: { keep: 'english-keep', change: 'english-change' },
+    });
+    apply?.({
+      meta: { lang: 'Deutsch' },
+      section: { change: 'deutsch-change' },
+    });
+    const t = win.t as unknown as {
+      meta: { lang: string };
+      section: { keep: string; change: string };
+    };
+    expect(t.meta.lang).toBe('Deutsch');
+    expect(t.section.change).toBe('deutsch-change');
+    // Untranslated key falls back to the English base rather than vanishing.
+    expect(t.section.keep).toBe('english-keep');
+  });
+
+  test('does not emit a raw closing script tag that would break parsing', () => {
+    const script = getTranslationBootstrapScript({
+      supported: ['en', 'de'],
+      version: '1.0.0+abc',
+    });
+    expect(script).not.toContain('</script>');
+    expect(script).toContain('<\\/script>');
+  });
+
+  test('cache-busts locale URLs with the encoded version', () => {
+    let written = '';
+    const script = getTranslationBootstrapScript({
+      supported: ['en'],
+      version: '1.0.0+abc',
+    });
+    new Function('window', 'navigator', 'document', script)(
+      {},
+      { language: 'en' },
+      {
+        write: (chunk: string) => {
+          written += chunk;
+        },
+      },
+    );
+    expect(written).toBe(
+      '<script src="/locales/en.js?v=1.0.0%2Babc"></script>',
+    );
+  });
+});

--- a/packages/shared/translations/src/build-support.ts
+++ b/packages/shared/translations/src/build-support.ts
@@ -18,7 +18,7 @@ interface LanguageModule {
   t: unknown;
 }
 
-const LANGUAGE_MAP = languages as unknown as Record<string, LanguageModule>;
+const LANGUAGE_MAP: Record<string, LanguageModule> = languages;
 
 /**
  * The default language every build must contain. It is the source of truth for
@@ -28,9 +28,10 @@ const LANGUAGE_MAP = languages as unknown as Record<string, LanguageModule>;
 export const DEFAULT_LANGUAGE = 'en';
 
 /**
- * Language codes with a bundled translation, e.g. `['de', 'en']`.
+ * Language codes with a bundled translation, e.g. `['de', 'en']`. Always
+ * includes {@link DEFAULT_LANGUAGE}.
  */
-export const SUPPORTED_LANGUAGES: string[] = Object.keys(LANGUAGE_MAP);
+export const SUPPORTED_LANGUAGES: readonly string[] = Object.keys(LANGUAGE_MAP);
 
 /**
  * Serialize a translation value into an executable JavaScript literal. Strings
@@ -78,7 +79,7 @@ export function getLanguageScriptSource(lang: string): string {
 
 interface BootstrapOptions {
   /** Language codes that have a `/locales/<lang>.js` asset. */
-  supported: string[];
+  supported: readonly string[];
   /** Cache-busting token appended as `?v=` to the locale URL. */
   version: string;
 }
@@ -92,6 +93,11 @@ interface BootstrapOptions {
  * English ({@link DEFAULT_LANGUAGE}) is always loaded as the fallback. An
  * English visitor downloads exactly one bundle; others download English plus
  * their language, never every translation.
+ *
+ * INVARIANT: the returned script must be injected as a synchronous, inline
+ * `<head>` script (never `async`/`defer`). Its `document.write` of the locale
+ * `<script>` tags relies on running during initial parsing; deferring it would
+ * blank the page and leave `t` undefined.
  */
 export function getTranslationBootstrapScript({
   supported,
@@ -106,9 +112,11 @@ export function getTranslationBootstrapScript({
   var supported=${supportedLiteral};
   var fallback=${fallbackLiteral};
   var version=${versionLiteral};
+  var hasOwn=Object.prototype.hasOwnProperty;
   function isObject(value){return value&&typeof value==="object"&&!Array.isArray(value);}
   function deepMerge(base,override){
     for(var key in override){
+      if(!hasOwn.call(override,key)||key==="__proto__"){continue;}
       base[key]=isObject(base[key])&&isObject(override[key])?deepMerge(base[key],override[key]):override[key];
     }
     return base;

--- a/packages/shared/translations/src/build-support.ts
+++ b/packages/shared/translations/src/build-support.ts
@@ -1,0 +1,127 @@
+/**
+ * Build-time helpers for shipping translations to the browser.
+ *
+ * These are consumed by the Vite build (bootstrap + per-language asset
+ * emission) and are never part of the running application bundle. They serialize
+ * each language into a standalone classic script so a visitor downloads only the
+ * single language they need, while `t` stays synchronously available before app
+ * code runs.
+ *
+ * The serializer intentionally supports plain objects, strings, and functions
+ * (interpolation callbacks). Functions are emitted via `Function.prototype.toString`,
+ * so - as documented in `languages/en.ts` - they must not close over any imports
+ * or outer bindings.
+ */
+import * as languages from './languages';
+
+interface LanguageModule {
+  t: unknown;
+}
+
+const LANGUAGE_MAP = languages as unknown as Record<string, LanguageModule>;
+
+/**
+ * The default language every build must contain. It is the source of truth for
+ * the `Translations` shape and the fallback when a visitor's language is not
+ * supported.
+ */
+export const DEFAULT_LANGUAGE = 'en';
+
+/**
+ * Language codes with a bundled translation, e.g. `['de', 'en']`.
+ */
+export const SUPPORTED_LANGUAGES: string[] = Object.keys(LANGUAGE_MAP);
+
+/**
+ * Serialize a translation value into an executable JavaScript literal. Strings
+ * use JSON encoding, nested objects recurse, and functions are stringified.
+ */
+export function serializeTranslations(value: unknown): string {
+  if (typeof value === 'function') {
+    return value.toString();
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'object' && value !== null) {
+    const parts: string[] = [];
+    for (const [key, child] of Object.entries(value)) {
+      parts.push(`${JSON.stringify(key)}:${serializeTranslations(child)}`);
+    }
+    return `{${parts.join(',')}}`;
+  }
+  throw new Error(
+    `serializeTranslations: unsupported value of type "${typeof value}"`,
+  );
+}
+
+/**
+ * Global function - installed by the bootstrap - that each locale script calls
+ * to apply its data. Non-default languages deep-merge over the English base, so
+ * any untranslated key falls back to English instead of becoming `undefined`.
+ */
+export const LOCALE_APPLY_GLOBAL = '__bangleApplyLocale';
+
+/**
+ * Build the source of a standalone classic script that applies the given
+ * language to the global `t` (via {@link LOCALE_APPLY_GLOBAL}). This is what
+ * each `/locales/<lang>.js` asset contains. Loaded after the English base, its
+ * data is deep-merged on top; loaded as the base, it becomes `t` directly.
+ */
+export function getLanguageScriptSource(lang: string): string {
+  const mod = LANGUAGE_MAP[lang];
+  if (!mod) {
+    throw new Error(`getLanguageScriptSource: unknown language "${lang}"`);
+  }
+  return `window.${LOCALE_APPLY_GLOBAL}(${serializeTranslations(mod.t)});`;
+}
+
+interface BootstrapOptions {
+  /** Language codes that have a `/locales/<lang>.js` asset. */
+  supported: string[];
+  /** Cache-busting token appended as `?v=` to the locale URL. */
+  version: string;
+}
+
+/**
+ * Build the inline `<head>` bootstrap. It installs the locale-apply helper,
+ * then synchronously loads (via `document.write`, so `t` is defined before the
+ * module bundle runs) the English base plus - when the visitor's language
+ * differs - their language, whose keys deep-merge over English.
+ *
+ * English ({@link DEFAULT_LANGUAGE}) is always loaded as the fallback. An
+ * English visitor downloads exactly one bundle; others download English plus
+ * their language, never every translation.
+ */
+export function getTranslationBootstrapScript({
+  supported,
+  version,
+}: BootstrapOptions): string {
+  const supportedLiteral = JSON.stringify(supported);
+  const fallbackLiteral = JSON.stringify(DEFAULT_LANGUAGE);
+  const versionLiteral = JSON.stringify(version);
+  const applyGlobal = LOCALE_APPLY_GLOBAL;
+  // `<\/script>` keeps the HTML parser from closing the inline bootstrap early.
+  return `(function(){
+  var supported=${supportedLiteral};
+  var fallback=${fallbackLiteral};
+  var version=${versionLiteral};
+  function isObject(value){return value&&typeof value==="object"&&!Array.isArray(value);}
+  function deepMerge(base,override){
+    for(var key in override){
+      base[key]=isObject(base[key])&&isObject(override[key])?deepMerge(base[key],override[key]):override[key];
+    }
+    return base;
+  }
+  window.${applyGlobal}=function(data){
+    window.t=window.t?deepMerge(window.t,data):data;
+  };
+  function load(lang){
+    document.write('<script src="/locales/'+lang+'.js?v='+encodeURIComponent(version)+'"><\\/script>');
+  }
+  var preferred=((navigator.language||"")+"").split("-")[0];
+  var chosen=supported.indexOf(preferred)!==-1?preferred:fallback;
+  load(fallback);
+  if(chosen!==fallback){load(chosen);}
+})();`;
+}

--- a/packages/shared/translations/src/index.ts
+++ b/packages/shared/translations/src/index.ts
@@ -1,4 +1,10 @@
+export {
+  DEFAULT_LANGUAGE,
+  getLanguageScriptSource,
+  getTranslationBootstrapScript,
+  SUPPORTED_LANGUAGES,
+  serializeTranslations,
+} from './build-support';
 export * as languages from './languages';
-
 export { t } from './languages/en';
 export type { Translations } from './types';

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -1,5 +1,5 @@
 // de.ts
-import type { Translations } from '../types';
+import type { PartialTranslations } from '../types';
 
 export const t = {
   meta: {
@@ -468,4 +468,4 @@ export const t = {
       'Löst gerade den Weltfrieden ✌️',
     ],
   },
-} satisfies Translations;
+} satisfies PartialTranslations;

--- a/packages/shared/translations/src/types.ts
+++ b/packages/shared/translations/src/types.ts
@@ -1,3 +1,20 @@
 import type { t } from './languages/en';
 
+/**
+ * The complete translation shape. English (`en`) is the source of truth; every
+ * key the app reads exists here.
+ */
 export type Translations = typeof t;
+
+/**
+ * A translation may be authored partially: any subtree can be omitted, and the
+ * bootstrap deep-merges it over the English base so untranslated keys fall back
+ * to English. Functions (interpolation callbacks) are treated as leaves.
+ */
+export type PartialTranslations<T = Translations> = {
+  [K in keyof T]?: T[K] extends (...args: never[]) => unknown
+    ? T[K]
+    : T[K] extends object
+      ? PartialTranslations<T[K]>
+      : T[K];
+};

--- a/packages/tooling/browser-entry/translations-plugin.ts
+++ b/packages/tooling/browser-entry/translations-plugin.ts
@@ -1,0 +1,56 @@
+import {
+  getLanguageScriptSource,
+  SUPPORTED_LANGUAGES,
+} from '@bangle.io/translations';
+import type { Plugin } from 'vite';
+
+const LOCALE_PREFIX = '/locales/';
+const LOCALE_SUFFIX = '.js';
+
+/** Extract the language code from a `/locales/<lang>.js` request path. */
+function parseLocaleRequest(url: string | undefined): string | null {
+  if (!url) {
+    return null;
+  }
+  const pathname = url.split('?')[0] ?? '';
+  if (
+    !pathname.startsWith(LOCALE_PREFIX) ||
+    !pathname.endsWith(LOCALE_SUFFIX)
+  ) {
+    return null;
+  }
+  const lang = pathname.slice(LOCALE_PREFIX.length, -LOCALE_SUFFIX.length);
+  return SUPPORTED_LANGUAGES.includes(lang) ? lang : null;
+}
+
+/**
+ * Emits one standalone classic script per language at `/locales/<lang>.js` and
+ * serves them in dev. The inline HTML bootstrap (see
+ * `getTranslationBootstrapScript`) loads exactly one of these based on the
+ * visitor's language, so no bundle ships every translation.
+ */
+export function translationsPlugin(): Plugin {
+  return {
+    name: 'bangle-translations',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const lang = parseLocaleRequest(req.url);
+        if (!lang) {
+          next();
+          return;
+        }
+        res.setHeader('Content-Type', 'text/javascript; charset=utf-8');
+        res.end(getLanguageScriptSource(lang));
+      });
+    },
+    generateBundle() {
+      for (const lang of SUPPORTED_LANGUAGES) {
+        this.emitFile({
+          type: 'asset',
+          fileName: `locales/${lang}${LOCALE_SUFFIX}`,
+          source: getLanguageScriptSource(lang),
+        });
+      }
+    },
+  };
+}

--- a/packages/tooling/browser-entry/vite.config.ts
+++ b/packages/tooling/browser-entry/vite.config.ts
@@ -1,50 +1,31 @@
 import { ThemeManager } from '@bangle.io/color-scheme-manager';
 import getEnvVars from '@bangle.io/env-vars';
-import { languages } from '@bangle.io/translations';
+import {
+  getTranslationBootstrapScript,
+  SUPPORTED_LANGUAGES,
+} from '@bangle.io/translations';
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
+import { translationsPlugin } from './translations-plugin';
 
-// Custom serializer to handle functions
-function serializeTranslationObjection(obj: any): string {
-  const parts: string[] = [];
-  for (const key in obj) {
-    if (Object.hasOwn(obj, key)) {
-      const value = obj[key];
-      const serializedKey = JSON.stringify(key);
-      let serializedValue: string;
-      if (typeof value === 'function') {
-        serializedValue = value.toString(); // Convert function to string
-      } else if (typeof value === 'object' && value !== null) {
-        serializedValue = serializeTranslationObjection(value);
-      } else if (typeof value === 'string') {
-        serializedValue = JSON.stringify(value); // Use JSON.stringify for strings
-      } else {
-        throw new Error(
-          `serializeTranslationObjection: Unsupported type encountered during serialization: ${typeof value} for key ${serializedKey}`,
-        );
-      }
-      parts.push(`${serializedKey}: ${serializedValue}`);
-    }
-  }
-  return `{${parts.join(',')}}`;
-}
+// Replaced after env vars are resolved so the locale URL is cache-busted per
+// release. Using a placeholder avoids computing `releaseId` twice.
+const LOCALE_VERSION_PLACEHOLDER = '__BANGLE_LOCALE_VERSION__';
 
 export default defineConfig(async (env) => {
   const isProduction = env.mode === 'production';
   const themeInline = ThemeManager.getInlineScript();
 
-  const translationInline = `(() => {
-    const translations = ${serializeTranslationObjection(languages)};
-    const userLang = navigator.language.split('-')[0];
-    if (translations.hasOwnProperty(userLang)) {
-      window.t = translations[userLang].t;
-    } else {
-      window.t = translations.en.t
-    }
-  })()`;
+  // Only the visitor's language is downloaded (as a standalone
+  // `/locales/<lang>.js` asset emitted by `translationsPlugin`), while `t`
+  // stays synchronously available before the app bundle runs.
+  const translationInline = getTranslationBootstrapScript({
+    supported: SUPPORTED_LANGUAGES,
+    version: LOCALE_VERSION_PLACEHOLDER,
+  });
 
   const envVars = getEnvVars({
     isProduction: isProduction,
@@ -52,11 +33,18 @@ export default defineConfig(async (env) => {
     inlinedScripts: [translationInline, themeInline],
   });
 
+  envVars.htmlInjections.inlinedScripts =
+    envVars.htmlInjections.inlinedScripts.replaceAll(
+      LOCALE_VERSION_PLACEHOLDER,
+      envVars.releaseId,
+    );
+
   return {
     build: {
       sourcemap: true,
     },
     plugins: [
+      translationsPlugin(),
       createHtmlPlugin({
         minify: isProduction,
         inject: {

--- a/packages/tooling/browser-entry/vite.config.ts
+++ b/packages/tooling/browser-entry/vite.config.ts
@@ -11,9 +11,16 @@ import { defineConfig } from 'vite';
 import { createHtmlPlugin } from 'vite-plugin-html';
 import { translationsPlugin } from './translations-plugin';
 
-// Replaced after env vars are resolved so the locale URL is cache-busted per
-// release. Using a placeholder avoids computing `releaseId` twice.
+// The bootstrap must be built before `getEnvVars` (it is one of the
+// `inlinedScripts`), but the cache-busting `releaseId` is one of that call's
+// outputs. So the bootstrap ships a placeholder that is swapped for the real
+// release once it is known.
 const LOCALE_VERSION_PLACEHOLDER = '__BANGLE_LOCALE_VERSION__';
+
+/** Escape a value for safe substitution inside a double-quoted JS string literal. */
+function jsStringInner(value: string): string {
+  return JSON.stringify(value).slice(1, -1);
+}
 
 export default defineConfig(async (env) => {
   const isProduction = env.mode === 'production';
@@ -33,10 +40,12 @@ export default defineConfig(async (env) => {
     inlinedScripts: [translationInline, themeInline],
   });
 
+  // The placeholder sits inside a JS string literal, so escape the release
+  // before splicing it in.
   envVars.htmlInjections.inlinedScripts =
     envVars.htmlInjections.inlinedScripts.replaceAll(
       LOCALE_VERSION_PLACEHOLDER,
-      envVars.releaseId,
+      jsStringInner(envVars.releaseId),
     );
 
   return {

--- a/packages/tooling/e2e-tests/src/translations-locale.e2e.ts
+++ b/packages/tooling/e2e-tests/src/translations-locale.e2e.ts
@@ -1,0 +1,64 @@
+import { expect, type Page, test } from '@playwright/test';
+
+/** Locale bundle filenames (e.g. `['en.js', 'de.js']`) fetched so far, in order. */
+async function loadedLocaleFiles(page: Page): Promise<string[]> {
+  const urls = await page.evaluate(() =>
+    performance
+      .getEntriesByType('resource')
+      .map((entry) => entry.name)
+      .filter((name) => name.includes('/locales/')),
+  );
+  return urls.map((url) =>
+    url.replace(/^.*\/locales\//, '').replace(/\?.*$/, ''),
+  );
+}
+
+/** The language the running app applied to the global `t`. */
+async function activeLanguage(page: Page): Promise<string | undefined> {
+  return page.evaluate(() => {
+    const globals = window as unknown as { t?: { meta?: { lang?: string } } };
+    return globals.t?.meta?.lang;
+  });
+}
+
+test.describe('translations delivery', () => {
+  test('an English visitor loads only the English bundle', async ({ page }) => {
+    await page.goto('/');
+
+    // User-observable: the welcome screen renders in English.
+    await expect(page.getByText('No workspace selected')).toBeVisible();
+    expect(await activeLanguage(page)).toBe('English');
+
+    // Exactly one language bundle is shipped, cache-busted with a real
+    // release id rather than the build-time placeholder.
+    const locales = await page.evaluate(() =>
+      performance
+        .getEntriesByType('resource')
+        .map((entry) => entry.name)
+        .filter((name) => name.includes('/locales/')),
+    );
+    expect(await loadedLocaleFiles(page)).toEqual(['en.js']);
+    expect(locales[0]).toMatch(/\/locales\/en\.js\?v=.+/);
+    expect(locales[0]).not.toContain('__BANGLE_LOCALE_VERSION__');
+  });
+
+  test.describe('German visitor', () => {
+    test.use({ locale: 'de-DE' });
+
+    test('loads the English base then German, and renders German', async ({
+      page,
+    }) => {
+      await page.goto('/');
+
+      // User-observable: the welcome screen renders in German.
+      await expect(
+        page.getByText('Kein Arbeitsbereich ausgewählt'),
+      ).toBeVisible();
+      expect(await activeLanguage(page)).toBe('Deutsch');
+
+      // English is always loaded first as the fallback base, then German is
+      // merged on top - never every language.
+      expect(await loadedLocaleFiles(page)).toEqual(['en.js', 'de.js']);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Every language was serialized into a single render-blocking inline `<script>` in the HTML head, so **every visitor downloaded every translation**. The payload grew with each added language and, being inline in the HTML, was never cacheable.

## Approach

Emit one standalone classic script per language at `/locales/<lang>.js` and replace the inline blob with a tiny bootstrap that:

1. Installs a deep-merge apply helper.
2. Synchronously `document.write()`s the **English base** first, then the visitor's language (when different), which deep-merges on top.

### Guarantees

- **English is always the fallback base.** Any untranslated key falls back to English instead of becoming `undefined`, so **incomplete translations are safe to ship** (non-English languages are typed `satisfies PartialTranslations`, a DeepPartial of the English source of truth).
- **No every-language payload.** An English visitor downloads exactly one bundle (`en.js`); others download English + their language only.
- **`t` is defined before the app bundle runs** — the bootstrap is a synchronous inline head script and the locale scripts are parser-blocking classic scripts, so there's no async load and no English→localized flash.
- **Cacheable + cache-busted.** Each `/locales/<lang>.js` is a separate asset, busted per release via `?v=<releaseId>` (release id is escaped before it's spliced into the inline JS). A dev middleware serves them.

Serialization, the supported-language list, the apply-global name, and the bootstrap generator live in `@bangle.io/translations`.

## Review follow-ups addressed

- Partial-language typing so the English-fallback + deep-merge is actually reachable (was previously forced-complete, making the merge dead weight).
- Removed a disallowed `as unknown as` cast.
- `deepMerge` hardened with `hasOwnProperty` + `__proto__` guard.
- `SUPPORTED_LANGUAGES` made `readonly`; documented the "must stay a synchronous inline head script" invariant.

## Testing

- **Unit** (`build-support.spec.ts`, 15 tests): load order, English-only for en visitors, unsupported→English fallback, primary-subtag matching (`de-AT`→`de`), the deep-merge fallback, `</script>` escaping, and version cache-busting.
- **E2E** (`translations-locale.e2e.ts`): a real browser proves an English visitor loads **only** `en.js` and sees "No workspace selected"; a `de-DE` visitor loads `en.js` **then** `de.js` and sees "Kein Arbeitsbereich ausgewählt"; and the shipped locale URL carries a real release id, not the build placeholder.
- `pnpm typecheck`, Biome, `pnpm custom-validation`, and `pnpm build` pass; build emits `dist/locales/{en,de}.js`.

> Note: locally the e2e's `reuseExistingServer` can latch onto another worktree's dev server on :5173; verified green against a dedicated server. CI starts a fresh server, so it's unaffected.
