### PR TITLE
[codex] support multi-file explorer actions

### DIFF
--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -48,7 +48,10 @@ export const AppSidebar = ({ children }: SidebarProps) => {
 
   const getActionsForEntry = useMemo(
     () =>
-      (entry: FileTreeEntry): FileTreeEntryAction[] => {
+      (
+        entry: FileTreeEntry,
+        selectedEntries: readonly FileTreeEntry[],
+      ): FileTreeEntryAction[] => {
         const actions: FileTreeEntryAction[] = [];
         const getFileWsPath = (relativePath: string) =>
           activeWsName
@@ -66,7 +69,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             id: 'new-note-here',
             label: t.app.components.appSidebar.newNoteHereActionTitle,
             Icon: PlusIcon,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               commandDispatcher.dispatch(
                 'command::ws:quick-new-note',
                 {
@@ -81,7 +84,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             id: 'new-folder-here',
             label: t.app.components.appSidebar.newFolderHereActionTitle,
             Icon: FolderPlus,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               commandDispatcher.dispatch(
                 'command::ui:create-directory-dialog',
                 {
@@ -126,13 +129,40 @@ export const AppSidebar = ({ children }: SidebarProps) => {
 
         const wsPath = getFileWsPath(entry.path);
         const filePath = wsPath ? WsPath.safeParseFile(wsPath).data : undefined;
+        const selectedFileWsPaths = [
+          ...new Set(
+            selectedEntries
+              .filter((selectedEntry) => selectedEntry.kind === 'file')
+              .map((selectedEntry) => getFileWsPath(selectedEntry.path))
+              .filter((selectedWsPath): selectedWsPath is string =>
+                Boolean(selectedWsPath),
+              ),
+          ),
+        ];
+        const pushDeleteSelectedFilesAction = () => {
+          actions.push({
+            id: 'delete-selected-files',
+            label: t.app.components.appSidebar.deleteSelectedFilesActionTitle({
+              count: selectedFileWsPaths.length,
+            }),
+            Icon: Trash2,
+            variant: 'destructive' as const,
+            onClick: () => {
+              commandDispatcher.dispatch(
+                'command::ui:delete-files-dialog',
+                { wsPaths: selectedFileWsPaths },
+                'ui',
+              );
+            },
+          });
+        };
 
         if (filePath) {
           actions.push({
             id: 'copy-path',
             label: t.app.components.appSidebar.copyPathActionTitle,
             Icon: Copy,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               const wsPath = getFileWsPath(entry.path);
               if (!wsPath) {
                 return;
@@ -151,7 +181,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             id: 'open',
             label: t.app.components.appSidebar.openActionTitle,
             Icon: ExternalLink,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               const wsPath = getFileWsPath(entry.path);
               if (!wsPath) {
                 return;
@@ -168,7 +198,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             id: 'rename-file',
             label: t.app.components.appSidebar.renameActionTitle,
             Icon: Pencil,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               const wsPath = getFileWsPath(entry.path);
               if (!wsPath) {
                 return;
@@ -181,12 +211,18 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             },
           });
 
+          if (selectedFileWsPaths.length > 1) {
+            pushDeleteSelectedFilesAction();
+
+            return actions;
+          }
+
           actions.push({
             id: 'delete-file',
             label: t.app.components.appSidebar.deleteActionTitle,
             Icon: Trash2,
             variant: 'destructive' as const,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               const wsPath = getFileWsPath(entry.path);
               if (!wsPath) {
                 return;
@@ -203,11 +239,17 @@ export const AppSidebar = ({ children }: SidebarProps) => {
         }
 
         if (filePath?.isNote()) {
+          if (selectedFileWsPaths.length > 1) {
+            pushDeleteSelectedFilesAction();
+
+            return actions;
+          }
+
           actions.push({
             id: 'rename',
             label: t.app.components.appSidebar.renameActionTitle,
             Icon: Pencil,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               const wsPath = getFileWsPath(entry.path);
               if (!wsPath) {
                 return;
@@ -224,7 +266,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             id: 'move',
             label: t.app.components.appSidebar.moveActionTitle,
             Icon: Move,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               const wsPath = getFileWsPath(entry.path);
               if (!wsPath) {
                 return;
@@ -242,7 +284,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             label: t.app.components.appSidebar.deleteActionTitle,
             Icon: Trash2,
             variant: 'destructive' as const,
-            onClick: (entry) => {
+            onClick: ({ entry }) => {
               const wsPath = getFileWsPath(entry.path);
               if (!wsPath) {
                 return;
@@ -312,10 +354,9 @@ export const AppSidebar = ({ children }: SidebarProps) => {
           commandDispatcher.dispatch(
             'command::ws:move-ws-path',
             {
-              destDirWsPath: WsDirPath.fromParts(
-                activeWsName,
-                destinationDirectory ?? '',
-              ).wsPath,
+              destDirWsPath: destinationDirectory
+                ? WsDirPath.fromParts(activeWsName, destinationDirectory).wsPath
+                : `${activeWsName}:`,
               wsPath: WsPath.fromParts(activeWsName, sourceRelativePath).wsPath,
             },
             'ui',

--- a/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ui-handlers.spec.ts
@@ -244,6 +244,45 @@ describe('UI command handlers', () => {
     });
   });
 
+  describe('command::ui:delete-files-dialog', () => {
+    it('confirms selected file deletion and dispatches a batch delete', async () => {
+      const { dispatch, testEnv, services, getCommandResults } =
+        await setupTest({
+          targetId: 'command::ui:delete-files-dialog',
+          workspaces: [
+            {
+              name: 'test-ws',
+              notes: ['test-ws:first.md', 'test-ws:second.md'],
+            },
+          ],
+          autoNavigate: 'workspace',
+        });
+
+      dispatch('command::ui:delete-files-dialog', {
+        wsPaths: ['test-ws:first.md', 'test-ws:second.md'],
+      });
+
+      const alertDialog = testEnv.store.get(
+        services.workbenchState.$alertDialog,
+      );
+      expect(alertDialog).toBeDefined();
+      expect(alertDialog?.dialogId).toBe('dialog::delete-files-alert');
+      expect(alertDialog?.title).toBe(t.app.dialogs.confirmDeleteFiles.title);
+      expect(alertDialog?.description).toContain('first.md');
+      expect(alertDialog?.description).toContain('second.md');
+
+      alertDialog?.onContinue?.();
+
+      await vi.waitFor(() => {
+        expect(
+          getCommandResults()
+            .filter((result) => result.type === 'success')
+            .map((result) => result.command.id),
+        ).toContain('command::ws:delete-ws-paths');
+      });
+    });
+  });
+
   describe('command::ui:rename-note-dialog', () => {
     it('should open the rename note dialog and dispatch command::ws:rename-ws-path on new name', async () => {
       const { dispatch, testEnv, services, getCommandResults } =

--- a/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
@@ -83,6 +83,40 @@ describe('WS command handlers', () => {
     });
   });
 
+  describe('command::ws:delete-ws-paths', () => {
+    test('deletes selected files in one durable batch', async () => {
+      const FIRST_WS_PATH = 'test-ws:first.md';
+      const SECOND_WS_PATH = 'test-ws:nested/second.md';
+      const KEEP_WS_PATH = 'test-ws:keep.md';
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ws:delete-ws-paths',
+        workspaces: [
+          {
+            name: 'test-ws',
+            notes: [FIRST_WS_PATH, SECOND_WS_PATH, KEEP_WS_PATH],
+          },
+        ],
+        autoNavigate: 'workspace',
+      });
+
+      dispatch('command::ws:delete-ws-paths', {
+        wsPaths: [FIRST_WS_PATH, SECOND_WS_PATH],
+      });
+
+      await vi.waitFor(async () => {
+        await expect(
+          services.fileSystem.readFile(FIRST_WS_PATH),
+        ).resolves.toBeUndefined();
+        await expect(
+          services.fileSystem.readFile(SECOND_WS_PATH),
+        ).resolves.toBeUndefined();
+        await expect(
+          services.fileSystem.readFile(KEEP_WS_PATH),
+        ).resolves.toBeDefined();
+      });
+    });
+  });
+
   describe('command::ws:rename-ws-path', () => {
     test('reports storage rename failures before navigating to the destination', async () => {
       const SOURCE_WS_PATH = 'test-ws:source.md';
@@ -121,6 +155,30 @@ describe('WS command handlers', () => {
   });
 
   describe('command::ws:move-ws-path', () => {
+    test('normalizes slash root destination when moving a nested file to workspace root', async () => {
+      const SOURCE_WS_PATH = 'test-ws:folder/source.md';
+      const DESTINATION_WS_PATH = 'test-ws:source.md';
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ws:move-ws-path',
+        workspaces: [{ name: 'test-ws', notes: [SOURCE_WS_PATH] }],
+        autoNavigate: 'workspace',
+      });
+
+      dispatch('command::ws:move-ws-path', {
+        destDirWsPath: 'test-ws:/',
+        wsPath: SOURCE_WS_PATH,
+      });
+
+      await vi.waitFor(async () => {
+        await expect(
+          services.fileSystem.readFile(SOURCE_WS_PATH),
+        ).resolves.toBeUndefined();
+        await expect(
+          services.fileSystem.readFile(DESTINATION_WS_PATH),
+        ).resolves.toBeDefined();
+      });
+    });
+
     test('reports storage move failures before navigating to the destination', async () => {
       const SOURCE_WS_PATH = 'test-ws:source.md';
       const DESTINATION_DIR_WS_PATH = 'test-ws:archive/';

--- a/packages/core/command-handlers/src/ui-handlers/note-management.ts
+++ b/packages/core/command-handlers/src/ui-handlers/note-management.ts
@@ -134,6 +134,52 @@ export const noteManagementHandlers = [
   }),
 
   c(
+    'command::ui:delete-files-dialog',
+    ({ workbenchState }, { wsPaths }, key) => {
+      const { store, dispatch } = getCtx(key);
+      const filePaths = [...new Set(wsPaths)].map(
+        (selectedWsPath) =>
+          WsPath.safeParse(selectedWsPath).data?.asFile() ?? null,
+      );
+
+      if (filePaths.length === 0 || filePaths.some((path) => path === null)) {
+        throwAppError(
+          'error::file:invalid-note-path',
+          t.app.errors.file.invalidNotePath,
+          {
+            invalidWsPath: wsPaths.join(', '),
+          },
+        );
+      }
+
+      const validFilePaths = filePaths.filter(
+        (path): path is NonNullable<(typeof filePaths)[number]> =>
+          path !== null,
+      );
+
+      store.set(workbenchState.$alertDialog, () => {
+        return {
+          dialogId: 'dialog::delete-files-alert',
+          title: t.app.dialogs.confirmDeleteFiles.title,
+          tone: 'destructive',
+          description: t.app.dialogs.confirmDeleteFiles.description({
+            count: validFilePaths.length,
+            fileNames: validFilePaths.map((path) => path.fileName),
+          }),
+          continueText: t.app.dialogs.confirmDeleteFiles.continueText,
+          onContinue: () => {
+            dispatch('command::ws:delete-ws-paths', {
+              wsPaths: validFilePaths.map((path) => path.wsPath),
+            });
+            dispatch('command::ui:focus-editor', null);
+          },
+          onCancel: () => {},
+        };
+      });
+    },
+  ),
+
+  c(
     'command::ui:rename-note-dialog',
     ({ workspaceState, workbenchState }, { wsPath }, key) => {
       const { store, dispatch } = getCtx(key);

--- a/packages/core/command-handlers/src/ws-command-handlers.ts
+++ b/packages/core/command-handlers/src/ws-command-handlers.ts
@@ -1,5 +1,6 @@
 // packages/core/command-handlers/src/ws-command-handlers.ts
 import { throwAppError } from '@bangle.io/base-utils';
+import { toast } from '@bangle.io/ui-components';
 import { WsDirPath, WsPath } from '@bangle.io/ws-path';
 import { c, getCtx } from './helper';
 
@@ -25,6 +26,21 @@ function isUnderDirectory(filePath: WsPath, dirPath: WsDirPath): boolean {
   return (
     filePath.wsName === dirPath.wsName && filePath.path.startsWith(dirPath.path)
   );
+}
+
+function basename(path: string): string {
+  return path.replace(/\/+$/, '').split('/').at(-1) || path;
+}
+
+function normalizeDestinationDirWsPath(destDirWsPath: string): string {
+  const separatorIndex = destDirWsPath.indexOf(':');
+  if (separatorIndex < 0) {
+    return destDirWsPath;
+  }
+
+  const wsName = destDirWsPath.slice(0, separatorIndex);
+  const path = destDirWsPath.slice(separatorIndex + 1).replace(/^\/+/, '');
+  return path ? WsDirPath.fromParts(wsName, path).wsPath : `${wsName}:`;
 }
 
 export const wsCommandHandlers = [
@@ -72,12 +88,20 @@ export const wsCommandHandlers = [
       const filePath = WsPath.assertFile(wsPath);
       const fileNameWithoutExt = filePath.fileNameWithoutExtension;
 
-      await fileSystem.createFile(
-        wsPath,
-        new File([''], fileNameWithoutExt, {
-          type: 'text/plain',
-        }),
-      );
+      try {
+        await fileSystem.createFile(
+          wsPath,
+          new File([''], fileNameWithoutExt, {
+            type: 'text/plain',
+          }),
+        );
+        toast.success(
+          t.app.toasts.fileCreated({ fileName: filePath.fileName }),
+        );
+      } catch (error) {
+        toast.error(t.app.toasts.fileCreateFailed);
+        throw error;
+      }
 
       if (navigate) {
         navigation.goWsPath(wsPath);
@@ -104,7 +128,37 @@ export const wsCommandHandlers = [
   ),
 
   c('command::ws:delete-ws-path', async ({ fileSystem }, { wsPath }) => {
-    await fileSystem.deleteFile(wsPath);
+    const filePath = WsPath.assertFile(wsPath);
+
+    try {
+      await fileSystem.deleteFile(wsPath);
+      toast.success(t.app.toasts.fileDeleted({ fileName: filePath.fileName }));
+    } catch (error) {
+      toast.error(t.app.toasts.fileDeleteFailed);
+      throw error;
+    }
+  }),
+
+  c('command::ws:delete-ws-paths', async ({ fileSystem }, { wsPaths }) => {
+    const uniqueWsPaths = [...new Set(wsPaths)];
+
+    if (uniqueWsPaths.length === 0) {
+      throwAppError(
+        'error::file:invalid-note-path',
+        t.app.errors.file.invalidNotePath,
+        {
+          invalidWsPath: '',
+        },
+      );
+    }
+
+    try {
+      await fileSystem.deleteFiles(uniqueWsPaths);
+      toast.success(t.app.toasts.filesDeleted({ count: uniqueWsPaths.length }));
+    } catch (error) {
+      toast.error(t.app.toasts.filesDeleteFailed);
+      throw error;
+    }
   }),
 
   c(
@@ -135,16 +189,25 @@ export const wsCommandHandlers = [
         );
       }
 
+      const newFilePath = WsPath.assertFile(newWsPath);
       const needsRedirect =
         navigation.resolveAtoms().activeWsFilePath?.wsPath === wsPath;
 
       // Keep the open note visible during the rename instead of navigating to
       // ws-home first (which paints an intermediate screen for the duration of
       // the async write). Redirect straight to the renamed path once it lands.
-      await fileSystem.renameFile({
-        oldWsPath: wsPath,
-        newWsPath,
-      });
+      try {
+        await fileSystem.renameFile({
+          oldWsPath: wsPath,
+          newWsPath,
+        });
+        toast.success(
+          t.app.toasts.fileRenamed({ fileName: newFilePath.fileName }),
+        );
+      } catch (error) {
+        toast.error(t.app.toasts.fileRenameFailed);
+        throw error;
+      }
       if (needsRedirect) {
         navigation.goWsPath(newWsPath);
       }
@@ -161,7 +224,9 @@ export const wsCommandHandlers = [
       const { store } = getCtx(key);
 
       const filePath = WsPath.assertFile(wsPath);
-      const destDir = WsPath.fromString(destDirWsPath).asDir();
+      const destDir = WsPath.fromString(
+        normalizeDestinationDirWsPath(destDirWsPath),
+      ).asDir();
       if (!destDir) {
         throwAppError(
           'error::workspace:not-opened',
@@ -172,7 +237,10 @@ export const wsCommandHandlers = [
         );
       }
 
-      const newWsPath = destDir.createFilePath(filePath.fileName).wsPath;
+      const newWsPath = WsPath.fromParts(
+        destDir.wsName,
+        WsPath.pathJoin(destDir.isRoot ? '' : destDir.path, filePath.fileName),
+      ).wsPath;
 
       if (wsPath === newWsPath) {
         return;
@@ -200,10 +268,16 @@ export const wsCommandHandlers = [
       // the current note until the durable rename lands, then redirect straight
       // to the new path. The wsPaths update and this redirect settle in the same
       // microtask, so the moved note never flashes an intermediate screen.
-      await fileSystem.renameFile({
-        oldWsPath: wsPath,
-        newWsPath,
-      });
+      try {
+        await fileSystem.renameFile({
+          oldWsPath: wsPath,
+          newWsPath,
+        });
+        toast.success(t.app.toasts.fileMoved({ fileName: filePath.fileName }));
+      } catch (error) {
+        toast.error(t.app.toasts.fileMoveFailed);
+        throw error;
+      }
       if (needsRedirect) {
         navigation.goWsPath(newWsPath);
       }
@@ -334,7 +408,15 @@ export const wsCommandHandlers = [
         (pair) => pair.oldWsPath === currentWsPath,
       )?.newWsPath;
 
-      await fileSystem.renameFiles(pairs);
+      try {
+        await fileSystem.renameFiles(pairs);
+        toast.success(
+          t.app.toasts.folderRenamed({ folderName: basename(newDir.path) }),
+        );
+      } catch (error) {
+        toast.error(t.app.toasts.folderRenameFailed);
+        throw error;
+      }
 
       if (redirectTarget) {
         navigation.goWsPath(redirectTarget);
@@ -360,7 +442,15 @@ export const wsCommandHandlers = [
       // Delete first, then leave the route stable. The editor and asset pages
       // derive existence from workspace-state atoms and render not-found states
       // when the routed file disappears.
-      await fileSystem.deleteFiles(descendants.map((path) => path.wsPath));
+      try {
+        await fileSystem.deleteFiles(descendants.map((path) => path.wsPath));
+        toast.success(
+          t.app.toasts.folderDeleted({ folderName: basename(dirPath.path) }),
+        );
+      } catch (error) {
+        toast.error(t.app.toasts.folderDeleteFailed);
+        throw error;
+      }
     },
   ),
   c('command::ws:go-ws-home', ({ navigation }) => {

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -154,6 +154,19 @@ export const uiCommands = narrow([
     },
   },
   {
+    id: 'command::ui:delete-files-dialog',
+    title: 'Delete Files',
+    keywords: ['delete', 'files', 'remove'],
+    dependencies: {
+      services: ['workbenchState'],
+      commands: ['command::ws:delete-ws-paths', 'command::ui:focus-editor'],
+    },
+    autoFocusEditor: false,
+    args: {
+      wsPaths: T.Array(T.String),
+    },
+  },
+  {
     id: 'command::ui:rename-note-dialog',
     title: 'Rename Note',
     keywords: ['rename', 'note', 'file'],

--- a/packages/shared/commands/src/ws-commands.ts
+++ b/packages/shared/commands/src/ws-commands.ts
@@ -115,6 +115,15 @@ export const wsCommands = narrow([
     },
   },
   {
+    id: 'command::ws:delete-ws-paths',
+    title: 'Delete Files',
+    omniSearch: false,
+    dependencies: { services: ['fileSystem', 'navigation'] },
+    args: {
+      wsPaths: T.Array(T.String),
+    },
+  },
+  {
     id: 'command::ws:rename-ws-path',
     title: 'Rename Note',
     omniSearch: false,

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -196,6 +196,20 @@ export const t = {
           `Sind Sie sicher, dass Sie "${fileName}" löschen möchten?`,
         continueText: 'Löschen',
       },
+      confirmDeleteFiles: {
+        title: 'Löschen bestätigen',
+        description: ({
+          count,
+          fileNames,
+        }: {
+          count: number;
+          fileNames: string[];
+        }) =>
+          `${count} Dateien löschen? ${fileNames.slice(0, 5).join(', ')}${
+            fileNames.length > 5 ? ', ...' : ''
+          } werden entfernt.`,
+        continueText: 'Dateien löschen',
+      },
       renameNote: {
         title: 'Notiz umbenennen',
         description: ({
@@ -434,6 +448,27 @@ export const t = {
         maxFileSize: string;
       }) =>
         `${fileName} ist zu gross. Maximale Dateigroesse ist ${maxFileSize}.`,
+      fileCreated: ({ fileName }: { fileName: string }) =>
+        `${fileName} erstellt`,
+      fileCreateFailed: 'Datei konnte nicht erstellt werden',
+      fileDeleted: ({ fileName }: { fileName: string }) =>
+        `${fileName} geloescht`,
+      fileDeleteFailed: 'Datei konnte nicht geloescht werden',
+      filesDeleted: ({ count }: { count: number }) =>
+        count === 1 ? '1 Datei geloescht' : `${count} Dateien geloescht`,
+      filesDeleteFailed: 'Dateien konnten nicht geloescht werden',
+      fileMoved: ({ fileName }: { fileName: string }) =>
+        `${fileName} verschoben`,
+      fileMoveFailed: 'Datei konnte nicht verschoben werden',
+      fileRenamed: ({ fileName }: { fileName: string }) =>
+        `Umbenannt zu ${fileName}`,
+      fileRenameFailed: 'Datei konnte nicht umbenannt werden',
+      folderDeleted: ({ folderName }: { folderName: string }) =>
+        `${folderName} geloescht`,
+      folderDeleteFailed: 'Ordner konnte nicht geloescht werden',
+      folderRenamed: ({ folderName }: { folderName: string }) =>
+        `Umbenannt zu ${folderName}`,
+      folderRenameFailed: 'Ordner konnte nicht umbenannt werden',
       openAsset: 'Öffnen',
       pathCopied: 'Pfad kopiert',
       pathCopyFailed: 'Pfad konnte nicht kopiert werden',
@@ -532,6 +567,8 @@ export const t = {
         renameActionTitle: 'Umbenennen',
         moveActionTitle: 'Verschieben',
         deleteActionTitle: 'Löschen',
+        deleteSelectedFilesActionTitle: ({ count }: { count: number }) =>
+          `${count} Dateien löschen`,
         workspacesLabel: 'Arbeitsbereiche',
         noWorkspaceSelectedTitle: 'Kein Arbeitsbereich ausgewählt',
         noWorkspaceSelectedSubtitle:

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -569,6 +569,7 @@ export const t = {
         deleteActionTitle: 'Löschen',
         deleteSelectedFilesActionTitle: ({ count }: { count: number }) =>
           `${count} Dateien löschen`,
+        moveToWorkspaceRootLabel: 'In Arbeitsbereichsstamm verschieben',
         workspacesLabel: 'Arbeitsbereiche',
         noWorkspaceSelectedTitle: 'Kein Arbeitsbereich ausgewählt',
         noWorkspaceSelectedSubtitle:

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -571,6 +571,7 @@ export const t = {
         deleteActionTitle: 'Delete',
         deleteSelectedFilesActionTitle: ({ count }: { count: number }) =>
           `Delete ${count} files`,
+        moveToWorkspaceRootLabel: 'Move to workspace root',
         workspacesLabel: 'Workspaces',
         noWorkspaceSelectedTitle: 'No workspace selected',
         noWorkspaceSelectedSubtitle: 'Click to select a workspace',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -215,6 +215,20 @@ export const t = {
           `Are you sure you want to delete "${fileName}"?`,
         continueText: 'Delete',
       },
+      confirmDeleteFiles: {
+        title: 'Confirm Delete',
+        description: ({
+          count,
+          fileNames,
+        }: {
+          count: number;
+          fileNames: string[];
+        }) =>
+          `Delete ${count} files? ${fileNames.slice(0, 5).join(', ')}${
+            fileNames.length > 5 ? ', ...' : ''
+          } will be removed.`,
+        continueText: 'Delete Files',
+      },
       renameNote: {
         title: 'Rename Note',
         description: ({
@@ -439,6 +453,26 @@ export const t = {
         fileName: string;
         maxFileSize: string;
       }) => `${fileName} is too large. Maximum file size is ${maxFileSize}.`,
+      fileCreated: ({ fileName }: { fileName: string }) =>
+        `Created ${fileName}`,
+      fileCreateFailed: 'Could not create file',
+      fileDeleted: ({ fileName }: { fileName: string }) =>
+        `Deleted ${fileName}`,
+      fileDeleteFailed: 'Could not delete file',
+      filesDeleted: ({ count }: { count: number }) =>
+        count === 1 ? 'Deleted 1 file' : `Deleted ${count} files`,
+      filesDeleteFailed: 'Could not delete files',
+      fileMoved: ({ fileName }: { fileName: string }) => `Moved ${fileName}`,
+      fileMoveFailed: 'Could not move file',
+      fileRenamed: ({ fileName }: { fileName: string }) =>
+        `Renamed to ${fileName}`,
+      fileRenameFailed: 'Could not rename file',
+      folderDeleted: ({ folderName }: { folderName: string }) =>
+        `Deleted ${folderName}`,
+      folderDeleteFailed: 'Could not delete folder',
+      folderRenamed: ({ folderName }: { folderName: string }) =>
+        `Renamed to ${folderName}`,
+      folderRenameFailed: 'Could not rename folder',
       openAsset: 'Open',
       pathCopied: 'Path copied',
       pathCopyFailed: 'Could not copy path',
@@ -535,6 +569,8 @@ export const t = {
         renameActionTitle: 'Rename',
         moveActionTitle: 'Move',
         deleteActionTitle: 'Delete',
+        deleteSelectedFilesActionTitle: ({ count }: { count: number }) =>
+          `Delete ${count} files`,
         workspacesLabel: 'Workspaces',
         noWorkspaceSelectedTitle: 'No workspace selected',
         noWorkspaceSelectedSubtitle: 'Click to select a workspace',

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -31,6 +31,43 @@ function sleep(t = DEFAULT_SLEEP_TIME) {
   return new Promise((res) => setTimeout(res, t));
 }
 
+// Pierre's file tree uses a pointer-based drag that only engages once it sees
+// pointer moves separated across animation frames; a synchronous
+// `locator.dragTo` (or a single stepped move) collapses into a click that just
+// selects the row. Drive the gesture with real mouse events and let a frame
+// elapse between phases so the durable move actually fires.
+export async function dragTreeItemOnto(
+  page: Page,
+  source: Locator,
+  target: Locator,
+) {
+  const sourceBox = await source.boundingBox();
+  const targetBox = await target.boundingBox();
+
+  if (!sourceBox || !targetBox) {
+    throw new Error('Expected drag source and target to be visible');
+  }
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+  const settleFrame = () => page.waitForTimeout(60);
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await settleFrame();
+  await page.mouse.move(sourceX, sourceY - 8);
+  await settleFrame();
+  await page.mouse.move((sourceX + targetX) / 2, (sourceY + targetY) / 2);
+  await settleFrame();
+  await page.mouse.move(targetX, targetY);
+  await settleFrame();
+  await page.mouse.move(targetX, targetY);
+  await settleFrame();
+  await page.mouse.up();
+}
+
 export function getEditorLocator(page: Page, _options: { editorId?: string }) {
   return page.locator(EDITOR_SELECTOR);
 }

--- a/packages/tooling/e2e-tests/src/file-explorer-file-operations.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer-file-operations.e2e.ts
@@ -1,10 +1,45 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 import {
   createBrowserWorkspace,
-  dragTreeItemOnto,
   readStoredMarkdown,
   writeStoredMarkdown,
 } from './common';
+
+async function dragTreeItemOntoRevealedTarget(
+  page: Page,
+  source: Locator,
+  target: Locator,
+) {
+  const sourceBox = await source.boundingBox();
+  if (!sourceBox) {
+    throw new Error('Expected drag source to be visible');
+  }
+
+  const sourceX = sourceBox.x + sourceBox.width / 2;
+  const sourceY = sourceBox.y + sourceBox.height / 2;
+  const settleFrame = () => page.waitForTimeout(60);
+
+  await page.mouse.move(sourceX, sourceY);
+  await page.mouse.down();
+  await settleFrame();
+  await page.mouse.move(sourceX, sourceY - 8);
+  await settleFrame();
+  await expect(target).toBeVisible();
+
+  const targetBox = await target.boundingBox();
+  if (!targetBox) {
+    throw new Error('Expected revealed drop target to be visible');
+  }
+
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move((sourceX + targetX) / 2, (sourceY + targetY) / 2);
+  await settleFrame();
+  await page.mouse.move(targetX, targetY);
+  await settleFrame();
+  await page.mouse.up();
+}
 
 test('file explorer deletes multiple selected files from one confirmation', async ({
   page,
@@ -153,12 +188,14 @@ test('file explorer can drag a nested note back to the workspace root', async ({
   await docsFolder.focus();
   await page.keyboard.press('ArrowRight');
   const nestedNote = explorer.getByRole('treeitem', { name: /^nested\.md$/ });
-  const keepNote = explorer.getByRole('treeitem', { name: /^keep\.md$/ });
   await expect(nestedNote).toBeVisible();
-  await expect(keepNote).toBeVisible();
 
   await nestedNote.click();
-  await dragTreeItemOnto(page, nestedNote, keepNote);
+  await dragTreeItemOntoRevealedTarget(
+    page,
+    nestedNote,
+    explorer.getByRole('button', { name: 'Move to workspace root' }),
+  );
 
   await expect(page.getByText('Moved nested.md')).toBeVisible();
   await expect

--- a/packages/tooling/e2e-tests/src/file-explorer-file-operations.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer-file-operations.e2e.ts
@@ -1,0 +1,177 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspace,
+  dragTreeItemOnto,
+  readStoredMarkdown,
+  writeStoredMarkdown,
+} from './common';
+
+test('file explorer deletes multiple selected files from one confirmation', async ({
+  page,
+}) => {
+  const workspaceName = `explorer-multi-delete-${Date.now()}`;
+  await createBrowserWorkspace(page, { workspaceName });
+  await writeStoredMarkdown(page, workspaceName, 'alpha', 'Alpha');
+  await writeStoredMarkdown(page, workspaceName, 'beta', 'Beta');
+  await writeStoredMarkdown(page, workspaceName, 'gamma', 'Gamma');
+  await writeStoredMarkdown(page, workspaceName, 'keep', 'Keep');
+
+  await page.goto(
+    `/ws#route=ws-home&wsName=${encodeURIComponent(workspaceName)}`,
+  );
+  await page.reload();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+  const alphaRow = explorer.getByRole('treeitem', { name: /^alpha\.md$/ });
+  const betaRow = explorer.getByRole('treeitem', { name: /^beta\.md$/ });
+  const gammaRow = explorer.getByRole('treeitem', { name: /^gamma\.md$/ });
+  const keepRow = explorer.getByRole('treeitem', { name: /^keep\.md$/ });
+
+  await expect(alphaRow).toBeVisible();
+  await expect(betaRow).toBeVisible();
+  await expect(gammaRow).toBeVisible();
+  await expect(keepRow).toBeVisible();
+
+  await alphaRow.click();
+  await gammaRow.click({ modifiers: ['Shift'] });
+
+  await expect(alphaRow).toHaveAttribute('aria-selected', 'true');
+  await expect(betaRow).toHaveAttribute('aria-selected', 'true');
+  await expect(gammaRow).toHaveAttribute('aria-selected', 'true');
+
+  await gammaRow.hover();
+  await explorer.getByRole('button', { name: 'Options' }).click();
+  await page.getByRole('button', { name: 'Delete 3 files' }).click();
+
+  const confirmDeleteDialog = page.getByRole('alertdialog', {
+    name: 'Confirm Delete',
+  });
+  await expect(confirmDeleteDialog).toBeVisible();
+  await expect(confirmDeleteDialog).toContainText('alpha.md');
+  await expect(confirmDeleteDialog).toContainText('beta.md');
+  await expect(confirmDeleteDialog).toContainText('gamma.md');
+  await confirmDeleteDialog
+    .getByRole('button', { name: 'Delete Files' })
+    .click();
+
+  await expect(page.getByText('Deleted 3 files')).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'alpha'))
+    .toBeUndefined();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'beta'))
+    .toBeUndefined();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'gamma'))
+    .toBeUndefined();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'keep'))
+    .toBe('Keep');
+
+  await page.reload();
+  await expect(alphaRow).toHaveCount(0);
+  await expect(betaRow).toHaveCount(0);
+  await expect(gammaRow).toHaveCount(0);
+  await expect(keepRow).toBeVisible();
+});
+
+test('file explorer ignores stale multi-selection when opening an unselected row menu', async ({
+  page,
+}) => {
+  const workspaceName = `explorer-stale-selection-${Date.now()}`;
+  await createBrowserWorkspace(page, { workspaceName });
+  await writeStoredMarkdown(page, workspaceName, 'alpha', 'Alpha');
+  await writeStoredMarkdown(page, workspaceName, 'beta', 'Beta');
+  await writeStoredMarkdown(page, workspaceName, 'gamma', 'Gamma');
+  await writeStoredMarkdown(page, workspaceName, 'keep', 'Keep');
+
+  await page.goto(
+    `/ws#route=ws-home&wsName=${encodeURIComponent(workspaceName)}`,
+  );
+  await page.reload();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+  const alphaRow = explorer.getByRole('treeitem', { name: /^alpha\.md$/ });
+  const betaRow = explorer.getByRole('treeitem', { name: /^beta\.md$/ });
+  const gammaRow = explorer.getByRole('treeitem', { name: /^gamma\.md$/ });
+  const keepRow = explorer.getByRole('treeitem', { name: /^keep\.md$/ });
+
+  await alphaRow.click();
+  await gammaRow.click({ modifiers: ['Shift'] });
+  await expect(alphaRow).toHaveAttribute('aria-selected', 'true');
+  await expect(betaRow).toHaveAttribute('aria-selected', 'true');
+  await expect(gammaRow).toHaveAttribute('aria-selected', 'true');
+
+  await keepRow.hover();
+  await explorer.getByRole('button', { name: 'Options' }).click();
+
+  await expect(
+    page.getByRole('button', { name: 'Delete 3 files' }),
+  ).toHaveCount(0);
+  await page.getByRole('button', { name: 'Delete' }).click();
+
+  const confirmDeleteDialog = page.getByRole('alertdialog', {
+    name: 'Confirm Delete',
+  });
+  await expect(confirmDeleteDialog).toBeVisible();
+  await expect(confirmDeleteDialog).toContainText('keep');
+  await expect(confirmDeleteDialog).not.toContainText('alpha.md');
+  await expect(confirmDeleteDialog).not.toContainText('beta.md');
+  await expect(confirmDeleteDialog).not.toContainText('gamma.md');
+  await confirmDeleteDialog.getByRole('button', { name: 'Cancel' }).click();
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'alpha'))
+    .toBe('Alpha');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'beta'))
+    .toBe('Beta');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'gamma'))
+    .toBe('Gamma');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'keep'))
+    .toBe('Keep');
+});
+
+test('file explorer can drag a nested note back to the workspace root', async ({
+  page,
+}) => {
+  const workspaceName = `explorer-root-move-${Date.now()}`;
+  await createBrowserWorkspace(page, { workspaceName });
+  await writeStoredMarkdown(page, workspaceName, 'docs/nested', 'Move root');
+  await writeStoredMarkdown(page, workspaceName, 'keep', 'Keep');
+
+  await page.goto(
+    `/ws#route=ws-home&wsName=${encodeURIComponent(workspaceName)}`,
+  );
+  await page.reload();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+  const docsFolder = explorer.getByRole('treeitem', { name: /^docs$/ });
+
+  await docsFolder.focus();
+  await page.keyboard.press('ArrowRight');
+  const nestedNote = explorer.getByRole('treeitem', { name: /^nested\.md$/ });
+  const keepNote = explorer.getByRole('treeitem', { name: /^keep\.md$/ });
+  await expect(nestedNote).toBeVisible();
+  await expect(keepNote).toBeVisible();
+
+  await nestedNote.click();
+  await dragTreeItemOnto(page, nestedNote, keepNote);
+
+  await expect(page.getByText('Moved nested.md')).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'nested'))
+    .toBe('Move root');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'docs/nested'))
+    .toBeUndefined();
+  await page.reload();
+  await expect(
+    explorer.getByRole('treeitem', { name: /^nested\.md$/ }),
+  ).toBeVisible();
+  await expect(explorer.getByRole('treeitem', { name: /^docs$/ })).toHaveCount(
+    0,
+  );
+});

--- a/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
@@ -2,6 +2,7 @@ import { expect, type Page, test } from '@playwright/test';
 import {
   clearEditor,
   createBrowserWorkspace,
+  dragTreeItemOnto,
   expectNoPageHorizontalOverflow,
   getEditorLocator,
   getEditorText,
@@ -41,43 +42,6 @@ async function expectContextMenuIsNotClipped(page: Page) {
       { message: 'Expected the file-tree context menu to be fully hittable' },
     )
     .toBe(true);
-}
-
-// Pierre's file tree uses a pointer-based drag that only engages once it sees
-// pointer moves separated across animation frames; a synchronous
-// `locator.dragTo` (or a single stepped move) collapses into a click that just
-// selects the row. Drive the gesture with real mouse events and let a frame
-// elapse between phases so the durable move actually fires.
-async function dragTreeItemOnto(
-  page: Page,
-  source: ReturnType<Page['getByRole']>,
-  target: ReturnType<Page['getByRole']>,
-) {
-  const sourceBox = await source.boundingBox();
-  const targetBox = await target.boundingBox();
-
-  if (!sourceBox || !targetBox) {
-    throw new Error('Expected drag source and target to be visible');
-  }
-
-  const sourceX = sourceBox.x + sourceBox.width / 2;
-  const sourceY = sourceBox.y + sourceBox.height / 2;
-  const targetX = targetBox.x + targetBox.width / 2;
-  const targetY = targetBox.y + targetBox.height / 2;
-  const settleFrame = () => page.waitForTimeout(60);
-
-  await page.mouse.move(sourceX, sourceY);
-  await page.mouse.down();
-  await settleFrame();
-  await page.mouse.move(sourceX, sourceY - 8);
-  await settleFrame();
-  await page.mouse.move((sourceX + targetX) / 2, (sourceY + targetY) / 2);
-  await settleFrame();
-  await page.mouse.move(targetX, targetY);
-  await settleFrame();
-  await page.mouse.move(targetX, targetY);
-  await settleFrame();
-  await page.mouse.up();
 }
 
 async function getFileExplorerLayout(page: Page) {

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -57,7 +57,10 @@ export type AppSidebarProps = {
   navItems: NavItem[];
   onSearchClick?: () => void;
   activeFilePaths?: string[];
-  getActionsForEntry: (entry: FileTreeEntry) => readonly FileTreeEntryAction[];
+  getActionsForEntry: (
+    entry: FileTreeEntry,
+    selectedEntries: readonly FileTreeEntry[],
+  ) => readonly FileTreeEntryAction[];
   onCreateDirectory: (pathPrefix: string | undefined) => void;
   onCreateNote: (pathPrefix: string | undefined) => void;
   onMoveFile: (

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -8,7 +8,7 @@ import type {
 } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
 import { FilePlus2, FileText, FolderPlus } from 'lucide-react';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { BANGLE_PIERRE_FILE_TREE_ICONS } from './pierre-file-tree-icons';
 import {
   type FileTreeEntry,
@@ -318,6 +318,7 @@ export function PierreFileTree({
   const filePathSetRef = useRef<ReadonlySet<string>>(filePathSet);
   const modelRef = useRef<PierreFileTreeModel | null>(null);
   const contextMenuSelectedEntriesRef = useRef<readonly FileTreeEntry[]>([]);
+  const dragSourcePathRef = useRef<string | null>(null);
   const onOpenFileRef = useRef(onOpenFile);
   const onMoveFileRef = useRef(onMoveFile);
   const pendingUserOpenPathRef = useRef<string | null>(null);
@@ -325,6 +326,7 @@ export function PierreFileTree({
   const suppressSelectionOpenRef = useRef(false);
   const suppressSelectionOpenTimerRef = useRef<number | undefined>(undefined);
   const treePathsRef = useRef<readonly string[]>(treePaths);
+  const rootElementRef = useRef<HTMLDivElement | null>(null);
   filePathSetRef.current = filePathSet;
   onOpenFileRef.current = onOpenFile;
   onMoveFileRef.current = onMoveFile;
@@ -369,6 +371,11 @@ export function PierreFileTree({
     }
   };
 
+  const resetDragAffordance = useCallback((): void => {
+    dragSourcePathRef.current = null;
+    rootElementRef.current?.removeAttribute('data-root-drop-active');
+  }, []);
+
   const suppressSelectionOpenForDrag = (): void => {
     resetSelectionOpenSuppression();
     suppressSelectionOpenRef.current = true;
@@ -379,10 +386,14 @@ export function PierreFileTree({
   };
 
   const canDragFile = (paths: readonly string[]): boolean => {
+    const sourcePath = normalizePierreFilePath(paths[0] || '');
     const canDrag =
-      paths.length === 1 &&
-      filePathSetRef.current.has(normalizePierreFilePath(paths[0] || ''));
+      paths.length === 1 && filePathSetRef.current.has(sourcePath);
     if (canDrag) {
+      dragSourcePathRef.current = sourcePath;
+      if (getParentDirectory(sourcePath) !== undefined) {
+        rootElementRef.current?.setAttribute('data-root-drop-active', 'true');
+      }
       suppressSelectionOpenForDrag();
     }
     return canDrag;
@@ -438,6 +449,7 @@ export function PierreFileTree({
       onDropComplete: handleDropComplete,
       onDropError: () => {
         resetSelectionOpenSuppression();
+        resetDragAffordance();
         if (modelRef.current) {
           resetModelPathsPreservingExpansion(
             modelRef.current,
@@ -516,9 +528,43 @@ export function PierreFileTree({
     [],
   );
 
+  useEffect(() => {
+    const handleDragEnd = () => {
+      resetDragAffordance();
+    };
+
+    window.addEventListener('dragend', handleDragEnd);
+    return () => {
+      window.removeEventListener('dragend', handleDragEnd);
+    };
+  }, [resetDragAffordance]);
+
+  const handleRootDrop = (event: React.DragEvent<HTMLButtonElement>): void => {
+    const sourcePath = dragSourcePathRef.current;
+    if (
+      !rootElementRef.current?.hasAttribute('data-root-drop-active') ||
+      !sourcePath
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    resetSelectionOpenSuppression();
+    resetDragAffordance();
+
+    if (getParentDirectory(sourcePath) !== undefined) {
+      onMoveFileRef.current(sourcePath, undefined);
+    }
+  };
+
   return (
     <div
-      className={cn('flex min-h-0 flex-1 flex-col', className)}
+      ref={rootElementRef}
+      className={cn(
+        'group/root-drop relative flex min-h-0 flex-1 flex-col',
+        className,
+      )}
       data-testid="bangle-file-explorer"
     >
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -561,6 +607,21 @@ export function PierreFileTree({
             <FolderPlus className="size-3.5" />
           </button>
         </div>
+        <button
+          aria-label={t.app.components.appSidebar.moveToWorkspaceRootLabel}
+          className="absolute top-1 right-2 left-2 z-30 hidden h-7 shrink-0 items-center justify-center rounded-sm border border-sidebar-border border-dashed bg-sidebar-accent/95 text-[11px] text-sidebar-accent-foreground shadow-xs transition-colors hover:border-sidebar-accent-foreground/60 hover:bg-sidebar-accent group-data-[root-drop-active=true]/root-drop:flex"
+          type="button"
+          onDragEnter={(event) => {
+            event.preventDefault();
+          }}
+          onDragOver={(event) => {
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+          }}
+          onDrop={handleRootDrop}
+        >
+          {t.app.components.appSidebar.moveToWorkspaceRootLabel}
+        </button>
         <FileTree
           aria-label={t.app.components.appSidebar.fileTreeLabel}
           className="min-h-0 flex-1 overflow-hidden"

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -167,9 +167,14 @@ function resetModelPathsPreservingExpansion(
 function getDropDestinationDirectory(
   event: FileTreeDropContext | FileTreeDropResult,
 ): string | undefined {
-  return event.target.kind === 'root' || !event.target.directoryPath
-    ? undefined
-    : normalizePierreDirectoryPath(event.target.directoryPath);
+  if (event.target.kind === 'root' || !event.target.directoryPath) {
+    return undefined;
+  }
+
+  const normalizedPath = normalizeInputPath(event.target.directoryPath);
+  return normalizedPath
+    ? normalizePierreDirectoryPath(normalizedPath)
+    : undefined;
 }
 
 function toEntry(item: ContextMenuItem): FileTreeEntry {
@@ -180,6 +185,76 @@ function toEntry(item: ContextMenuItem): FileTreeEntry {
         ? normalizePierreDirectoryPath(item.path)
         : normalizePierreFilePath(item.path),
   };
+}
+
+function toEntryFromPath(
+  path: string,
+  filePathSet: ReadonlySet<string>,
+): FileTreeEntry | undefined {
+  const normalizedPath = normalizeInputPath(path);
+
+  if (!normalizedPath) {
+    return undefined;
+  }
+
+  return filePathSet.has(normalizedPath)
+    ? { kind: 'file', path: normalizePierreFilePath(normalizedPath) }
+    : { kind: 'directory', path: normalizePierreDirectoryPath(normalizedPath) };
+}
+
+function getSelectedEntriesFromMountedTree(
+  model: PierreFileTreeModel,
+  filePathSet: ReadonlySet<string>,
+): readonly FileTreeEntry[] {
+  const selectedItems =
+    model
+      .getFileTreeContainer()
+      ?.shadowRoot?.querySelectorAll<HTMLElement>(
+        "button[data-type='item'][data-item-selected][data-item-path]",
+      ) ?? [];
+
+  return Array.from(selectedItems)
+    .map((element) => {
+      const path = element.dataset.itemPath;
+      if (!path) {
+        return undefined;
+      }
+
+      if (element.dataset.itemType === 'file') {
+        return {
+          kind: 'file' as const,
+          path: normalizePierreFilePath(path),
+        };
+      }
+
+      return toEntryFromPath(path, filePathSet);
+    })
+    .filter((entry): entry is FileTreeEntry => entry !== undefined);
+}
+
+function getSelectedEntriesFromModel(
+  model: PierreFileTreeModel,
+  filePathSet: ReadonlySet<string>,
+): readonly FileTreeEntry[] {
+  return model
+    .getSelectedPaths()
+    .map((path) => toEntryFromPath(path, filePathSet))
+    .filter((entry): entry is FileTreeEntry => entry !== undefined);
+}
+
+function getCurrentSelectedEntries(
+  model: PierreFileTreeModel,
+  filePathSet: ReadonlySet<string>,
+): readonly FileTreeEntry[] {
+  const modelSelectedEntries = getSelectedEntriesFromModel(model, filePathSet);
+  const mountedSelectedEntries = getSelectedEntriesFromMountedTree(
+    model,
+    filePathSet,
+  );
+
+  return mountedSelectedEntries.length > modelSelectedEntries.length
+    ? mountedSelectedEntries
+    : modelSelectedEntries;
 }
 
 export interface PierreFileTreeProps {
@@ -195,7 +270,10 @@ export interface PierreFileTreeProps {
   onOpenFile: (relativePath: string) => void;
   showNoteFilesOnly: boolean;
   onShowNoteFilesOnlyChange: (showNoteFilesOnly: boolean) => void;
-  getActionsForEntry: (entry: FileTreeEntry) => readonly FileTreeEntryAction[];
+  getActionsForEntry: (
+    entry: FileTreeEntry,
+    selectedEntries: readonly FileTreeEntry[],
+  ) => readonly FileTreeEntryAction[];
 }
 
 export function PierreFileTree({
@@ -239,6 +317,7 @@ export function PierreFileTree({
   );
   const filePathSetRef = useRef<ReadonlySet<string>>(filePathSet);
   const modelRef = useRef<PierreFileTreeModel | null>(null);
+  const contextMenuSelectedEntriesRef = useRef<readonly FileTreeEntry[]>([]);
   const onOpenFileRef = useRef(onOpenFile);
   const onMoveFileRef = useRef(onMoveFile);
   const pendingUserOpenPathRef = useRef<string | null>(null);
@@ -337,6 +416,17 @@ export function PierreFileTree({
       contextMenu: {
         buttonVisibility: 'when-needed',
         enabled: true,
+        onOpen: () => {
+          if (!modelRef.current) {
+            contextMenuSelectedEntriesRef.current = [];
+            return;
+          }
+
+          contextMenuSelectedEntriesRef.current = getCurrentSelectedEntries(
+            modelRef.current,
+            filePathSetRef.current,
+          );
+        },
         triggerMode: 'both',
       },
     },
@@ -368,6 +458,7 @@ export function PierreFileTree({
         if (suppressSelectionOpenRef.current) {
           return;
         }
+        selectedPathRef.current = normalizedPath;
         pendingUserOpenPathRef.current = normalizedPath;
         onOpenFileRef.current(normalizedPath);
       }
@@ -476,7 +567,20 @@ export function PierreFileTree({
           model={model}
           renderContextMenu={(item, context) => {
             const entry = toEntry(item);
-            const actions = getActionsForEntry(entry);
+            const selectedEntries =
+              contextMenuSelectedEntriesRef.current.length > 0
+                ? contextMenuSelectedEntriesRef.current
+                : getCurrentSelectedEntries(model, filePathSetRef.current);
+            const entryIsSelected = selectedEntries.some(
+              (selectedEntry) =>
+                selectedEntry.kind === entry.kind &&
+                selectedEntry.path === entry.path,
+            );
+            const menuSelectedEntries =
+              selectedEntries.length > 1 && entryIsSelected
+                ? selectedEntries
+                : [entry];
+            const actions = getActionsForEntry(entry, menuSelectedEntries);
 
             if (actions.length === 0) {
               return null;
@@ -503,7 +607,10 @@ export function PierreFileTree({
                       disabled={disabled}
                       onClick={() => {
                         context.close({ restoreFocus: false });
-                        onClick(entry);
+                        onClick({
+                          entry,
+                          selectedEntries: menuSelectedEntries,
+                        });
                       }}
                     >
                       {Icon && <Icon className="size-4" />}

--- a/packages/ui/ui-components/src/file-tree/types.ts
+++ b/packages/ui/ui-components/src/file-tree/types.ts
@@ -7,7 +7,12 @@ export interface FileTreeEntry {
   path: string;
 }
 
-export type FileTreeEntryAction = Action<FileTreeEntry>;
+interface FileTreeEntryActionContext {
+  entry: FileTreeEntry;
+  selectedEntries: readonly FileTreeEntry[];
+}
+
+export type FileTreeEntryAction = Action<FileTreeEntryActionContext>;
 
 export function normalizePierreDirectoryPath(path: string): string {
   return path.replace(/\/+$/, '');


### PR DESCRIPTION
## Summary
- add file explorer multi-select action support and batch delete confirmation
- add success/failure toasts for common file and folder operations
- fix nested-to-root drag moves by canonicalizing root destination wsPaths
- add E2E coverage for multi-delete, stale-selection menu safety, and root drag moves

## Root Cause
Dragging a nested file back to the workspace root could build a destination directory as `workspace:/` instead of canonical `workspace:`. That later produced `workspace:/file.md`, which violates ws-path validation because the file path begins with `/`.

The multi-select delete implementation also needed to avoid stale selection actions when a context menu is opened on an unselected row, so the menu now collapses to the clicked row unless that row is part of the current multi-selection.

## Validation
- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm e2e:ci`
- `pnpm local-ci-check`
- focused Playwright file-operation E2E
- `playwright-cli` smoke for nested-to-root drag move and toast
- two parallel agent reviews: thermonuclear + standard code review; addressed actionable findings
