### PR TITLE
fix: stop file tree re-navigating on browser back/forward

### DIFF
--- a/packages/tooling/e2e-tests/src/browser-history-navigation.e2e.ts
+++ b/packages/tooling/e2e-tests/src/browser-history-navigation.e2e.ts
@@ -1,0 +1,56 @@
+import { expect, type Page, test } from '@playwright/test';
+import { createBrowserWorkspaceAndNote, getEditorLocator } from './common';
+
+const workspaceName = 'history-nav-ws';
+
+function editorUrl(relativePath: string): string {
+  return `/ws#route=editor&wsPath=${encodeURIComponent(
+    `${workspaceName}:${relativePath}`,
+  )}`;
+}
+
+async function createNoteViaDialog(page: Page, noteName: string) {
+  await page.getByRole('button', { name: 'Bangle.io' }).click();
+  await page.getByRole('menuitem', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill(noteName);
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(getEditorLocator(page, {})).toBeVisible();
+}
+
+async function openNoteFromExplorer(page: Page, fileName: string) {
+  const explorer = page.getByTestId('bangle-file-explorer');
+  await explorer.getByRole('treeitem', { name: fileName }).click();
+  await expect(page).toHaveURL(editorUrl(fileName));
+}
+
+// Regression: opening a note from the file explorer must create exactly one
+// browser-history entry. A stale implementation re-fired the tree's "open"
+// callback when the active route (and therefore the tree selection) changed
+// from browser back/forward, pushing a duplicate entry that silently destroyed
+// the forward stack — so Back appeared to do nothing and Forward stopped
+// working.
+test('browser back and forward navigate between opened notes', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'note-a',
+  });
+  await createNoteViaDialog(page, 'note-b');
+
+  // Establish a clean history: A then B, each a single navigation.
+  await openNoteFromExplorer(page, 'note-a.md');
+  await openNoteFromExplorer(page, 'note-b.md');
+
+  // A single Back returns to A (no phantom duplicate entry to click through).
+  await page.goBack();
+  await expect(page).toHaveURL(editorUrl('note-a.md'));
+
+  // The forward entry (B) must survive — this is the core of the bug.
+  await page.goForward();
+  await expect(page).toHaveURL(editorUrl('note-b.md'));
+
+  // And Back still works afterwards, proving history is not corrupted.
+  await page.goBack();
+  await expect(page).toHaveURL(editorUrl('note-a.md'));
+});

