### PR TITLE
chore: add deterministic worktree ports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,37 @@ pnpm storybook               # Storybook on port 6006
 pnpm local-ci-check          # every root *:ci script
 ```
 
+## Worktree Ports
+
+Before running dev servers or Playwright from a Codex/git worktree, export a
+deterministic port set from the worktree root:
+
+```bash
+eval "$(node scripts/dev-ports.js --env)"
+```
+
+The script hashes the current git worktree path plus branch name into a stable
+bucket. It does not check whether a port is free; rare hash collisions are an
+accepted tradeoff. Use `BANGLE_PORT_SEED=<name>` when a worktree needs to share
+or override that identity.
+
+The exported variables are:
+
+- `BANGLE_DEV_PORT` for `pnpm start`.
+- `BANGLE_PREVIEW_PORT` for `pnpm preview-production`.
+- `BANGLE_STORYBOOK_PORT` for `pnpm storybook`.
+- `BANGLE_E2E_PORT` for the app server launched by `pnpm e2e:ci`.
+- `BANGLE_E2E_CT_PORT` for the Playwright component-test server.
+
+Generated ports stay in development ranges above 3000: CT `3100-3899`,
+preview `4173-4972`, dev `5173-5972`, Storybook `6006-6805`, and E2E
+`7173-7972`. Manual overrides below `3000` are rejected.
+
+Use `node scripts/dev-ports.js` to inspect the full set, or
+`node scripts/dev-ports.js dev` to print one role's port. Any variable can be
+manually overridden for a one-off command, for example
+`BANGLE_DEV_PORT=5317 pnpm start`.
+
 Custom repository maintenance runs with Bun from the root:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,18 @@ pnpm start
 
 The development instance will be available on `localhost:5173`.
 
+When working from multiple git worktrees, export a deterministic port set before
+running dev servers or Playwright:
+
+```bash
+eval "$(node scripts/dev-ports.js --env)"
+```
+
+This sets separate ports for the Vite dev server, production preview,
+Storybook, Playwright E2E, and Playwright component tests. Generated ports stay
+above `3000`, and manual overrides below `3000` are rejected. You can inspect
+the assigned ports with `node scripts/dev-ports.js`.
+
 **3. Explore the Codebase**
 
 - Explore the services setup in `packages/core/initialize-services`.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Head to <https://bangle.io> to use the app.
 
 - `pnpm install` to install
 
-- `pnpm start` to start a development instance on `localhost:4000`
+- `pnpm start` to start a development instance on `localhost:5173`
+
+For parallel worktrees, run `eval "$(node scripts/dev-ports.js --env)"` first
+to give dev, preview, Storybook, and Playwright servers deterministic ports for
+that worktree.
 
 Please read [Contributing.md](./CONTRIBUTING.md) for more details.
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "desktop:dist": "pnpm --filter \"@bangle.io/desktop-entry\" run dist",
     "desktop:open": "pnpm desktop:build && BANGLE_DESKTOP_BROWSER_DIST=\"$PWD/packages/tooling/browser-entry/dist\" pnpm --filter \"@bangle.io/desktop-entry\" exec electron \"$PWD/packages/tooling/desktop-entry/dist/main.cjs\"",
     "desktop:release:stable": "pnpm --filter \"@bangle.io/desktop-entry\" run release:stable",
+    "dev-ports": "node scripts/dev-ports.js",
     "lint:ci": "pnpm run custom-validation && pnpm run typecheck && biome ci .  --diagnostic-level=error",
     "test:ci": "pnpm vitest run --configLoader runner --maxWorkers=50%",
     "e2e-install": "pnpm --filter \"@bangle.io/e2e-tests\" exec playwright install --with-deps chromium",

--- a/packages/tooling/browser-entry/vite.config.ts
+++ b/packages/tooling/browser-entry/vite.config.ts
@@ -16,10 +16,29 @@ import { translationsPlugin } from './translations-plugin';
 // outputs. So the bootstrap ships a placeholder that is swapped for the real
 // release once it is known.
 const LOCALE_VERSION_PLACEHOLDER = '__BANGLE_LOCALE_VERSION__';
+const MIN_DEV_PORT = 3000;
+const MAX_PORT = 65_535;
 
 /** Escape a value for safe substitution inside a double-quoted JS string literal. */
 function jsStringInner(value: string): string {
   return JSON.stringify(value).slice(1, -1);
+}
+
+function readPortEnv(name: string): number | undefined {
+  const value = process.env[name];
+
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < MIN_DEV_PORT || port > MAX_PORT) {
+    throw new Error(
+      `${name} must be an integer port from ${MIN_DEV_PORT} to ${MAX_PORT}.`,
+    );
+  }
+
+  return port;
 }
 
 export default defineConfig(async (env) => {
@@ -51,6 +70,12 @@ export default defineConfig(async (env) => {
   return {
     build: {
       sourcemap: true,
+    },
+    server: {
+      port: readPortEnv('BANGLE_DEV_PORT'),
+    },
+    preview: {
+      port: readPortEnv('BANGLE_PREVIEW_PORT'),
     },
     plugins: [
       translationsPlugin(),

--- a/packages/tooling/e2e-tests/playwright-ct.config.ts
+++ b/packages/tooling/e2e-tests/playwright-ct.config.ts
@@ -2,6 +2,26 @@ import getEnvVars from '@bangle.io/env-vars';
 import { defineConfig, devices } from '@playwright/experimental-ct-react';
 import tailwindcss from '@tailwindcss/vite';
 
+const MIN_DEV_PORT = 3000;
+const MAX_PORT = 65_535;
+
+function readPortEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < MIN_DEV_PORT || port > MAX_PORT) {
+    throw new Error(
+      `${name} must be an integer port from ${MIN_DEV_PORT} to ${MAX_PORT}.`,
+    );
+  }
+
+  return port;
+}
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -29,7 +49,7 @@ export default defineConfig({
     trace: 'on-first-retry',
 
     /* Port to use for Playwright component endpoint. */
-    ctPort: 3100,
+    ctPort: readPortEnv('BANGLE_E2E_CT_PORT', 3100),
     ctViteConfig: async () => {
       const envVars = getEnvVars({
         isProduction: true,

--- a/packages/tooling/e2e-tests/playwright.config.ts
+++ b/packages/tooling/e2e-tests/playwright.config.ts
@@ -1,6 +1,30 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const PORT = 5173;
+const MIN_DEV_PORT = 3000;
+const MAX_PORT = 65_535;
+
+function readPortEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < MIN_DEV_PORT || port > MAX_PORT) {
+    throw new Error(
+      `${name} must be an integer port from ${MIN_DEV_PORT} to ${MAX_PORT}.`,
+    );
+  }
+
+  return port;
+}
+
+const PORT = readPortEnv(
+  'BANGLE_E2E_PORT',
+  readPortEnv('BANGLE_DEV_PORT', 5173),
+);
+const BASE_URL = `http://localhost:${PORT}`;
 const isCI = Boolean(process.env.CI);
 
 /**
@@ -24,7 +48,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -70,8 +94,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: `pnpm -w run start --port ${PORT}`,
-    port: PORT,
+    command: `BANGLE_DEV_PORT=${PORT} pnpm --dir ../browser-entry exec vite --configLoader runner --host localhost --port ${PORT} --strictPort`,
+    url: BASE_URL,
     reuseExistingServer: !isCI,
   },
 });

--- a/packages/tooling/e2e-tests/src/workspace-dialog.e2e.tsx
+++ b/packages/tooling/e2e-tests/src/workspace-dialog.e2e.tsx
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/experimental-ct-react';
+import { expect, test } from '@playwright/test';
 
 test('Submit workspace name', async ({ page }) => {
   await page.goto('/');

--- a/packages/tooling/storybook/package.json
+++ b/packages/tooling/storybook/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build-chromatic": "pnpm chromatic --project-token $CHROMATIC_PROJECT_TOKEN",
     "build-storybook": "storybook build",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev --port ${BANGLE_STORYBOOK_PORT:-6006}",
     "test-storybook": "test-storybook"
   },
   "dependencies": {

--- a/scripts/dev-ports.js
+++ b/scripts/dev-ports.js
@@ -1,0 +1,238 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { basename } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export const PORT_BUCKET_COUNT = 800;
+export const MIN_DEV_PORT = 3000;
+export const MAX_PORT = 65_535;
+
+export const PORT_ROLES = {
+  dev: {
+    base: 5173,
+    env: 'BANGLE_DEV_PORT',
+  },
+  preview: {
+    base: 4173,
+    env: 'BANGLE_PREVIEW_PORT',
+  },
+  storybook: {
+    base: 6006,
+    env: 'BANGLE_STORYBOOK_PORT',
+  },
+  e2e: {
+    base: 7173,
+    env: 'BANGLE_E2E_PORT',
+  },
+  'e2e-ct': {
+    base: 3100,
+    env: 'BANGLE_E2E_CT_PORT',
+  },
+};
+
+function execGit(args, cwd) {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function hashToSlot(seed, bucketCount = PORT_BUCKET_COUNT) {
+  const digest = createHash('sha256').update(seed).digest();
+  return digest.readUInt32BE(0) % bucketCount;
+}
+
+function parsePort(value, envName) {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < MIN_DEV_PORT || port > MAX_PORT) {
+    throw new Error(
+      `${envName} must be an integer port from ${MIN_DEV_PORT} to ${MAX_PORT}.`,
+    );
+  }
+
+  return port;
+}
+
+function resolveSeed({ cwd = process.cwd(), explicitSeed } = {}) {
+  if (explicitSeed) {
+    return explicitSeed;
+  }
+
+  if (process.env.BANGLE_PORT_SEED) {
+    return process.env.BANGLE_PORT_SEED;
+  }
+
+  const worktreeRoot = execGit(['rev-parse', '--show-toplevel'], cwd) || cwd;
+  const branch =
+    execGit(['branch', '--show-current'], cwd) ||
+    execGit(['rev-parse', '--short', 'HEAD'], cwd) ||
+    basename(worktreeRoot);
+
+  return `${worktreeRoot}:${branch}`;
+}
+
+export function getDevPorts(options = {}) {
+  const seed = resolveSeed(options);
+  const slot = hashToSlot(seed, options.bucketCount);
+  const ports = {};
+
+  for (const [role, config] of Object.entries(PORT_ROLES)) {
+    ports[role] =
+      parsePort(process.env[config.env], config.env) ?? config.base + slot;
+  }
+
+  return {
+    seed,
+    slot,
+    ports,
+  };
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/dev-ports.js [role] [--env|--json]
+
+Print deterministic development ports for this git worktree.
+
+Roles:
+${Object.keys(PORT_ROLES)
+  .map((role) => `  ${role}`)
+  .join('\n')}
+
+Examples:
+  node scripts/dev-ports.js
+  node scripts/dev-ports.js dev
+  eval "$(node scripts/dev-ports.js --env)"
+  BANGLE_PORT_SEED=my-worktree node scripts/dev-ports.js --json
+`);
+}
+
+function parseArgs(args) {
+  const parsed = {
+    format: 'text',
+    role: undefined,
+    seed: undefined,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--help' || arg === '-h') {
+      parsed.format = 'help';
+      continue;
+    }
+
+    if (arg === '--env') {
+      parsed.format = 'env';
+      continue;
+    }
+
+    if (arg === '--json') {
+      parsed.format = 'json';
+      continue;
+    }
+
+    if (arg === '--seed') {
+      const seed = args[index + 1];
+      if (!seed) {
+        throw new Error('--seed requires a non-empty value.');
+      }
+      parsed.seed = seed;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--seed=')) {
+      parsed.seed = arg.slice('--seed='.length);
+      if (!parsed.seed) {
+        throw new Error('--seed requires a non-empty value.');
+      }
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    if (parsed.role) {
+      throw new Error(`Only one port role can be requested.`);
+    }
+    parsed.role = arg;
+  }
+
+  if (parsed.role && !Object.hasOwn(PORT_ROLES, parsed.role)) {
+    throw new Error(`Unknown port role: ${parsed.role}`);
+  }
+
+  return parsed;
+}
+
+export function formatDevPorts(result, format, role) {
+  if (format === 'json') {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+
+  if (format === 'env') {
+    const lines = [
+      `export BANGLE_PORT_SEED=${shellQuote(result.seed)}`,
+      `export BANGLE_PORT_SLOT=${result.slot}`,
+    ];
+
+    for (const [portRole, config] of Object.entries(PORT_ROLES)) {
+      lines.push(`export ${config.env}=${result.ports[portRole]}`);
+    }
+
+    return `${lines.join('\n')}\n`;
+  }
+
+  if (role) {
+    return `${result.ports[role]}\n`;
+  }
+
+  const lines = [
+    `seed: ${result.seed}`,
+    `slot: ${result.slot}`,
+    ...Object.keys(PORT_ROLES).map((portRole) => {
+      const config = PORT_ROLES[portRole];
+      return `${portRole}: ${result.ports[portRole]} (${config.env})`;
+    }),
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+
+    if (args.format === 'help') {
+      printHelp();
+      return;
+    }
+
+    const result = getDevPorts({ explicitSeed: args.seed });
+    process.stdout.write(formatDevPorts(result, args.format, args.role));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/dev-ports.spec.js
+++ b/scripts/dev-ports.spec.js
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  formatDevPorts,
+  getDevPorts,
+  MIN_DEV_PORT,
+  PORT_BUCKET_COUNT,
+  PORT_ROLES,
+} from './dev-ports.js';
+
+describe('dev-ports', () => {
+  beforeEach(() => {
+    for (const config of Object.values(PORT_ROLES)) {
+      vi.stubEnv(config.env, '');
+    }
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test('derives deterministic ports from an explicit seed', () => {
+    const first = getDevPorts({ explicitSeed: 'worktree-a' });
+    const second = getDevPorts({ explicitSeed: 'worktree-a' });
+
+    expect(first).toEqual(second);
+    expect(first.slot).toBeGreaterThanOrEqual(0);
+    expect(first.slot).toBeLessThan(PORT_BUCKET_COUNT);
+
+    for (const [role, config] of Object.entries(PORT_ROLES)) {
+      expect(first.ports[role]).toBe(config.base + first.slot);
+    }
+  });
+
+  test('honors explicit environment port overrides', () => {
+    vi.stubEnv('BANGLE_DEV_PORT', '5555');
+    vi.stubEnv('BANGLE_E2E_CT_PORT', '3555');
+
+    const result = getDevPorts({ explicitSeed: 'worktree-a' });
+
+    expect(result.ports.dev).toBe(5555);
+    expect(result.ports['e2e-ct']).toBe(3555);
+    expect(result.ports.preview).toBe(PORT_ROLES.preview.base + result.slot);
+  });
+
+  test('rejects low port overrides', () => {
+    vi.stubEnv('BANGLE_DEV_PORT', '2999');
+
+    expect(() => getDevPorts({ explicitSeed: 'worktree-a' })).toThrow(
+      `BANGLE_DEV_PORT must be an integer port from ${MIN_DEV_PORT}`,
+    );
+  });
+
+  test('prints shell exports for command setup', () => {
+    const result = getDevPorts({ explicitSeed: "branch ' one" });
+
+    expect(formatDevPorts(result, 'env')).toContain(
+      "export BANGLE_PORT_SEED='branch '\\'' one'",
+    );
+    expect(formatDevPorts(result, 'env')).toContain(
+      `export BANGLE_DEV_PORT=${result.ports.dev}`,
+    );
+    expect(formatDevPorts(result, 'env')).toContain(
+      `export BANGLE_E2E_CT_PORT=${result.ports['e2e-ct']}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a deterministic worktree/branch based dev port allocator
- wire Vite, preview, Storybook, Playwright E2E, and Playwright CT to port overrides
- document the workflow in AGENTS.md, CONTRIBUTING.md, and README.md

## Validation
- eval "export BANGLE_PORT_SEED='local-ci-port-work'
export BANGLE_PORT_SLOT=401
export BANGLE_DEV_PORT=5574
export BANGLE_PREVIEW_PORT=4574
export BANGLE_STORYBOOK_PORT=6407
export BANGLE_E2E_PORT=7574
export BANGLE_E2E_CT_PORT=3501"; CI=1 pnpm local-ci-check
