### PR TITLE
feat: add workspaces settings page

### DIFF
--- a/packages/core/app/src/index.tsx
+++ b/packages/core/app/src/index.tsx
@@ -85,6 +85,7 @@ function AppRoutes() {
     case 'not-found':
       return <PageNotFound />;
     case 'settings-general':
+    case 'settings-workspaces':
       return <PageSettings />;
 
     default: {

--- a/packages/core/app/src/pages/__tests__/page-settings-workspaces.spec.tsx
+++ b/packages/core/app/src/pages/__tests__/page-settings-workspaces.spec.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+/// <reference types="@vitest/browser/matchers" />
+import '@testing-library/jest-dom/vitest';
+import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import { renderWithServices } from '@bangle.io/test-utils';
+import { screen, waitFor, within } from '@testing-library/react';
+import React, { act } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkspacesSettingsPage } from '../page-settings-workspaces';
+
+const WORKSPACE_WITH_NOTE = 'ws-with-note';
+const EMPTY_WORKSPACE = 'ws-empty';
+
+async function setupWorkspaces(
+  services: Awaited<
+    ReturnType<ReturnType<typeof renderWithServices>['autoMountServices']>
+  >,
+) {
+  await act(async () => {
+    await services.workspaceOps.createWorkspaceInfo({
+      name: WORKSPACE_WITH_NOTE,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.workspaceOps.createWorkspaceInfo({
+      name: EMPTY_WORKSPACE,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    services.commandDispatcher.dispatch(
+      'command::ws:create-note',
+      { wsPath: `${WORKSPACE_WITH_NOTE}:note1.md`, navigate: undefined },
+      'test',
+    );
+  });
+}
+
+function noteCellFor(wsName: string): HTMLElement {
+  const nameLink = screen.getByRole('link', { name: wsName });
+  const infoCell = nameLink.parentElement;
+  if (!infoCell) {
+    throw new Error(`Could not find info cell for workspace ${wsName}`);
+  }
+  return infoCell;
+}
+
+describe('WorkspacesSettingsPage', () => {
+  it('shows per-workspace note counts scoped to each row', async () => {
+    const testRender = renderWithServices();
+    const services = await testRender.autoMountServices();
+    await setupWorkspaces(services);
+
+    testRender.mountComponent({ ui: <WorkspacesSettingsPage />, services });
+
+    await waitFor(() => {
+      expect(
+        within(noteCellFor(WORKSPACE_WITH_NOTE)).getByText('1 note'),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(noteCellFor(EMPTY_WORKSPACE)).getByText('0 notes'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Notes unavailable" instead of "0 notes" when the count fails to load', async () => {
+    const testRender = renderWithServices();
+    const services = await testRender.autoMountServices();
+    await setupWorkspaces(services);
+
+    // A read/permission failure must never be presented as an empty ("0 notes")
+    // workspace — it must surface as unavailable.
+    vi.spyOn(services.fileSystem, 'listFiles').mockRejectedValue(
+      new Error('listing failed'),
+    );
+
+    testRender.mountComponent({ ui: <WorkspacesSettingsPage />, services });
+
+    await waitFor(() => {
+      expect(
+        within(noteCellFor(WORKSPACE_WITH_NOTE)).getByText('Notes unavailable'),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(noteCellFor(EMPTY_WORKSPACE)).getByText('Notes unavailable'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('0 notes')).not.toBeInTheDocument();
+    expect(screen.queryByText('1 note')).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/app/src/pages/page-settings-workspaces.tsx
+++ b/packages/core/app/src/pages/page-settings-workspaces.tsx
@@ -1,0 +1,303 @@
+import { useCoreServices } from '@bangle.io/context';
+import { Button, DropdownMenu } from '@bangle.io/ui-components';
+import { WsPath } from '@bangle.io/ws-path';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { ExternalLink, MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import React from 'react';
+import { getRelativeTimeOrNull } from '../common/get-relative-time';
+
+type NoteCountState =
+  | { status: 'loading' }
+  | { status: 'ready'; count: number }
+  | { status: 'error' };
+
+export function WorkspacesSettingsPage() {
+  const {
+    commandDispatcher,
+    fileSystem,
+    navigation,
+    userActivityService,
+    workbenchState,
+    workspaceState,
+  } = useCoreServices();
+  const workspaces = useAtomValue(workspaceState.$workspaces);
+  // `$workspaces` returns a fresh array on every recompute, so memoize the name
+  // list on a stable serialized key. This keeps `workspaceNames`' identity
+  // stable when the set of names is unchanged, avoiding a note-count refetch of
+  // every workspace on unrelated workspace-list recomputes. `\0` cannot appear
+  // in a workspace name.
+  const workspaceNamesKey = workspaces
+    .map((workspace) => workspace.name)
+    .join('\0');
+  const workspaceNames = React.useMemo(
+    () => (workspaceNamesKey ? workspaceNamesKey.split('\0') : []),
+    [workspaceNamesKey],
+  );
+  const allRecentWsPaths = useAtomValue(userActivityService.$allRecentWsPaths);
+  const fileListRevisionCount = useAtomValue(fileSystem.$fileListRevisionCount);
+  const setAlertDialog = useSetAtom(workbenchState.$alertDialog);
+  const noteCounts = useWorkspaceNoteCounts(
+    workspaceNames,
+    fileListRevisionCount,
+  );
+
+  const lastOpenedByWorkspace = React.useMemo(() => {
+    const latest = new Map<string, number>();
+
+    for (const item of allRecentWsPaths) {
+      const result = WsPath.safeParse(item.wsPath);
+      if (result.validationError || !result.data) {
+        continue;
+      }
+      const wsName = result.data.wsName;
+      const current = latest.get(wsName) ?? 0;
+      if (item.timestamp > current) {
+        latest.set(wsName, item.timestamp);
+      }
+    }
+
+    return latest;
+  }, [allRecentWsPaths]);
+
+  const sortedWorkspaces = React.useMemo(
+    () =>
+      [...workspaces].sort((left, right) => {
+        const leftOpened =
+          lastOpenedByWorkspace.get(left.name) ?? left.lastModified;
+        const rightOpened =
+          lastOpenedByWorkspace.get(right.name) ?? right.lastModified;
+        return rightOpened - leftOpened || left.name.localeCompare(right.name);
+      }),
+    [lastOpenedByWorkspace, workspaces],
+  );
+
+  const openCreateWorkspaceDialog = () => {
+    commandDispatcher.dispatch(
+      'command::ui:create-workspace-dialog',
+      null,
+      'ui',
+    );
+  };
+
+  const requestDeleteWorkspace = (wsName: string) => {
+    setAlertDialog({
+      dialogId: `dialog::settings-delete-workspace-${wsName}`,
+      title: t.app.dialogs.confirmDeleteWorkspace.title,
+      tone: 'destructive',
+      description: t.app.dialogs.confirmDeleteWorkspace.description({
+        wsName,
+      }),
+      continueText: t.app.dialogs.confirmDeleteWorkspace.continueText,
+      onContinue: () => {
+        commandDispatcher.dispatch(
+          'command::ws:delete-workspace',
+          { wsName },
+          'ui',
+        );
+      },
+      onCancel: () => {},
+    });
+  };
+
+  return (
+    <section className="space-y-2.5">
+      <div className="flex items-center justify-between px-1">
+        <h2 className="flex items-center gap-2 font-semibold text-[11px] text-muted-foreground uppercase tracking-normal">
+          <span aria-hidden className="inline-block h-px w-3 bg-border" />
+          {t.app.settings.workspaces.sectionTitle}
+        </h2>
+        <Button
+          className="h-6 gap-1 rounded-sm px-1.5 font-normal text-[11px] text-muted-foreground hover:text-foreground"
+          onClick={openCreateWorkspaceDialog}
+          size="sm"
+          variant="ghost"
+        >
+          <Plus className="h-3 w-3" />
+          <span>{t.app.settings.workspaces.newWorkspace}</span>
+        </Button>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border bg-card/80 text-card-foreground shadow-sm">
+        {sortedWorkspaces.length === 0 ? (
+          <div className="px-5 py-8 text-center">
+            <h3 className="font-medium text-sm">
+              {t.app.settings.workspaces.emptyTitle}
+            </h3>
+            <p className="mt-1 text-muted-foreground text-sm">
+              {t.app.settings.workspaces.emptyDescription}
+            </p>
+          </div>
+        ) : (
+          sortedWorkspaces.map((workspace) => {
+            const noteCount = noteCounts[workspace.name] ?? {
+              status: 'loading' as const,
+            };
+            const lastOpened =
+              lastOpenedByWorkspace.get(workspace.name) ??
+              workspace.lastModified;
+            const relativeLastOpened = lastOpened
+              ? getRelativeTimeOrNull(lastOpened)
+              : null;
+            const workspaceHref = navigation.toUri({
+              route: 'ws-home',
+              payload: { wsName: workspace.name },
+            });
+
+            return (
+              <div
+                className="grid gap-3 border-border/60 border-t px-4 py-3.5 first:border-t-0 sm:grid-cols-[minmax(0,1fr)_auto_auto] sm:items-center sm:px-5"
+                key={workspace.name}
+              >
+                <div className="min-w-0 space-y-1">
+                  <a
+                    className="block truncate font-medium text-foreground text-sm hover:underline"
+                    href={workspaceHref}
+                  >
+                    {workspace.name}
+                  </a>
+                  <p className="text-muted-foreground text-xs">
+                    {formatNoteCount(noteCount)}
+                  </p>
+                </div>
+
+                <div className="min-w-36 text-muted-foreground text-xs sm:text-right">
+                  <span>{t.app.settings.workspaces.lastOpened}</span>
+                  <span aria-hidden> · </span>
+                  <span title={lastOpened ? formatDateTime(lastOpened) : ''}>
+                    {relativeLastOpened ??
+                      t.app.settings.workspaces.neverOpened}
+                  </span>
+                </div>
+
+                <WorkspaceActionsMenu
+                  onDelete={() => requestDeleteWorkspace(workspace.name)}
+                  openHref={workspaceHref}
+                  wsName={workspace.name}
+                />
+              </div>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}
+
+function WorkspaceActionsMenu({
+  wsName,
+  openHref,
+  onDelete,
+}: {
+  wsName: string;
+  openHref: string;
+  onDelete: () => void;
+}) {
+  return (
+    <DropdownMenu.DropdownMenu>
+      <DropdownMenu.DropdownMenuTrigger asChild>
+        <Button
+          aria-label={t.app.settings.workspaces.actionsLabel({ wsName })}
+          className="h-8 w-8 justify-self-start p-0 sm:justify-self-end"
+          size="icon"
+          variant="ghost"
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenu.DropdownMenuTrigger>
+      <DropdownMenu.DropdownMenuContent align="end" className="min-w-44">
+        <DropdownMenu.DropdownMenuItem asChild>
+          <a href={openHref}>
+            <ExternalLink className="mr-2 h-4 w-4" />
+            <span>{t.app.settings.workspaces.openWorkspace}</span>
+          </a>
+        </DropdownMenu.DropdownMenuItem>
+        <DropdownMenu.DropdownMenuSeparator />
+        <DropdownMenu.DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onSelect={onDelete}
+        >
+          <Trash2 className="mr-2 h-4 w-4" />
+          <span>{t.app.settings.workspaces.deleteWorkspace}</span>
+        </DropdownMenu.DropdownMenuItem>
+      </DropdownMenu.DropdownMenuContent>
+    </DropdownMenu.DropdownMenu>
+  );
+}
+
+function useWorkspaceNoteCounts(
+  workspaceNames: readonly string[],
+  fileListRevisionCount: number,
+): Record<string, NoteCountState> {
+  const { fileSystem } = useCoreServices();
+  const [noteCounts, setNoteCounts] = React.useState<
+    Record<string, NoteCountState>
+  >({});
+  React.useEffect(() => {
+    let cancelled = false;
+    const abortController = new AbortController();
+    // `fileListRevisionCount` bumps on file create/delete/rename (not on content
+    // edits). Referencing it here keeps it a real effect dependency so the counts
+    // refetch when the file list changes; it has no other use in the body.
+    void fileListRevisionCount;
+
+    setNoteCounts((previous) => {
+      const next: Record<string, NoteCountState> = {};
+      for (const wsName of workspaceNames) {
+        next[wsName] = previous[wsName] ?? { status: 'loading' };
+      }
+      return next;
+    });
+
+    void Promise.all(
+      workspaceNames.map(async (wsName) => {
+        try {
+          const files = await fileSystem.listFiles(
+            wsName,
+            abortController.signal,
+          );
+          return [wsName, { status: 'ready', count: files.length }] as const;
+        } catch {
+          if (abortController.signal.aborted) {
+            return [wsName, { status: 'loading' }] as const;
+          }
+          return [wsName, { status: 'error' }] as const;
+        }
+      }),
+    ).then((entries) => {
+      if (cancelled) {
+        return;
+      }
+
+      setNoteCounts(Object.fromEntries(entries));
+    });
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+  }, [fileSystem, fileListRevisionCount, workspaceNames]);
+
+  return noteCounts;
+}
+
+function formatNoteCount(noteCount: NoteCountState) {
+  switch (noteCount.status) {
+    case 'ready':
+      return t.app.settings.workspaces.noteCount({ count: noteCount.count });
+    case 'error':
+      return t.app.settings.workspaces.noteCountUnavailable;
+    case 'loading':
+      return t.app.settings.workspaces.noteCountLoading;
+    default: {
+      const _exhaustiveCheck: never = noteCount;
+      return _exhaustiveCheck;
+    }
+  }
+}
+
+function formatDateTime(timestamp: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(timestamp);
+}

--- a/packages/core/app/src/pages/page-settings.tsx
+++ b/packages/core/app/src/pages/page-settings.tsx
@@ -1,3 +1,8 @@
+import {
+  isSettingsRouteInfo,
+  SETTINGS_PAGE_DEFINITIONS,
+  type SettingsPageId,
+} from '@bangle.io/constants';
 import { useCoreServices } from '@bangle.io/context';
 import type { AppRouteInfo, ThemePreference } from '@bangle.io/types';
 import {
@@ -12,10 +17,16 @@ import {
   ToggleGroupItem,
 } from '@bangle.io/ui-components';
 import { useAtom, useAtomValue } from 'jotai';
-import { ArrowLeft, Settings2 } from 'lucide-react';
+import {
+  ArrowLeft,
+  BriefcaseBusiness,
+  type LucideIcon,
+  Settings2,
+} from 'lucide-react';
 import React from 'react';
 import { AppHeader } from '../layout/app-header';
 import { PageContentContainer } from '../layout/main-content-container';
+import { WorkspacesSettingsPage } from './page-settings-workspaces';
 
 const THEME_VALUES = [
   'system',
@@ -29,23 +40,31 @@ const THEME_OPTIONS: Array<{ value: ThemePreference; label: string }> = [
   { value: 'dark', label: t.app.dialogs.changeTheme.options.dark },
 ];
 
-const SETTINGS_PAGES = [
-  {
-    id: 'general',
+// Presentation for each settings page. Keyed by SettingsPageId so adding a page
+// to SETTINGS_PAGE_DEFINITIONS (in @bangle.io/constants) forces a matching entry
+// here at compile time.
+const SETTINGS_PAGE_META: Record<
+  SettingsPageId,
+  { label: string; icon: LucideIcon; title: string }
+> = {
+  general: {
     label: t.app.settings.nav.general,
-    route: 'settings-general' as const,
     icon: Settings2,
+    title: t.app.settings.general.title,
   },
-] as const;
-
-type SettingsPageId = (typeof SETTINGS_PAGES)[number]['id'];
+  workspaces: {
+    label: t.app.settings.nav.workspaces,
+    icon: BriefcaseBusiness,
+    title: t.app.settings.workspaces.title,
+  },
+};
 
 function isThemePreference(value: string): value is ThemePreference {
   return THEME_VALUES.some((theme) => theme === value);
 }
 
 function getSettingsReturnTo(routeInfo: AppRouteInfo) {
-  if (routeInfo.route !== 'settings-general') {
+  if (!isSettingsRouteInfo(routeInfo)) {
     return undefined;
   }
 
@@ -53,7 +72,7 @@ function getSettingsReturnTo(routeInfo: AppRouteInfo) {
 }
 
 function safeAppHref(href: string | undefined) {
-  if (!href || !href.startsWith('/') || href.startsWith('//')) {
+  if (!href?.startsWith('/') || href.startsWith('//')) {
     return undefined;
   }
 
@@ -61,7 +80,13 @@ function safeAppHref(href: string | undefined) {
 }
 
 export function PageSettings() {
-  return <SettingsLayout activePage="general" />;
+  const { navigation } = useCoreServices();
+  const routeInfo = useAtomValue(navigation.$routeInfo);
+  const activePage =
+    SETTINGS_PAGE_DEFINITIONS.find((page) => page.route === routeInfo.route)
+      ?.id ?? 'general';
+
+  return <SettingsLayout activePage={activePage} />;
 }
 
 function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
@@ -77,14 +102,14 @@ function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
       route: 'welcome',
       payload: {},
     });
-  const navItems = SETTINGS_PAGES.map((page) => ({
+  const navItems = SETTINGS_PAGE_DEFINITIONS.map((page) => ({
     id: page.id,
-    label: page.label,
+    label: SETTINGS_PAGE_META[page.id].label,
     href: navigation.toUri({
       route: page.route,
       payload: { returnTo },
     }),
-    icon: page.icon,
+    icon: SETTINGS_PAGE_META[page.id].icon,
   }));
 
   return (
@@ -104,63 +129,69 @@ function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
                 items={navItems}
               />
             }
-            title={t.app.settings.general.title}
+            title={SETTINGS_PAGE_META[activePage].title}
           />
 
           <SettingsPage.SettingsPageContent>
-            <SettingsPage.SettingsSection
-              title={t.app.settings.general.appearanceSection}
-            >
-              <SettingsPage.SettingsRow
-                control={
-                  <ThemePreferenceSelect
-                    onValueChange={(preference) => {
-                      workbenchState.changeThemePreference(preference);
-                    }}
-                    value={themePref}
+            {activePage === 'general' ? (
+              <>
+                <SettingsPage.SettingsSection
+                  title={t.app.settings.general.appearanceSection}
+                >
+                  <SettingsPage.SettingsRow
+                    control={
+                      <ThemePreferenceSelect
+                        onValueChange={(preference) => {
+                          workbenchState.changeThemePreference(preference);
+                        }}
+                        value={themePref}
+                      />
+                    }
+                    description={t.app.settings.general.themeDescription}
+                    title={t.app.settings.general.themeTitle}
                   />
-                }
-                description={t.app.settings.general.themeDescription}
-                title={t.app.settings.general.themeTitle}
-              />
-            </SettingsPage.SettingsSection>
+                </SettingsPage.SettingsSection>
 
-            <SettingsPage.SettingsSection
-              title={t.app.settings.general.editorSection}
-            >
-              <SettingsPage.SettingsRow
-                control={
-                  <SegmentedControl
-                    aria-label={t.app.settings.general.wideEditorToggle}
-                    onValueChange={(value) => {
-                      if (value === 'default') {
-                        setWideEditor(false);
-                      }
-                      if (value === 'wide') {
-                        setWideEditor(true);
-                      }
-                    }}
-                    type="single"
-                    value={wideEditor ? 'wide' : 'default'}
-                  >
-                    <ToggleGroupItem
-                      className={SEGMENTED_ITEM_CLASS}
-                      value="default"
-                    >
-                      {t.app.settings.general.defaultWidth}
-                    </ToggleGroupItem>
-                    <ToggleGroupItem
-                      className={SEGMENTED_ITEM_CLASS}
-                      value="wide"
-                    >
-                      {t.app.settings.general.wideWidth}
-                    </ToggleGroupItem>
-                  </SegmentedControl>
-                }
-                description={t.app.settings.general.wideEditorDescription}
-                title={t.app.settings.general.wideEditorTitle}
-              />
-            </SettingsPage.SettingsSection>
+                <SettingsPage.SettingsSection
+                  title={t.app.settings.general.editorSection}
+                >
+                  <SettingsPage.SettingsRow
+                    control={
+                      <SegmentedControl
+                        aria-label={t.app.settings.general.wideEditorToggle}
+                        onValueChange={(value) => {
+                          if (value === 'default') {
+                            setWideEditor(false);
+                          }
+                          if (value === 'wide') {
+                            setWideEditor(true);
+                          }
+                        }}
+                        type="single"
+                        value={wideEditor ? 'wide' : 'default'}
+                      >
+                        <ToggleGroupItem
+                          className={SEGMENTED_ITEM_CLASS}
+                          value="default"
+                        >
+                          {t.app.settings.general.defaultWidth}
+                        </ToggleGroupItem>
+                        <ToggleGroupItem
+                          className={SEGMENTED_ITEM_CLASS}
+                          value="wide"
+                        >
+                          {t.app.settings.general.wideWidth}
+                        </ToggleGroupItem>
+                      </SegmentedControl>
+                    }
+                    description={t.app.settings.general.wideEditorDescription}
+                    title={t.app.settings.general.wideEditorTitle}
+                  />
+                </SettingsPage.SettingsSection>
+              </>
+            ) : (
+              <WorkspacesSettingsPage />
+            )}
           </SettingsPage.SettingsPageContent>
         </SettingsPage.SettingsPageLayout>
       </PageContentContainer>

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 /// <reference types="@vitest/browser/matchers" />
 import '@testing-library/jest-dom/vitest';
+import { SETTINGS_PAGE_DEFINITIONS } from '@bangle.io/constants';
 import { describe, expect, it, vi } from 'vitest';
 import { setupTest } from './test-utils';
 
@@ -32,7 +33,7 @@ describe('UI command handlers', () => {
   });
 
   describe('command::ui:open-settings', () => {
-    it('should navigate to general settings', async () => {
+    it('should navigate to settings', async () => {
       const { dispatch, services } = await setupTest({
         targetId: 'command::ui:open-settings',
       });
@@ -42,6 +43,62 @@ describe('UI command handlers', () => {
       await vi.waitFor(() => {
         expect(services.navigation.resolveAtoms().routeInfo).toEqual({
           route: 'settings-general',
+          payload: {
+            returnTo: services.navigation.toUri({
+              route: 'welcome',
+              payload: {},
+            }),
+          },
+        });
+      });
+    });
+
+    it.each(
+      SETTINGS_PAGE_DEFINITIONS,
+    )('should navigate to $id settings', async (settingsPage) => {
+      const { dispatch, services } = await setupTest({
+        targetId: settingsPage.commandId,
+      });
+
+      dispatch(settingsPage.commandId, null);
+
+      await vi.waitFor(() => {
+        expect(services.navigation.resolveAtoms().routeInfo).toEqual({
+          route: settingsPage.route,
+          payload: {
+            returnTo: services.navigation.toUri({
+              route: 'welcome',
+              payload: {},
+            }),
+          },
+        });
+      });
+    });
+
+    it('should preserve returnTo while navigating between settings pages', async () => {
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ui:open-settings-general',
+      });
+
+      dispatch('command::ui:open-settings-general', null);
+
+      await vi.waitFor(() => {
+        expect(services.navigation.resolveAtoms().routeInfo).toEqual({
+          route: 'settings-general',
+          payload: {
+            returnTo: services.navigation.toUri({
+              route: 'welcome',
+              payload: {},
+            }),
+          },
+        });
+      });
+
+      dispatch('command::ui:open-settings-workspaces', null);
+
+      await vi.waitFor(() => {
+        expect(services.navigation.resolveAtoms().routeInfo).toEqual({
+          route: 'settings-workspaces',
           payload: {
             returnTo: services.navigation.toUri({
               route: 'welcome',

--- a/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
+++ b/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
@@ -71,7 +71,7 @@ export const basicOperationsHandlers = [
   }),
 
   c('command::ui:open-settings', ({ navigation }) => {
-    navigation.goSettingsGeneral();
+    navigation.goSettingsPage('settings-general');
   }),
 
   c('command::ui:open-settings-general', ({ navigation }) => {

--- a/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
+++ b/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
@@ -74,6 +74,14 @@ export const basicOperationsHandlers = [
     navigation.goSettingsGeneral();
   }),
 
+  c('command::ui:open-settings-general', ({ navigation }) => {
+    navigation.goSettingsPage('settings-general');
+  }),
+
+  c('command::ui:open-settings-workspaces', ({ navigation }) => {
+    navigation.goSettingsPage('settings-workspaces');
+  }),
+
   c(
     'command::ui:toggle-all-files',
     ({ workbenchState }, { prefillInput }, key) => {

--- a/packages/core/service-core/src/__tests__/file-system-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/file-system-service.spec.ts
@@ -88,6 +88,7 @@ describe('FileSystemService', () => {
 
     return {
       fileSystem: services.fileSystem,
+      store: testEnv.store,
       workspaceOps: services.workspaceOps,
       controller,
     };
@@ -109,5 +110,45 @@ describe('FileSystemService', () => {
 
     const notExistsResult = await fileSystem.exists(NON_EXISTING_FILE);
     expect(notExistsResult).toBe(false);
+  });
+
+  it('increments file-list revision for file list changes', async () => {
+    const { fileSystem, store } = await setupFileSystemTest({ controller });
+    const readRevision = () => store.get(fileSystem.$fileListRevisionCount);
+
+    const initialRevision = readRevision();
+
+    await fileSystem.createTextFile(
+      'test-workspace:created-after-settings.md',
+      'Test content',
+    );
+    expect(readRevision()).toBeGreaterThan(initialRevision);
+
+    // A content update (editing/saving an existing note) must NOT bump the
+    // revision: the file list is unchanged, so the settings note-count list must
+    // not refetch every workspace on each save.
+    const beforeContentUpdate = readRevision();
+    await fileSystem.writeFile(
+      'test-workspace:created-after-settings.md',
+      new File(['Updated content'], 'created-after-settings', {
+        type: 'text/plain',
+      }),
+    );
+    expect(readRevision()).toBe(beforeContentUpdate);
+
+    const afterCreateRevision = readRevision();
+    await fileSystem.renameFile({
+      oldWsPath: 'test-workspace:created-after-settings.md',
+      newWsPath: 'test-workspace:renamed-after-settings.md',
+    });
+    expect(readRevision()).toBeGreaterThan(afterCreateRevision);
+
+    const afterRenameRevision = readRevision();
+    await fileSystem.deleteFile('test-workspace:renamed-after-settings.md');
+    expect(readRevision()).toBeGreaterThan(afterRenameRevision);
+
+    const afterDeleteRevision = readRevision();
+    store.set(fileSystem.$fileForceUpdateCount, (count) => count + 1);
+    expect(readRevision()).toBeGreaterThan(afterDeleteRevision);
   });
 });

--- a/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
@@ -55,6 +55,54 @@ async function setupWorkspaceStateService({
   return { rootEmitter: testEnv.rootEmitter, services, store: testEnv.store };
 }
 
+describe('WorkspaceStateService $workspaces list', () => {
+  let controller = new AbortController();
+
+  beforeEach(() => {
+    controller = new AbortController();
+  });
+
+  afterEach(() => {
+    controller.abort();
+  });
+
+  it('drops a workspace from $workspaces after it is deleted', async () => {
+    const testEnv = createTestEnvironment({ controller }).setDefaultConfig();
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+    const store = testEnv.store;
+
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'keep-ws',
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'delete-ws',
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        store.get(services.workspaceState.$workspaces).map((ws) => ws.name),
+      ).toEqual(expect.arrayContaining(['keep-ws', 'delete-ws']));
+    });
+
+    // Soft-delete emits an 'update' change; $workspaces must still refresh so the
+    // deleted workspace disappears from any live list without a reload.
+    await services.workspaceOps.deleteWorkspaceInfo('delete-ws');
+
+    await vi.waitFor(() => {
+      const names = store
+        .get(services.workspaceState.$workspaces)
+        .map((ws) => ws.name);
+      expect(names).toContain('keep-ws');
+      expect(names).not.toContain('delete-ws');
+    });
+  });
+});
+
 describe('WorkspaceStateService backlink index', () => {
   let controller = new AbortController();
 

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -71,6 +71,9 @@ export class FileSystemService extends BaseService {
       get(this.$fileForceUpdateCount)
     );
   });
+  $fileListRevisionCount = atom((get) => {
+    return get(this.$fileCreateCount) + get(this.$fileTreeChangeCount);
+  });
 
   constructor(
     context: BaseServiceContext,

--- a/packages/core/service-core/src/navigation-service.ts
+++ b/packages/core/service-core/src/navigation-service.ts
@@ -182,10 +182,6 @@ export class NavigationService extends BaseService {
     });
   }
 
-  public goSettingsGeneral() {
-    this.goSettingsPage('settings-general');
-  }
-
   public goSettingsPage(route: SettingsRoute) {
     const currentRoute = this.store.get(this.$routeInfo);
     const returnTo = isSettingsRouteInfo(currentRoute)

--- a/packages/core/service-core/src/navigation-service.ts
+++ b/packages/core/service-core/src/navigation-service.ts
@@ -3,7 +3,11 @@ import {
   type BaseServiceContext,
   createAppError,
 } from '@bangle.io/base-utils';
-import { SERVICE_NAME } from '@bangle.io/constants';
+import {
+  isSettingsRouteInfo,
+  SERVICE_NAME,
+  type SettingsRoute,
+} from '@bangle.io/constants';
 import type {
   AppRouteInfo,
   BaseRouter,
@@ -179,14 +183,17 @@ export class NavigationService extends BaseService {
   }
 
   public goSettingsGeneral() {
+    this.goSettingsPage('settings-general');
+  }
+
+  public goSettingsPage(route: SettingsRoute) {
     const currentRoute = this.store.get(this.$routeInfo);
-    const returnTo =
-      currentRoute.route === 'settings-general'
-        ? currentRoute.payload.returnTo
-        : this.toUri(currentRoute);
+    const returnTo = isSettingsRouteInfo(currentRoute)
+      ? currentRoute.payload.returnTo
+      : this.toUri(currentRoute);
 
     this.go({
-      route: 'settings-general',
+      route,
       payload: returnTo ? { returnTo } : {},
     });
   }

--- a/packages/core/service-core/src/workspace-ops-service.ts
+++ b/packages/core/service-core/src/workspace-ops-service.ts
@@ -35,12 +35,13 @@ export class WorkspaceOpsService extends BaseService {
   async hookMount(): Promise<void> {
     this.database.subscribe(
       { tableName: DATABASE_TABLE_NAME.workspaceInfo },
-      (change) => {
+      (_change) => {
         this.invalidateCache();
         this.store.set(this.$workspaceInfoAnyChange, (v) => v + 1);
-        if (change.type === 'create' || change.type === 'delete') {
-          this.store.set(this.$workspaceInfoListChange, (v) => v + 1);
-        }
+        // Workspaces are soft-deleted (and restored) via `updateEntry`, which
+        // emits an 'update' change rather than 'delete'. Any change can therefore
+        // alter the visible (non-deleted) workspace set, so refresh the list.
+        this.store.set(this.$workspaceInfoListChange, (v) => v + 1);
       },
       this.abortSignal,
     );

--- a/packages/core/service-core/src/workspace-ops-service.ts
+++ b/packages/core/service-core/src/workspace-ops-service.ts
@@ -18,8 +18,13 @@ import { atom } from 'jotai';
 export class WorkspaceOpsService extends BaseService {
   static deps = ['database'] as const;
 
-  $workspaceInfoAnyChange = atom(0);
-  $workspaceInfoListChange = atom(0);
+  /**
+   * Bumps on every workspaceInfo change (create, update, delete). Soft-deletes
+   * and restores go through `updateEntry`, which emits an 'update' change rather
+   * than 'delete', so consumers that track the visible (non-deleted) workspace
+   * set must treat any change as significant.
+   */
+  $workspaceInfoChange = atom(0);
 
   private workspaceInfoCache = new Map<string, WorkspaceInfo>();
 
@@ -35,13 +40,9 @@ export class WorkspaceOpsService extends BaseService {
   async hookMount(): Promise<void> {
     this.database.subscribe(
       { tableName: DATABASE_TABLE_NAME.workspaceInfo },
-      (_change) => {
+      () => {
         this.invalidateCache();
-        this.store.set(this.$workspaceInfoAnyChange, (v) => v + 1);
-        // Workspaces are soft-deleted (and restored) via `updateEntry`, which
-        // emits an 'update' change rather than 'delete'. Any change can therefore
-        // alter the visible (non-deleted) workspace set, so refresh the list.
-        this.store.set(this.$workspaceInfoListChange, (v) => v + 1);
+        this.store.set(this.$workspaceInfoChange, (v) => v + 1);
       },
       this.abortSignal,
     );

--- a/packages/core/service-core/src/workspace-state-service.ts
+++ b/packages/core/service-core/src/workspace-state-service.ts
@@ -95,7 +95,7 @@ export class WorkspaceStateService extends BaseService {
 
   $workspaces = createAsyncAtom(
     async (get) => {
-      get(this.workspaceOps.$workspaceInfoListChange);
+      get(this.workspaceOps.$workspaceInfoChange);
       const workspaces = await this.workspaceOps.getAllWorkspaces();
       return workspaces;
     },

--- a/packages/platform/service-platform/src/router/__tests__/hash-strategy.spec.ts
+++ b/packages/platform/service-platform/src/router/__tests__/hash-strategy.spec.ts
@@ -108,6 +108,20 @@ describe('HashStrategy', () => {
         hash: '#route=settings-general&returnTo=%2Fws%23route%3Deditor%26wsPath%3Dnotes%253Aindex.md',
       });
     });
+
+    it('should encode settings workspaces route', () => {
+      const routeInfo: AppRouteInfo = {
+        route: 'settings-workspaces',
+        payload: {},
+      };
+
+      const result = strategy.encodeRouteInfo(routeInfo, basePath);
+      expect(result).toEqual({
+        pathname: '/app',
+        search: '',
+        hash: '#route=settings-workspaces',
+      });
+    });
   });
 
   describe('decodeRouteInfo', () => {
@@ -187,6 +201,19 @@ describe('HashStrategy', () => {
         payload: {
           returnTo: '/ws#route=editor&wsPath=notes%3Aindex.md',
         },
+      });
+    });
+
+    it('should decode settings workspaces route', () => {
+      const encoded: EncodedRoute = {
+        pathname: '/app',
+        search: '',
+        hash: '#route=settings-workspaces',
+      };
+
+      expect(strategy.decodeRouteInfo(encoded, basePath)).toEqual({
+        route: 'settings-workspaces',
+        payload: {},
       });
     });
   });

--- a/packages/platform/service-platform/src/router/__tests__/path-based-strategy.spec.ts
+++ b/packages/platform/service-platform/src/router/__tests__/path-based-strategy.spec.ts
@@ -194,6 +194,19 @@ describe('PathBasedStrategy', () => {
         hash: '',
       });
     });
+
+    it('should encode settings workspaces route', () => {
+      const routeInfo: AppRouteInfo = {
+        route: 'settings-workspaces',
+        payload: {},
+      };
+
+      expect(strategy.encodeRouteInfo(routeInfo, basePath)).toEqual({
+        pathname: '/app/settings-workspaces',
+        search: '',
+        hash: '',
+      });
+    });
   });
 
   describe('decodeRouteInfo', () => {
@@ -311,6 +324,18 @@ describe('PathBasedStrategy', () => {
         payload: {
           returnTo: '/ws#route=editor&wsPath=notes%3Aindex.md',
         },
+      });
+    });
+
+    it('should decode settings workspaces route', () => {
+      const encoded: EncodedRoute = {
+        pathname: '/settings-workspaces',
+        search: '',
+      };
+
+      expect(strategy.decodeRouteInfo(encoded, basePath)).toEqual({
+        route: 'settings-workspaces',
+        payload: {},
       });
     });
   });

--- a/packages/platform/service-platform/src/router/common.ts
+++ b/packages/platform/service-platform/src/router/common.ts
@@ -151,6 +151,13 @@ export function handleRouteInfo(
       };
     }
 
+    case 'settings-workspaces': {
+      return {
+        route: 'settings-workspaces',
+        payload: params.returnTo ? { returnTo: params.returnTo } : {},
+      };
+    }
+
     default:
       return { route: 'not-found', payload: { path: route } };
   }

--- a/packages/shared/commands/src/__tests__/commands.spec.ts
+++ b/packages/shared/commands/src/__tests__/commands.spec.ts
@@ -2,7 +2,11 @@
 // index.test.ts
 
 import { assertIsDefined } from '@bangle.io/base-utils';
-import { commandExcludedServices } from '@bangle.io/constants';
+import {
+  commandExcludedServices,
+  SETTINGS_DEFAULT_COMMAND,
+  SETTINGS_PAGE_DEFINITIONS,
+} from '@bangle.io/constants';
 import { T } from '@bangle.io/mini-js-utils';
 import type { Command } from '@bangle.io/types';
 import { describe, expect, it } from 'vitest';
@@ -87,5 +91,28 @@ describe('Bangle App Commands Validation', () => {
         expect(commandIds).toContain(depCommand);
       }
     }
+  });
+
+  it('should expose settings pages as omni-search commands', () => {
+    const settingsCommands = allCommands
+      .filter((command) => command.id.startsWith('command::ui:open-settings'))
+      .map((command) => ({
+        id: command.id,
+        title: command.title,
+        omniSearch: command.omniSearch,
+      }));
+
+    expect(settingsCommands).toEqual([
+      {
+        id: SETTINGS_DEFAULT_COMMAND.id,
+        title: SETTINGS_DEFAULT_COMMAND.title,
+        omniSearch: true,
+      },
+      ...SETTINGS_PAGE_DEFINITIONS.map((page) => ({
+        id: page.commandId,
+        title: page.commandTitle,
+        omniSearch: true,
+      })),
+    ]);
   });
 });

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -1,6 +1,17 @@
-import { KEYBOARD_SHORTCUTS } from '@bangle.io/constants';
+import {
+  KEYBOARD_SHORTCUTS,
+  SETTINGS_DEFAULT_COMMAND,
+  SETTINGS_PAGE_DEFINITIONS,
+} from '@bangle.io/constants';
 import { T } from '@bangle.io/mini-js-utils';
 import { narrow } from './common';
+
+// Each settings page exposes an omni-search command. The list is small and
+// stable, so the commands are written inline (rather than generated) to keep
+// per-command literal types flowing into `BangleAppCommand` without a cast.
+// The `command.spec` test asserts these stay in sync with SETTINGS_PAGE_DEFINITIONS.
+const [GENERAL_SETTINGS_PAGE, WORKSPACES_SETTINGS_PAGE] =
+  SETTINGS_PAGE_DEFINITIONS;
 
 // pattern command::ui:{action}-{target}
 export const uiCommands = narrow([
@@ -67,10 +78,32 @@ export const uiCommands = narrow([
     args: {},
   },
   {
-    id: 'command::ui:open-settings',
-    title: 'Open Settings',
+    id: SETTINGS_DEFAULT_COMMAND.id,
+    title: SETTINGS_DEFAULT_COMMAND.title,
+    keywords: [...SETTINGS_DEFAULT_COMMAND.keywords],
     omniSearch: true,
-    keywords: ['settings', 'preferences', 'general'],
+    dependencies: {
+      services: ['navigation'],
+    },
+    autoFocusEditor: false,
+    args: null,
+  },
+  {
+    id: GENERAL_SETTINGS_PAGE.commandId,
+    title: GENERAL_SETTINGS_PAGE.commandTitle,
+    keywords: [...GENERAL_SETTINGS_PAGE.commandKeywords],
+    omniSearch: true,
+    dependencies: {
+      services: ['navigation'],
+    },
+    autoFocusEditor: false,
+    args: null,
+  },
+  {
+    id: WORKSPACES_SETTINGS_PAGE.commandId,
+    title: WORKSPACES_SETTINGS_PAGE.commandTitle,
+    keywords: [...WORKSPACES_SETTINGS_PAGE.commandKeywords],
+    omniSearch: true,
     dependencies: {
       services: ['navigation'],
     },

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -12,6 +12,44 @@ export const KEYBOARD_SHORTCUTS = {
   toggleOmniSearch: { id: 'toggleOmniSearch', keys: ['ctrl', 'k'] },
 } as const;
 
+export const SETTINGS_DEFAULT_COMMAND = {
+  id: 'command::ui:open-settings',
+  route: 'settings-general',
+  title: 'Settings',
+  keywords: ['settings', 'preferences'],
+} as const;
+
+export const SETTINGS_PAGE_DEFINITIONS = [
+  {
+    id: 'general',
+    route: 'settings-general',
+    commandId: 'command::ui:open-settings-general',
+    commandTitle: 'Settings - General',
+    commandKeywords: ['settings', 'preferences', 'general'],
+  },
+  {
+    id: 'workspaces',
+    route: 'settings-workspaces',
+    commandId: 'command::ui:open-settings-workspaces',
+    commandTitle: 'Settings - Workspaces',
+    commandKeywords: ['settings', 'preferences', 'workspaces', 'workspace'],
+  },
+] as const;
+
+export type SettingsPageDefinition = (typeof SETTINGS_PAGE_DEFINITIONS)[number];
+export type SettingsPageId = SettingsPageDefinition['id'];
+export type SettingsRoute = SettingsPageDefinition['route'];
+
+export function isSettingsRoute(route: string): route is SettingsRoute {
+  return SETTINGS_PAGE_DEFINITIONS.some((page) => page.route === route);
+}
+
+export function isSettingsRouteInfo<RouteInfo extends { route: string }>(
+  routeInfo: RouteInfo,
+): routeInfo is Extract<RouteInfo, { route: SettingsRoute }> {
+  return isSettingsRoute(routeInfo.route);
+}
+
 export const WORKSPACE_STORAGE_TYPE = {
   Help: 'helpfs',
   NativeFS: 'nativefs',

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -130,8 +130,27 @@ export const t = {
         enabled: 'Aktiviert',
         disabled: 'Deaktiviert',
       },
+      workspaces: {
+        title: 'Arbeitsbereiche',
+        sectionTitle: 'Arbeitsbereiche',
+        newWorkspace: 'Neuer Arbeitsbereich',
+        emptyTitle: 'Keine Arbeitsbereiche',
+        emptyDescription:
+          'Erstellen Sie einen Arbeitsbereich, um Notizen zu schreiben.',
+        noteCount: ({ count }: { count: number }) =>
+          count === 1 ? '1 Notiz' : `${count} Notizen`,
+        noteCountLoading: 'Notizen werden geladen...',
+        noteCountUnavailable: 'Notizen nicht verfügbar',
+        lastOpened: 'Zuletzt geöffnet',
+        neverOpened: 'Nie geöffnet',
+        actionsLabel: ({ wsName }: { wsName: string }) =>
+          `Arbeitsbereichsaktionen für ${wsName}`,
+        openWorkspace: 'Arbeitsbereich öffnen',
+        deleteWorkspace: 'Arbeitsbereich löschen',
+      },
       nav: {
         general: 'Allgemein',
+        workspaces: 'Arbeitsbereiche',
       },
     },
     dialogs: {

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -136,8 +136,26 @@ export const t = {
         enabled: 'Enabled',
         disabled: 'Disabled',
       },
+      workspaces: {
+        title: 'Workspaces',
+        sectionTitle: 'Workspaces',
+        newWorkspace: 'New workspace',
+        emptyTitle: 'No workspaces',
+        emptyDescription: 'Create a workspace to start writing notes.',
+        noteCount: ({ count }: { count: number }) =>
+          count === 1 ? '1 note' : `${count} notes`,
+        noteCountLoading: 'Loading notes...',
+        noteCountUnavailable: 'Notes unavailable',
+        lastOpened: 'Last opened',
+        neverOpened: 'Never opened',
+        actionsLabel: ({ wsName }: { wsName: string }) =>
+          `Workspace actions for ${wsName}`,
+        openWorkspace: 'Open workspace',
+        deleteWorkspace: 'Delete workspace',
+      },
       nav: {
         general: 'General',
+        workspaces: 'Workspaces',
       },
     },
     dialogs: {

--- a/packages/shared/types/base-router.ts
+++ b/packages/shared/types/base-router.ts
@@ -52,6 +52,13 @@ export type AppRouteInfo =
       };
     }
   | {
+      route: 'settings-workspaces';
+      metadata?: Record<string, string>;
+      payload: {
+        returnTo?: string;
+      };
+    }
+  | {
       route: 'welcome';
       metadata?: Record<string, string>;
       payload: Record<string, never>;

--- a/packages/tooling/desktop-entry/scripts/smoke-test.mjs
+++ b/packages/tooling/desktop-entry/scripts/smoke-test.mjs
@@ -171,6 +171,25 @@ async function waitForStoredMarkdown(page, expected) {
   );
 }
 
+async function waitForEditorText(page, expected, label) {
+  const deadline = Date.now() + 10_000;
+  let lastValue;
+
+  while (Date.now() < deadline) {
+    lastValue = (await page.locator(editorSelector).innerText()).trim();
+    if (lastValue === expected) {
+      return;
+    }
+    await page.waitForTimeout(100);
+  }
+
+  throw new Error(
+    `[desktop-smoke] Expected note content after ${label} to be ${JSON.stringify(
+      expected,
+    )}, got ${JSON.stringify(lastValue)}.`,
+  );
+}
+
 let app = await launchApp();
 let page = await firstWindow(app);
 
@@ -190,14 +209,7 @@ try {
   await openNoteRoute(page);
   await page.locator(editorSelector).waitFor();
 
-  const textAfterReload = await page.locator(editorSelector).innerText();
-  if (textAfterReload.trim() !== noteContent) {
-    throw new Error(
-      `[desktop-smoke] Expected note content after reload to be ${JSON.stringify(
-        noteContent,
-      )}, got ${JSON.stringify(textAfterReload.trim())}.`,
-    );
-  }
+  await waitForEditorText(page, noteContent, 'reload');
   await waitForStoredMarkdown(page, noteContent);
 
   console.log('[desktop-smoke] Checking persistence after restart.');
@@ -207,14 +219,7 @@ try {
   await openNoteRoute(page);
   await page.locator(editorSelector).waitFor();
 
-  const textAfterRestart = await page.locator(editorSelector).innerText();
-  if (textAfterRestart.trim() !== noteContent) {
-    throw new Error(
-      `[desktop-smoke] Expected note content after restart to be ${JSON.stringify(
-        noteContent,
-      )}, got ${JSON.stringify(textAfterRestart.trim())}.`,
-    );
-  }
+  await waitForEditorText(page, noteContent, 'restart');
 
   console.log('[desktop-smoke] Electron persistence smoke passed.');
 } finally {

--- a/packages/tooling/e2e-tests/src/settings-workspaces.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-workspaces.e2e.ts
@@ -1,0 +1,132 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspace,
+  createBrowserWorkspaceAndNote,
+} from './common';
+
+async function openWorkspacesSettings(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: /Bangle\.io/ }).click();
+  await page.getByRole('menuitem', { name: 'Settings' }).click();
+  await page.getByRole('link', { name: 'Workspaces' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Workspaces' }).first(),
+  ).toBeVisible();
+}
+
+// The note-count cell lives in the same row as the workspace-name link, so scope
+// the assertion to that link's row to prove per-workspace correctness.
+function noteCountCell(
+  page: import('@playwright/test').Page,
+  workspaceName: string,
+) {
+  return page.getByRole('link', { name: workspaceName }).locator('..');
+}
+
+test('workspaces settings lists workspaces and exposes row actions', async ({
+  page,
+}) => {
+  const workspaceWithNote = 'settings-workspaces-notes';
+  const emptyWorkspace = 'settings-workspaces-empty';
+
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: workspaceWithNote,
+    noteName: 'first-note',
+  });
+  await createBrowserWorkspace(page, { workspaceName: emptyWorkspace });
+
+  await openWorkspacesSettings(page);
+
+  await expect(
+    page.getByRole('link', { name: workspaceWithNote }),
+  ).toBeVisible();
+  await expect(page.getByRole('link', { name: emptyWorkspace })).toBeVisible();
+  await expect(
+    noteCountCell(page, workspaceWithNote).getByText('1 note'),
+  ).toBeVisible();
+  await expect(
+    noteCountCell(page, emptyWorkspace).getByText('0 notes'),
+  ).toBeVisible();
+  await expect(page.getByText(/Last opened/).first()).toBeVisible();
+
+  // The route is URL-addressable: reloading must re-hydrate the workspaces page.
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(
+    page.getByRole('heading', { name: 'Workspaces' }).first(),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: workspaceWithNote }),
+  ).toBeVisible();
+
+  await page
+    .getByRole('button', {
+      name: `Workspace actions for ${workspaceWithNote}`,
+    })
+    .click();
+  await expect(
+    page.getByRole('menuitem', { name: 'Open workspace' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('menuitem', { name: 'Delete workspace' }),
+  ).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await page.getByRole('button', { name: 'New workspace' }).click();
+  await expect(
+    page.getByRole('dialog', { name: 'Select a workspace type' }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  await page.getByRole('button', { name: /Search/ }).click();
+  await page.getByRole('combobox').fill('settings');
+  await expect(
+    page.getByRole('option', { exact: true, name: '> Settings' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('option', { name: '> Settings - General' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('option', { name: '> Settings - Workspaces' }),
+  ).toBeVisible();
+});
+
+test('workspaces settings deletes a workspace from the row actions', async ({
+  page,
+}) => {
+  const keptWorkspace = 'settings-workspaces-keep';
+  const deletedWorkspace = 'settings-workspaces-delete';
+
+  await createBrowserWorkspace(page, { workspaceName: keptWorkspace });
+  await createBrowserWorkspace(page, { workspaceName: deletedWorkspace });
+
+  await openWorkspacesSettings(page);
+
+  await expect(
+    page.getByRole('link', { name: deletedWorkspace }),
+  ).toBeVisible();
+
+  await page
+    .getByRole('button', {
+      name: `Workspace actions for ${deletedWorkspace}`,
+    })
+    .click();
+  await page.getByRole('menuitem', { name: 'Delete workspace' }).click();
+
+  const confirmation = page.getByRole('alertdialog');
+  await expect(confirmation).toBeVisible();
+  await confirmation.getByRole('button', { name: 'Delete' }).click();
+
+  // The deleted workspace is gone and the other survives, before and after reload.
+  await expect(page.getByRole('link', { name: deletedWorkspace })).toHaveCount(
+    0,
+  );
+  await expect(page.getByRole('link', { name: keptWorkspace })).toBeVisible();
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(
+    page.getByRole('heading', { name: 'Workspaces' }).first(),
+  ).toBeVisible();
+  await expect(page.getByRole('link', { name: deletedWorkspace })).toHaveCount(
+    0,
+  );
+  await expect(page.getByRole('link', { name: keptWorkspace })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Adds a **Settings → Workspaces** page that lists every workspace with an async per-workspace note count, last-opened time, and row actions (open / delete). Each settings page is now exposed as an omni-search command ("Settings - General", "Settings - Workspaces").

## What's included

- **Settings registry**: settings pages are data-driven from `SETTINGS_PAGE_DEFINITIONS` in `@bangle.io/constants`; `settings-workspaces` is routed through both hash and path router strategies. `SETTINGS_PAGE_META` (icons/labels/titles) is typed as `Record<SettingsPageId, …>` so adding a page fails to compile without a matching entry.
- **New page** `page-settings-workspaces.tsx`: sorted workspace list, async note counts with explicit loading / ready / error states, last-opened relative time, and a dropdown for open/delete wired through the existing confirm-delete dialog and `command::ws:delete-workspace`.
- **Bug fix (surfaced by the delete E2E)**: deleting a workspace didn't update any live list until reload. Soft-delete goes through `updateEntry`, which emits an `'update'` DB change, but `$workspaceInfoListChange` only bumped on `create`/`delete`. It now bumps on any workspace-info change so `$workspaces` reflects deletions immediately. (`$workspaceInfoAnyChange` had no consumers.)

## Review-driven cleanups (thermonuclear review)

- Replaced a generic command-factory + unchecked `as` cast with two inline literal commands (`narrow`'s `const` preserves the per-command literal ids that `dispatch`'s `Extract<…>` relies on).
- Memoized workspace names on a serialized key to avoid refetching every workspace's note count on unrelated workspace-list recomputes.
- Imported `SettingsPageId` from constants instead of re-deriving it.

## Tests

- **Unit**: `$fileListRevisionCount` contract — increments on create/rename/delete/force-update and **not** on content updates (prevents note-count refetch on every save); `$workspaces` drops a workspace after delete.
- **Page** (`page-settings-workspaces.spec.tsx`): row-scoped note counts; a failed `listFiles` renders **"Notes unavailable"**, never a misleading **"0 notes"**.
- **E2E** (`settings-workspaces.e2e.ts`): lists workspaces with row-scoped counts, exposes row actions, surfaces settings commands in search, reload/persistence of the route; a second test performs the full delete flow and asserts the workspace is gone before and after reload.
- Router encode/decode specs and settings-navigation command-handler specs.

Also carries an incidental desktop smoke-test cleanup (shared `waitForEditorText` helper) from the branch.

## Verification

- `pnpm lint:ci` ✓  ·  `pnpm test:ci` ✓ (106 files / 1162 tests)  ·  `settings-workspaces.e2e.ts` ✓ (2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)