### PR TITLE
fix: resolve duplicate wiki-link names to the closest note

### DIFF
--- a/packages/shared/ws-path/src/__tests__/internal-link.spec.ts
+++ b/packages/shared/ws-path/src/__tests__/internal-link.spec.ts
@@ -81,17 +81,44 @@ describe('resolveWikiLinkTarget', () => {
     expect(resolveWikiLinkTarget(home, 'hello', caseIndex)?.wsPath).toBe(
       'notes:hello.md',
     );
-    expect(resolveWikiLinkTarget(home, 'HELLO', caseIndex)).toBeUndefined();
+    expect(resolveWikiLinkTarget(home, 'HELLO', caseIndex)?.wsPath).toBe(
+      'notes:Hello.md',
+    );
   });
 
-  it('keeps duplicate basenames unresolved unless a path disambiguates them', () => {
-    expect(resolveWikiLinkTarget(home, 'name', index)).toBeUndefined();
+  it('resolves duplicate basenames to the closest note, path still disambiguates', () => {
+    expect(resolveWikiLinkTarget(home, 'name', index)?.wsPath).toBe(
+      'notes:folder/name.md',
+    );
     expect(resolveWikiLinkTarget(home, 'folder/name', index)?.wsPath).toBe(
       'notes:folder/name.md',
     );
     expect(resolveWikiLinkTarget(home, '/other/name', index)?.wsPath).toBe(
       'notes:other/name.markdown',
     );
+  });
+
+  it('prefers a duplicate in the current note directory, then the shallowest path', () => {
+    const sameDirIndex = createWikiLinkIndex(
+      [
+        WsFilePath.fromString('notes:todo.md'),
+        WsFilePath.fromString('notes:projects/todo.md'),
+        WsFilePath.fromString('notes:projects/deep/todo.md'),
+      ],
+      'notes',
+    );
+    expect(
+      resolveWikiLinkTarget('notes:projects/plan.md', 'todo', sameDirIndex)
+        ?.wsPath,
+    ).toBe('notes:projects/todo.md');
+    expect(
+      resolveWikiLinkTarget('notes:elsewhere/plan.md', 'todo', sameDirIndex)
+        ?.wsPath,
+    ).toBe('notes:todo.md');
+    expect(
+      resolveWikiLinkTarget('notes:projects/deep/plan.md', 'todo', sameDirIndex)
+        ?.wsPath,
+    ).toBe('notes:projects/deep/todo.md');
   });
 
   it('supports current-note-relative targets and rejects unsafe targets', () => {
@@ -132,7 +159,9 @@ describe('resolveWikiLinkTarget', () => {
     expect(resolveWikiLinkTarget(home, 'home', index)?.wsPath).toBe(
       'notes:home.md',
     );
-    expect(resolveWikiLinkTarget(home, 'name', index)).toBeUndefined();
+    expect(resolveWikiLinkTarget(home, 'name', index)?.wsPath).toBe(
+      'notes:folder/name.md',
+    );
     expect(searchTargetFor(index, folderName)).toBe('/folder/name');
     expect(index.notes.map((path) => path.wsPath)).not.toContain(
       'elsewhere:name.md',

--- a/packages/shared/ws-path/src/internal-link.ts
+++ b/packages/shared/ws-path/src/internal-link.ts
@@ -153,6 +153,30 @@ export function createWikiLinkIndex(
   };
 }
 
+function dirPrefix(path: WsFilePath): string {
+  return path.filePath.slice(0, path.filePath.lastIndexOf('/') + 1);
+}
+
+/**
+ * Picks the closest note when a bare wiki target matches several files:
+ * same directory as the current note, then fewest path segments, then
+ * lexicographic file path so resolution stays deterministic.
+ */
+function pickClosestWikiLinkMatch(
+  current: WsFilePath,
+  matches: readonly WsFilePath[],
+): WsFilePath | undefined {
+  const currentDir = dirPrefix(current);
+  const compare = (a: WsFilePath, b: WsFilePath): number =>
+    Number(dirPrefix(a) !== currentDir) - Number(dirPrefix(b) !== currentDir) ||
+    a.filePath.split('/').length - b.filePath.split('/').length ||
+    (a.filePath < b.filePath ? -1 : a.filePath > b.filePath ? 1 : 0);
+  return matches.reduce<WsFilePath | undefined>(
+    (best, match) => (!best || compare(match, best) < 0 ? match : best),
+    undefined,
+  );
+}
+
 /** Resolves legacy and relative wiki targets against the known notes in one workspace. */
 export function resolveWikiLinkTarget(
   currentWsPath: string | WsFilePath,
@@ -189,10 +213,10 @@ export function resolveWikiLinkTarget(
 
   const stem = withoutMarkdownExtension(target);
   const exact = index.byStem.get(stem) ?? [];
-  if (exact.length === 1) return exact[0];
-  if (exact.length > 1) return undefined;
-  const insensitive = index.byLowerStem.get(stem.toLocaleLowerCase()) ?? [];
-  return insensitive.length === 1 ? insensitive[0] : undefined;
+  const matches = exact.length
+    ? exact
+    : (index.byLowerStem.get(stem.toLocaleLowerCase()) ?? []);
+  return pickClosestWikiLinkMatch(current, matches);
 }
 
 /** Resolves where an unresolved wiki target should be created. */

--- a/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
+++ b/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
@@ -370,7 +370,7 @@ test('renders resolved and unresolved wiki links with distinct dark-mode afforda
   expect(missingStyle.borderWidth).toBe('0px');
 });
 
-test('keeps escape, code, malformed, and ambiguous wiki text non-destructive', async ({
+test('keeps escape, code, and malformed wiki text non-destructive and resolves duplicate names', async ({
   page,
 }) => {
   const workspaceName = 'wiki-link-literals';
@@ -437,9 +437,20 @@ test('keeps escape, code, malformed, and ambiguous wiki text non-destructive', a
   await expect(editor.locator('code').first()).toHaveText('[[inline]]');
   await expect(editor.locator('pre')).toContainText('[[fenced]]');
   await expect(editor).toContainText('[[nested [[bad]]]]');
+
+  const sameLink = editor.getByRole('link', { name: 'Same', exact: true });
+  await expect(sameLink).toBeVisible();
   await expect(
     editor.getByRole('link', { name: 'Same (note not found)' }),
-  ).toBeVisible();
+  ).toHaveCount(0);
+  await sameLink.click();
+  await expect(page).toHaveURL(
+    /ws#route=editor&wsPath=wiki-link-literals%3Aone%2FSame\.md$/,
+  );
+  await expect(getEditorLocator(page, {})).toContainText('one');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Same'))
+    .toBeUndefined();
 });
 
 test('does not trigger wiki-link suggestions while typing inside a Markdown link', async ({

--- a/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
+++ b/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
@@ -453,6 +453,75 @@ test('keeps escape, code, and malformed wiki text non-destructive and resolves d
     .toBeUndefined();
 });
 
+test('resolves duplicate wiki-link names to the note closest to the current note', async ({
+  page,
+}) => {
+  const workspaceName = 'wiki-link-closest';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+  await writeStoredMarkdown(page, workspaceName, 'todo', 'root todo');
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'projects/todo',
+    'projects todo',
+  );
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'projects/plan',
+    'Plan [[todo]]',
+  );
+  await writeStoredMarkdown(page, workspaceName, 'Home', 'Home [[todo]]');
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const todoLink = editor.getByRole('link', { name: 'todo', exact: true });
+
+  // From a root note, [[todo]] prefers the shallowest match: the root todo.md.
+  await expect(todoLink).toBeVisible();
+  await todoLink.click();
+  await expect(page).toHaveURL(
+    /ws#route=editor&wsPath=wiki-link-closest%3Atodo\.md$/,
+  );
+  await expect(editor).toContainText('root todo');
+
+  const linkedMentions = page.getByRole('region', { name: 'Linked mentions' });
+  await expect(
+    linkedMentions.getByRole('link', { name: 'Home.md' }),
+  ).toBeVisible();
+  await expect(
+    linkedMentions.getByRole('link', { name: 'projects/plan.md' }),
+  ).toHaveCount(0);
+
+  // From projects/plan.md, the same [[todo]] prefers its sibling projects/todo.md.
+  await page.goto(
+    `/ws#route=editor&wsPath=${encodeURIComponent(`${workspaceName}:projects/plan.md`)}`,
+  );
+  await expect(todoLink).toBeVisible();
+  await todoLink.click();
+  await expect(page).toHaveURL(
+    /ws#route=editor&wsPath=wiki-link-closest%3Aprojects%2Ftodo\.md$/,
+  );
+  await expect(editor).toContainText('projects todo');
+  await expect(
+    linkedMentions.getByRole('link', { name: 'projects/plan.md' }),
+  ).toBeVisible();
+  await expect(
+    linkedMentions.getByRole('link', { name: 'Home.md' }),
+  ).toHaveCount(0);
+
+  // Navigation resolved to existing notes; nothing new was created.
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'todo'))
+    .toBe('root todo');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'projects/todo'))
+    .toBe('projects todo');
+});
+
 test('does not trigger wiki-link suggestions while typing inside a Markdown link', async ({
   page,
 }) => {


### PR DESCRIPTION
## Problem

A bare `[[todo]]` wiki link worked while only one `todo.md` existed. The moment a second `todo.md` appeared anywhere in the workspace, the link turned grey (unresolved), and clicking it silently created a **third** `todo.md` at the workspace root instead of opening either existing note.

`resolveWikiLinkTarget` deliberately returned `undefined` when a bare name matched more than one note, and the unresolved-click path (`createMissingWikiLinkTarget`) then treated it as a missing note.

## Behavior spec (Obsidian-mapped)

A link to a name that exists must never dangle. Resolution for `[[target]]`:

1. **Explicit path** (`folder/todo`, `/folder/todo`, `./x`, `../x`) — resolved as a path; unchanged.
2. **Bare name** (`todo`) — matched by filename stem, `.md`/`.markdown` optional, exact case preferred over case-insensitive; unchanged.
3. **New:** if several notes share the stem, resolve to the closest note deterministically:
   - a note in the same directory as the current note, then
   - the shallowest path (fewest segments), then
   - the lexicographically smallest path.
4. Only a name with **no** match renders unresolved; clicking still creates the note (bare name → workspace root, explicit path → at that path).

Write-time disambiguation is already correct and unchanged: the `[[` picker inserts `/full/path` targets when a name is ambiguous, so newly authored links stay unambiguous (Obsidian's "shortest path when unique" convention). This change fixes the read-time behavior for links that *become* ambiguous after a same-name note is added later.

All consumers pick the fix up through the one resolver: grey-state decoration, click navigation, and the linked-mentions/backlink index.

## Changes

- `packages/shared/ws-path/src/internal-link.ts`: `pickClosestWikiLinkMatch` tie-break instead of returning `undefined` on multiple matches.
- `packages/shared/ws-path/src/__tests__/internal-link.spec.ts`: duplicate-basename expectations rewritten; new same-dir / depth / alphabetical / case-insensitive tie-break coverage.
- `packages/tooling/e2e-tests/src/wiki-links.e2e.ts`:
  - the ambiguous `[[Same]]` scenario now asserts the link resolves, navigates to `one/Same.md`, and does **not** create a phantom root note;
  - new `resolves duplicate wiki-link names to the note closest to the current note` test proves the tie-break end to end: from a root note `[[todo]]` opens the root `todo.md`, from `projects/plan.md` the same `[[todo]]` opens the sibling `projects/todo.md`, linked mentions attribute each source note to the note its link actually resolves to, and neither existing note is overwritten nor a new one created.

## Testing

- `pnpm local-ci-check` passes (lint:ci, test:ci — 121 files / 1402 tests, full Playwright E2E + CT, desktop smoke).
- Filtered run: all 11 `wiki-links.e2e.ts` tests pass, including the duplicate-name workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)