### PR TITLE
feat: add collapsible headings (fold/unfold sections)

### DIFF
--- a/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
+++ b/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
@@ -123,4 +123,12 @@ export const basicOperationsHandlers = [
       pmEditorService.focusEditor();
     },
   ),
+
+  c('command::ui:toggle-heading-collapse', ({ pmEditorService }) => {
+    pmEditorService.toggleHeadingCollapse();
+  }),
+
+  c('command::ui:uncollapse-all-headings', ({ pmEditorService }) => {
+    pmEditorService.uncollapseAllHeadings();
+  }),
 ];

--- a/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
+++ b/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
@@ -131,4 +131,16 @@ export const basicOperationsHandlers = [
   c('command::ui:uncollapse-all-headings', ({ pmEditorService }) => {
     pmEditorService.uncollapseAllHeadings();
   }),
+
+  c('command::ui:collapse-all-headings-1', ({ pmEditorService }) => {
+    pmEditorService.collapseAllHeadings(1);
+  }),
+
+  c('command::ui:collapse-all-headings-2', ({ pmEditorService }) => {
+    pmEditorService.collapseAllHeadings(2);
+  }),
+
+  c('command::ui:collapse-all-headings-3', ({ pmEditorService }) => {
+    pmEditorService.collapseAllHeadings(3);
+  }),
 ];

