### PR TITLE
fix(editor): stop duplicate image nodes on paste/drop

### DIFF
--- a/packages/core/editor/src/__tests__/asset-file-plugin.spec.ts
+++ b/packages/core/editor/src/__tests__/asset-file-plugin.spec.ts
@@ -444,6 +444,118 @@ describe('setupAssetFilePlugin', () => {
     view.destroy();
   });
 
+  it('does not duplicate a pasted image surfaced through items and files with mismatched lastModified', async () => {
+    const stored = deferred<StoredMarkdownAsset[]>();
+    const storeFiles = vi.fn(() => stored.promise);
+    const { view } = createView({ storeFiles });
+
+    // Real browsers hand back a *distinct* File object for the `items` view and
+    // the `files` view of the same pasted image, and those objects can carry
+    // different `lastModified` timestamps. The previous implementation keyed
+    // de-duplication on lastModified, so the same image slipped through twice
+    // and produced a second image node. jsdom leaves File.lastModified
+    // undefined, so the mismatch is forced explicitly to mirror the browser.
+    const fileFromItem = new File(['image'], 'Photo.png', {
+      type: 'image/png',
+    });
+    Object.defineProperty(fileFromItem, 'lastModified', { value: 1000 });
+    const fileFromFiles = new File(['image'], 'Photo.png', {
+      type: 'image/png',
+    });
+    Object.defineProperty(fileFromFiles, 'lastModified', { value: 2000 });
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        items: [
+          {
+            kind: 'file',
+            getAsFile: () => fileFromItem,
+          },
+        ],
+        files: [fileFromFiles],
+        types: ['Files'],
+        getData: () => '',
+      },
+    } as unknown as ClipboardEvent;
+
+    expect(
+      view.someProp('handlePaste', (handler) =>
+        handler(view, event, Slice.empty),
+      ),
+    ).toBe(true);
+
+    // Exactly one file is stored — never both views of the same image.
+    expect(storeFiles).toHaveBeenCalledTimes(1);
+    expect(storeFiles).toHaveBeenCalledWith(
+      view,
+      [fileFromItem],
+      expect.any(AbortSignal),
+    );
+
+    stored.resolve([
+      {
+        file: fileFromItem,
+        wsPath: WsFilePath.fromString('workspace:notes/assets/photo.png'),
+        href: 'assets/photo.png',
+        label: 'Photo.png',
+        isImage: true,
+      },
+    ]);
+
+    await vi.waitFor(() => {
+      const imageSources: string[] = [];
+      view.state.doc.descendants((node) => {
+        if (node.type.name === 'image') {
+          imageSources.push(node.attrs.src);
+        }
+      });
+      expect(imageSources).toEqual(['assets/photo.png']);
+    });
+    view.destroy();
+  });
+
+  it('reads pasted files from clipboardData.files when items exposes no file entries', async () => {
+    const stored = deferred<StoredMarkdownAsset[]>();
+    const storeFiles = vi.fn(() => stored.promise);
+    const { view } = createView({ storeFiles });
+
+    const file = new File(['image'], 'Photo.png', { type: 'image/png' });
+    const event = {
+      preventDefault: vi.fn(),
+      clipboardData: {
+        // Only a non-file item is present (e.g. accompanying text/html); the
+        // file is reachable solely through `files`.
+        items: [
+          {
+            kind: 'string',
+            type: 'text/html',
+            getAsFile: () => null,
+          },
+        ],
+        files: [file],
+        types: ['text/html', 'Files'],
+        getData: () => '',
+      },
+    } as unknown as ClipboardEvent;
+
+    expect(
+      view.someProp('handlePaste', (handler) =>
+        handler(view, event, Slice.empty),
+      ),
+    ).toBe(true);
+    expect(storeFiles).toHaveBeenCalledWith(
+      view,
+      [file],
+      expect.any(AbortSignal),
+    );
+
+    stored.resolve([]);
+    await vi.waitFor(() => {
+      expect(view.state.doc.textContent).toBe('Hello ');
+    });
+    view.destroy();
+  });
+
   it('inserts a dropped image at a document-boundary drop position', async () => {
     const stored = deferred<StoredMarkdownAsset[]>();
     const storeFiles = vi.fn(() => stored.promise);

--- a/packages/core/editor/src/asset-file-plugin.ts
+++ b/packages/core/editor/src/asset-file-plugin.ts
@@ -60,33 +60,33 @@ type AssetFilePluginMeta =
     };
 
 function collectFiles(dataTransfer: DataTransfer): File[] {
-  const files: File[] = [];
-  const seen = new Set<string>();
-
-  const addFile = (file: File) => {
-    const key = `${file.name}\0${file.size}\0${file.type}\0${file.lastModified}`;
-    if (seen.has(key)) {
-      return;
-    }
-    files.push(file);
-    seen.add(key);
-  };
-
+  // `dataTransfer.items` (file entries) and `dataTransfer.files` are two
+  // overlapping views of the *same* pasted/dropped payload, not two disjoint
+  // sets. Merging them duplicated content: browsers materialize a distinct
+  // `File` object for each view, and those objects can carry different
+  // `lastModified` timestamps (stamped at slightly different sub-millisecond
+  // moments), so any name/size/type/lastModified de-duplication is unreliable
+  // and intermittently let the same image through twice — producing a second
+  // image node. Read a single authoritative source instead, never a union.
+  //
+  // Prefer the typed `items` list; fall back to `files` when `items` yields no
+  // file entries (older browsers and some clipboard paths only populate one).
+  // Both should enumerate the same files, so pick whichever is more complete
+  // rather than combining them.
+  const fromItems: File[] = [];
   for (const item of Array.from(dataTransfer.items ?? [])) {
     if (item.kind !== 'file') {
       continue;
     }
     const file = item.getAsFile();
     if (file) {
-      addFile(file);
+      fromItems.push(file);
     }
   }
 
-  for (const file of Array.from(dataTransfer.files ?? [])) {
-    addFile(file);
-  }
+  const fromFiles = Array.from(dataTransfer.files ?? []);
 
-  return files;
+  return fromItems.length >= fromFiles.length ? fromItems : fromFiles;
 }
 
 function isInternalProseMirrorDrag(

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -178,6 +178,8 @@ test('pastes workspace-backed image and PDF assets, reloads, and opens asset pag
   expect(markdown).toContain('[Spec Sheet.PDF](assets/spec-sheet-');
   expect(markdown).toContain('.pdf)');
 
+  // A single pasted image must yield exactly one image node, never a duplicate.
+  await expect(editor.locator('img')).toHaveCount(1);
   await expect(editor.locator('img')).toHaveAttribute('src', /^blob:/);
 
   await page.reload({ waitUntil: 'networkidle' });


### PR DESCRIPTION
## Problem

Pasting (or dropping) an image into the editor **intermittently created two image nodes**, and even the single-image case showed a brief flash of a second node. It reproduced "sometimes" — timing-dependent.

## Root cause

`collectFiles()` in `asset-file-plugin.ts` unioned files from **both** overlapping views of the same payload — `DataTransfer.items` (via `getAsFile()`) **and** `DataTransfer.files` — then de-duplicated with a key that included `lastModified`:

```
`${file.name}\0${file.size}\0${file.type}\0${file.lastModified}`
```

Browsers materialize a **distinct `File` object** for each view, and their `lastModified` timestamps are stamped at slightly different sub-millisecond moments. When they differed, the dedup key differed, so the same image was collected twice → `storeWorkspaceAssetFiles` wrote it twice (the second write collided on the millisecond-timestamped filename and retried with a `-2` suffix) → `createAssetNodes` inserted **two `<img>` nodes**.

The existing tests never caught it because they build a *synthetic* `DataTransfer` via `items.add(file)`, where `items` and `files` return the **same** `File` instance with identical `lastModified`, so dedup always succeeded. Mature editors (Novel, Tiptap, ProseKit) read a **single** source and never merge the two.

## Fix

Read one authoritative source, never a union: prefer the typed `items` list and fall back to `files` only when `items` yields no file entries. This eliminates the fragile `lastModified` dependency entirely, and also fixes the latent case where two genuinely distinct files sharing name/size/type were wrongly collapsed.

## Tests

- Unit regression forcing the `items`/`files` `lastModified` mismatch (fails on the old code, passes on the fix) and a `files`-only fallback case.
- Asset-workflow e2e now asserts a single pasted image yields exactly one image node.

Verified: `pnpm lint:ci`, `pnpm test:ci` (1403 passed), and the asset paste e2e in real Chromium all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)