### PR TITLE
[codex] reserve PWA titlebar overlay geometry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@
 - Before opening or updating a PR, and before any release,
   `pnpm local-ci-check` must pass. It runs every root script ending in `:ci`,
   including Playwright.
+- When working on a non-main branch, end every turn by committing completed
+  changes and creating or updating the PR for that branch.
 - Documentation-only changes do not require the code suites. Verify the
   documented paths and commands instead.
 - Never hide a failing check. Distinguish failures introduced by the change

--- a/packages/core/app/src/common/__tests__/pwa-install.spec.ts
+++ b/packages/core/app/src/common/__tests__/pwa-install.spec.ts
@@ -27,6 +27,17 @@ function makeInstallPromptEvent(
 
 beforeEach(async () => {
   vi.resetModules();
+  document.documentElement.removeAttribute(
+    'data-bangle-window-controls-overlay',
+  );
+  document.documentElement.removeAttribute(
+    'data-bangle-window-controls-overlay-controls',
+  );
+  document.documentElement.removeAttribute('style');
+  Object.defineProperty(document.documentElement, 'clientWidth', {
+    configurable: true,
+    value: 0,
+  });
   pwaInstall = await import('../pwa-install');
 });
 
@@ -191,5 +202,44 @@ describe('window controls overlay', () => {
         '--bangle-titlebar-area-height',
       ),
     ).toBe('40px');
+  });
+
+  it('marks both control edges when the titlebar area leaves left and right regions unavailable', () => {
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: 1000,
+    });
+    const windowControlsOverlay = new EventTarget() as EventTarget & {
+      getTitlebarAreaRect: () => Pick<
+        DOMRectReadOnly,
+        'height' | 'width' | 'x' | 'y'
+      >;
+      visible: boolean;
+    };
+    windowControlsOverlay.visible = true;
+    windowControlsOverlay.getTitlebarAreaRect = () => ({
+      height: 40,
+      width: 760,
+      x: 88,
+      y: 0,
+    });
+
+    pwaInstall.syncWindowControlsOverlayState({
+      documentRef: document,
+      navigatorRef: {
+        windowControlsOverlay,
+      },
+    });
+
+    expect(
+      document.documentElement.getAttribute(
+        'data-bangle-window-controls-overlay-controls',
+      ),
+    ).toBe('both');
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--bangle-titlebar-area-width',
+      ),
+    ).toBe('760px');
   });
 });

--- a/packages/core/app/src/common/pwa-install.ts
+++ b/packages/core/app/src/common/pwa-install.ts
@@ -38,6 +38,7 @@ const APP_DOCUMENT_SUBTITLE = 'Notes';
 const WINDOW_CONTROLS_OVERLAY_ATTRIBUTE = 'data-bangle-window-controls-overlay';
 const WINDOW_CONTROLS_OVERLAY_CONTROLS_ATTRIBUTE =
   'data-bangle-window-controls-overlay-controls';
+const TITLEBAR_EDGE_OCCLUSION_EPSILON = 0.5;
 
 let initializedWindow: Window | undefined;
 let trackingAbortController: AbortController | undefined;
@@ -71,6 +72,31 @@ function isStandaloneDisplay(windowRef: Window) {
     windowRef.matchMedia?.('(display-mode: standalone)').matches === true ||
     navigatorWithStandalone.standalone === true
   );
+}
+
+function getWindowControlsOverlayControls(
+  rect: TitlebarAreaRect,
+  viewportWidth: number,
+) {
+  const hasLeftControls = rect.x > TITLEBAR_EDGE_OCCLUSION_EPSILON;
+  const hasRightControls =
+    viewportWidth > 0
+      ? viewportWidth - rect.x - rect.width > TITLEBAR_EDGE_OCCLUSION_EPSILON
+      : rect.x <= TITLEBAR_EDGE_OCCLUSION_EPSILON;
+
+  if (hasLeftControls && hasRightControls) {
+    return 'both';
+  }
+
+  if (hasLeftControls) {
+    return 'left';
+  }
+
+  if (hasRightControls) {
+    return 'right';
+  }
+
+  return 'none';
 }
 
 export function syncAppDocumentTitle(documentRef: Document | undefined) {
@@ -126,7 +152,7 @@ export function syncWindowControlsOverlayState(input: {
     );
     documentElement.setAttribute(
       WINDOW_CONTROLS_OVERLAY_CONTROLS_ATTRIBUTE,
-      rect.x === 0 ? 'right' : 'left',
+      getWindowControlsOverlayControls(rect, documentElement.clientWidth),
     );
   };
 

--- a/packages/tooling/browser-entry/src/index.css
+++ b/packages/tooling/browser-entry/src/index.css
@@ -139,24 +139,26 @@ html[data-bangle-window-controls-overlay="visible"]
   user-select: auto;
 }
 
-html[data-bangle-window-controls-overlay="visible"][data-bangle-window-controls-overlay-controls="right"]
+html[data-bangle-window-controls-overlay="visible"]
   .desktop-titlebar-surface {
   padding-right: max(
     0.75rem,
-    calc(
-      100vw - var(--bangle-titlebar-area-x, env(titlebar-area-x, 0px)) -
-        var(--bangle-titlebar-area-width, env(titlebar-area-width, 100vw))
-    )
+    calc(var(--bangle-titlebar-right-inset) + 0.5rem)
   );
+  background: hsl(var(--BV-background));
+  backdrop-filter: none;
 }
 
