### PR TITLE
fix: preserve heading whitespace drag selection

### DIFF
--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -82,6 +82,14 @@ function toggleButtons(view: { dom: HTMLElement }): HTMLButtonElement[] {
   ];
 }
 
+function trailingSlot(view: { dom: HTMLElement }): HTMLElement {
+  const slot = view.dom.querySelector<HTMLElement>('.B-block-trailing-slot');
+  if (!slot) {
+    throw new Error('Expected trailing slot to render');
+  }
+  return slot;
+}
+
 describe('getHeadingFoldRange', () => {
   it('spans everything up to the next heading of the same level', () => {
     const d = doc(h1('One'), p('a'), p('b'), h1('Two'), p('c'));
@@ -253,10 +261,36 @@ describe('toggle affordance', () => {
     const text = headingDom?.firstChild;
     expect(text?.textContent).toBe('One');
     expect(
-      text &&
-        slot &&
-        slot.compareDocumentPosition(text) & Node.DOCUMENT_POSITION_PRECEDING,
+      text != null &&
+        slot != null &&
+        (slot.compareDocumentPosition(text) &
+          Node.DOCUMENT_POSITION_PRECEDING) !==
+          0,
     ).toBeTruthy();
+  });
+
+  it('keeps the trailing widget transparent to native drag selections', () => {
+    const editor = editorTest.createEditor(doc(h1('One'), p('a')));
+    const slot = trailingSlot(editor.view);
+    const widgetDesc = (
+      slot as HTMLElement & {
+        pmViewDesc?: {
+          ignoreForSelection?: boolean;
+          stopEvent?: (event: Event) => boolean;
+        };
+      }
+    ).pmViewDesc;
+
+    // ProseMirror otherwise normalizes DOM selections back to the widget's
+    // declared side, which breaks native horizontal text selection when a drag
+    // starts from the whitespace after a heading.
+    expect(widgetDesc?.ignoreForSelection).toBe(true);
+
+    const event = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+    expect(widgetDesc?.stopEvent?.(event)).toBe(true);
   });
 
   it('clicking the toggle folds and unfolds the section', () => {

--- a/packages/js-lib/banger-editor/src/trailing-slot.ts
+++ b/packages/js-lib/banger-editor/src/trailing-slot.ts
@@ -46,6 +46,17 @@ export function createTrailingWidget({
       key,
       side: 1,
       ignoreSelection: true,
+      relaxedSide: true,
+      stopEvent: isTrailingSlotEvent,
     },
+  );
+}
+
+function isTrailingSlotEvent(event: Event): boolean {
+  return (
+    event.type === 'mousedown' ||
+    event.type === 'pointerdown' ||
+    event.type === 'touchstart' ||
+    event.type === 'click'
   );
 }

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -317,6 +317,65 @@ test('the fold toggle trails the last line of a wrapped heading', async ({
   await expect(editor.getByText('content below')).toBeVisible();
 });
 
+test('dragging left from heading whitespace selects heading text', async ({
+  page,
+}) => {
+  const workspaceName = 'collapsible-heading-whitespace-selection';
+  const noteName = 'Home';
+  const source = [
+    '# Select Me Heading',
+    '',
+    'content below',
+    '',
+    '# Next',
+    '',
+    'tail',
+  ].join('\n');
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(page, workspaceName, noteName, source);
+  await page.reload();
+
+  const editor = getEditorLocator(page, {});
+  const heading = editor.locator('h1', { hasText: 'Select Me Heading' });
+  await expect(heading).toBeVisible();
+
+  const dragMetrics = await heading.evaluate((element) => {
+    const textNode = [...element.childNodes].find(
+      (node): node is Text =>
+        node.nodeType === Node.TEXT_NODE &&
+        node.textContent?.includes('Select Me Heading') === true,
+    );
+    if (!textNode) {
+      throw new Error('Expected heading text node');
+    }
+
+    const range = document.createRange();
+    range.selectNodeContents(textNode);
+    const textRect = range.getBoundingClientRect();
+    const headingRect = element.getBoundingClientRect();
+    range.detach();
+
+    if (headingRect.right - textRect.right < 48) {
+      throw new Error('Expected empty whitespace to the right of the heading');
+    }
+
+    return {
+      endX: textRect.left + 1,
+      startX: headingRect.right - 8,
+      y: textRect.top + textRect.height / 2,
+    };
+  });
+
+  await page.mouse.move(dragMetrics.startX, dragMetrics.y);
+  await page.mouse.down();
+  await page.mouse.move(dragMetrics.endX, dragMetrics.y, { steps: 12 });
+  await page.mouse.up();
+
+  await expect
+    .poll(() => page.evaluate(() => window.getSelection()?.toString() ?? ''))
+    .toContain('Select Me Heading');
+});
+
 test('a heading with nothing beneath it shows a disabled toggle', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- Let trailing heading widgets use ProseMirror `relaxedSide` so browser drag selections can cross the widget boundary.
- Stop editor mouse handling for direct trailing-widget pointer/click events.
- Add unit coverage for the widget selection contract and a Playwright regression for dragging left from empty heading whitespace.

## Tests
- `pnpm vitest packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts`
- `eval "$(node scripts/dev-ports.js --env)" && pnpm --filter "@bangle.io/e2e-tests" run test src/collapsible-headings.e2e.ts`
- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm local-ci-check`