--- a/packages/core/editor/src/__tests__/collapsible-heading-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/collapsible-heading-markdown.spec.ts
@@ -1,0 +1,136 @@
+import {
+  EditorState,
+  markdownLoader,
+  resolve,
+  Schema,
+  setupBase,
+  setupCollapsibleHeading,
+  setupHeading,
+  setupParagraph,
+  TextSelection,
+  type Transaction,
+} from '@bangle.io/prosemirror-plugins';
+import { describe, expect, it } from 'vitest';
+
+const SOURCE = `# One
+
+alpha
+
+beta
+
+## Sub
+
+delta with plain trailing text
+
+# Two
+
+gamma`;
+
+function createTestSetup() {
+  const collapsible = setupCollapsibleHeading();
+  const extensions = [
+    setupBase(),
+    setupParagraph(),
+    setupHeading(),
+    collapsible,
+  ];
+  const resolved = resolve(extensions);
+  const schema = new Schema({ nodes: resolved.nodes, marks: resolved.marks });
+  const markdown = markdownLoader(extensions, schema);
+  return { collapsible, extensions, markdown, resolved, schema };
+}
+
+/** Creates editor state with the fold plugin active, cursor at doc start. */
+function createState(source: string) {
+  const { collapsible, markdown, resolved, schema } = createTestSetup();
+  const state = EditorState.create({
+    doc: markdown.parser.parse(source),
+    schema,
+    plugins: resolved.resolvePlugins({ schema }),
+  });
+  return { collapsible, markdown, state };
+}
+
+function headingPos(state: EditorState, text: string): number {
+  let found = -1;
+  state.doc.descendants((node, pos) => {
+    if (
+      found === -1 &&
+      node.type.name === 'heading' &&
+      node.textContent === text
+    ) {
+      found = pos;
+    }
+    return found === -1;
+  });
+  if (found === -1) {
+    throw new Error(`Heading "${text}" not found`);
+  }
+  return found;
+}
+
+function apply(
+  state: EditorState,
+  command: (s: EditorState, d: (tr: Transaction) => void) => boolean,
+) {
+  let next = state;
+  const result = command(state, (tr) => {
+    next = state.apply(tr);
+  });
+  expect(result).toBe(true);
+  return next;
+}
+
+describe('collapsible heading Markdown fidelity', () => {
+  it('heading schema carries no collapse state', () => {
+    const { schema } = createTestSetup();
+    const attrs = Object.keys(schema.nodes.heading?.spec.attrs ?? {});
+    expect(attrs).toEqual(['level']);
+  });
+
+  it('serializes the full document while a section is folded', () => {
+    let { collapsible, markdown, state } = createState(SOURCE);
+    state = apply(
+      state,
+      collapsible.command.toggleHeadingCollapseAtPos(headingPos(state, 'One')),
+    );
+
+    expect(collapsible.query.listCollapsedHeadings(state)).toHaveLength(1);
+    expect(markdown.serializer.serialize(state.doc)).toBe(SOURCE);
+  });
+
+  it('round trips byte-for-byte with multiple folded sections', () => {
+    let { collapsible, markdown, state } = createState(SOURCE);
+    state = apply(
+      state,
+      collapsible.command.toggleHeadingCollapseAtPos(headingPos(state, 'Sub')),
+    );
+    state = apply(
+      state,
+      collapsible.command.toggleHeadingCollapseAtPos(headingPos(state, 'Two')),
+    );
+
+    const serialized = markdown.serializer.serialize(state.doc);
+    expect(serialized).toBe(SOURCE);
+
+    // A reload of the serialized output parses to an identical document.
+    const reparsed = markdown.parser.parse(serialized);
+    expect(reparsed.toJSON()).toEqual(state.doc.toJSON());
+  });
+
+  it('folding via the selection command never mutates the document', () => {
+    let { collapsible, markdown, state } = createState(SOURCE);
+    const docBefore = state.doc;
+    state = state.apply(
+      state.tr.setSelection(
+        TextSelection.create(state.doc, headingPos(state, 'One') + 1),
+      ),
+    );
+    state = apply(state, (s, d) =>
+      collapsible.command.toggleHeadingCollapse(s, d),
+    );
+
+    expect(state.doc.eq(docBefore)).toBe(true);
+    expect(markdown.serializer.serialize(state.doc)).toBe(SOURCE);
+  });
+});

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -1,6 +1,5 @@
 import type { Logger } from '@bangle.io/logger';
 import {
-  defaultCalculateNodeOffset,
   type LinkConfig,
   setupActiveNode,
   setupBase,
@@ -57,19 +56,6 @@ export function setupExtensions(
       pluginOptions: {
         notDraggableClassName: 'prosemirror-flat-list',
         excludedTags: ['blockquote'],
-        calculateNodeOffset: (args) => {
-          const rect = defaultCalculateNodeOffset(args);
-          // Headings host the fold toggle in the gutter slot beside the
-          // first line; stack the drag handle directly beneath it (flush,
-          // no gap — a gap would let the hover tracking lose the heading on
-          // the way down) instead of pushing it further left, where it can
-          // fall off narrow screens.
-          if (args.node.matches('h1, h2, h3, h4, h5, h6')) {
-            rect.top += 22;
-            rect.left -= 2;
-          }
-          return rect;
-        },
       },
     }),
     dropGapCursor: setupDropGapCursor({

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@bangle.io/logger';
 import {
+  defaultCalculateNodeOffset,
   type LinkConfig,
   setupActiveNode,
   setupBase,
@@ -7,6 +8,7 @@ import {
   setupBold,
   setupCode,
   setupCodeBlock,
+  setupCollapsibleHeading,
   setupDragNode,
   setupDropGapCursor,
   setupHardBreak,
@@ -55,6 +57,15 @@ export function setupExtensions(
       pluginOptions: {
         notDraggableClassName: 'prosemirror-flat-list',
         excludedTags: ['blockquote'],
+        calculateNodeOffset: (args) => {
+          const rect = defaultCalculateNodeOffset(args);
+          // Headings host the fold toggle in the gutter slot next to the
+          // text; move the drag handle one slot further left.
+          if (args.node.matches('h1, h2, h3, h4, h5, h6')) {
+            rect.left -= 24;
+          }
+          return rect;
+        },
       },
     }),
     dropGapCursor: setupDropGapCursor({
@@ -66,6 +77,10 @@ export function setupExtensions(
     }),
     hardBreak: setupHardBreak(),
     heading: setupHeading(),
+    collapsibleHeading: setupCollapsibleHeading({
+      collapseLabel: t.app.editor.collapsibleHeading.collapse,
+      expandLabel: t.app.editor.collapsibleHeading.expand,
+    }),
     history: setupHistory(),
     paragraph: setupParagraph(),
     strike: setupStrike(),

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -59,10 +59,14 @@ export function setupExtensions(
         excludedTags: ['blockquote'],
         calculateNodeOffset: (args) => {
           const rect = defaultCalculateNodeOffset(args);
-          // Headings host the fold toggle in the gutter slot next to the
-          // text; move the drag handle one slot further left.
+          // Headings host the fold toggle in the gutter slot beside the
+          // first line; stack the drag handle directly beneath it (flush,
+          // no gap — a gap would let the hover tracking lose the heading on
+          // the way down) instead of pushing it further left, where it can
+          // fall off narrow screens.
           if (args.node.matches('h1, h2, h3, h4, h5, h6')) {
-            rect.left -= 24;
+            rect.top += 22;
+            rect.left -= 2;
           }
           return rect;
         },

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -488,6 +488,17 @@ export class PmEditorService extends BaseService {
     );
   }
 
+  /** Folds every heading of the given level in the active editor. */
+  collapseAllHeadings(level: number): boolean {
+    const view = this.getActiveEditorView();
+    if (!view) {
+      return false;
+    }
+    return this.extensions.collapsibleHeading.command.collapseAllHeadingsAtLevel(
+      level,
+    )(view.state, view.dispatch);
+  }
+
   /** Expands every folded heading section in the active editor. */
   uncollapseAllHeadings(): boolean {
     const view = this.getActiveEditorView();

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -475,4 +475,41 @@ export class PmEditorService extends BaseService {
       }
     }
   }
+
+  /** Folds/unfolds the heading section at the current selection. */
+  toggleHeadingCollapse(): boolean {
+    const view = this.getActiveEditorView();
+    if (!view) {
+      return false;
+    }
+    return this.extensions.collapsibleHeading.command.toggleHeadingCollapse(
+      view.state,
+      view.dispatch,
+    );
+  }
+
+  /** Expands every folded heading section in the active editor. */
+  uncollapseAllHeadings(): boolean {
+    const view = this.getActiveEditorView();
+    if (!view) {
+      return false;
+    }
+    return this.extensions.collapsibleHeading.command.uncollapseAllHeadings(
+      view.state,
+      view.dispatch,
+    );
+  }
+
+  private getActiveEditorView() {
+    let fallback: ReturnType<typeof createEditor> | undefined;
+    for (const editor of this.editors.values()) {
+      if ('editorView' in editor && !editor.editorView.isDestroyed) {
+        if (editor.editorView.hasFocus()) {
+          return editor.editorView;
+        }
+        fallback ??= editor.editorView;
+      }
+    }
+    return fallback;
+  }
 }

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -560,9 +560,16 @@ div.ProseMirror {
     opacity: 1;
   }
 
-  & .B-collapsible-heading-toggle:hover {
+  & .B-collapsible-heading-toggle:not(:disabled):hover {
     background-color: hsl(var(--BV-accent));
     color: hsl(var(--BV-foreground));
+  }
+
+  /* A heading with nothing beneath it keeps the toggle for visual
+     consistency, but dimmed and inert. */
+  & :is(h1, h2, h3, h4, h5, h6):hover .B-collapsible-heading-toggle:disabled {
+    opacity: 0.35;
+    cursor: default;
   }
 
   & .B-collapsible-heading-toggle[data-folded="true"] svg {
@@ -587,6 +594,10 @@ div.ProseMirror {
 @media (hover: none) {
   div.ProseMirror .B-collapsible-heading-toggle {
     opacity: 0.6;
+  }
+
+  div.ProseMirror .B-collapsible-heading-toggle:disabled {
+    opacity: 0.25;
   }
 }
 

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -518,3 +518,91 @@ div.ProseMirror {
     }
   }
 }
+
+/* Collapsible headings: the fold toggle sits in the left gutter of each
+   foldable heading; folded sections stay in the document and are only
+   visually concealed. */
+div.ProseMirror {
+  & h1,
+  & h2,
+  & h3,
+  & h4,
+  & h5,
+  & h6 {
+    position: relative;
+  }
+
+  & .B-collapsible-heading-toggle-wrapper {
+    position: absolute;
+    right: 100%;
+    top: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    padding-right: 0.125rem;
+    user-select: none;
+  }
+
+  & .B-collapsible-heading-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+    border: none;
+    border-radius: 0.25rem;
+    background: transparent;
+    color: hsl(var(--BV-muted-foreground));
+    cursor: pointer;
+    opacity: 0;
+    transition:
+      opacity 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  & .B-collapsible-heading-toggle svg {
+    width: 1rem;
+    height: 1rem;
+    transition: transform 0.15s ease;
+  }
+
+  & :is(h1, h2, h3, h4, h5, h6):hover .B-collapsible-heading-toggle,
+  & .B-collapsible-heading-toggle:focus-visible,
+  & .B-collapsible-heading-toggle[data-folded="true"] {
+    opacity: 1;
+  }
+
+  & .B-collapsible-heading-toggle:hover {
+    background-color: hsl(var(--BV-accent));
+    color: hsl(var(--BV-foreground));
+  }
+
+  & .B-collapsible-heading-toggle[data-folded="true"] svg {
+    transform: rotate(-90deg);
+  }
+
+  & .B-collapsible-heading-folded::after {
+    content: "\22EF"; /* Midline horizontal ellipsis */
+    margin-left: 0.5rem;
+    font-size: 0.6em;
+    opacity: 0.5;
+  }
+
+  & .B-collapsible-heading-hidden {
+    display: none;
+  }
+}
+
+@media (hover: none) {
+  div.ProseMirror .B-collapsible-heading-toggle {
+    opacity: 0.6;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  div.ProseMirror .B-collapsible-heading-toggle,
+  div.ProseMirror .B-collapsible-heading-toggle svg {
+    transition: none;
+  }
+}

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -519,11 +519,10 @@ div.ProseMirror {
   }
 }
 
-/* Collapsible headings: the fold toggle flows inline at the end of the
-   heading text (the left gutter stays reserved for the block drag handle);
-   folded sections stay in the document and are only visually concealed. */
 div.ProseMirror {
-  & .B-collapsible-heading-toggle-wrapper {
+  /* Trailing slot: inline widgets that follow a block's text (fold toggles,
+     future badges). On a wrapped block the slot flows with the last line. */
+  & .B-block-trailing-slot {
     display: inline-flex;
     align-items: center;
     vertical-align: middle;
@@ -570,10 +569,10 @@ div.ProseMirror {
     transform: rotate(-90deg);
   }
 
-  /* Hidden-content cue next to the toggle. Rendered inside the wrapper: a
+  /* Hidden-content cue next to the toggle. Rendered inside the slot: a
      ::after on the heading itself would land after ProseMirror's trailing
      break and wrap to its own line. */
-  & .B-collapsible-heading-toggle-wrapper:has(> [data-folded="true"])::after {
+  & .B-block-trailing-slot:has(> [data-folded="true"])::after {
     content: "\22EF"; /* Midline horizontal ellipsis */
     margin-left: 0.25rem;
     font-size: 0.6em;

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -535,8 +535,12 @@ div.ProseMirror {
   & .B-collapsible-heading-toggle-wrapper {
     position: absolute;
     right: 100%;
-    top: 0;
-    bottom: 0;
+    /* Hug the toggle button, centered on the first line: the drag handle
+       stacks directly beneath it in the same gutter slot, and a taller
+       (transparent) wrapper would sit under the handle and interfere with
+       drag hit-testing. */
+    top: calc((1lh - 1.25rem) / 2);
+    height: 1.25rem;
     display: flex;
     align-items: center;
     padding-right: 0.125rem;

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -519,31 +519,15 @@ div.ProseMirror {
   }
 }
 
-/* Collapsible headings: the fold toggle sits in the left gutter of each
-   foldable heading; folded sections stay in the document and are only
-   visually concealed. */
+/* Collapsible headings: the fold toggle flows inline at the end of the
+   heading text (the left gutter stays reserved for the block drag handle);
+   folded sections stay in the document and are only visually concealed. */
 div.ProseMirror {
-  & h1,
-  & h2,
-  & h3,
-  & h4,
-  & h5,
-  & h6 {
-    position: relative;
-  }
-
   & .B-collapsible-heading-toggle-wrapper {
-    position: absolute;
-    right: 100%;
-    /* Hug the toggle button, centered on the first line: the drag handle
-       stacks directly beneath it in the same gutter slot, and a taller
-       (transparent) wrapper would sit under the handle and interfere with
-       drag hit-testing. */
-    top: calc((1lh - 1.25rem) / 2);
-    height: 1.25rem;
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    padding-right: 0.125rem;
+    vertical-align: middle;
+    margin-left: 0.375rem;
     user-select: none;
   }
 
@@ -586,9 +570,12 @@ div.ProseMirror {
     transform: rotate(-90deg);
   }
 
-  & .B-collapsible-heading-folded::after {
+  /* Hidden-content cue next to the toggle. Rendered inside the wrapper: a
+     ::after on the heading itself would land after ProseMirror's trailing
+     break and wrap to its own line. */
+  & .B-collapsible-heading-toggle-wrapper:has(> [data-folded="true"])::after {
     content: "\22EF"; /* Midline horizontal ellipsis */
-    margin-left: 0.5rem;
+    margin-left: 0.25rem;
     font-size: 0.6em;
     opacity: 0.5;
   }

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -8,9 +8,10 @@ import {
   setupCollapsibleHeading,
 } from '../collapsible-heading';
 import { setupHeading } from '../heading';
+import { setupList } from '../list';
 import { setupParagraph } from '../paragraph';
 import type { PMNode } from '../pm';
-import { TextSelection } from '../pm';
+import { NodeSelection, TextSelection } from '../pm';
 import { createBangerEditorTestSetup } from '../test-helpers';
 
 const collapsible = setupCollapsibleHeading();
@@ -21,15 +22,18 @@ const editorTest = createBangerEditorTestSetup({
     setupParagraph(),
     setupCodeBlock(),
     setupHeading(),
+    setupList(),
     collapsible,
   ],
   builderAliases: {
+    bullet: { nodeType: 'list', kind: 'bullet' },
     codeBlock: { nodeType: 'code_block', language: '' },
     doc: { nodeType: 'doc' },
     p: { nodeType: 'paragraph' },
     h1: { nodeType: 'heading', level: 1 },
     h2: { nodeType: 'heading', level: 2 },
     h3: { nodeType: 'heading', level: 3 },
+    h4: { nodeType: 'heading', level: 4 },
   },
 });
 
@@ -37,6 +41,9 @@ const { doc, p } = editorTest.builders;
 const h1 = editorTest.nodeBuilder('h1');
 const h2 = editorTest.nodeBuilder('h2');
 const h3 = editorTest.nodeBuilder('h3');
+const h4 = editorTest.nodeBuilder('h4');
+const bullet = editorTest.nodeBuilder('bullet');
+const codeBlock = editorTest.nodeBuilder('codeBlock');
 
 afterEach(() => {
   editorTest.cleanup();
@@ -347,5 +354,374 @@ describe('selection guard', () => {
     // The fold stays folded and the cursor lands on visible content.
     expect(view.state.selection.$head.parent.textContent).not.toBe('inside');
     expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(1);
+  });
+});
+
+describe('collapse all headings at a level', () => {
+  const original = () =>
+    doc(h1('One'), p('a'), h2('Sub'), p('b'), h1('Two'), p('c'));
+
+  it('folds every heading of that level and nothing deeper', () => {
+    const editor = editorTest.createEditor(original());
+    const { view } = editor;
+
+    expect(
+      collapsible.command.collapseAllHeadingsAtLevel(1)(
+        view.state,
+        view.dispatch,
+      ),
+    ).toBe(true);
+
+    const folded = collapsible.query.listCollapsedHeadings(view.state);
+    expect(folded.map((f) => f.node.textContent)).toEqual(['One', 'Two']);
+    // Sub is hidden inside One's section but carries no fold state of its
+    // own — collapsing level 1 must not recursively collapse level 2.
+    expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b', 'c']);
+    editor.expectDoc(original());
+
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+    // One's whole section reappears, including Sub's content.
+    expect(hiddenTexts(view)).toEqual(['c']);
+    expect(
+      collapsible.query.isHeadingCollapsed(
+        view.state,
+        headingPos(view.state.doc, 'Sub'),
+      ),
+    ).toBe(false);
+  });
+
+  it('folds only the requested level', () => {
+    const editor = editorTest.createEditor(original());
+    const { view } = editor;
+
+    collapsible.command.collapseAllHeadingsAtLevel(2)(
+      view.state,
+      view.dispatch,
+    );
+
+    expect(
+      collapsible.query
+        .listCollapsedHeadings(view.state)
+        .map((f) => f.node.textContent),
+    ).toEqual(['Sub']);
+    expect(hiddenTexts(view)).toEqual(['b']);
+  });
+
+  it('skips headings already hidden inside a folded section', () => {
+    const editor = editorTest.createEditor(original());
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+
+    // The only level-2 heading is hidden inside One's fold; nothing to do.
+    expect(
+      collapsible.command.collapseAllHeadingsAtLevel(2)(
+        view.state,
+        view.dispatch,
+      ),
+    ).toBe(false);
+    expect(
+      collapsible.query
+        .listCollapsedHeadings(view.state)
+        .map((f) => f.node.textContent),
+    ).toEqual(['One']);
+  });
+
+  it('returns false when no heading of that level is foldable', () => {
+    const editor = editorTest.createEditor(doc(h1('One'), p('a')));
+    const { view } = editor;
+    expect(
+      collapsible.command.collapseAllHeadingsAtLevel(3)(
+        view.state,
+        view.dispatch,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('nested folds', () => {
+  it('collapse h2, collapse h1, uncollapse h1 keeps h2 folded, uncollapse h2 restores all', () => {
+    const original = doc(
+      h1('One'),
+      p('a'),
+      h2('Sub'),
+      p('b'),
+      h1('Two'),
+      p('c'),
+    );
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+
+    // Fold the inner h2 first.
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'Sub'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['b']);
+
+    // Fold the enclosing h1: its whole section hides, including folded Sub.
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b']);
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(2);
+
+    // Unfold the h1: Sub reappears and is still folded.
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['b']);
+    expect(
+      collapsible.query.isHeadingCollapsed(
+        view.state,
+        headingPos(view.state.doc, 'Sub'),
+      ),
+    ).toBe(true);
+
+    // Unfold the h2: back exactly where we started.
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'Sub'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual([]);
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(0);
+    editor.expectDoc(original);
+  });
+
+  it('uncollapseAllHeadings clears folds at every nesting depth', () => {
+    // Ported from the legacy "uncollapse all headings nested" case.
+    const original = doc(
+      h2('heading-a'),
+      p('one'),
+      h4('two'),
+      p('three'),
+      codeBlock('four'),
+      h3('heading-b'),
+      p('five'),
+      h4('heading-c'),
+      p('seven'),
+      codeBlock('eight'),
+      h3('heading-d'),
+      p('nine'),
+      p('ten'),
+      h4('eleven'),
+      p('twelve'),
+    );
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+
+    for (const text of ['heading-c', 'heading-b', 'heading-a']) {
+      collapsible.command.toggleHeadingCollapseAtPos(
+        headingPos(view.state.doc, text),
+      )(view.state, view.dispatch);
+    }
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(3);
+    expect(hiddenTexts(view)).not.toEqual([]);
+
+    collapsible.command.uncollapseAllHeadings(view.state, view.dispatch);
+
+    expect(hiddenTexts(view)).toEqual([]);
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(0);
+    editor.expectDoc(original);
+  });
+});
+
+describe('moving folded sections', () => {
+  it('moves the heading together with its hidden section to the end', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), p('b'), h1('Two'), p('c')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+
+    expect(
+      collapsible.command.moveFoldedHeadingSection(
+        pos,
+        view.state.doc.content.size,
+      )(view.state, view.dispatch),
+    ).toBe(true);
+
+    editor.expectDoc(doc(h1('Two'), p('c'), h1('One'), p('a'), p('b')));
+    // The section arrives still folded, with a NodeSelection on the heading.
+    expect(hiddenTexts(view)).toEqual(['a', 'b']);
+    expect(
+      collapsible.query.isHeadingCollapsed(
+        view.state,
+        headingPos(view.state.doc, 'One'),
+      ),
+    ).toBe(true);
+    expect(view.state.selection).toBeInstanceOf(NodeSelection);
+  });
+
+  it('moves a folded section upwards', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h1('Two'), p('c')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'Two');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+
+    expect(
+      collapsible.command.moveFoldedHeadingSection(pos, 0)(
+        view.state,
+        view.dispatch,
+      ),
+    ).toBe(true);
+
+    editor.expectDoc(doc(h1('Two'), p('c'), h1('One'), p('a')));
+    expect(hiddenTexts(view)).toEqual(['c']);
+  });
+
+  it('preserves nested fold state across a move', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h2('Sub'), p('b'), h1('Two'), p('c')),
+    );
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'Sub'),
+    )(view.state, view.dispatch);
+    const onePos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(onePos)(
+      view.state,
+      view.dispatch,
+    );
+
+    collapsible.command.moveFoldedHeadingSection(
+      onePos,
+      view.state.doc.content.size,
+    )(view.state, view.dispatch);
+
+    editor.expectDoc(
+      doc(h1('Two'), p('c'), h1('One'), p('a'), h2('Sub'), p('b')),
+    );
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(2);
+
+    // Unfolding the moved h1 reveals Sub, which is still folded.
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['b']);
+    expect(
+      collapsible.query.isHeadingCollapsed(
+        view.state,
+        headingPos(view.state.doc, 'Sub'),
+      ),
+    ).toBe(true);
+  });
+
+  it('refuses to drop a section into itself and leaves the doc untouched', () => {
+    const original = doc(h1('One'), p('a'), p('b'), h1('Two'), p('c'));
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+
+    const insideOwnRange = pos + 3;
+    expect(
+      collapsible.command.moveFoldedHeadingSection(pos, insideOwnRange)(
+        view.state,
+        view.dispatch,
+      ),
+    ).toBe(false);
+    editor.expectDoc(original);
+    expect(hiddenTexts(view)).toEqual(['a', 'b']);
+  });
+
+  it('does nothing for a heading that is not folded', () => {
+    const editor = editorTest.createEditor(doc(h1('One'), p('a'), h1('Two')));
+    const { view } = editor;
+    expect(
+      collapsible.command.moveFoldedHeadingSection(
+        headingPos(view.state.doc, 'One'),
+        view.state.doc.content.size,
+      )(view.state, view.dispatch),
+    ).toBe(false);
+  });
+});
+
+// Fold-boundary cases ported from the legacy collapsible-heading tests
+// (bangle.dev base-components), re-expressed for view-only folding.
+describe('legacy ported cases', () => {
+  it('higher level below: h3 folds up to the next h2', () => {
+    const editor = editorTest.createEditor(
+      doc(h3('ab'), p('hello'), p('abcd'), h2('bye')),
+    );
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'ab'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['hello', 'abcd']);
+  });
+
+  it('same level below: h3 folds up to the next h3', () => {
+    const editor = editorTest.createEditor(
+      doc(h3('ab'), p('hello'), p('abcd'), h3('bye')),
+    );
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'ab'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['hello', 'abcd']);
+  });
+
+  it('lower level below: h3 swallows an h4 section through the end', () => {
+    const editor = editorTest.createEditor(
+      doc(h3('ab'), p('12'), p('abcd'), h4('bye'), p('1'), p('2')),
+    );
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'ab'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['12', 'abcd', 'bye', '1', '2']);
+  });
+
+  it('multi level: h3 folds through an h4 but stops at an h2', () => {
+    const editor = editorTest.createEditor(
+      doc(h3('ab'), p('12'), h4('bye4'), p('1'), h2('bye2'), p('2')),
+    );
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'ab'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['12', 'bye4', '1']);
+  });
+
+  it('folds code blocks and lists like any other block', () => {
+    const original = doc(
+      p('a'),
+      h4('hi'),
+      p('1'),
+      h3('ab'),
+      bullet(p('first')),
+      bullet(p('last')),
+      codeBlock('foobar'),
+      p('2'),
+      h4('bye'),
+    );
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'ab'),
+    )(view.state, view.dispatch);
+
+    expect(hiddenTexts(view)).toEqual(['first', 'last', 'foobar', '2', 'bye']);
+
+    // Toggling again restores the original doc exactly (legacy invariant).
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'ab'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual([]);
+    editor.expectDoc(original);
   });
 });

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -225,6 +225,27 @@ describe('toggle affordance', () => {
     expect(toggleButtons(editor.view)).toHaveLength(2);
   });
 
