### PR TITLE
chore(deps): bump remaining dependency updates

### DIFF
--- a/.github/workflows/cloudflare-pr-preview.yml
+++ b/.github/workflows/cloudflare-pr-preview.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Deploy Cloudflare Pages preview
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Deploy Cloudflare Pages production
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/cloudflare-staging.yml
+++ b/.github/workflows/cloudflare-staging.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Deploy Cloudflare Pages staging
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -152,7 +152,7 @@ jobs:
           if-no-files-found: error
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.preflight.outputs.tag }}
           target_commitish: ${{ github.sha }}

--- a/packages/js-lib/banger-editor/package.json
+++ b/packages/js-lib/banger-editor/package.json
@@ -31,7 +31,7 @@
     "@types/markdown-it": "^14.1.2"
   },
   "dependencies": {
-    "@bangle.dev/prosemirror-all": "2.0.0-alpha.18",
+    "@bangle.dev/prosemirror-all": "2.0.0-alpha.19",
     "jotai": "^2.20.1",
     "markdown-it": "14.3.0",
     "orderedmap": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,8 +410,8 @@ importers:
   packages/js-lib/banger-editor:
     dependencies:
       '@bangle.dev/prosemirror-all':
-        specifier: 2.0.0-alpha.18
-        version: 2.0.0-alpha.18
+        specifier: 2.0.0-alpha.19
+        version: 2.0.0-alpha.19
       jotai:
         specifier: ^2.20.1
         version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.7)
@@ -1692,8 +1692,8 @@ packages:
     peerDependencies:
       prosemirror-markdown: '*'
 
-  '@bangle.dev/prosemirror-all@2.0.0-alpha.18':
-    resolution: {integrity: sha512-taxj5NNwHpuJL7nc2ZzLz/VA0jxxVHet5AKORV5/Y3GwetNlfbvfpPFg0D1rDWKoLsgu8+amLfQkJOwGqaK0uQ==}
+  '@bangle.dev/prosemirror-all@2.0.0-alpha.19':
+    resolution: {integrity: sha512-eV1R7UiWDBxxWOXM55C9asnbDARx6jKuZNoYTGq4cgUlxNm0P9fZd+NmzLBN2xxeJZP2/PcnFOuIb6lxp4O7uA==}
 
   '@bangle.io/config-template@0.0.7':
     resolution: {integrity: sha512-nPFkcM3aU/w+NJxwiQrpfu7Md3wpQrVY870ieeaZNyqPGvYj7qOng06Z7GalEvR2a6dLsvsQC3X1MgQImEOCGw==}
@@ -8083,9 +8083,6 @@ packages:
   prosemirror-dropcursor@1.8.2:
     resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
 
-  prosemirror-flat-list@0.5.8:
-    resolution: {integrity: sha512-QHeogWkwVktecyFcCnWpJUs8d3gJ/D5H+67X1dqAIKPUCBJjsc5DNQMZ68QJ5gPHn0v6HYCIaCcQlZZu+YTvcA==}
-
   prosemirror-flat-list@0.6.0:
     resolution: {integrity: sha512-/C11nhH5gdNxj9qVKRlaox/ndK4+X1o/hGTkNCJWdzGVqBVgRkKI/dc6GdZ4/RNvudEtgnTk4QOMOB0zcFTeHQ==}
 
@@ -10146,13 +10143,13 @@ snapshots:
       markdown-it: 14.3.0
       prosemirror-markdown: 1.13.4
 
-  '@bangle.dev/prosemirror-all@2.0.0-alpha.18':
+  '@bangle.dev/prosemirror-all@2.0.0-alpha.19':
     dependencies:
       '@types/orderedmap': 2.0.0
       orderedmap: 2.1.1
       prosemirror-commands: 1.7.1
       prosemirror-dropcursor: 1.8.2
-      prosemirror-flat-list: 0.5.8
+      prosemirror-flat-list: 0.6.0
       prosemirror-gapcursor: 1.4.1
       prosemirror-history: 1.5.0
       prosemirror-inputrules: 1.5.1
@@ -17108,16 +17105,6 @@ snapshots:
 
   prosemirror-dropcursor@1.8.2:
     dependencies:
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.12.0
-      prosemirror-view: 1.42.0
-
-  prosemirror-flat-list@0.5.8:
-    dependencies:
-      prosemirror-commands: 1.7.1
-      prosemirror-inputrules: 1.5.1
-      prosemirror-model: 1.25.9
-      prosemirror-safari-ime-span: 1.0.2
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.42.0


### PR DESCRIPTION
## Summary
Picks up the three updates that were closed alongside #582 but weren't actually covered by that sweep (`pnpm update --latest` doesn't touch GitHub Actions workflow pins, and `@bangle.dev/prosemirror-all`'s alpha.19 wasn't picked up by the latest-tag resolution):

- `cloudflare/wrangler-action` v3 → v4 (was #570)
- `softprops/action-gh-release` v2 → v3 (was #569)
- `@bangle.dev/prosemirror-all` 2.0.0-alpha.18 → alpha.19 (was #577)

## Verification
- `pnpm lint:ci` — passes
- `pnpm test:ci` — 106 files / 1167 tests pass
- `pnpm build` — production build succeeds
- `pnpm e2e-ct-test` — 7/7 component tests pass
- Workflow YAML changes are version-bump only (no behavior config changed), not runnable locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)