-html[data-bangle-window-controls-overlay="visible"][data-bangle-window-controls-overlay-controls="left"]
+html[data-bangle-window-controls-overlay="visible"]:is(
+    [data-bangle-window-controls-overlay-controls="left"],
+    [data-bangle-window-controls-overlay-controls="both"]
+  )
   .peer[data-state="collapsed"][data-side="left"]
   ~ *
   .desktop-titlebar-main-spacer {
   width: max(
     4.75rem,
-    calc(var(--bangle-titlebar-area-x, env(titlebar-area-x, 0px)) + 0.5rem)
+    calc(var(--bangle-titlebar-left-inset) + 0.5rem)
   );
 }
 
@@ -171,13 +173,14 @@ html[data-bangle-desktop-platform="darwin"] .desktop-sidebar-titlebar-header {
   padding-top: 2rem;
 }
 
-html[data-bangle-window-controls-overlay="visible"][data-bangle-window-controls-overlay-controls="left"]
+html[data-bangle-window-controls-overlay="visible"]:is(
+    [data-bangle-window-controls-overlay-controls="left"],
+    [data-bangle-window-controls-overlay-controls="both"]
+  )
   .desktop-sidebar-titlebar-header {
   padding-top: max(
     0.5rem,
-    calc(
-      var(--bangle-titlebar-area-height, env(titlebar-area-height, 0px)) + 0.25rem
-    )
+    calc(var(--bangle-titlebar-area-height) + 0.25rem)
   );
 }
 
@@ -278,6 +281,14 @@ html[data-bangle-window-controls-overlay="visible"][data-bangle-window-controls-
 
 :root {
   --bangle-app-titlebar-height: 40px;
+  --bangle-titlebar-area-x: 0px;
+  --bangle-titlebar-area-y: 0px;
+  --bangle-titlebar-area-width: 100vw;
+  --bangle-titlebar-area-height: var(--bangle-app-titlebar-height);
+  --bangle-titlebar-left-inset: var(--bangle-titlebar-area-x);
+  --bangle-titlebar-right-inset: calc(
+    100vw - var(--bangle-titlebar-area-x) - var(--bangle-titlebar-area-width)
+  );
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);

--- a/packages/tooling/e2e-tests/src/app-shell-layout.e2e.ts
+++ b/packages/tooling/e2e-tests/src/app-shell-layout.e2e.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { createBrowserWorkspace } from './common';
+import {
+  createBrowserWorkspace,
+  createBrowserWorkspaceAndNote,
+} from './common';
 
 // Guards the app-shell macro layout: a full-height, edge-to-edge sidebar (the
 // flush "sidebar" variant, not the old rounded floating card), a thin titlebar,
@@ -52,4 +55,50 @@ test('app shell: full-height flush sidebar, thin titlebar, collapse/expand', asy
   await expect
     .poll(async () => (await sidebarPanel.boundingBox())?.x ?? -1)
     .toBeGreaterThanOrEqual(0);
+});
+
+test('app shell: PWA window controls overlay keeps titlebar actions outside reserved chrome geometry', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'overlay-layout-ws',
+    noteName: 'Overlay Note',
+  });
+
+  await page.evaluate(() => {
+    const titlebarLeftInset = 80;
+    const titlebarRightInset = 96;
+    const root = document.documentElement;
+
+    root.setAttribute('data-bangle-window-controls-overlay', 'visible');
+    root.setAttribute('data-bangle-window-controls-overlay-controls', 'both');
+    root.style.setProperty(
+      '--bangle-titlebar-area-x',
+      `${titlebarLeftInset}px`,
+    );
+    root.style.setProperty(
+      '--bangle-titlebar-area-width',
+      `calc(100vw - ${titlebarLeftInset + titlebarRightInset}px)`,
+    );
+    root.style.setProperty('--bangle-titlebar-area-height', '40px');
+  });
+
+  const titlebar = page.locator('header.desktop-titlebar-surface').first();
+  const toggleMaxWidthButton = page.getByRole('button', {
+    name: 'Toggle Max Width',
+  });
+  await expect(toggleMaxWidthButton).toBeVisible();
+
+  await expect
+    .poll(async () =>
+      titlebar.evaluate((element) => getComputedStyle(element).paddingRight),
+    )
+    .toBe('104px');
+  await expect
+    .poll(async () =>
+      toggleMaxWidthButton.evaluate(
+        (element) => window.innerWidth - element.getBoundingClientRect().right,
+      ),
+    )
+    .toBeGreaterThanOrEqual(96);
 });


### PR DESCRIPTION
## Summary

- derive left, right, both, or no PWA window-controls overlay regions from the titlebar area rect
- reserve the right-side overlay inset so titlebar actions do not sit under Chrome/PWA controls
- use a solid app background while the PWA overlay is visible so browser-controlled cutouts visually match the app surface
- add unit and Playwright coverage for the both-sides overlay geometry case
- document the requested non-main branch end-of-turn PR/commit expectation in AGENTS.md

## Root Cause

The app treated the Window Controls Overlay titlebar rectangle as if controls could only occupy one side. Chrome can expose titlebar geometry where both left and right regions are unavailable, which let right-side app actions overlap the browser-controlled titlebar area.

## Validation

- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm build`
- `pnpm --filter "@bangle.io/e2e-tests" exec playwright test -c ./playwright.config.ts --grep "PWA window controls overlay"`
- `pnpm local-ci-check`