+  it('renders the toggle in a trailing slot after the heading text', () => {
+    const editor = editorTest.createEditor(doc(h1('One'), p('a')));
+    const headingDom = editor.view.dom.querySelector('h1');
+    const slot = headingDom?.querySelector('.B-block-trailing-slot');
+
+    expect(slot).not.toBeNull();
+    expect(
+      slot?.querySelector('button.B-collapsible-heading-toggle'),
+    ).not.toBeNull();
+    // The slot participates in the heading's inline flow, after the text —
+    // on a wrapped heading it trails the last line.
+    expect(slot?.parentElement).toBe(headingDom);
+    const text = headingDom?.firstChild;
+    expect(text?.textContent).toBe('One');
+    expect(
+      text &&
+        slot &&
+        slot.compareDocumentPosition(text) & Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+  });
+
   it('clicking the toggle folds and unfolds the section', () => {
     const editor = editorTest.createEditor(doc(h1('One'), p('a'), p('b')));
     const { view } = editor;

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -1,0 +1,351 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { setupBase } from '../base';
+import { setupCodeBlock } from '../code-block';
+import {
+  getHeadingFoldRange,
+  setupCollapsibleHeading,
+} from '../collapsible-heading';
+import { setupHeading } from '../heading';
+import { setupParagraph } from '../paragraph';
+import type { PMNode } from '../pm';
+import { TextSelection } from '../pm';
+import { createBangerEditorTestSetup } from '../test-helpers';
+
+const collapsible = setupCollapsibleHeading();
+
+const editorTest = createBangerEditorTestSetup({
+  extensions: [
+    setupBase(),
+    setupParagraph(),
+    setupCodeBlock(),
+    setupHeading(),
+    collapsible,
+  ],
+  builderAliases: {
+    codeBlock: { nodeType: 'code_block', language: '' },
+    doc: { nodeType: 'doc' },
+    p: { nodeType: 'paragraph' },
+    h1: { nodeType: 'heading', level: 1 },
+    h2: { nodeType: 'heading', level: 2 },
+    h3: { nodeType: 'heading', level: 3 },
+  },
+});
+
+const { doc, p } = editorTest.builders;
+const h1 = editorTest.nodeBuilder('h1');
+const h2 = editorTest.nodeBuilder('h2');
+const h3 = editorTest.nodeBuilder('h3');
+
+afterEach(() => {
+  editorTest.cleanup();
+});
+
+/** Position right before the first heading whose text matches. */
+function headingPos(docNode: PMNode, text: string): number {
+  let found = -1;
+  docNode.descendants((node, pos) => {
+    if (
+      found === -1 &&
+      node.type.name === 'heading' &&
+      node.textContent === text
+    ) {
+      found = pos;
+    }
+    return found === -1;
+  });
+  if (found === -1) {
+    throw new Error(`Heading with text "${text}" not found`);
+  }
+  return found;
+}
+
+function hiddenTexts(view: { dom: HTMLElement }): string[] {
+  return [...view.dom.querySelectorAll('.B-collapsible-heading-hidden')].map(
+    (el) => el.textContent ?? '',
+  );
+}
+
+function toggleButtons(view: { dom: HTMLElement }): HTMLButtonElement[] {
+  return [
+    ...view.dom.querySelectorAll<HTMLButtonElement>(
+      'button.B-collapsible-heading-toggle',
+    ),
+  ];
+}
+
+describe('getHeadingFoldRange', () => {
+  it('spans everything up to the next heading of the same level', () => {
+    const d = doc(h1('One'), p('a'), p('b'), h1('Two'), p('c'));
+    const pos = headingPos(d, 'One');
+    const range = getHeadingFoldRange(d, pos);
+    expect(range).not.toBeNull();
+    // Hidden region is exactly the two paragraphs between the headings.
+    expect(d.slice(range!.from, range!.to).content.childCount).toBe(2);
+    expect(d.slice(range!.from, range!.to).content.child(0).textContent).toBe(
+      'a',
+    );
+    expect(d.slice(range!.from, range!.to).content.child(1).textContent).toBe(
+      'b',
+    );
+  });
+
+  it('includes deeper headings but stops at a higher-level heading', () => {
+    const d = doc(h1('One'), p('a'), h2('Sub'), p('b'), h1('Two'), p('c'));
+    const range = getHeadingFoldRange(d, headingPos(d, 'One'));
+    // Folds paragraph, sub-heading, and its paragraph — stops before "Two".
+    expect(d.slice(range!.from, range!.to).content.childCount).toBe(3);
+
+    const subRange = getHeadingFoldRange(d, headingPos(d, 'Sub'));
+    expect(d.slice(subRange!.from, subRange!.to).content.childCount).toBe(1);
+    expect(
+      d.slice(subRange!.from, subRange!.to).content.child(0).textContent,
+    ).toBe('b');
+  });
+
+  it('stops at a heading of a higher level than the fold owner', () => {
+    const d = doc(h2('Sub'), p('a'), h1('Top'), p('b'));
+    const range = getHeadingFoldRange(d, headingPos(d, 'Sub'));
+    expect(d.slice(range!.from, range!.to).content.childCount).toBe(1);
+  });
+
+  it('extends to the end of the document after the last heading', () => {
+    const d = doc(p('intro'), h1('Last'), p('a'), p('b'));
+    const range = getHeadingFoldRange(d, headingPos(d, 'Last'));
+    expect(range!.to).toBe(d.content.size);
+  });
+
+  it('returns null for adjacent headings and trailing headings', () => {
+    const d = doc(h1('One'), h1('Two'));
+    expect(getHeadingFoldRange(d, headingPos(d, 'One'))).toBeNull();
+    expect(getHeadingFoldRange(d, headingPos(d, 'Two'))).toBeNull();
+  });
+
+  it('returns null for positions that do not hold a heading', () => {
+    const d = doc(p('a'), h1('One'), p('b'));
+    expect(getHeadingFoldRange(d, 0)).toBeNull();
+    expect(getHeadingFoldRange(d, 10_000)).toBeNull();
+  });
+});
+
+describe('toggle and unfold commands', () => {
+  it('folds and unfolds without ever changing the document', () => {
+    const original = doc(h1('One'), p('a'), p('b'), h1('Two'), p('c'));
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+    // Cursor inside the first heading.
+    editor.setSelection(headingPos(view.state.doc, 'One') + 1);
+
+    expect(
+      collapsible.command.toggleHeadingCollapse(view.state, view.dispatch),
+    ).toBe(true);
+
+    expect(collapsible.query.isHeadingCollapsed(view.state)).toBe(true);
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(1);
+    expect(hiddenTexts(view)).toEqual(['a', 'b']);
+    editor.expectDoc(original);
+
+    expect(
+      collapsible.command.toggleHeadingCollapse(view.state, view.dispatch),
+    ).toBe(true);
+    expect(hiddenTexts(view)).toEqual([]);
+    expect(collapsible.query.isHeadingCollapsed(view.state)).toBe(false);
+    editor.expectDoc(original);
+  });
+
+  it('does not fold a heading with nothing beneath it', () => {
+    const editor = editorTest.createEditor(doc(h1('One'), h1('Two'), p('c')));
+    const { view } = editor;
+    editor.setSelection(headingPos(view.state.doc, 'One') + 1);
+
+    expect(
+      collapsible.command.toggleHeadingCollapse(view.state, view.dispatch),
+    ).toBe(false);
+    expect(hiddenTexts(view)).toEqual([]);
+  });
+
+  it('folds only the subsection when toggling a deeper heading', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h2('Sub'), p('b'), h1('Two'), p('c')),
+    );
+    const { view } = editor;
+    const subPos = headingPos(view.state.doc, 'Sub');
+
+    expect(
+      collapsible.command.toggleHeadingCollapseAtPos(subPos)(
+        view.state,
+        view.dispatch,
+      ),
+    ).toBe(true);
+    expect(hiddenTexts(view)).toEqual(['b']);
+  });
+
+  it('uncollapseAllHeadings expands every folded section', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    const first = headingPos(view.state.doc, 'One');
+    const second = headingPos(view.state.doc, 'Two');
+    collapsible.command.toggleHeadingCollapseAtPos(first)(
+      view.state,
+      view.dispatch,
+    );
+    collapsible.command.toggleHeadingCollapseAtPos(second)(
+      view.state,
+      view.dispatch,
+    );
+    expect(hiddenTexts(view)).toEqual(['a', 'b']);
+
+    expect(
+      collapsible.command.uncollapseAllHeadings(view.state, view.dispatch),
+    ).toBe(true);
+    expect(hiddenTexts(view)).toEqual([]);
+    // Nothing left to unfold.
+    expect(
+      collapsible.command.uncollapseAllHeadings(view.state, view.dispatch),
+    ).toBe(false);
+  });
+});
+
+describe('toggle affordance', () => {
+  it('renders a toggle button only for foldable headings', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h1('Empty'), h1('Last'), p('b')),
+    );
+    // "One" and "Last" are foldable; "Empty" has no content beneath it.
+    expect(toggleButtons(editor.view)).toHaveLength(2);
+  });
+
+  it('clicking the toggle folds and unfolds the section', () => {
+    const editor = editorTest.createEditor(doc(h1('One'), p('a'), p('b')));
+    const { view } = editor;
+
+    const [button] = toggleButtons(view);
+    expect(button).toBeDefined();
+    expect(button?.getAttribute('aria-expanded')).toBe('true');
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(hiddenTexts(view)).toEqual(['a', 'b']);
+
+    const [foldedButton] = toggleButtons(view);
+    expect(foldedButton?.getAttribute('aria-expanded')).toBe('false');
+    foldedButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(hiddenTexts(view)).toEqual([]);
+  });
+});
+
+describe('document edits around folds', () => {
+  it('keeps the fold anchored when content is inserted above it', () => {
+    const editor = editorTest.createEditor(
+      doc(p('intro'), h1('One'), p('a'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+    expect(hiddenTexts(view)).toEqual(['a']);
+
+    view.dispatch(view.state.tr.insertText('more ', 1));
+    expect(hiddenTexts(view)).toEqual(['a']);
+    expect(
+      collapsible.query.isHeadingCollapsed(
+        view.state,
+        headingPos(view.state.doc, 'One'),
+      ),
+    ).toBe(true);
+  });
+
+  it('reveals the hidden content when the folded heading is deleted', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+    expect(hiddenTexts(view)).toEqual(['a']);
+
+    const heading = view.state.doc.nodeAt(pos);
+    view.dispatch(view.state.tr.delete(pos, pos + (heading?.nodeSize ?? 0)));
+
+    expect(hiddenTexts(view)).toEqual([]);
+    expect(view.state.doc.textContent).toContain('a');
+  });
+
+  it('auto-unfolds when an edit lands inside the hidden region', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+    expect(hiddenTexts(view)).toEqual(['a']);
+
+    // Put the cursor at the end of the folded heading and split it: the new
+    // block would land inside the hidden region, so the fold must open.
+    const heading = view.state.doc.nodeAt(pos);
+    editor.setSelection(pos + (heading?.nodeSize ?? 0) - 1);
+    editor.pressKey('Enter');
+
+    expect(hiddenTexts(view)).toEqual([]);
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(0);
+  });
+});
+
+describe('selection guard', () => {
+  it('pushes a cursor moving forward past the hidden region', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('aaaa'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+
+    // Selection starts at the heading end, then moves into hidden content.
+    const heading = view.state.doc.nodeAt(pos);
+    editor.setSelection(pos + (heading?.nodeSize ?? 0) - 1);
+    const insideHidden = pos + (heading?.nodeSize ?? 0) + 2;
+    view.dispatch(
+      view.state.tr.setSelection(
+        TextSelection.create(view.state.doc, insideHidden),
+      ),
+    );
+
+    // Cursor must not be stranded inside the hidden paragraph.
+    const head = view.state.selection.head;
+    const hiddenStart = pos + (heading?.nodeSize ?? 0);
+    const twoPos = headingPos(view.state.doc, 'Two');
+    expect(head > hiddenStart && head < twoPos).toBe(false);
+    expect(hiddenTexts(view)).toEqual(['aaaa']);
+  });
+
+  it('moves the cursor to the heading when folding a section the cursor is inside', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('inside'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    const heading = view.state.doc.nodeAt(pos);
+    // Cursor inside the paragraph that is about to be hidden.
+    editor.setSelection(pos + (heading?.nodeSize ?? 0) + 3);
+
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+
+    expect(hiddenTexts(view)).toEqual(['inside']);
+    // The fold stays folded and the cursor lands on visible content.
+    expect(view.state.selection.$head.parent.textContent).not.toBe('inside');
+    expect(collapsible.query.listCollapsedHeadings(view.state)).toHaveLength(1);
+  });
+});

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -430,6 +430,28 @@ describe('collapse all headings at a level', () => {
     ).toEqual(['One']);
   });
 
