### PR TITLE
fix: surface a conflict when a drag-drop move collides with an existing note

### DIFF
--- a/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
@@ -179,6 +179,66 @@ describe('WS command handlers', () => {
       });
     });
 
+    test('reports a conflict without overwriting when the destination name is taken', async () => {
+      const SOURCE_WS_PATH = 'test-ws:a.md';
+      const DEST_DIR_WS_PATH = 'test-ws:folder/';
+      const EXISTING_WS_PATH = 'test-ws:folder/a.md';
+      const { dispatch, services, getCommandResults, testEnv } =
+        await setupTest({
+          targetId: 'command::ws:move-ws-path',
+          workspaces: [
+            { name: 'test-ws', notes: [SOURCE_WS_PATH, EXISTING_WS_PATH] },
+          ],
+          autoNavigate: 'workspace',
+        });
+
+      await services.fileSystem.writeFile(
+        SOURCE_WS_PATH,
+        new File(['source body'], 'a.md', { type: 'text/plain' }),
+      );
+      await services.fileSystem.writeFile(
+        EXISTING_WS_PATH,
+        new File(['destination body'], 'a.md', { type: 'text/plain' }),
+      );
+
+      const renameSpy = vi.spyOn(services.fileSystem, 'renameFile');
+
+      dispatch('command::ws:move-ws-path', {
+        destDirWsPath: DEST_DIR_WS_PATH,
+        wsPath: SOURCE_WS_PATH,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          getCommandResults().filter((result) => result.type === 'failure'),
+        ).toEqual([
+          expect.objectContaining({
+            command: expect.objectContaining({
+              id: 'command::ws:move-ws-path',
+            }),
+          }),
+        ]);
+        expect(testEnv.commonOpts.emitAppError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cause: expect.objectContaining({
+              name: 'error::file:already-existing',
+              payload: { wsPath: EXISTING_WS_PATH },
+            }),
+          }),
+        );
+      });
+
+      // The conflict must never fall through to a destructive rename: both the
+      // dragged note and the note it collides with keep their original content.
+      expect(renameSpy).not.toHaveBeenCalled();
+      await expect(
+        services.fileSystem.readFileAsText(SOURCE_WS_PATH),
+      ).resolves.toBe('source body');
+      await expect(
+        services.fileSystem.readFileAsText(EXISTING_WS_PATH),
+      ).resolves.toBe('destination body');
+    });
+
     test('reports storage move failures before navigating to the destination', async () => {
       const SOURCE_WS_PATH = 'test-ws:source.md';
       const DESTINATION_DIR_WS_PATH = 'test-ws:archive/';

--- a/packages/core/command-handlers/src/ws-command-handlers.ts
+++ b/packages/core/command-handlers/src/ws-command-handlers.ts
@@ -252,7 +252,9 @@ export const wsCommandHandlers = [
       if (existingWsPaths.includes(newWsPath)) {
         throwAppError(
           'error::file:already-existing',
-          t.app.errors.file.alreadyExistsInDest,
+          t.app.errors.file.alreadyExistsInDest({
+            fileName: filePath.fileName,
+          }),
           {
             wsPath: newWsPath,
           },
@@ -396,7 +398,9 @@ export const wsCommandHandlers = [
         ) {
           throwAppError(
             'error::file:already-existing',
-            t.app.errors.file.alreadyExistsInDest,
+            t.app.errors.file.alreadyExistsInDest({
+              fileName: WsPath.assertFile(pair.newWsPath).fileName,
+            }),
             {
               wsPath: pair.newWsPath,
             },

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -353,8 +353,8 @@ export const t = {
           'Datei kann während des Umbenennens nicht verschoben werden. Verwenden Sie den Verschiebebefehl.',
         cannotRenameToDifferentWorkspace:
           'Notiz kann nicht in einen anderen Arbeitsbereich umbenannt werden',
-        alreadyExistsInDest:
-          'Eine Notiz mit demselben Namen existiert bereits im Zielverzeichnis',
+        alreadyExistsInDest: ({ fileName }: { fileName: string }) =>
+          `Eine Notiz mit dem Namen „${fileName}“ existiert bereits im Zielordner`,
         originalNoteNotFound: 'Originalnotiz nicht gefunden',
       },
       wsPath: {

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -361,8 +361,8 @@ export const t = {
           'Cannot move file during rename operation. Use move command.',
         cannotRenameToDifferentWorkspace:
           'Cannot rename note to a different workspace',
-        alreadyExistsInDest:
-          'A note with the same name already exists in the destination directory',
+        alreadyExistsInDest: ({ fileName }: { fileName: string }) =>
+          `A note named "${fileName}" already exists in the destination folder`,
         originalNoteNotFound: 'Original note not found',
       },
       wsPath: {

--- a/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
@@ -524,6 +524,49 @@ test('file explorer keeps folders expanded when a note is moved', async ({
   });
 });
 
+test('file explorer surfaces a conflict when a drag-drop move collides with an existing note', async ({
+  page,
+}) => {
+  const workspaceName = `explorer-move-conflict-${Date.now()}`;
+  await createBrowserWorkspace(page, { workspaceName });
+
+  // `dest` already contains a note called `mover`, so dragging the root `mover`
+  // into it is a name collision. The tree's drag layer rejects the drop
+  // internally; without feedback the gesture used to vanish silently.
+  await writeStoredMarkdown(page, workspaceName, 'dest/mover', 'Existing body');
+  await writeStoredMarkdown(page, workspaceName, 'mover', 'Move me');
+
+  await page.goto(
+    `/ws#route=ws-home&wsName=${encodeURIComponent(workspaceName)}`,
+  );
+  await page.reload();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+  await expect(explorer).toBeVisible();
+
+  // Both notes are called `mover.md`, so disambiguate the root note (the drag
+  // source) from the colliding child by their exact tree path.
+  const mover = explorer.locator('[data-item-path="mover.md"]');
+  const dest = explorer.getByRole('treeitem', { name: /^dest$/ });
+  // Pierre only begins a drag from an already-selected row, so select first.
+  await mover.click();
+  await dragTreeItemOnto(page, mover, dest);
+
+  // The conflict is reported to the user by name instead of failing silently.
+  await expect(
+    page.getByText('A note named "mover.md" already exists in the destination'),
+  ).toBeVisible();
+
+  // Neither note is moved or overwritten: the source stays at the root and the
+  // colliding note keeps its own content.
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'mover'))
+    .toBe('Move me');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'dest/mover'))
+    .toBe('Existing body');
+});
+
 test('file explorer shows common workspace files and opens non-notes as assets', async ({
   page,
 }) => {

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -453,8 +453,14 @@ export function PierreFileTree({
       canDrag: canDragFile,
       canDrop: canDropFile,
       onDropComplete: handleDropComplete,
-      onDropError: () => {
+      onDropError: (_error, event) => {
         resetSelectionOpenSuppression();
+        // Pierre rejects a colliding drop inside its own optimistic store and
+        // would otherwise drop the gesture with no feedback. Re-drive the
+        // intended move through the durable move command so the owning service
+        // reports the conflict (or performs the move) instead of the drop
+        // silently vanishing.
+        commitDurableDrop(event);
         resetDragAffordance();
         if (modelRef.current) {
           resetModelPathsPreservingExpansion(


### PR DESCRIPTION
## Problem

Dragging a file in the file explorer onto a folder that already contains a note with the same name did **nothing** — silently. No toast, no move, no error. The user's reported UX gap.

## Root cause

The file tree's drag layer (`@pierre/trees`) runs its own optimistic move with a default `collision: 'error'` strategy. On a name collision it throws `Destination already exists: ...` and invokes the tree's `onDropError` callback instead of `onDropComplete`. bangle's `onDropError` handler quietly reset drag affordance and did nothing else — so the durable move command (`command::ws:move-ws-path`), which *already* detects conflicts and shows a localized toast, never ran.

## Fix

- **`pierre-file-tree.tsx`**: `onDropError` now re-drives the intended move through the same durable move command used by the happy path (`commitDurableDrop`). The command handler owns conflict policy and pre-checks the destination *before* any rename, so a conflict is reported exactly like the move-dialog and omni-search paths — and never overwrites the colliding note.
- **Conflict message** now names the file (`A note named "x.md" already exists in the destination folder`) across every move entry point (en + de).

## Tests

- **E2E** (`file-explorer.e2e.ts`): drags a note onto a folder holding a same-named note; asserts the named conflict toast appears and that neither note is moved or overwritten.
- **Unit** (`ws-command-handlers.spec.ts`): exercises the real (unmocked) conflict pre-check and asserts `renameFile` is never called and both notes keep their original content.

## Verification

- `pnpm lint:ci` ✅ (custom-validation, tsgo, biome)
- `pnpm test:ci` ✅ (1402 passed)
- New E2E + existing drag-move/happy-path E2E ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)