### PR TITLE
[codex] add Base UI shadcn foundation

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "packages/tooling/browser-entry/src/index.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@bangle.io/base-ui",
+    "utils": "@bangle.io/ui-misc",
+    "ui": "@bangle.io/base-ui",
+    "lib": "@bangle.io/base-ui",
+    "hooks": "@bangle.io/base-ui"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/packages/ui/base-ui/package.json
+++ b/packages/ui/base-ui/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@bangle.io/base-ui",
+  "description": "Base UI-backed shadcn components for Bangle.io",
+  "license": "AGPL-3.0-or-later",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bangle-io/bangle-io.git",
+    "directory": "packages/ui/base-ui"
+  },
+  "authors": [
+    {
+      "name": "Kushan Joshi",
+      "email": "0o3ko0@gmail.com",
+      "web": "http://github.com/kepta"
+    }
+  ],
+  "homepage": "https://bangle.io",
+  "bugs": "https://github.com/bangle-io/bangle-io/issues",
+  "banglePackageConfig": {
+    "env": "browser",
+    "kind": "library"
+  },
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {},
+  "dependencies": {
+    "@bangle.io/ui-misc": "workspace:*",
+    "@base-ui/react": "^1.6.0",
+    "class-variance-authority": "^0.7.1",
+    "react": "19.2.7"
+  },
+  "devDependencies": {}
+}

--- a/packages/ui/base-ui/src/button.tsx
+++ b/packages/ui/base-ui/src/button.tsx
@@ -1,0 +1,61 @@
+import { cn } from '@bangle.io/ui-misc';
+import { Button as ButtonPrimitive } from '@base-ui/react/button';
+import { cva, type VariantProps } from 'class-variance-authority';
+import React from 'react';
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        destructive:
+          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
+        ghost:
+          'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
+        link: 'text-primary underline-offset-4 hover:underline',
+        outline:
+          'border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklch,var(--secondary),var(--foreground)_5%)] aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+      },
+      size: {
+        default:
+          'h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        icon: 'size-8',
+        'icon-lg': 'size-9',
+        'icon-sm':
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3.5",
+        'icon-xs':
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+type ButtonProps = ButtonPrimitive.Props & VariantProps<typeof buttonVariants>;
+
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: ButtonProps) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export type { ButtonProps };
+export { Button, buttonVariants };

--- a/packages/ui/base-ui/src/index.ts
+++ b/packages/ui/base-ui/src/index.ts
@@ -1,0 +1,8 @@
+export { cn, useIsMobile } from '@bangle.io/ui-misc';
+export type { ButtonProps } from './button';
+export { Button, buttonVariants } from './button';
+export type { InputProps } from './input';
+export { Input } from './input';
+export type { SeparatorProps } from './separator';
+export { Separator } from './separator';
+export { Skeleton } from './skeleton';

--- a/packages/ui/base-ui/src/input.tsx
+++ b/packages/ui/base-ui/src/input.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@bangle.io/ui-misc';
+import { Input as InputPrimitive } from '@base-ui/react/input';
+import React from 'react';
+
+type InputProps = React.ComponentProps<typeof InputPrimitive>;
+
+function Input({ className, type, ...props }: InputProps) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base outline-none transition-colors file:inline-flex file:h-6 file:border-0 file:bg-transparent file:font-medium file:text-foreground file:text-sm placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 dark:disabled:bg-input/80',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type { InputProps };
+export { Input };

--- a/packages/ui/base-ui/src/separator.tsx
+++ b/packages/ui/base-ui/src/separator.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@bangle.io/ui-misc';
+import { Separator as SeparatorPrimitive } from '@base-ui/react/separator';
+import React from 'react';
+
+type SeparatorProps = SeparatorPrimitive.Props;
+
+function Separator({
+  className,
+  orientation = 'horizontal',
+  ...props
+}: SeparatorProps) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export type { SeparatorProps };
+export { Separator };