+  it('skips a hidden heading even when it is the first folded child', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), h2('Sub'), p('b'), h1('Two'), p('c')),
+    );
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+
+    expect(
+      collapsible.command.collapseAllHeadingsAtLevel(2)(
+        view.state,
+        view.dispatch,
+      ),
+    ).toBe(false);
+    expect(
+      collapsible.query
+        .listCollapsedHeadings(view.state)
+        .map((f) => f.node.textContent),
+    ).toEqual(['One']);
+  });
+
   it('returns false when no heading of that level is foldable', () => {
     const editor = editorTest.createEditor(doc(h1('One'), p('a')));
     const { view } = editor;

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -217,12 +217,25 @@ describe('toggle and unfold commands', () => {
 });
 
 describe('toggle affordance', () => {
-  it('renders a toggle button only for foldable headings', () => {
+  it('renders a toggle for every heading, disabled when there is nothing to fold', () => {
     const editor = editorTest.createEditor(
       doc(h1('One'), p('a'), h1('Empty'), h1('Last'), p('b')),
     );
-    // "One" and "Last" are foldable; "Empty" has no content beneath it.
-    expect(toggleButtons(editor.view)).toHaveLength(2);
+    const buttons = toggleButtons(editor.view);
+    expect(buttons).toHaveLength(3);
+    // "Empty" has no content beneath it: its toggle renders for visual
+    // consistency but is inert.
+    expect(buttons.map((button) => button.disabled)).toEqual([
+      false,
+      true,
+      false,
+    ]);
+
+    buttons[1]?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(hiddenTexts(editor.view)).toEqual([]);
+    expect(collapsible.query.listCollapsedHeadings(editor.view.state)).toEqual(
+      [],
+    );
   });
 
   it('renders the toggle in a trailing slot after the heading text', () => {

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -3,8 +3,10 @@ import {
   type Command,
   Decoration,
   DecorationSet,
+  dropPoint,
   type EditorState,
   type EditorView,
+  NodeSelection,
   Plugin,
   PluginKey,
   type PMNode,
@@ -56,6 +58,7 @@ export type HeadingFoldRange = {
 
 type FoldMeta =
   | { type: 'toggle'; pos: number }
+  | { type: 'fold'; positions: number[] }
   | { type: 'unfold'; positions: number[] }
   | { type: 'unfoldAll' };
 
@@ -149,6 +152,97 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
     return toggleAtPos(found.pos)(state, dispatch);
   };
 
+  const collapseAllAtLevel = (level: number): Command => {
+    return (state, dispatch) => {
+      const pluginState = key.getState(state);
+      if (!pluginState) {
+        return false;
+      }
+      const targets: number[] = [];
+      state.doc.descendants((node, pos) => {
+        if (node.type.name !== config.headingName) {
+          return true;
+        }
+        if (
+          node.attrs.level === level &&
+          !pluginState.folded.includes(pos) &&
+          // A heading already hidden inside another folded section is left
+          // alone: folding it too would silently stack recursive fold state.
+          !pluginState.ranges.some((r) => pos > r.from && pos < r.to) &&
+          getHeadingFoldRange(state.doc, pos, config.headingName)
+        ) {
+          targets.push(pos);
+        }
+        return false;
+      });
+      if (targets.length === 0) {
+        return false;
+      }
+      if (dispatch) {
+        dispatch(
+          state.tr.setMeta(key, {
+            type: 'fold',
+            positions: targets,
+          } satisfies FoldMeta),
+        );
+      }
+      return true;
+    };
+  };
+
+  /**
+   * Moves a folded heading together with its hidden section to `dropPos`.
+   * Nested fold state inside the section is preserved by re-anchoring it
+   * relative to the heading's new position. Fails (returns false) for drops
+   * inside the section itself and for non-top-level headings.
+   */
+  const moveFoldedSection = (headingPos: number, dropPos: number): Command => {
+    return (state, dispatch) => {
+      const pluginState = key.getState(state);
+      if (!pluginState?.folded.includes(headingPos)) {
+        return false;
+      }
+      if (state.doc.resolve(headingPos).depth !== 0) {
+        return false;
+      }
+      const range = getHeadingFoldRange(
+        state.doc,
+        headingPos,
+        config.headingName,
+      );
+      if (!range) {
+        return false;
+      }
+      if (dropPos >= headingPos && dropPos <= range.to) {
+        return false;
+      }
+      const slice = state.doc.slice(headingPos, range.to);
+      const insertPos = dropPoint(state.doc, dropPos, slice);
+      if (
+        insertPos == null ||
+        (insertPos >= headingPos && insertPos <= range.to)
+      ) {
+        return false;
+      }
+      if (dispatch) {
+        const tr = state.tr;
+        tr.delete(headingPos, range.to);
+        const mapped = tr.mapping.map(insertPos);
+        tr.insert(mapped, slice.content);
+        tr.setMeta(key, {
+          type: 'fold',
+          positions: pluginState.folded
+            .filter((pos) => pos >= headingPos && pos < range.to)
+            .map((pos) => mapped + (pos - headingPos)),
+        } satisfies FoldMeta);
+        tr.setSelection(NodeSelection.create(tr.doc, mapped));
+        tr.scrollIntoView();
+        dispatch(tr);
+      }
+      return true;
+    };
+  };
+
   const uncollapseAll: Command = (state, dispatch) => {
     const pluginState = key.getState(state);
     if (!pluginState || pluginState.folded.length === 0) {
@@ -189,7 +283,7 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
   };
 
   const plugin = {
-    fold: pluginFold(config, key, toggleAtPos),
+    fold: pluginFold(config, key, toggleAtPos, moveFoldedSection),
     keybindings: pluginKeybindings(config, toggleAtSelection),
   };
 
@@ -197,6 +291,8 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
     id: 'collapsible-heading',
     plugin,
     command: {
+      collapseAllHeadingsAtLevel: collapseAllAtLevel,
+      moveFoldedHeadingSection: moveFoldedSection,
       toggleHeadingCollapse: toggleAtSelection,
       toggleHeadingCollapseAtPos: toggleAtPos,
       uncollapseAllHeadings: uncollapseAll,
@@ -221,6 +317,7 @@ function pluginFold(
   config: RequiredConfig,
   key: PluginKey<FoldPluginState>,
   toggleAtPos: (pos: number) => Command,
+  moveFoldedSection: (headingPos: number, dropPos: number) => Command,
 ) {
   return ({ schema }: PluginContext) => {
     // Ensure the heading node exists so a misconfigured name fails loudly.
@@ -247,6 +344,8 @@ function pluginFold(
             folded = folded.includes(meta.pos)
               ? folded.filter((pos) => pos !== meta.pos)
               : [...folded, meta.pos];
+          } else if (meta?.type === 'fold') {
+            folded = [...new Set([...folded, ...meta.positions])];
           } else if (meta?.type === 'unfold') {
             folded = folded.filter((pos) => !meta.positions.includes(pos));
           } else if (meta?.type === 'unfoldAll') {
@@ -301,6 +400,35 @@ function pluginFold(
       props: {
         decorations(state) {
           return key.getState(state)?.decorations ?? DecorationSet.empty;
+        },
+        // A folded heading must travel with its hidden section. The default
+        // drop handling would move only the heading node (the drag handle
+        // sets a NodeSelection on it), leaving the section behind and
+        // silently expanding it — so the drop is rebuilt here instead.
+        handleDrop(view, event, _slice, moved) {
+          if (!moved) {
+            return false;
+          }
+          const state = view.state;
+          const selection = state.selection;
+          if (!(selection instanceof NodeSelection)) {
+            return false;
+          }
+          const pluginState = key.getState(state);
+          if (!pluginState?.folded.includes(selection.from)) {
+            return false;
+          }
+          const coords = view.posAtCoords({
+            left: event.clientX,
+            top: event.clientY,
+          });
+          if (coords) {
+            moveFoldedSection(selection.from, coords.pos)(state, view.dispatch);
+          }
+          // Swallow the drop even when the move was a no-op (e.g. dropping a
+          // section onto itself): the default handler would tear the folded
+          // section apart.
+          return true;
         },
       },
     });

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -19,6 +19,7 @@ import {
   type KeyCode,
   type PluginContext,
 } from './pm-utils';
+import { createTrailingWidget } from './trailing-slot';
 
 /**
  * Collapsible headings: fold the blocks that follow a heading (up to the next
@@ -460,19 +461,18 @@ function buildPluginState(
     }
 
     const isFolded = foldedSet.has(pos);
-    // The toggle renders inline at the end of the heading text, keeping the
-    // left gutter free for the block drag handle.
+    // The toggle renders in the block's trailing slot — inline at the end
+    // of the heading text — keeping the left gutter free for the block
+    // drag handle. Other features can add their own trailing widgets
+    // alongside it.
     decorations.push(
-      Decoration.widget(
-        pos + node.nodeSize - 1,
-        (view: EditorView) =>
-          createToggleWidget(view, pos, isFolded, config, toggleAtPos),
-        {
-          key: `collapsible-heading:${pos}:${isFolded}`,
-          side: 1,
-          ignoreSelection: true,
-        },
-      ),
+      createTrailingWidget({
+        node,
+        pos,
+        key: `collapsible-heading:${pos}:${isFolded}`,
+        render: (view: EditorView) =>
+          createToggleButton(view, pos, isFolded, config, toggleAtPos),
+      }),
     );
 
     if (!isFolded) {
@@ -577,17 +577,13 @@ function selectionOutsideFolds(
 const CHEVRON_PATH =
   'M6.34 7.76 4.93 9.17 12 16.24l7.07-7.07-1.41-1.41L12 13.41 6.34 7.76Z';
 
-function createToggleWidget(
+function createToggleButton(
   view: EditorView,
   headingPos: number,
   folded: boolean,
   config: RequiredConfig,
   toggleAtPos: (pos: number) => Command,
 ): HTMLElement {
-  const wrapper = document.createElement('span');
-  wrapper.className = 'B-collapsible-heading-toggle-wrapper';
-  wrapper.contentEditable = 'false';
-
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'B-collapsible-heading-toggle';
@@ -618,6 +614,5 @@ function createToggleWidget(
     toggleAtPos(headingPos)(view.state, view.dispatch);
   });
 
-  wrapper.appendChild(button);
-  return wrapper;
+  return button;
 }

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -1,0 +1,483 @@
+import { collection, keybinding } from './common';
+import {
+  type Command,
+  Decoration,
+  DecorationSet,
+  type EditorState,
+  type EditorView,
+  Plugin,
+  PluginKey,
+  type PMNode,
+  Selection,
+} from './pm';
+import {
+  findParentNodeOfType,
+  getNodeType,
+  type KeyCode,
+  type PluginContext,
+} from './pm-utils';
+
+/**
+ * Collapsible headings: fold the blocks that follow a heading (up to the next
+ * heading of the same or higher level) so long notes are easier to scan.
+ *
+ * Folding is strictly a view concern. The document — and therefore the
+ * serialized Markdown — is never modified; hidden blocks stay in the doc and
+ * are only concealed with decorations. Fold state lives in plugin state and
+ * resets when the editor is recreated.
+ */
+export type CollapsibleHeadingConfig = {
+  /** Node name of the heading this plugin folds. Defaults to `heading`. */
+  headingName?: string;
+  keyToggleCollapse?: KeyCode;
+  /** Accessible label for the fold toggle when the section is expanded. */
+  collapseLabel?: string;
+  /** Accessible label for the fold toggle when the section is folded. */
+  expandLabel?: string;
+};
+
+type RequiredConfig = Required<CollapsibleHeadingConfig>;
+
+const DEFAULT_CONFIG: RequiredConfig = {
+  headingName: 'heading',
+  keyToggleCollapse: false,
+  collapseLabel: 'Collapse section',
+  expandLabel: 'Expand section',
+};
+
+export type HeadingFoldRange = {
+  /** Position right before the heading node that owns the fold. */
+  headingPos: number;
+  /** Start of the hidden region: the boundary right after the heading node. */
+  from: number;
+  /** End of the hidden region: the boundary after the last folded sibling. */
+  to: number;
+};
+
+type FoldMeta =
+  | { type: 'toggle'; pos: number }
+  | { type: 'unfold'; positions: number[] }
+  | { type: 'unfoldAll' };
+
+type FoldPluginState = {
+  /** Sorted positions (before the node) of currently folded headings. */
+  folded: number[];
+  /** Hidden ranges derived from `folded` against the current doc. */
+  ranges: HeadingFoldRange[];
+  decorations: DecorationSet;
+};
+
+/**
+ * Computes the range of sibling blocks that fold under the heading at
+ * `headingPos`: everything after the heading up to (excluding) the next
+ * sibling heading with the same or a higher level. Returns null when the
+ * position does not hold a heading or the heading has nothing to fold.
+ */
+export function getHeadingFoldRange(
+  doc: PMNode,
+  headingPos: number,
+  headingName = 'heading',
+): HeadingFoldRange | null {
+  if (headingPos < 0 || headingPos > doc.content.size) {
+    return null;
+  }
+  const heading = doc.nodeAt(headingPos);
+  if (!heading || heading.type.name !== headingName) {
+    return null;
+  }
+
+  const $pos = doc.resolve(headingPos);
+  const parent = $pos.parent;
+  const headingIndex = $pos.index();
+  if (parent.maybeChild(headingIndex) !== heading) {
+    return null;
+  }
+
+  const from = headingPos + heading.nodeSize;
+  let to = from;
+  for (let i = headingIndex + 1; i < parent.childCount; i++) {
+    const sibling = parent.child(i);
+    if (
+      sibling.type.name === headingName &&
+      sibling.attrs.level <= heading.attrs.level
+    ) {
+      break;
+    }
+    to += sibling.nodeSize;
+  }
+
+  return to === from ? null : { headingPos, from, to };
+}
+
+export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
+  const config: RequiredConfig = {
+    ...DEFAULT_CONFIG,
+    ...userConfig,
+  };
+
+  const key = new PluginKey<FoldPluginState>('collapsible-heading');
+
+  const toggleAtPos = (pos: number): Command => {
+    return (state, dispatch) => {
+      const pluginState = key.getState(state);
+      if (!pluginState) {
+        return false;
+      }
+      const isFolded = pluginState.folded.includes(pos);
+      if (
+        !isFolded &&
+        !getHeadingFoldRange(state.doc, pos, config.headingName)
+      ) {
+        return false;
+      }
+      if (dispatch) {
+        dispatch(
+          state.tr.setMeta(key, { type: 'toggle', pos } satisfies FoldMeta),
+        );
+      }
+      return true;
+    };
+  };
+
+  const toggleAtSelection: Command = (state, dispatch) => {
+    const found = findParentNodeOfType(
+      getNodeType(state.schema, config.headingName),
+    )(state.selection);
+    if (!found) {
+      return false;
+    }
+    return toggleAtPos(found.pos)(state, dispatch);
+  };
+
+  const uncollapseAll: Command = (state, dispatch) => {
+    const pluginState = key.getState(state);
+    if (!pluginState || pluginState.folded.length === 0) {
+      return false;
+    }
+    if (dispatch) {
+      dispatch(state.tr.setMeta(key, { type: 'unfoldAll' } satisfies FoldMeta));
+    }
+    return true;
+  };
+
+  const listCollapsedHeadings = (state: EditorState) => {
+    const pluginState = key.getState(state);
+    if (!pluginState) {
+      return [];
+    }
+    return pluginState.ranges.map((range) => {
+      const node = state.doc.nodeAt(range.headingPos);
+      if (!node) {
+        throw new Error('collapsible-heading: folded heading node missing');
+      }
+      return { pos: range.headingPos, node };
+    });
+  };
+
+  const isHeadingCollapsed = (state: EditorState, pos?: number): boolean => {
+    const pluginState = key.getState(state);
+    if (!pluginState) {
+      return false;
+    }
+    if (pos != null) {
+      return pluginState.folded.includes(pos);
+    }
+    const found = findParentNodeOfType(
+      getNodeType(state.schema, config.headingName),
+    )(state.selection);
+    return found ? pluginState.folded.includes(found.pos) : false;
+  };
+
+  const plugin = {
+    fold: pluginFold(config, key, toggleAtPos),
+    keybindings: pluginKeybindings(config, toggleAtSelection),
+  };
+
+  return collection({
+    id: 'collapsible-heading',
+    plugin,
+    command: {
+      toggleHeadingCollapse: toggleAtSelection,
+      toggleHeadingCollapseAtPos: toggleAtPos,
+      uncollapseAllHeadings: uncollapseAll,
+    },
+    query: {
+      isHeadingCollapsed,
+      listCollapsedHeadings,
+    },
+  });
+}
+
+function pluginKeybindings(config: RequiredConfig, toggleAtSelection: Command) {
+  return () => {
+    return keybinding(
+      [[config.keyToggleCollapse, toggleAtSelection]],
+      'collapsible-heading',
+    );
+  };
+}
+
+function pluginFold(
+  config: RequiredConfig,
+  key: PluginKey<FoldPluginState>,
+  toggleAtPos: (pos: number) => Command,
+) {
+  return ({ schema }: PluginContext) => {
+    // Ensure the heading node exists so a misconfigured name fails loudly.
+    getNodeType(schema, config.headingName);
+
+    return new Plugin<FoldPluginState>({
+      key,
+      state: {
+        init: (_, state) => {
+          return buildPluginState(state.doc, [], config, toggleAtPos);
+        },
+        apply: (tr, prev, _oldState, newState) => {
+          const meta = tr.getMeta(key) as FoldMeta | undefined;
+
+          let folded = prev.folded;
+          if (tr.docChanged) {
+            folded = folded.flatMap((pos) => {
+              const result = tr.mapping.mapResult(pos);
+              return result.deleted ? [] : [result.pos];
+            });
+          }
+
+          if (meta?.type === 'toggle') {
+            folded = folded.includes(meta.pos)
+              ? folded.filter((pos) => pos !== meta.pos)
+              : [...folded, meta.pos];
+          } else if (meta?.type === 'unfold') {
+            folded = folded.filter((pos) => !meta.positions.includes(pos));
+          } else if (meta?.type === 'unfoldAll') {
+            folded = [];
+          }
+
+          if (!tr.docChanged && folded === prev.folded) {
+            return prev;
+          }
+
+          return buildPluginState(newState.doc, folded, config, toggleAtPos);
+        },
+      },
+      appendTransaction: (transactions, oldState, newState) => {
+        const pluginState = key.getState(newState);
+        if (!pluginState || pluginState.ranges.length === 0) {
+          return null;
+        }
+        const { selection } = newState;
+        if (!selection.empty) {
+          return null;
+        }
+        const head = selection.head;
+        const containing = pluginState.ranges.filter(
+          (range) => head > range.from && head < range.to,
+        );
+        if (containing.length === 0) {
+          return null;
+        }
+
+        // A doc change that lands the cursor inside a folded region means the
+        // user just edited hidden content (e.g. Enter at the end of a folded
+        // heading). Reveal the section instead of letting the edit vanish.
+        if (transactions.some((tr) => tr.docChanged)) {
+          return newState.tr.setMeta(key, {
+            type: 'unfold',
+            positions: containing.map((range) => range.headingPos),
+          } satisfies FoldMeta);
+        }
+
+        // Pure selection movement: push the cursor out of the hidden region,
+        // following the direction the user was travelling.
+        const forward = head > oldState.selection.head;
+        const outside = selectionOutsideFolds(
+          newState.doc,
+          pluginState.ranges,
+          head,
+          forward,
+        );
+        return outside ? newState.tr.setSelection(outside) : null;
+      },
+      props: {
+        decorations(state) {
+          return key.getState(state)?.decorations ?? DecorationSet.empty;
+        },
+      },
+    });
+  };
+}
+
+function buildPluginState(
+  doc: PMNode,
+  requestedFolds: number[],
+  config: RequiredConfig,
+  toggleAtPos: (pos: number) => Command,
+): FoldPluginState {
+  const foldedSet = new Set(requestedFolds);
+  const folded: number[] = [];
+  const ranges: HeadingFoldRange[] = [];
+  const decorations: Decoration[] = [];
+
+  doc.descendants((node, pos) => {
+    if (node.type.name !== config.headingName) {
+      return true;
+    }
+
+    const range = getHeadingFoldRange(doc, pos, config.headingName);
+    if (!range) {
+      return false;
+    }
+
+    const isFolded = foldedSet.has(pos);
+    decorations.push(
+      Decoration.widget(
+        pos + 1,
+        (view: EditorView) =>
+          createToggleWidget(view, pos, isFolded, config, toggleAtPos),
+        {
+          key: `collapsible-heading:${pos}:${isFolded}`,
+          side: -1,
+          ignoreSelection: true,
+        },
+      ),
+    );
+
+    if (!isFolded) {
+      return false;
+    }
+
+    folded.push(pos);
+    ranges.push(range);
+    decorations.push(
+      Decoration.node(pos, pos + node.nodeSize, {
+        class: 'B-collapsible-heading-folded',
+      }),
+    );
+    decorations.push(...hiddenBlockDecorations(doc, range));
+    return false;
+  });
+
+  folded.sort((a, b) => a - b);
+  ranges.sort((a, b) => a.headingPos - b.headingPos);
+
+  return {
+    folded,
+    ranges,
+    decorations: DecorationSet.create(doc, decorations),
+  };
+}
+
+/** One node decoration per folded sibling block, so nodeViews stay mounted. */
+function hiddenBlockDecorations(
+  doc: PMNode,
+  range: HeadingFoldRange,
+): Decoration[] {
+  const $heading = doc.resolve(range.headingPos);
+  const parent = $heading.parent;
+  const decorations: Decoration[] = [];
+  let childPos = range.from;
+  for (let i = $heading.index() + 1; i < parent.childCount; i++) {
+    if (childPos >= range.to) {
+      break;
+    }
+    const child = parent.child(i);
+    decorations.push(
+      Decoration.node(childPos, childPos + child.nodeSize, {
+        class: 'B-collapsible-heading-hidden',
+      }),
+    );
+    childPos += child.nodeSize;
+  }
+  return decorations;
+}
+
+/**
+ * Finds the closest visible cursor position outside every folded range,
+ * preferring the travel direction. Returns null when `head` is already
+ * outside or no better position exists.
+ */
+function selectionOutsideFolds(
+  doc: PMNode,
+  ranges: HeadingFoldRange[],
+  head: number,
+  preferForward: boolean,
+): Selection | null {
+  if (preferForward) {
+    let pos = head;
+    for (let i = 0; i <= ranges.length; i++) {
+      const range = ranges.find((r) => pos > r.from && pos < r.to);
+      if (!range) {
+        return pos === head ? null : Selection.near(doc.resolve(pos), 1);
+      }
+      const next = Selection.near(doc.resolve(range.to), 1);
+      if (next.head <= pos) {
+        // Cannot make forward progress (e.g. the fold reaches the end of the
+        // doc); fall back to searching backwards.
+        break;
+      }
+      pos = next.head;
+    }
+  }
+
+  let pos = head;
+  for (let i = 0; i <= ranges.length; i++) {
+    const range = ranges.find((r) => pos > r.from && pos < r.to);
+    if (!range) {
+      return pos === head ? null : Selection.near(doc.resolve(pos), -1);
+    }
+    const previous = Selection.near(doc.resolve(range.from), -1);
+    if (previous.head >= pos) {
+      return null;
+    }
+    pos = previous.head;
+  }
+  return null;
+}
+
+const CHEVRON_PATH =
+  'M6.34 7.76 4.93 9.17 12 16.24l7.07-7.07-1.41-1.41L12 13.41 6.34 7.76Z';
+
+function createToggleWidget(
+  view: EditorView,
+  headingPos: number,
+  folded: boolean,
+  config: RequiredConfig,
+  toggleAtPos: (pos: number) => Command,
+): HTMLElement {
+  const wrapper = document.createElement('span');
+  wrapper.className = 'B-collapsible-heading-toggle-wrapper';
+  wrapper.contentEditable = 'false';
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'B-collapsible-heading-toggle';
+  button.tabIndex = -1;
+  button.setAttribute('aria-expanded', String(!folded));
+  button.setAttribute('data-folded', String(folded));
+  button.setAttribute(
+    'aria-label',
+    folded ? config.expandLabel : config.collapseLabel,
+  );
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('aria-hidden', 'true');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', CHEVRON_PATH);
+  path.setAttribute('fill', 'currentColor');
+  svg.appendChild(path);
+  button.appendChild(svg);
+
+  // Keep the editor selection/focus untouched while interacting with the
+  // toggle; the click is handled entirely through the fold command.
+  button.addEventListener('mousedown', (event) => {
+    event.preventDefault();
+  });
+  button.addEventListener('click', (event) => {
+    event.preventDefault();
+    toggleAtPos(headingPos)(view.state, view.dispatch);
+  });
+
+  wrapper.appendChild(button);
+  return wrapper;
+}

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -460,14 +460,16 @@ function buildPluginState(
     }
 
     const isFolded = foldedSet.has(pos);
+    // The toggle renders inline at the end of the heading text, keeping the
+    // left gutter free for the block drag handle.
     decorations.push(
       Decoration.widget(
-        pos + 1,
+        pos + node.nodeSize - 1,
         (view: EditorView) =>
           createToggleWidget(view, pos, isFolded, config, toggleAtPos),
         {
           key: `collapsible-heading:${pos}:${isFolded}`,
-          side: -1,
+          side: 1,
           ignoreSelection: true,
         },
       ),

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -15,6 +15,7 @@ import {
 import {
   findParentNodeOfType,
   getNodeType,
+  isNodeSelection,
   type KeyCode,
   type PluginContext,
 } from './pm-utils';
@@ -168,7 +169,9 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
           !pluginState.folded.includes(pos) &&
           // A heading already hidden inside another folded section is left
           // alone: folding it too would silently stack recursive fold state.
-          !pluginState.ranges.some((r) => pos > r.from && pos < r.to) &&
+          !pluginState.ranges.some((range) =>
+            isNodeStartInsideFoldedContent(pos, range),
+          ) &&
           getHeadingFoldRange(state.doc, pos, config.headingName)
         ) {
           targets.push(pos);
@@ -411,7 +414,7 @@ function pluginFold(
           }
           const state = view.state;
           const selection = state.selection;
-          if (!(selection instanceof NodeSelection)) {
+          if (!isNodeSelection(selection)) {
             return false;
           }
           const pluginState = key.getState(state);
@@ -517,6 +520,13 @@ function hiddenBlockDecorations(
     childPos += child.nodeSize;
   }
   return decorations;
+}
+
+function isNodeStartInsideFoldedContent(
+  pos: number,
+  range: HeadingFoldRange,
+): boolean {
+  return pos >= range.from && pos < range.to;
 }
 
 /**

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -456,26 +456,31 @@ function buildPluginState(
     }
 
     const range = getHeadingFoldRange(doc, pos, config.headingName);
-    if (!range) {
-      return false;
-    }
-
-    const isFolded = foldedSet.has(pos);
+    const foldable = range != null;
+    const isFolded = foldable && foldedSet.has(pos);
     // The toggle renders in the block's trailing slot — inline at the end
     // of the heading text — keeping the left gutter free for the block
     // drag handle. Other features can add their own trailing widgets
-    // alongside it.
+    // alongside it. Headings with nothing beneath them still show the
+    // toggle for visual consistency, but disabled.
     decorations.push(
       createTrailingWidget({
         node,
         pos,
-        key: `collapsible-heading:${pos}:${isFolded}`,
+        key: `collapsible-heading:${pos}:${isFolded}:${foldable}`,
         render: (view: EditorView) =>
-          createToggleButton(view, pos, isFolded, config, toggleAtPos),
+          createToggleButton(
+            view,
+            pos,
+            isFolded,
+            foldable,
+            config,
+            toggleAtPos,
+          ),
       }),
     );
 
-    if (!isFolded) {
+    if (!range || !isFolded) {
       return false;
     }
 
@@ -581,6 +586,7 @@ function createToggleButton(
   view: EditorView,
   headingPos: number,
   folded: boolean,
+  foldable: boolean,
   config: RequiredConfig,
   toggleAtPos: (pos: number) => Command,
 ): HTMLElement {
@@ -588,6 +594,7 @@ function createToggleButton(
   button.type = 'button';
   button.className = 'B-collapsible-heading-toggle';
   button.tabIndex = -1;
+  button.disabled = !foldable;
   button.setAttribute('aria-expanded', String(!folded));
   button.setAttribute('data-folded', String(folded));
   button.setAttribute(
@@ -604,15 +611,17 @@ function createToggleButton(
   svg.appendChild(path);
   button.appendChild(svg);
 
-  // Keep the editor selection/focus untouched while interacting with the
-  // toggle; the click is handled entirely through the fold command.
-  button.addEventListener('mousedown', (event) => {
-    event.preventDefault();
-  });
-  button.addEventListener('click', (event) => {
-    event.preventDefault();
-    toggleAtPos(headingPos)(view.state, view.dispatch);
-  });
+  if (foldable) {
+    // Keep the editor selection/focus untouched while interacting with the
+    // toggle; the click is handled entirely through the fold command.
+    button.addEventListener('mousedown', (event) => {
+      event.preventDefault();
+    });
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      toggleAtPos(headingPos)(view.state, view.dispatch);
+    });
+  }
 
   return button;
 }

--- a/packages/js-lib/banger-editor/src/drag/index.ts
+++ b/packages/js-lib/banger-editor/src/drag/index.ts
@@ -11,7 +11,7 @@ type DragConfig = {
   pluginOptions?: Partial<GlobalDragHandlePluginOptions> | undefined;
 };
 
-function defaultCalculateNodeOffset(args: NodeOffsetCalculationArgs) {
+export function defaultCalculateNodeOffset(args: NodeOffsetCalculationArgs) {
   const { node, rect, lineHeight, paddingTop } = args;
   const newRect = { ...rect };
 

--- a/packages/js-lib/banger-editor/src/drag/index.ts
+++ b/packages/js-lib/banger-editor/src/drag/index.ts
@@ -11,7 +11,7 @@ type DragConfig = {
   pluginOptions?: Partial<GlobalDragHandlePluginOptions> | undefined;
 };
 
-export function defaultCalculateNodeOffset(args: NodeOffsetCalculationArgs) {
+function defaultCalculateNodeOffset(args: NodeOffsetCalculationArgs) {
   const { node, rect, lineHeight, paddingTop } = args;
   const newRect = { ...rect };
 

--- a/packages/js-lib/banger-editor/src/heading.ts
+++ b/packages/js-lib/banger-editor/src/heading.ts
@@ -40,7 +40,6 @@ export type HeadingConfig = {
   keyEmptyCut?: KeyCode;
   keyInsertEmptyParaAbove?: KeyCode;
   keyInsertEmptyParaBelow?: KeyCode;
-  keyToggleCollapse?: KeyCode;
   keyJumpToStartOfHeading?: KeyCode;
   keyJumpToEndOfHeading?: KeyCode;
 };
@@ -65,7 +64,6 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyEmptyCut: false,
   keyInsertEmptyParaAbove: 'Mod-Shift-Enter',
   keyInsertEmptyParaBelow: 'Mod-Enter',
-  keyToggleCollapse: false,
   // TODO base keymap already handles these, it possible doesnt handle inline nodes (need to check)
   keyJumpToStartOfHeading: false,
   keyJumpToEndOfHeading: false,
@@ -85,9 +83,6 @@ export function setupHeading(userConfig?: HeadingConfig) {
         level: {
           default: 1,
         },
-        collapseContent: {
-          default: null,
-        },
       },
       content: 'inline*',
       group: 'block',
@@ -96,31 +91,13 @@ export function setupHeading(userConfig?: HeadingConfig) {
       parseDOM: config.levels.map((level) => {
         return {
           tag: `h${level}`,
-          getAttrs: (dom: HTMLElement) => {
-            const result = { level: parseLevel(level) };
-            const attrs = dom.getAttribute('data-bangle-attrs');
-
-            if (!attrs) {
-              return result;
-            }
-
-            const obj = JSON.parse(attrs);
-
-            return Object.assign({}, result, obj);
+          getAttrs: () => {
+            return { level: parseLevel(level) };
           },
         };
       }),
       toDOM: (node: PMNode) => {
-        const result: any = [`h${node.attrs.level}`, {}, 0];
-
-        if (node.attrs.collapseContent) {
-          result[1]['data-bangle-attrs'] = JSON.stringify({
-            collapseContent: node.attrs.collapseContent,
-          });
-          result[1].class = 'bangle-heading-collapsed';
-        }
-
-        return result;
+        return [`h${node.attrs.level}`, {}, 0];
       },
     },
   };

--- a/packages/js-lib/banger-editor/src/index.ts
+++ b/packages/js-lib/banger-editor/src/index.ts
@@ -35,5 +35,6 @@ export * from './suggestions';
 export * from './table';
 export * from './table-menu';
 export * from './trailing-node';
+export * from './trailing-slot';
 export * from './underline';
 export * from './wiki-link';

--- a/packages/js-lib/banger-editor/src/index.ts
+++ b/packages/js-lib/banger-editor/src/index.ts
@@ -4,6 +4,7 @@ export * from './blockquote';
 export * from './bold';
 export * from './code';
 export * from './code-block';
+export * from './collapsible-heading';
 export {
   type CollectionType,
   collection,

--- a/packages/js-lib/banger-editor/src/trailing-slot.ts
+++ b/packages/js-lib/banger-editor/src/trailing-slot.ts
@@ -1,0 +1,51 @@
+import { Decoration, type EditorView, type PMNode } from './pm';
+
+/**
+ * Shared styling hook for widgets that flow inline at the end of a block's
+ * text (fold toggles, future badges/affordances). The slot participates in
+ * inline layout, so on a wrapped block it sits at the end of the last line.
+ */
+export const BLOCK_TRAILING_SLOT_CLASS = 'B-block-trailing-slot';
+
+/**
+ * Builds a widget decoration anchored at the end of a textblock's inline
+ * content. Multiple features may each attach their own trailing widget to
+ * the same block: the decorations render side by side, in the order they
+ * are supplied, and share spacing via BLOCK_TRAILING_SLOT_CLASS.
+ *
+ * `render` returns the widget's content; returning null renders an empty
+ * slot. The slot itself is non-editable and invisible to the selection.
+ */
+export function createTrailingWidget({
+  node,
+  pos,
+  key,
+  render,
+}: {
+  /** The block node the widget trails. */
+  node: PMNode;
+  /** Position right before `node`. */
+  pos: number;
+  /** Stable widget identity; include anything that should force a redraw. */
+  key: string;
+  render: (view: EditorView) => HTMLElement | null;
+}): Decoration {
+  return Decoration.widget(
+    pos + node.nodeSize - 1,
+    (view: EditorView) => {
+      const slot = document.createElement('span');
+      slot.className = BLOCK_TRAILING_SLOT_CLASS;
+      slot.contentEditable = 'false';
+      const content = render(view);
+      if (content) {
+        slot.appendChild(content);
+      }
+      return slot;
+    },
+    {
+      key,
+      side: 1,
+      ignoreSelection: true,
+    },
+  );
+}

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -295,4 +295,26 @@ export const uiCommands = narrow([
     omniSearch: true,
     args: null,
   },
+
+  {
+    id: 'command::ui:toggle-heading-collapse',
+    title: 'Toggle Collapse Heading Section',
+    keywords: ['collapse', 'expand', 'fold', 'heading', 'section'],
+    dependencies: {
+      services: ['pmEditorService'],
+    },
+    omniSearch: true,
+    args: null,
+  },
+
+  {
+    id: 'command::ui:uncollapse-all-headings',
+    title: 'Expand All Heading Sections',
+    keywords: ['expand', 'uncollapse', 'unfold', 'heading', 'all', 'section'],
+    dependencies: {
+      services: ['pmEditorService'],
+    },
+    omniSearch: true,
+    args: null,
+  },
 ]);

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -317,4 +317,37 @@ export const uiCommands = narrow([
     omniSearch: true,
     args: null,
   },
+
+  {
+    id: 'command::ui:collapse-all-headings-1',
+    title: 'Collapse All Heading 1 Sections',
+    keywords: ['collapse', 'fold', 'heading', 'h1', 'all', 'section'],
+    dependencies: {
+      services: ['pmEditorService'],
+    },
+    omniSearch: true,
+    args: null,
+  },
+
+  {
+    id: 'command::ui:collapse-all-headings-2',
+    title: 'Collapse All Heading 2 Sections',
+    keywords: ['collapse', 'fold', 'heading', 'h2', 'all', 'section'],
+    dependencies: {
+      services: ['pmEditorService'],
+    },
+    omniSearch: true,
+    args: null,
+  },
+
+  {
+    id: 'command::ui:collapse-all-headings-3',
+    title: 'Collapse All Heading 3 Sections',
+    keywords: ['collapse', 'fold', 'heading', 'h3', 'all', 'section'],
+    dependencies: {
+      services: ['pmEditorService'],
+    },
+    omniSearch: true,
+    args: null,
+  },
 ]);

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -64,6 +64,10 @@ export const t = {
         copied: 'Copied',
         editLanguage: 'Edit language',
       },
+      collapsibleHeading: {
+        collapse: 'Collapse section',
+        expand: 'Expand section',
+      },
       wikiLinkMenu: {
         label: 'Link to a note',
         empty: 'No notes found',

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -316,3 +316,38 @@ test('the fold toggle trails the last line of a wrapped heading', async ({
   await heading.getByRole('button', { name: 'Expand section' }).click();
   await expect(editor.getByText('content below')).toBeVisible();
 });
+
+test('a heading with nothing beneath it shows a disabled toggle', async ({
+  page,
+}) => {
+  const workspaceName = 'collapsible-headings-empty';
+  const noteName = 'Home';
+  const source = ['# Empty', '', '# Full', '', 'content below'].join('\n');
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(page, workspaceName, noteName, source);
+  await page.reload();
+
+  const editor = getEditorLocator(page, {});
+  await expect(editor.getByText('content below')).toBeVisible();
+
+  const emptyToggle = editor
+    .locator('h1', { hasText: 'Empty' })
+    .getByRole('button', { name: 'Collapse section' });
+  const fullToggle = editor
+    .locator('h1', { hasText: 'Full' })
+    .getByRole('button', { name: 'Collapse section' });
+
+  await expect(emptyToggle).toBeDisabled();
+  await expect(fullToggle).toBeEnabled();
+
+  // Clicking the inert toggle folds nothing and touches nothing.
+  await emptyToggle.click({ force: true });
+  await expect(editor.getByText('content below')).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(source);
+
+  // The enabled sibling still folds normally.
+  await fullToggle.click();
+  await expect(editor.getByText('content below')).toBeHidden();
+});

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspaceAndNote,
+  getEditorLocator,
+  readStoredMarkdown,
+  waitForEditorFocus,
+  writeStoredMarkdown,
+} from './common';
+
+const SOURCE = [
+  '# One',
+  '',
+  'alpha',
+  '',
+  'beta',
+  '',
+  '## Sub',
+  '',
+  'nested content',
+  '',
+  '# Two',
+  '',
+  'gamma',
+].join('\n');
+
+async function openSeededNote(page: import('@playwright/test').Page) {
+  const workspaceName = 'collapsible-headings';
+  const noteName = 'Home';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(page, workspaceName, noteName, SOURCE);
+  await page.reload();
+
+  const editor = getEditorLocator(page, {});
+  await expect(editor.getByText('alpha')).toBeVisible();
+  return { editor, noteName, workspaceName };
+}
+
+test('folds and expands a heading section from the gutter toggle', async ({
+  page,
+}) => {
+  const { editor, noteName, workspaceName } = await openSeededNote(page);
+
+  // "One", "Sub", and "Two" all have content beneath them.
+  const collapseToggles = editor.getByRole('button', {
+    name: 'Collapse section',
+  });
+  await expect(collapseToggles).toHaveCount(3);
+
+  await collapseToggles.first().click();
+
+  // Everything under "# One" up to "# Two" is hidden, including the nested
+  // "## Sub" heading; the rest of the note stays visible.
+  await expect(editor.getByText('alpha')).toBeHidden();
+  await expect(editor.getByText('beta')).toBeHidden();
+  await expect(editor.getByText('Sub')).toBeHidden();
+  await expect(editor.getByText('nested content')).toBeHidden();
+  await expect(editor.getByText('One')).toBeVisible();
+  await expect(editor.getByText('gamma')).toBeVisible();
+
+  // Folding is a view concern: the stored Markdown must keep every byte.
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(SOURCE);
+
+  await editor.getByRole('button', { name: 'Expand section' }).click();
+  await expect(editor.getByText('alpha')).toBeVisible();
+  await expect(editor.getByText('nested content')).toBeVisible();
+});
+
+test('a folded note survives reload with no content lost', async ({ page }) => {
+  const { editor, noteName, workspaceName } = await openSeededNote(page);
+
+  await editor
+    .getByRole('button', { name: 'Collapse section' })
+    .first()
+    .click();
+  await expect(editor.getByText('alpha')).toBeHidden();
+
+  await page.reload();
+
+  // Fold state is per-session; after reload the full note is visible again
+  // and nothing was written back to storage.
+  const reloadedEditor = getEditorLocator(page, {});
+  await expect(reloadedEditor.getByText('alpha')).toBeVisible();
+  await expect(reloadedEditor.getByText('beta')).toBeVisible();
+  await expect(reloadedEditor.getByText('nested content')).toBeVisible();
+  await expect(reloadedEditor.getByText('gamma')).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(SOURCE);
+});
+
+test('the cursor cannot get stranded inside a folded section', async ({
+  page,
+}) => {
+  const { editor, noteName, workspaceName } = await openSeededNote(page);
+
+  await editor
+    .getByRole('button', { name: 'Collapse section' })
+    .first()
+    .click();
+  await expect(editor.getByText('alpha')).toBeHidden();
+
+  // Walk from the folded heading towards the hidden region and type: the
+  // text must land in visible content, not vanish into the fold.
+  await editor.getByText('One').click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.press('End');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.insertText('X');
+
+  await expect(editor.getByText('X', { exact: false })).toBeVisible();
+  await expect(editor.getByText('alpha')).toBeHidden();
+
+  // The folded content is still intact in storage alongside the new text.
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toContain('alpha');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toContain('X');
+});

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -265,3 +265,54 @@ test('collapse-all and expand-all heading commands work from omni search', async
     editor.getByRole('button', { name: 'Expand section' }),
   ).toHaveCount(0);
 });
+
+test('the fold toggle trails the last line of a wrapped heading', async ({
+  page,
+}) => {
+  const workspaceName = 'collapsible-headings-wrap';
+  const noteName = 'Home';
+  const longHeading = `# ${'really long heading that keeps going '.repeat(6)}and ends here`;
+  const source = [
+    longHeading,
+    '',
+    'content below',
+    '',
+    '# Next',
+    '',
+    'tail',
+  ].join('\n');
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(page, workspaceName, noteName, source);
+  await page.reload();
+
+  const editor = getEditorLocator(page, {});
+  const heading = editor.locator('h1').first();
+  await expect(heading).toContainText('and ends here');
+
+  const toggle = heading.getByRole('button', { name: 'Collapse section' });
+  const headingBox = await heading.boundingBox();
+  const toggleBox = await toggle.boundingBox();
+  if (!headingBox || !toggleBox) {
+    throw new Error('Expected the heading and its toggle to be visible');
+  }
+
+  // The heading wraps over multiple lines and the toggle flows with the
+  // inline content, so it sits on the LAST line — inside the heading box,
+  // in its bottom half — not floating beside the first line.
+  expect(headingBox.height).toBeGreaterThan(toggleBox.height * 3);
+  expect(toggleBox.y).toBeGreaterThan(headingBox.y + headingBox.height / 2);
+  expect(toggleBox.y + toggleBox.height).toBeLessThanOrEqual(
+    headingBox.y + headingBox.height + 1,
+  );
+
+  // Folding still works from the trailing toggle on a wrapped heading.
+  await toggle.click();
+  await expect(editor.getByText('content below')).toBeHidden();
+  await expect(editor.getByText('tail')).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(source);
+
+  await heading.getByRole('button', { name: 'Expand section' }).click();
+  await expect(editor.getByText('content below')).toBeVisible();
+});

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -1,7 +1,8 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import {
   createBrowserWorkspaceAndNote,
   getEditorLocator,
+  pressAppShortcut,
   readStoredMarkdown,
   waitForEditorFocus,
   writeStoredMarkdown,
@@ -23,7 +24,7 @@ const SOURCE = [
   'gamma',
 ].join('\n');
 
-async function openSeededNote(page: import('@playwright/test').Page) {
+async function openSeededNote(page: Page) {
   const workspaceName = 'collapsible-headings';
   const noteName = 'Home';
   await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
@@ -119,4 +120,147 @@ test('the cursor cannot get stranded inside a folded section', async ({
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
     .toContain('X');
+});
+
+test('dragging a folded heading moves the whole section without losing content', async ({
+  page,
+}) => {
+  const { editor, noteName, workspaceName } = await openSeededNote(page);
+
+  await editor
+    .getByRole('button', { name: 'Collapse section' })
+    .first()
+    .click();
+  await expect(editor.getByText('alpha')).toBeHidden();
+
+  // Reveal the drag handle by hovering the folded heading, then drive a
+  // native drag from the handle to below the last paragraph. Stepped moves
+  // with settled frames keep the HTML5 drag gesture from collapsing into a
+  // click.
+  const headingBox = await editor.getByText('One').boundingBox();
+  const gammaBox = await editor.getByText('gamma').boundingBox();
+  if (!headingBox || !gammaBox) {
+    throw new Error('Expected heading and drop target to be visible');
+  }
+  await page.mouse.move(
+    headingBox.x + headingBox.width / 2,
+    headingBox.y + headingBox.height / 2,
+  );
+  const handle = page.locator('[data-drag-handle]');
+  await expect(handle).toBeVisible();
+  const handleBox = await handle.boundingBox();
+  if (!handleBox) {
+    throw new Error('Expected the drag handle to be visible');
+  }
+
+  const startX = handleBox.x + handleBox.width / 2;
+  const startY = handleBox.y + handleBox.height / 2;
+  const dropX = gammaBox.x + gammaBox.width / 2;
+  const dropY = gammaBox.y + gammaBox.height + 12;
+  const settleFrame = () => page.waitForTimeout(60);
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await settleFrame();
+  await page.mouse.move(startX, startY - 8);
+  await settleFrame();
+  await page.mouse.move((startX + dropX) / 2, (startY + dropY) / 2);
+  await settleFrame();
+  await page.mouse.move(dropX, dropY);
+  await settleFrame();
+  await page.mouse.move(dropX, dropY);
+  await settleFrame();
+  await page.mouse.up();
+
+  // The whole section travelled: it is still folded at its new home and
+  // nothing is missing once expanded.
+  await expect(editor.getByText('One')).toBeVisible();
+  await expect(editor.getByText('alpha')).toBeHidden();
+  await expect
+    .poll(async () => {
+      const markdown =
+        (await readStoredMarkdown(page, workspaceName, noteName)) ?? '';
+      return (
+        markdown.indexOf('gamma') !== -1 &&
+        markdown.indexOf('gamma') < markdown.indexOf('# One')
+      );
+    })
+    .toBe(true);
+  const movedMarkdown =
+    (await readStoredMarkdown(page, workspaceName, noteName)) ?? '';
+  for (const line of ['alpha', 'beta', '## Sub', 'nested content', 'gamma']) {
+    expect(movedMarkdown).toContain(line);
+  }
+
+  await editor.getByRole('button', { name: 'Expand section' }).click();
+  await expect(editor.getByText('alpha')).toBeVisible();
+  await expect(editor.getByText('nested content')).toBeVisible();
+});
+
+test('nested folds survive folding and unfolding the outer section', async ({
+  page,
+}) => {
+  const { editor } = await openSeededNote(page);
+  const collapseToggles = editor.getByRole('button', {
+    name: 'Collapse section',
+  });
+
+  // Fold the inner "## Sub" first (toggles are in document order).
+  await collapseToggles.nth(1).click();
+  await expect(editor.getByText('nested content')).toBeHidden();
+  await expect(editor.getByText('beta')).toBeVisible();
+
+  // Fold the enclosing "# One": everything under it hides, including Sub.
+  await collapseToggles.first().click();
+  await expect(editor.getByText('alpha')).toBeHidden();
+  await expect(editor.getByText('Sub')).toBeHidden();
+
+  // Unfold "# One": Sub comes back still folded.
+  await editor.getByRole('button', { name: 'Expand section' }).first().click();
+  await expect(editor.getByText('Sub')).toBeVisible();
+  await expect(editor.getByText('alpha')).toBeVisible();
+  await expect(editor.getByText('nested content')).toBeHidden();
+
+  // Unfold "## Sub": back exactly where we started.
+  await editor.getByRole('button', { name: 'Expand section' }).first().click();
+  await expect(editor.getByText('nested content')).toBeVisible();
+  await expect(
+    editor.getByRole('button', { name: 'Expand section' }),
+  ).toHaveCount(0);
+});
+
+test('collapse-all and expand-all heading commands work from omni search', async ({
+  page,
+}) => {
+  const { editor } = await openSeededNote(page);
+  await editor.getByText('gamma').click();
+  await waitForEditorFocus(page, {});
+
+  await pressAppShortcut(page, 'k');
+  const commandInput = page.getByPlaceholder('Type a command or search...');
+  await commandInput.fill('Collapse All Heading 1');
+  await page.keyboard.press('Enter');
+
+  // Both level-1 sections fold; the nested "## Sub" hides with One's section
+  // but must not gain fold state of its own.
+  await expect(editor.getByText('alpha')).toBeHidden();
+  await expect(editor.getByText('beta')).toBeHidden();
+  await expect(editor.getByText('Sub')).toBeHidden();
+  await expect(editor.getByText('nested content')).toBeHidden();
+  await expect(editor.getByText('gamma')).toBeHidden();
+  await expect(editor.getByText('One')).toBeVisible();
+  await expect(editor.getByText('Two')).toBeVisible();
+
+  await pressAppShortcut(page, 'k');
+  await commandInput.fill('Expand All Heading Sections');
+  await page.keyboard.press('Enter');
+
+  // Everything is visible again — expand-all also proves collapse-all did
+  // not recursively fold "## Sub" (it comes back expanded).
+  for (const text of ['alpha', 'beta', 'Sub', 'nested content', 'gamma']) {
+    await expect(editor.getByText(text)).toBeVisible();
+  }
+  await expect(
+    editor.getByRole('button', { name: 'Expand section' }),
+  ).toHaveCount(0);
 });

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -162,7 +162,8 @@ test('dragging a folded heading moves the whole section without losing content',
   await page.mouse.move(startX, startY);
   await page.mouse.down();
   await settleFrame();
-  await page.mouse.move(startX, startY - 8);
+  // Wiggle towards the drop target to start the drag.
+  await page.mouse.move(startX, startY + 8);
   await settleFrame();
   await page.mouse.move((startX + dropX) / 2, (startY + dropY) / 2);
   await settleFrame();

--- a/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
@@ -70,12 +70,15 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
 
     await editorHandle.pressSequentially('# Merry Christmas', { delay: 30 });
     const text = await getEditorText(page, {});
-    expect(text).toBe('Merry Christmas');
+    // The heading's trailing fold-toggle widget makes ProseMirror keep an
+    // invisible trailing break, which innerText reports as trailing
+    // newlines; the rendered text is unchanged.
+    expect(text.trimEnd()).toBe('Merry Christmas');
   });
 
   await test.step('verify persistence after reload', async () => {
     await page.reload({ waitUntil: 'networkidle' });
     const textAfterReload = await getEditorText(page, {});
-    expect(textAfterReload).toBe('Merry Christmas');
+    expect(textAfterReload.trimEnd()).toBe('Merry Christmas');
   });
 });

--- a/plans/010-collapsible-headings.md
+++ b/plans/010-collapsible-headings.md
@@ -60,6 +60,15 @@ below for why). Shipped on this branch:
 - Fold state is intentionally per-session (resets on reload); nothing is ever
   written to the `.md`. Persisting fold state outside the note remains
   possible future work.
+- Per-level commands: `command::ui:collapse-all-headings-1/2/3` fold every
+  heading of that level without recursively folding deeper headings (a
+  heading already hidden inside a folded section is skipped). Nested fold
+  state composes: folding an outer section preserves inner folds, so
+  unfolding restores the previous view.
+- Dragging a folded heading (via the block drag handle) moves the entire
+  hidden section with it and re-folds at the destination, preserving nested
+  fold state — the plugin intercepts `handleDrop` and rebuilds the move,
+  since the default drop would relocate only the heading node.
 
 Verification: unit specs in
 `packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts`

--- a/plans/010-collapsible-headings.md
+++ b/plans/010-collapsible-headings.md
@@ -50,10 +50,18 @@ below for why). Shipped on this branch:
 - The legacy `collapseContent` scaffold (attribute, `data-bangle-attrs`
   DOM blob, dormant `HeadingConfig.keyToggleCollapse`) was **removed** from
   `heading.ts` — it was a latent data-loss path.
+- The toggle renders through a small reusable primitive,
+  `createTrailingWidget` in
+  `packages/js-lib/banger-editor/src/trailing-slot.ts`: an inline widget slot
+  at the end of a block's text (`# heading ›`). It flows with the inline
+  content, so on a wrapped heading it trails the last line, and it leaves the
+  left gutter entirely to the block drag handle (an earlier gutter-stacked
+  design broke drag-node targeting). Future features can attach their own
+  trailing affordances to any block through the same helper; multiple slots
+  render side by side.
 - App wiring: `collapsibleHeading` extension in
-  `packages/core/editor/src/extensions.ts` (labels via translations), gutter
-  styles in `typography.css` (the drag handle shifts one slot left on headings
-  so both affordances coexist), omni-search commands
+  `packages/core/editor/src/extensions.ts` (labels via translations), slot and
+  toggle styles in `typography.css`, omni-search commands
   `command::ui:toggle-heading-collapse` and
   `command::ui:uncollapse-all-headings` with handlers calling
   `PmEditorService.toggleHeadingCollapse()` / `.uncollapseAllHeadings()`.

--- a/plans/010-collapsible-headings.md
+++ b/plans/010-collapsible-headings.md
@@ -1,0 +1,249 @@
+---
+title: Collapsible Headings (fold / unfold sections)
+status: completed
+type: plan
+archived: false
+archived_on:
+created: 2026-07-03
+updated: 2026-07-03
+owner: agent
+related_prs: []
+related_issues: []
+---
+
+# Collapsible Headings
+
+## Summary
+
+Bring back the ability to collapse and uncollapse a heading — clicking a caret
+next to a heading hides every block beneath it up to the next heading of the
+same or higher level, and clicking again restores it. This existed in the
+pre-rewrite app and was dropped during the rewrite. This plan is a guide for a
+future implementer: it frames the real decisions, points at the references
+worth studying, and flags the one trap that can corrupt user notes. It does not
+prescribe code.
+
+The product target is deliberately narrow: fold/unfold sections of a single
+Markdown note for readability. It is **not** toggle/"details" blocks, not
+arbitrary collapsible containers, not an outline panel. Folding is a *view*
+affordance over ordinary Markdown headings; the stored note must stay ordinary
+Markdown.
+
+## Current status
+
+Implemented with **Option B** (view-only folding; see the decision section
+below for why). Shipped on this branch:
+
+- `packages/js-lib/banger-editor/src/collapsible-heading.ts` — a new
+  `setupCollapsibleHeading` collection: fold-range computation
+  (`getHeadingFoldRange`), plugin state holding folded heading positions
+  (mapped through transactions), node decorations that conceal folded blocks
+  (`display: none` via class, nodeViews stay mounted), a widget-decoration
+  chevron button per foldable heading, commands
+  (`toggleHeadingCollapse`, `toggleHeadingCollapseAtPos`,
+  `uncollapseAllHeadings`), queries, and an optional `keyToggleCollapse`
+  keybinding config.
+- Safety behavior: an `appendTransaction` guard pushes a cursor out of hidden
+  regions on selection-only moves, and **auto-unfolds** a section when a doc
+  edit lands inside it (e.g. Enter at the end of a folded heading) so typing
+  can never become invisible. Deleting a folded heading reveals its content.
+- The legacy `collapseContent` scaffold (attribute, `data-bangle-attrs`
+  DOM blob, dormant `HeadingConfig.keyToggleCollapse`) was **removed** from
+  `heading.ts` — it was a latent data-loss path.
+- App wiring: `collapsibleHeading` extension in
+  `packages/core/editor/src/extensions.ts` (labels via translations), gutter
+  styles in `typography.css` (the drag handle shifts one slot left on headings
+  so both affordances coexist), omni-search commands
+  `command::ui:toggle-heading-collapse` and
+  `command::ui:uncollapse-all-headings` with handlers calling
+  `PmEditorService.toggleHeadingCollapse()` / `.uncollapseAllHeadings()`.
+- Fold state is intentionally per-session (resets on reload); nothing is ever
+  written to the `.md`. Persisting fold state outside the note remains
+  possible future work.
+
+Verification: unit specs in
+`packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts`
+(fold ranges, toggle/unfold-all, selection guard, auto-unfold, doc
+invariance), Markdown round-trip specs in
+`packages/core/editor/src/__tests__/collapsible-heading-markdown.spec.ts`
+(byte-for-byte serialization with sections folded), and Playwright E2E in
+`packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts` (fold/expand via
+the gutter toggle, reload data-safety, cursor-stranding). `pnpm lint:ci`,
+`pnpm test:ci`, `pnpm e2e:ci`, and `pnpm build` pass; a manual
+playwright-cli smoke pass covered hover affordance, level scoping,
+omni-search commands, reload persistence, and console cleanliness.
+
+## The one decision that matters: where does "hidden" live?
+
+There are two families of implementation, and they differ in exactly one way —
+whether the collapsed state is part of the document or not. Everything else
+(carets, animation, keymaps) is downstream of this choice. Teach yourself the
+tradeoff before touching code.
+
+**Option A — content lives in a node attribute (the legacy / scaffolded path).**
+The legacy mechanism moved the hidden sibling blocks *out of the document* and
+stored them, serialized, inside the heading's `collapseContent` attribute; the
+current schema is the residue of that. This makes collapse durable across
+reloads for free and needs no side channel. Its fatal risk is Markdown
+fidelity: the hidden blocks are no longer normal document nodes, so a naive
+serializer drops them — which is precisely the state the code is in now. Under
+this option, **saving a note with a collapsed heading silently deletes the
+folded content from the `.md` file.** That directly violates Core Priority 1
+(protect user data) and 2 (Markdown fidelity). If you keep this path you must
+prove — with round-trip tests — that folded content survives
+serialize→parse→reload byte-for-byte, and decide what a *non-Bangle* Markdown
+tool (or a git diff) sees when it opens that file. There likely is no honest
+Markdown representation of "content hidden inside a heading attribute," which is
+the strongest argument against Option A.
+
+**Option B — content stays in the document; only the *view* hides it.**
+The blocks remain ordinary siblings in the doc and in the Markdown. Folding is a
+transient decoration/plugin state that hides them visually (CSS `hidden` /
+class), keyed by heading identity. Markdown output is untouched, so fidelity is
+free and there is nothing to migrate. The cost: fold state is view-state, so if
+you want it to survive reload you persist a small map **outside the note**
+(local view-state / IndexedDB keyed by workspace path + heading), never in the
+`.md`. This keeps the note as the single source of truth and treats folding as
+what it actually is — a reading preference.
+
+Recommendation to weigh, not obey: Option B fits this app's priorities better
+(durable Markdown, view concerns out of content). If you choose it, the existing
+`collapseContent` attribute and its `toDOM`/`parseDOM`/`data-bangle-attrs`
+handling should probably be **removed**, not extended — leaving it in place is a
+latent data-loss bug even if the toggle is never shipped. Confirm that judgement
+against the legacy behaviour before deleting.
+
+## Where to draw inspiration
+
+Three editors were surveyed for this feature. The blunt finding: **none of them
+implement true heading-based folding.** That is itself the lesson — this is a
+slightly unusual feature, and the legacy Bangle implementation is the closest
+prior art that exists. Study these for the *sub-problems*, not for a drop-in
+design.
+
+- **Legacy Bangle (this repo's own history) — the primary reference.** The last
+  commit that shipped the working feature is `d97008e7` ("fix core palettetest
+  (#447)", 2023-09-24), immediately before the rewrite commit `6cc66f40`
+  ("setup things") deleted it. Read:
+  - `lib/editor-plugins/collapsible-heading-deco.ts` — the ~160-line decoration
+    plugin that rendered clickable SVG chevrons and, on click, called
+    `heading.toggleHeadingCollapse()`. Note it also coupled to an
+    intersection-observer plugin to avoid decorating off-screen headings — a
+    perf tactic worth understanding before copying, since the rewrite's editor
+    may not carry that infrastructure.
+  - `extensions/core-editor/index.ts` — the command wiring
+    (`operation::@bangle.io/core-editor:collapse-heading` and
+    `:uncollapse-all-heading`), which is the shape the new command layer
+    (`packages/shared/commands` + `packages/core/command-handlers`) should
+    mirror.
+  - The actual fold logic (`toggleHeadingCollapse`, `listCollapsedHeading`,
+    `uncollapseAllHeadings`) lived in `@bangle.dev/base-components`, not in the
+    repo. This is where the `collapseContent`-attribute mechanism came from —
+    trace it there before assuming how it behaved, especially around Markdown.
+
+- **TipTap's `Details` extension (`@tiptap/extension-details`) — best source for
+  the hard edge cases**, even though it is a *container* toggle block, not
+  heading folding. Two ideas transfer regardless of which option you pick:
+  1. **A `persist` flag that switches the same feature between "view-only"
+     (state not in the doc) and "durable" (state as a node attribute).** This is
+     exactly the Option A/B axis above, made concrete — a clean way to reason
+     about it even if you don't expose the flag.
+  2. **The bookkeeping folding forces on you:** a selection-correction plugin
+     (via `appendTransaction`) that pushes the cursor *out* of hidden content
+     when arrow keys or a click would strand it inside a collapsed region, and a
+     reusable `isNodeVisible` helper (`offsetParent !== null`) instead of ad-hoc
+     visibility checks. ProseMirror does not natively know that in-document
+     content is visually hidden; whichever option you choose, you inherit this
+     problem and TipTap has already solved it well. It also hides via a `hidden`
+     attribute + CSS rather than `display:none`/node removal, keeping the
+     nodeView stable.
+
+- **ProseKit — no fold feature, but two small transferable habits.** Debounced
+  hover-state diffing so the caret doesn't flicker as the pointer crosses gaps
+  between blocks, and gating expand/collapse animation on
+  `prefers-reduced-motion`. Its block-handle also demonstrates anchoring an
+  affordance as a floating overlay tracked to a DOM rect instead of a widget
+  decoration — an option if chevron re-render cost becomes a problem, at the
+  price of manual rect tracking on scroll/resize.
+
+- A fourth reference examined (a reverse-engineered capture of a proprietary
+  Markdown editor) had **no** collapsible-heading feature; its heading node is
+  stock. Nothing to borrow for this specifically. (Describe it generically in
+  any durable artifact; do not name it.)
+
+Takeaway from the survey: the mainstream pattern in other editors is a *toggle
+container node*, which restructures the document and changes the serialized
+output. That is the wrong shape for a Markdown-durable note app. Heading-level
+folding as a pure view concern (Option B) is the less-travelled but better-fit
+path here.
+
+## Rough shape of the work (not prescriptive)
+
+Enough detail to plan, not enough to skip thinking:
+
+1. Decide Option A vs B and reconcile the existing `collapseContent` scaffold
+   accordingly (extend it, or remove it — do not ignore it).
+2. Fold engine in `packages/js-lib/banger-editor` next to `heading.ts`,
+   composed the way `table/` and other features are (schema/plugin/command/query
+   split). It needs: "given a heading, find its folded range up to the next
+   same-or-higher heading," a toggle, an "uncollapse all," and a query for
+   current state. The range computation is the core logic and deserves the most
+   unit tests.
+3. The caret affordance — reuse the existing decoration/`hover.ts`/
+   `selection-menu` patterns already in `banger-editor` rather than inventing a
+   new overlay system.
+4. Commands + keybinding surfaced through `packages/shared/commands` and
+   `packages/core/command-handlers`, mirroring the legacy operation IDs, and
+   honouring the dormant `keyToggleCollapse` config.
+5. Selection/keyboard correctness around hidden regions (the TipTap lesson).
+6. Persistence, only if desired, via view-state outside the note (Option B) —
+   never by writing fold state into the `.md`.
+
+## Out of scope
+
+- Toggle/"details" blocks or any new collapsible container node.
+- Folding lists, code blocks, or arbitrary blocks — headings only.
+- An outline / table-of-contents panel.
+- Persisting fold state inside the Markdown file under any option.
+
+## Verification
+
+Per the root `AGENTS.md`, a released feature needs committed Playwright
+coverage, and data-path changes need failure/round-trip coverage. At minimum:
+
+- **Markdown round-trip unit tests (non-negotiable):** a note with one or more
+  collapsed headings must serialize→parse→reload with the folded content intact,
+  byte-for-byte. This is the test that catches the current scaffold's data-loss
+  behaviour; write it first and watch it fail before fixing.
+- Unit tests for the fold-range computation: nested levels, a heading with no
+  following content, trailing content after the last heading, adjacent headings,
+  and folding while the cursor sits inside the region.
+- A Playwright E2E proving the user-visible workflow: create a Browser
+  workspace + note, fold a heading, assert the content is hidden, **reload**,
+  and assert both the fold behaviour and — critically — that no content was
+  lost. Cover the persistence path you chose.
+- Keyboard/selection behaviour: cursor cannot get stranded inside a collapsed
+  region via arrow keys or click.
+
+## Known blockers / risks
+
+- **Data loss via serialization (highest risk).** The current
+  `collapseContent` path drops folded content from Markdown. Any Option-A design
+  must close this before shipping; the round-trip test above is the gate.
+- **Missing perf infrastructure.** The legacy plugin leaned on an
+  intersection-observer plugin the rewritten editor may not have. Confirm what
+  exists before porting the decoration wholesale.
+- **Legacy behaviour is partly in `@bangle.dev/base-components`, not this repo.**
+  Reconstructing exact semantics means reading that dependency, not just
+  `d97008e7`.
+
+## Next steps
+
+1. Read `d97008e7:lib/editor-plugins/collapsible-heading-deco.ts` and
+   `d97008e7:extensions/core-editor/index.ts`, and trace
+   `toggleHeadingCollapse`/`listCollapsedHeading` into
+   `@bangle.dev/base-components` to pin down the legacy mechanism.
+2. Write the failing Markdown round-trip test against the current scaffold to
+   make the data-loss concrete.
+3. Choose Option A vs B (recommend B) and reconcile the `collapseContent`
+   scaffold before building anything new.


### PR DESCRIPTION
## What

Brings back collapsible headings, dropped during the rewrite (implements `plans/010-collapsible-headings.md`). Every heading with content beneath it gets a hover-revealed chevron in the left gutter; clicking it folds everything up to the next heading of the same or higher level. Also available as omni-search commands (**Toggle Collapse Heading Section**, **Expand All Heading Sections**).

## Why this design (Option B from the plan)

Folding is strictly a **view concern**: fold state lives in ProseMirror plugin state and decorations, the document is never mutated, and the serialized Markdown stays byte-for-byte identical. Fold state intentionally resets on reload. The plan's alternative (the legacy `collapseContent` node attribute) has no honest Markdown representation and silently deleted folded content on save — that scaffold is **removed** from `heading.ts` in this PR as a latent data-loss bug.

## Notable behavior

- **Nothing can vanish**: a cursor moving into a hidden region is pushed out; an edit landing inside a folded region (e.g. Enter at the end of a folded heading) auto-unfolds it; deleting a folded heading reveals its content.
- Level scoping: folding an H2 stops at the next H1/H2; folding an H1 swallows nested H2 sections.
- The block drag handle shifts one gutter slot left on headings so both affordances coexist without overlap.
- Fold engine is a self-contained `setupCollapsibleHeading` collection in `banger-editor` (schema-free: plugin + commands + queries), wired in `core/editor` with translated labels and `PmEditorService` methods for the command handlers.

## Reviewer notes

- The one risky change is the `heading.ts` scaffold removal — `collapseContent` attr and `data-bangle-attrs` parse/serialize are gone. Nothing else referenced them (verified by grep); the round-trip specs guard the serializer.
- Fold persistence across reloads is deliberately out of scope (would need view-state storage outside the note; plan documents this as possible future work).

## Testing

- `pnpm lint:ci`, `pnpm test:ci` (1199 passed), `pnpm e2e:ci`, `pnpm build` all pass.
- New unit specs: fold-range computation (nested levels, adjacent headings, trailing content), toggle/unfold-all, selection guard, auto-unfold, doc invariance (`packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts`).
- New Markdown round-trip specs proving byte-for-byte serialization with sections folded (`packages/core/editor/src/__tests__/collapsible-heading-markdown.spec.ts`).
- New Playwright E2E: fold/expand via the gutter toggle, reload with zero data loss, cursor cannot get stranded (`packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts`).
- Manual playwright-cli smoke pass against the dev server: hover affordance + drag-handle spacing, level scoping, omni-search commands, reload persistence, Enter-on-folded-heading, console cleanliness — all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)