--- a/packages/ui/ui-components/src/file-tree/__tests__/should-open-selected-file.spec.ts
+++ b/packages/ui/ui-components/src/file-tree/__tests__/should-open-selected-file.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { shouldOpenSelectedFile } from '../types';
+
+describe('shouldOpenSelectedFile', () => {
+  it('opens when the user selects a file different from the active route', () => {
+    expect(
+      shouldOpenSelectedFile({
+        selectedPath: 'notes/b.md',
+        activeRoutePath: 'notes/a.md',
+        isKnownFilePath: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('opens when nothing is active yet', () => {
+    expect(
+      shouldOpenSelectedFile({
+        selectedPath: 'notes/a.md',
+        activeRoutePath: null,
+        isKnownFilePath: true,
+      }),
+    ).toBe(true);
+  });
+
+  // This is the regression guard: browser back/forward (and any external
+  // navigation) re-selects the active file, and re-opening it would push a
+  // duplicate history entry that destroys the forward stack.
+  it('does NOT open when the selection already matches the active route', () => {
+    expect(
+      shouldOpenSelectedFile({
+        selectedPath: 'notes/a.md',
+        activeRoutePath: 'notes/a.md',
+        isKnownFilePath: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not open an unknown (non-tree) path', () => {
+    expect(
+      shouldOpenSelectedFile({
+        selectedPath: 'notes/ghost.md',
+        activeRoutePath: 'notes/a.md',
+        isKnownFilePath: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not open when there is no selected path', () => {
+    expect(
+      shouldOpenSelectedFile({
+        selectedPath: undefined,
+        activeRoutePath: 'notes/a.md',
+        isKnownFilePath: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldOpenSelectedFile({
+        selectedPath: '',
+        activeRoutePath: null,
+        isKnownFilePath: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -15,6 +15,7 @@ import {
   type FileTreeEntryAction,
   normalizePierreDirectoryPath,
   normalizePierreFilePath,
+  shouldOpenSelectedFile,
 } from './types';
 
 // Tune the Pierre tree to read like the rest of the sidebar (the previous file
@@ -323,6 +324,7 @@ export function PierreFileTree({
   const onMoveFileRef = useRef(onMoveFile);
   const pendingUserOpenPathRef = useRef<string | null>(null);
   const selectedPathRef = useRef<string | null>(null);
+  const activeSelectedPathRef = useRef<string | null>(null);
   const suppressSelectionOpenRef = useRef(false);
   const suppressSelectionOpenTimerRef = useRef<number | undefined>(undefined);
   const treePathsRef = useRef<readonly string[]>(treePaths);
@@ -331,6 +333,10 @@ export function PierreFileTree({
   onOpenFileRef.current = onOpenFile;
   onMoveFileRef.current = onMoveFile;
   treePathsRef.current = treePaths;
+  // The file the active route points at. Kept current on every render so
+  // `onSelectionChange` can tell a genuine user open from a route-driven
+  // re-select (see `shouldOpenSelectedFile`).
+  activeSelectedPathRef.current = activeTreePaths.at(-1) ?? null;
 
   // Single source of truth for "is this drop a real move?": exactly one dragged
   // file we know about, landing in a directory other than its current parent.
@@ -466,14 +472,36 @@ export function PierreFileTree({
         ? normalizePierreFilePath(selectedPath)
         : undefined;
 
-      if (normalizedPath && filePathSetRef.current.has(normalizedPath)) {
-        if (suppressSelectionOpenRef.current) {
-          return;
-        }
-        selectedPathRef.current = normalizedPath;
-        pendingUserOpenPathRef.current = normalizedPath;
-        onOpenFileRef.current(normalizedPath);
+      const isKnownFilePath = Boolean(
+        normalizedPath && filePathSetRef.current.has(normalizedPath),
+      );
+      if (!normalizedPath || !isKnownFilePath) {
+        return;
       }
+
+      if (suppressSelectionOpenRef.current) {
+        return;
+      }
+
+      // Track the tree's live selection even when we choose not to open, so a
+      // later user selection of a different file is still recognised.
+      selectedPathRef.current = normalizedPath;
+
+      if (
+        !shouldOpenSelectedFile({
+          selectedPath: normalizedPath,
+          activeRoutePath: activeSelectedPathRef.current,
+          isKnownFilePath,
+        })
+      ) {
+        // Route-driven re-select (browser back/forward, links, command
+        // navigation). Re-opening here would push a duplicate history entry and
+        // wipe the forward stack.
+        return;
+      }
+
+      pendingUserOpenPathRef.current = normalizedPath;
+      onOpenFileRef.current(normalizedPath);
     },
     paths: treePaths,
     search: false,

--- a/packages/ui/ui-components/src/file-tree/types.ts
+++ b/packages/ui/ui-components/src/file-tree/types.ts
@@ -21,3 +21,36 @@ export function normalizePierreDirectoryPath(path: string): string {
 export function normalizePierreFilePath(path: string): string {
   return normalizePierreDirectoryPath(path);
 }
+
+export interface SelectionOpenDecisionInput {
+  /** The path the tree reports as newly selected (already normalized). */
+  selectedPath: string | undefined;
+  /** The file path the active route currently points at, or null. */
+  activeRoutePath: string | null;
+  /** Whether the selected path is a real file present in the tree. */
+  isKnownFilePath: boolean;
+}
+
+/**
+ * Decide whether a file-tree selection change should open the file (i.e.
+ * trigger navigation).
+ *
+ * The tree re-selects the active file whenever the route changes from outside
+ * the tree — browser back/forward, in-note links, and command navigation all
+ * flow back in through `activePaths`, which programmatically re-selects the
+ * matching row. Reporting that echoed selection as a user "open" makes the app
+ * navigate to the location it is already at, which pushes a duplicate history
+ * entry and destroys the forward stack. A selection that already matches the
+ * active route is therefore never an open — only a selection that diverges from
+ * the route reflects genuine user intent.
+ */
+export function shouldOpenSelectedFile({
+  selectedPath,
+  activeRoutePath,
+  isKnownFilePath,
+}: SelectionOpenDecisionInput): boolean {
+  if (!selectedPath || !isKnownFilePath) {
+    return false;
+  }
+  return selectedPath !== activeRoutePath;
+}


### PR DESCRIPTION
## Problem

Browser back/forward history was broken. Repro: open a note from the file explorer (e.g. click an internal link like *Getting started*), then press Back — it appears to do nothing, and Forward stops working entirely. Navigating between notes silently corrupts the history stack.

## Root cause

The file explorer tree (`PierreFileTree`) has a controlled selection synced to the active route via the `activePaths` prop. When the route changes **from outside the tree** — browser back/forward, in-note links, command navigation — an effect programmatically re-selects the now-active row (`model.getItem(path).select()`). That fires the tree's `onSelectionChange`, which unconditionally treated **any** selection change as a user "open" and called `onOpenFile` → `command::ws:go-ws-path` → `navigation.goWsFile` → `history.pushState`.

So pressing Back produced this feedback loop:

```
popstate → route = A → activePaths = A → effect .select(A)
        → onSelectionChange(A) → onOpenFile(A) → pushState(A)  ← duplicate entry
```

The duplicate `pushState` of the location the app was already at overwrote the forward entry, destroying the forward stack. Confirmed empirically with a captured `history.pushState` stack trace against the live app.

## Fix

Only treat a tree selection as a user open when it **diverges from the active route**. A selection that already matches the active route is a route-driven re-select and must not navigate. Extracted the decision into a pure, documented `shouldOpenSelectedFile` policy helper.

## Tests

- **Unit** (`should-open-selected-file.spec.ts`): exhaustive coverage of the open-decision policy, including the route-match regression case.
- **E2E** (`browser-history-navigation.e2e.ts`): opens two notes, asserts a single Back returns to the first note and Forward still returns to the second. Verified this test **fails without the fix** (Forward stays on note-a) and passes with it.

## Verification

- `pnpm lint:ci` ✅ (validation, tsgo, biome)
- `pnpm test:ci` ✅ (121 files, 1401 passed)
- file-explorer + wiki-links e2e suites ✅ (19 passed) — existing open/selection behavior intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)