--- a/packages/ui/base-ui/src/skeleton.tsx
+++ b/packages/ui/base-ui/src/skeleton.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@bangle.io/ui-misc';
+import React from 'react';
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('animate-pulse rounded-md bg-muted', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/plans/003-shadcn-base-ui-migration.md
+++ b/plans/003-shadcn-base-ui-migration.md
@@ -7,7 +7,8 @@ archived_on:
 created: 2026-07-05
 updated: 2026-07-05
 owner: mixed
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/603
 related_issues: []
 ---
 

--- a/plans/003-shadcn-base-ui-migration.md
+++ b/plans/003-shadcn-base-ui-migration.md
@@ -24,12 +24,20 @@ target `@bangle.io/base-ui`.
 No backwards compatibility layer is required. Prefer direct Base UI semantics
 over preserving Radix-only props such as `asChild`.
 
+The end goal is a complete migration: all app and UI consumers should use the
+modern Base UI-backed component layer, Radix-only dependencies should disappear
+unless a deliberate non-shadcn exception remains, and the old `@bangle.io/shadcn`
+package should be removed. Different visual details are acceptable during this
+modernization. Broken workflows, focus behavior, keyboard behavior, persistence,
+or accessibility regressions are not acceptable.
+
 ## Current Status
 
 - `@bangle.io/shadcn` remains the current production Radix-backed package.
 - `@bangle.io/base-ui` is the new Base UI-backed target package.
-- The root `components.json` points shadcn CLI generation at
-  `packages/ui/base-ui/src` through the `@bangle.io/base-ui` alias.
+- The root `components.json` records the intended shadcn Base UI target package.
+  Direct root CLI generation is not enabled until shadcn can resolve the
+  monorepo aliases through `tsconfig.json` paths or package import aliases.
 - Tailwind v4 and React 19 foundations already exist in
   `packages/tooling/browser-entry/src/index.css`.
 
@@ -46,6 +54,68 @@ over preserving Radix-only props such as `asChild`.
 - Convert state selectors from Radix `data-state` values to Base UI presence
   attributes such as `data-open`, `data-closed`, `data-disabled`,
   `data-checked`, and `data-unchecked`.
+
+## Reference Docs Workflow
+
+Before migrating each component family, read the current official docs instead
+of copying assumptions from the old Radix wrappers:
+
+- Shadcn Base UI default / changelog:
+  `https://ui.shadcn.com/docs/changelog`
+- Shadcn CLI:
+  `https://ui.shadcn.com/docs/cli`
+- Shadcn `components.json`:
+  `https://ui.shadcn.com/docs/components-json`
+- Shadcn monorepo guidance:
+  `https://ui.shadcn.com/docs/monorepo`
+- Shadcn theming:
+  `https://ui.shadcn.com/docs/theming`
+- Shadcn Base component docs:
+  `https://ui.shadcn.com/docs/components/base/<component-name>`
+- Base UI composition:
+  `https://base-ui.com/react/handbook/composition`
+- Base UI TypeScript:
+  `https://base-ui.com/react/handbook/typescript`
+- Base UI component docs:
+  `https://base-ui.com/react/components/<component-name>`
+
+For every component migration, record in the PR description which docs were
+checked and any API differences that affected implementation. Treat shadcn docs
+as the styling/API starting point and Base UI docs as the source of truth for
+primitive behavior, composition, focus management, and accessibility semantics.
+
+## Reference Project Setup
+
+Use a throwaway project to inspect the latest generated shadcn Base UI code
+before editing Bangle wrappers. Do not let the CLI rewrite this monorepo
+directly until the generated output has been reviewed.
+
+```bash
+tmpdir="$(mktemp -d)"
+cd "$tmpdir"
+pnpm dlx shadcn@latest init -b base -t vite -p nova -n scratch \
+  -y --no-monorepo --no-reinstall --css-variables
+cd scratch
+pnpm dlx shadcn@latest add button dialog dropdown-menu select \
+  --dry-run --view
+```
+
+For the Bangle repo itself, keep `components.json` aligned with the target
+package, but do not run root CLI writes until alias resolution has been made
+explicit. The readiness check is:
+
+```bash
+pnpm dlx shadcn@latest info
+```
+
+That command must pass before using root-level `shadcn add`. Until then, use the
+throwaway project as the source reference, then adapt the generated code to
+Bangle's package boundaries, explicit public barrels, translations rules, and
+tests. Once alias resolution is fixed, inspect root output with:
+
+```bash
+pnpm dlx shadcn@latest add <component> --dry-run --view
+```
 
 ## Out Of Scope
 
@@ -72,10 +142,28 @@ over preserving Radix-only props such as `asChild`.
 9. Remove Radix dependencies and the old `@bangle.io/shadcn` package once all
    consumers have moved.
 
+## Modernization Rules
+
+- Prefer Base UI's current APIs even when this forces call-site updates.
+- Prefer explicit component props and semantic elements over compatibility
+  shims that preserve old Radix-only patterns.
+- Keep behavior stable through tests: opening/closing, keyboard navigation,
+  focus restoration, disabled states, form submission, selection, checked state,
+  scroll behavior, portal layering, and persistence-facing workflows.
+- Visual differences are acceptable when they come from the new shadcn/Base UI
+  defaults or a deliberate simplification.
+- Do not accept regressions in accessible names, roles, tab order, escape key
+  behavior, outside click behavior, or destructive-action confirmation flows.
+- When generated shadcn code conflicts with Bangle invariants, document the
+  difference in the PR and preserve Bangle's data-safety and local-first
+  behavior.
+
 ## Verification
 
 - For every code iteration, run `pnpm lint:ci` and `pnpm test:ci`.
 - Run focused Playwright tests for each user-visible component migration.
+- Add or update Playwright coverage for the migrated user workflow. Component
+  tests may supplement this, but released behavior needs E2E coverage.
 - Run `pnpm build` when changing package wiring, build inputs, dependencies, or
   theme behavior.
 - Before PR update, run `pnpm local-ci-check`.
@@ -92,6 +180,8 @@ over preserving Radix-only props such as `asChild`.
 ## Next Steps
 
 - Add Base UI versions of the remaining low-risk primitives.
+- Use a throwaway shadcn Base UI project to review the latest generated source
+  before each component-family migration.
 - Replace direct `@radix-ui/react-slot` usage in `@bangle.io/ui-components`
   wrappers with explicit component APIs or Base UI `render` where appropriate.
 - Pick one low-risk app workflow and migrate it fully with Playwright coverage.

--- a/plans/003-shadcn-base-ui-migration.md
+++ b/plans/003-shadcn-base-ui-migration.md
@@ -1,0 +1,96 @@
+---
+title: Shadcn Base UI Migration
+status: active
+type: plan
+archived: false
+archived_on:
+created: 2026-07-05
+updated: 2026-07-05
+owner: mixed
+related_prs: []
+related_issues: []
+---
+
+# Shadcn Base UI Migration
+
+## Summary
+
+Migrate Bangle's UI primitives from the existing Radix-backed
+`@bangle.io/shadcn` package to Base UI-backed shadcn components. Both component
+libraries may coexist during the migration, but new foundational work should
+target `@bangle.io/base-ui`.
+
+No backwards compatibility layer is required. Prefer direct Base UI semantics
+over preserving Radix-only props such as `asChild`.
+
+## Current Status
+
+- `@bangle.io/shadcn` remains the current production Radix-backed package.
+- `@bangle.io/base-ui` is the new Base UI-backed target package.
+- The root `components.json` points shadcn CLI generation at
+  `packages/ui/base-ui/src` through the `@bangle.io/base-ui` alias.
+- Tailwind v4 and React 19 foundations already exist in
+  `packages/tooling/browser-entry/src/index.css`.
+
+## Scope
+
+- Rebuild shadcn wrappers on `@base-ui/react` subpath imports.
+- Keep explicit public barrels. Avoid `export *` from public package entry
+  points.
+- Migrate app consumers in thin vertical slices so the repo stays buildable.
+- Replace `asChild` composition with Base UI `render` composition where the
+  underlying primitive participates in behavior.
+- Use `buttonVariants` or ordinary elements for links instead of rendering a
+  Base UI button as an anchor.
+- Convert state selectors from Radix `data-state` values to Base UI presence
+  attributes such as `data-open`, `data-closed`, `data-disabled`,
+  `data-checked`, and `data-unchecked`.
+
+## Out Of Scope
+
+- Do not rewrite unrelated app UI while migrating primitives.
+- Do not move business behavior into `ui` packages.
+- Do not migrate `Calendar` away from `react-day-picker` only for Base UI; it is
+  not a Base UI primitive swap.
+- Do not rewrite `Command` until a dedicated workflow can replace `cmdk` with a
+  Base UI composition such as `Autocomplete` plus `Dialog`.
+
+## Iteration Order
+
+1. Foundation: package, registry config, low-risk primitives, validator green.
+2. Presentational primitives: `input`, `separator`, `skeleton`.
+3. Field primitives: migrate labels alongside their controls with Base UI
+   `Field.Root` / `Field.Label` instead of a standalone native label wrapper.
+4. Action primitives: `button`, `toggle`, `toggle-group`; update consumers from
+   `asChild` to explicit links or `render`.
+5. Disclosure primitives: `collapsible`, `accordion`.
+6. Overlays: `tooltip`, `dialog`, `alert-dialog`, `sheet` as positioned dialog
+   or drawer.
+7. Menus and selection: `dropdown-menu`, `menubar`, `select`.
+8. Complex compositions: `command`, sidebar wrappers, namespace re-exports.
+9. Remove Radix dependencies and the old `@bangle.io/shadcn` package once all
+   consumers have moved.
+
+## Verification
+
+- For every code iteration, run `pnpm lint:ci` and `pnpm test:ci`.
+- Run focused Playwright tests for each user-visible component migration.
+- Run `pnpm build` when changing package wiring, build inputs, dependencies, or
+  theme behavior.
+- Before PR update, run `pnpm local-ci-check`.
+
+## Known Blockers
+
+- Namespace re-exports from `@bangle.io/ui-components` expose broad shadcn
+  surfaces and should be narrowed before large migrations.
+- Composition-heavy consumers use Radix `asChild`; these need semantic review,
+  not a mechanical rename.
+- Dialog, menu, select, and tooltip popup anatomy changes from direct content
+  parts to Base UI `Portal` / `Positioner` / `Popup` structures.
+
+## Next Steps
+
+- Add Base UI versions of the remaining low-risk primitives.
+- Replace direct `@radix-ui/react-slot` usage in `@bangle.io/ui-components`
+  wrappers with explicit component APIs or Base UI `render` where appropriate.
+- Pick one low-risk app workflow and migrate it fully with Playwright coverage.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -978,6 +978,21 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
 
+  packages/ui/base-ui:
+    dependencies:
+      '@bangle.io/ui-misc':
+        specifier: workspace:*
+        version: link:../ui-misc
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+
   packages/ui/shadcn:
     dependencies:
       '@bangle.io/ui-misc':
@@ -1555,6 +1570,33 @@ packages:
 
   '@bangle.io/config-template@0.0.7':
     resolution: {integrity: sha512-nPFkcM3aU/w+NJxwiQrpfu7Md3wpQrVY870ieeaZNyqPGvYj7qOng06Z7GalEvR2a6dLsvsQC3X1MgQImEOCGw==}
+
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: 19.2.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -8110,6 +8152,9 @@ packages:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
@@ -9797,6 +9842,31 @@ snapshots:
       prosemirror-markdown: 1.13.4
 
   '@bangle.io/config-template@0.0.7(patch_hash=0a38520ebfadd7609c241ee1e3d54cda505b50cadb57a967b8966ac9b17c6ad8)': {}
+
+  '@base-ui/react@1.6.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@date-fns/tz': 1.5.0
+      '@types/react': 19.2.17
+      date-fns: 4.4.0
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -16946,6 +17016,8 @@ snapshots:
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
+
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 


### PR DESCRIPTION
## Summary

- add a new `@bangle.io/base-ui` workspace package for Base UI-backed shadcn components
- add initial Base UI primitives for button, input, separator, and skeleton
- add root `components.json` configured for shadcn Base UI generation into the new package
- document the iterative migration plan in `plans/003-shadcn-base-ui-migration.md`

## Notes

This intentionally keeps the existing Radix-backed `@bangle.io/shadcn` package in place so migration can happen component by component. The plan calls out high-risk areas like `asChild` composition, menu/select/dialog popup anatomy, and namespace re-exports.

## Validation

- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm build`
- `eval "$(node scripts/dev-ports.js --env)" && pnpm local-ci-check`
