### PR TITLE
[codex] Restrict Dependabot to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,15 @@ updates:
     schedule:
       interval: 'daily'
     versioning-strategy: 'increase-if-necessary'
-    open-pull-requests-limit: 10
+    # Disable routine version-update PRs while still allowing Dependabot
+    # security updates when they are enabled in repository settings.
+    open-pull-requests-limit: 0
     commit-message:
       prefix: 'chore(deps)'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
+    # Disable routine version-update PRs while still allowing Dependabot
+    # security updates when they are enabled in repository settings.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- disable routine npm and GitHub Actions Dependabot version-update PRs with `open-pull-requests-limit: 0`
- keep the config entries so Dependabot security update settings can still apply

## Validation
- `git diff --check`
- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm local-ci-check`

## Notes
`pnpm local-ci-check` was run on the same `origin/main` + Dependabot-config diff before this matching origin PR was opened.