### PR TITLE
feat(wordgard): scaffold wordgard packages, markdown codec, and golden corpus (M1)

### DIFF
--- a/packages/core/editor/package.json
+++ b/packages/core/editor/package.json
@@ -50,5 +50,7 @@
     "react": "19.2.7",
     "shiki": "^4.3.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@bangle.io/test-utils": "workspace:*"
+  }
 }

--- a/packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts
+++ b/packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts
@@ -27,23 +27,29 @@ import { describe, expect, it } from 'vitest';
 // Markdown parsing or serialization behavior, without the app-only UI
 // plugins (suggestions, menus, placeholder, drag/drop) that carry no
 // Markdown fidelity of their own.
+//
+// Registration order must match `setupExtensions`' relative order for marks
+// (bold, strike, code, italic, link): PM mark rank follows schema insertion
+// order, and rank decides delimiter nesting when marks overlap — a different
+// order here would make this test bless canonical forms (`_~~x~~_`) that the
+// real app serializes differently (`~~_x_~~`).
 function createMarkdown() {
   const extensions = [
     setupBase(),
-    setupParagraph(),
-    setupHeading(),
     setupBlockquote(),
-    setupList(),
     setupBold(),
-    setupItalic(),
+    setupList(),
+    setupHardBreak(),
+    setupHeading(),
+    setupParagraph(),
     setupStrike(),
+    setupWikiLink(),
+    setupHorizontalRule(),
     setupCode(),
     setupCodeBlock(),
+    setupItalic(),
     setupLink(),
     setupImage(),
-    setupHardBreak(),
-    setupHorizontalRule(),
-    setupWikiLink(),
     setupTable(),
   ];
   const resolved = resolve(extensions);
@@ -55,9 +61,11 @@ function createMarkdown() {
  * Cross-engine parity contract test (see
  * `plans/011-wordgard-editor-w-migration.md`, milestone M1): every fixture in
  * `@bangle.io/test-utils`'s `MARKDOWN_CORPUS` whose `engines` includes
- * `'prosemirror'` must round-trip byte-identically through this engine's
- * parse/serialize pipeline. A future `editor-w` test asserts the same
- * contract for the Wordgard engine against the same corpus.
+ * `'prosemirror'` must serialize to its expected bytes (`canonical` for
+ * normalization fixtures, the input itself otherwise), and that expected
+ * form must be a fixed point of this engine's parse/serialize round trip.
+ * The Wordgard engine asserts the same contract against the same corpus in
+ * `packages/js-lib/wordgard-markdown`.
  */
 describe('Markdown golden corpus (ProseMirror engine)', () => {
   const fixtures = MARKDOWN_CORPUS.filter((fixture) =>
@@ -68,8 +76,15 @@ describe('Markdown golden corpus (ProseMirror engine)', () => {
     fixtures.map((fixture) => [fixture.name, fixture] as const),
   )('round trips byte-identically: %s', (_name, fixture) => {
     const markdown = createMarkdown();
-    const document = markdown.parser.parse(fixture.markdown);
-    const serialized = markdown.serializer.serialize(document);
-    expect(serialized).toBe(fixture.markdown);
+    const roundTrip = (input: string) =>
+      markdown.serializer.serialize(markdown.parser.parse(input));
+
+    const expected = fixture.canonical ?? fixture.markdown;
+    expect(roundTrip(fixture.markdown)).toBe(expected);
+    if (fixture.canonical !== undefined) {
+      // The canonical form must itself be stable, or the "normalization"
+      // never converges and every save would rewrite the note.
+      expect(roundTrip(fixture.canonical)).toBe(fixture.canonical);
+    }
   });
 });

--- a/packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts
+++ b/packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts
@@ -7,6 +7,7 @@ import {
   setupBold,
   setupCode,
   setupCodeBlock,
+  setupFrontmatter,
   setupHardBreak,
   setupHeading,
   setupHorizontalRule,
@@ -35,7 +36,8 @@ import { describe, expect, it } from 'vitest';
 // real app serializes differently (`~~_x_~~`).
 function createMarkdown() {
   const extensions = [
-    setupBase(),
+    setupBase({ docContent: 'frontmatter? block+' }),
+    setupFrontmatter(),
     setupBlockquote(),
     setupBold(),
     setupList(),

--- a/packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts
+++ b/packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts
@@ -1,0 +1,75 @@
+import {
+  markdownLoader,
+  resolve,
+  Schema,
+  setupBase,
+  setupBlockquote,
+  setupBold,
+  setupCode,
+  setupCodeBlock,
+  setupHardBreak,
+  setupHeading,
+  setupHorizontalRule,
+  setupImage,
+  setupItalic,
+  setupLink,
+  setupList,
+  setupParagraph,
+  setupStrike,
+  setupTable,
+  setupWikiLink,
+} from '@bangle.io/prosemirror-plugins';
+import { MARKDOWN_CORPUS } from '@bangle.io/test-utils';
+import { describe, expect, it } from 'vitest';
+
+// Mirrors the markdown-relevant subset of the app's real extension set (see
+// `packages/core/editor/src/extensions.ts`): every node/mark type that owns
+// Markdown parsing or serialization behavior, without the app-only UI
+// plugins (suggestions, menus, placeholder, drag/drop) that carry no
+// Markdown fidelity of their own.
+function createMarkdown() {
+  const extensions = [
+    setupBase(),
+    setupParagraph(),
+    setupHeading(),
+    setupBlockquote(),
+    setupList(),
+    setupBold(),
+    setupItalic(),
+    setupStrike(),
+    setupCode(),
+    setupCodeBlock(),
+    setupLink(),
+    setupImage(),
+    setupHardBreak(),
+    setupHorizontalRule(),
+    setupWikiLink(),
+    setupTable(),
+  ];
+  const resolved = resolve(extensions);
+  const schema = new Schema({ nodes: resolved.nodes, marks: resolved.marks });
+  return markdownLoader(extensions, schema);
+}
+
+/**
+ * Cross-engine parity contract test (see
+ * `plans/011-wordgard-editor-w-migration.md`, milestone M1): every fixture in
+ * `@bangle.io/test-utils`'s `MARKDOWN_CORPUS` whose `engines` includes
+ * `'prosemirror'` must round-trip byte-identically through this engine's
+ * parse/serialize pipeline. A future `editor-w` test asserts the same
+ * contract for the Wordgard engine against the same corpus.
+ */
+describe('Markdown golden corpus (ProseMirror engine)', () => {
+  const fixtures = MARKDOWN_CORPUS.filter((fixture) =>
+    fixture.engines.includes('prosemirror'),
+  );
+
+  it.each(
+    fixtures.map((fixture) => [fixture.name, fixture] as const),
+  )('round trips byte-identically: %s', (_name, fixture) => {
+    const markdown = createMarkdown();
+    const document = markdown.parser.parse(fixture.markdown);
+    const serialized = markdown.serializer.serialize(document);
+    expect(serialized).toBe(fixture.markdown);
+  });
+});

--- a/packages/js-lib/banger-editor/src/base.ts
+++ b/packages/js-lib/banger-editor/src/base.ts
@@ -135,7 +135,17 @@ function markdown(_config: RequiredConfig): CollectionType['markdown'] {
     nodes: {
       text: {
         toMarkdown(state, node) {
-          state.text(node.text ?? '');
+          // Text inside an autolink (`<https://…>`) must be written raw:
+          // escaping would inject backslashes into the URL itself
+          // (`<https://x/\_file>`). The link mark's serializer sets
+          // `inAutolink` (same protocol as prosemirror-markdown's default
+          // serializer; the field is @internal and stripped from the
+          // published typings, hence the widening cast — same pattern as
+          // table-markdown.ts's SerializerInternals).
+          const { inAutolink } = state as typeof state & {
+            inAutolink?: boolean;
+          };
+          state.text(node.text ?? '', !inAutolink);
         },
       },
     },

--- a/packages/js-lib/banger-editor/src/image.ts
+++ b/packages/js-lib/banger-editor/src/image.ts
@@ -154,7 +154,11 @@ function markdown(config: RequiredConfig): CollectionType['markdown'] {
             getAttrs: (tok) => ({
               src: tok.attrGet('src'),
               title: tok.attrGet('title') || null,
-              alt: tok.children?.[0]?.content || null,
+              // markdown-it splits alt text containing escapes (`![a\]b](x)`)
+              // or inline markup into several child tokens; reading only
+              // `children[0]` (as prosemirror-markdown does) silently
+              // truncates the alt at the first escape.
+              alt: tok.children?.map((child) => child.content).join('') || null,
             }),
           },
         },

--- a/packages/js-lib/banger-editor/src/link/link.ts
+++ b/packages/js-lib/banger-editor/src/link/link.ts
@@ -775,10 +775,24 @@ function markdown(config: RequiredConfig): CollectionType['markdown'] {
     marks: {
       [name]: {
         toMarkdown: {
-          open(_state, mark, parent, index) {
-            return isPlainURL(mark, parent, index, 1) ? '<' : '[';
+          open(state, mark, parent, index) {
+            // `inAutolink` tells the text serializer (see base.ts) not to
+            // escape the URL text between `<` and `>` — same protocol as
+            // prosemirror-markdown's default serializer. The field is
+            // @internal upstream and stripped from the published typings,
+            // hence the widening cast (same pattern as table-markdown.ts's
+            // SerializerInternals).
+            const internals = state as typeof state & {
+              inAutolink?: boolean;
+            };
+            internals.inAutolink = isPlainURL(mark, parent, index, 1);
+            return internals.inAutolink ? '<' : '[';
           },
           close(state, mark, parent, index) {
+            const internals = state as typeof state & {
+              inAutolink?: boolean;
+            };
+            internals.inAutolink = undefined;
             if (isPlainURL(mark, parent, index, -1)) {
               return '>';
             }

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -1,3 +1,4 @@
+import { LIST_KIND_ATTR, TASK_CHECKED_ATTR } from '@bangle.io/markdown-syntax';
 import type { MarkdownSerializerState } from 'prosemirror-markdown';
 import {
   type CollectionType,
@@ -348,10 +349,9 @@ function markdown(config: RequiredConfig): CollectionType['markdown'] {
           list_item: {
             block: listNodeName,
             getAttrs: (tok) => {
-              const kind = tok.attrGet('data-bangle-list-kind');
+              const kind = tok.attrGet(LIST_KIND_ATTR);
               if (kind === LIST_KIND.TASK) {
-                const isChecked =
-                  tok.attrGet('data-bangle-task-checked') === 'true';
+                const isChecked = tok.attrGet(TASK_CHECKED_ATTR) === 'true';
                 return { kind: LIST_KIND.TASK, checked: isChecked };
               }
               if (kind === 'ordered') {

--- a/packages/js-lib/banger-editor/src/table/table-markdown.ts
+++ b/packages/js-lib/banger-editor/src/table/table-markdown.ts
@@ -1,3 +1,4 @@
+import { tableTokenizer } from '@bangle.io/markdown-syntax';
 import type { MarkdownSerializerState } from 'prosemirror-markdown';
 import type { CollectionType } from '../common';
 import type { PMNode } from '../pm';
@@ -49,69 +50,11 @@ export function tableMarkdown(): CollectionType['markdown'] {
         },
       },
     },
-    tokenizerPlugins: [
-      (md) => {
-        md.enable('table');
-        // GFM cells hold line breaks as literal <br>. The tokenizer runs
-        // with html disabled, so <br> arrives as plain text; convert it to
-        // hardbreak tokens, but only inside table cells so <br> text in
-        // normal paragraphs keeps round-tripping as text.
-        //
-        // This must run before 'text_join': at that point escaped (\<br>)
-        // and entity (&lt;br&gt;) forms are still separate 'text_special'
-        // tokens, so matching only 'text' tokens converts exactly the raw
-        // occurrences and leaves intentional literals alone.
-        md.core.ruler.before('text_join', 'table-cell-br', (state) => {
-          let cellDepth = 0;
-          for (const token of state.tokens) {
-            if (token.type === 'th_open' || token.type === 'td_open') {
-              cellDepth++;
-            } else if (token.type === 'th_close' || token.type === 'td_close') {
-              cellDepth--;
-            } else if (
-              cellDepth > 0 &&
-              token.type === 'inline' &&
-              token.children
-            ) {
-              token.children = splitBrIntoHardbreaks(
-                token.children,
-                state.Token,
-              );
-            }
-          }
-        });
-      },
-    ],
+    // The GFM table token semantics (including <br>-in-cell handling) are
+    // engine-neutral and live in the shared syntax layer; this extension
+    // only opts the tokenizer into them.
+    tokenizerPlugins: [tableTokenizer],
   };
-}
-
-const CELL_BR_RE = /<br\s*\/?>/i;
-
-function splitBrIntoHardbreaks<
-  T extends { type: string; content: string; level: number },
->(children: T[], TokenCtor: new (type: string, tag: string, nesting: 0) => T) {
-  const result: T[] = [];
-  for (const child of children) {
-    if (child.type !== 'text' || !CELL_BR_RE.test(child.content)) {
-      result.push(child);
-      continue;
-    }
-    const parts = child.content.split(new RegExp(CELL_BR_RE.source, 'gi'));
-    parts.forEach((part, index) => {
-      if (part) {
-        const text = new TokenCtor('text', '', 0);
-        text.content = part;
-        text.level = child.level;
-        result.push(text);
-      }
-      if (index < parts.length - 1) {
-        const br = new TokenCtor('hardbreak', 'br', 0);
-        br.level = child.level;
-        result.push(br);
-      }
-    });
-  }
-  return result;
 }
 
 function alignFromToken(style: string | null): TableCellAlign | null {

--- a/packages/js-lib/markdown-syntax/package.json
+++ b/packages/js-lib/markdown-syntax/package.json
@@ -28,7 +28,6 @@
   },
   "scripts": {},
   "dependencies": {
-    "@bangle.dev/pm-markdown": "2.0.0-alpha.18",
     "markdown-it": "14.3.0"
   },
   "devDependencies": {

--- a/packages/js-lib/markdown-syntax/src/__tests__/list-syntax.spec.ts
+++ b/packages/js-lib/markdown-syntax/src/__tests__/list-syntax.spec.ts
@@ -1,0 +1,111 @@
+import type Token from 'markdown-it/lib/token.mjs';
+import { describe, expect, it } from 'vitest';
+import { LIST_KIND_ATTR, TASK_CHECKED_ATTR } from '../list-syntax';
+import { createBaseMarkdownTokenizer } from '../tokenizer';
+
+function tokenize(markdown: string): Token[] {
+  return createBaseMarkdownTokenizer().parse(markdown, {});
+}
+
+function listItems(tokens: Token[]): Token[] {
+  return tokens.filter((tok) => tok.type === 'list_item_open');
+}
+
+function inlineContent(tokens: Token[]): string[] {
+  return tokens.filter((tok) => tok.type === 'inline').map((t) => t.content);
+}
+
+describe('listTokenizer kinds', () => {
+  it('stamps bullet kind on bullet lists and their items', () => {
+    const tokens = tokenize('- one\n- two');
+    const open = tokens.find((t) => t.type === 'bullet_list_open');
+    expect(open?.attrGet(LIST_KIND_ATTR)).toBe('bullet');
+    for (const item of listItems(tokens)) {
+      expect(item.attrGet(LIST_KIND_ATTR)).toBe('bullet');
+    }
+  });
+
+  it('stamps ordered kind on ordered lists and their items', () => {
+    const tokens = tokenize('1. one\n2. two');
+    const open = tokens.find((t) => t.type === 'ordered_list_open');
+    expect(open?.attrGet(LIST_KIND_ATTR)).toBe('ordered');
+    for (const item of listItems(tokens)) {
+      expect(item.attrGet(LIST_KIND_ATTR)).toBe('ordered');
+    }
+  });
+
+  it('stamps kinds correctly for nested lists of different kinds', () => {
+    const tokens = tokenize('- outer\n\n  1. inner');
+    const kinds = listItems(tokens).map((t) => t.attrGet(LIST_KIND_ATTR));
+    expect(kinds).toEqual(['bullet', 'ordered']);
+  });
+});
+
+describe('listTokenizer task detection', () => {
+  it.each([
+    ['unchecked', '- [ ] todo', 'false'],
+    ['checked lowercase', '- [x] done', 'true'],
+    ['checked uppercase', '- [X] done', 'true'],
+  ])('detects a %s task and strips the marker', (_name, md, checked) => {
+    const tokens = tokenize(md);
+    const [item] = listItems(tokens);
+    expect(item?.attrGet(LIST_KIND_ATTR)).toBe('task');
+    expect(item?.attrGet(TASK_CHECKED_ATTR)).toBe(checked);
+    // The marker must be gone from BOTH the child tokens and the inline
+    // token's own content — a stale `content` would leak the marker to any
+    // consumer that reads it (e.g. an indexer).
+    const inline = tokens.find((t) => t.type === 'inline');
+    expect(inline?.content.startsWith('[')).toBe(false);
+    expect(inline?.children?.[0]?.content.startsWith('[')).toBe(false);
+  });
+
+  it('detects an empty task (`- [ ]` with no trailing text)', () => {
+    for (const md of ['- [ ]', '- [x]', '- [ ] ']) {
+      const tokens = tokenize(md);
+      const [item] = listItems(tokens);
+      expect(item?.attrGet(LIST_KIND_ATTR)).toBe('task');
+      expect(inlineContent(tokens)).toEqual(['']);
+      // The now-empty text child is removed, not left as an empty token.
+      const inline = tokens.find((t) => t.type === 'inline');
+      expect(inline?.children?.length ?? 0).toBe(0);
+    }
+  });
+
+  it('detects tasks inside ordered lists (GFM allows `1. [ ] x`)', () => {
+    const tokens = tokenize('1. [ ] task');
+    const [item] = listItems(tokens);
+    expect(item?.attrGet(LIST_KIND_ATTR)).toBe('task');
+    expect(item?.attrGet(TASK_CHECKED_ATTR)).toBe('false');
+  });
+
+  it('keeps following inline structure intact when stripping the marker', () => {
+    const tokens = tokenize('- [x] **bold** and [a link](https://x)');
+    const inline = tokens.find((t) => t.type === 'inline');
+    expect(inline?.children?.some((c) => c.type === 'strong_open')).toBe(true);
+    expect(inline?.children?.some((c) => c.type === 'link_open')).toBe(true);
+  });
+
+  it.each([
+    ['no space after bracket', '- [ ]no'],
+    ['marker not at item start', '- a [ ] b'],
+    ['non-checkbox bracket content', '- [y] no'],
+    ['escaped bracket', '- \\[ ] no'],
+    ['marker outside a list', '[ ] not in a list'],
+  ])('does not treat %s as a task', (_name, md) => {
+    const tokens = tokenize(md);
+    for (const item of listItems(tokens)) {
+      expect(item.attrGet(LIST_KIND_ATTR)).not.toBe('task');
+      expect(item.attrGet(TASK_CHECKED_ATTR)).toBeNull();
+    }
+  });
+
+  it('does not treat a task marker below the first paragraph as a task', () => {
+    const tokens = tokenize('- first paragraph\n\n  [ ] second paragraph');
+    const [item] = listItems(tokens);
+    expect(item?.attrGet(LIST_KIND_ATTR)).toBe('bullet');
+    expect(inlineContent(tokens)).toEqual([
+      'first paragraph',
+      '[ ] second paragraph',
+    ]);
+  });
+});

--- a/packages/js-lib/markdown-syntax/src/__tests__/table-syntax.spec.ts
+++ b/packages/js-lib/markdown-syntax/src/__tests__/table-syntax.spec.ts
@@ -1,0 +1,63 @@
+import type Token from 'markdown-it/lib/token.mjs';
+import { describe, expect, it } from 'vitest';
+import { tableTokenizer } from '../table-syntax';
+import { createBaseMarkdownTokenizer } from '../tokenizer';
+
+const TABLE_MD = '| a | b |\n| --- | --- |\n| c | d |';
+
+function types(tokens: Token[]): string[] {
+  return tokens.map((t) => t.type);
+}
+
+describe('tableTokenizer', () => {
+  it('is opt-in: the base tokenizer produces no table tokens', () => {
+    // Load-bearing for the Wordgard engine until M3: if the base tokenizer
+    // ever emits table tokens, every engine without table handling turns a
+    // note containing a table into a parse failure.
+    const tokens = createBaseMarkdownTokenizer().parse(TABLE_MD, {});
+    expect(types(tokens).some((t) => t.startsWith('table'))).toBe(false);
+    expect(types(tokens)).toContain('paragraph_open');
+  });
+
+  it('produces table tokens when enabled', () => {
+    const tokens = createBaseMarkdownTokenizer()
+      .use(tableTokenizer)
+      .parse(TABLE_MD, {});
+    for (const type of ['table_open', 'thead_open', 'th_open', 'td_open']) {
+      expect(types(tokens)).toContain(type);
+    }
+  });
+
+  it('converts literal <br> inside cells to hardbreak tokens', () => {
+    const tokens = createBaseMarkdownTokenizer()
+      .use(tableTokenizer)
+      .parse('| a<br>b |\n| --- |\n| c<br/>d |', {});
+    const cellInlines = tokens.filter((t) => t.type === 'inline');
+    const kinds = cellInlines.map((t) =>
+      (t.children ?? []).map((c) => `${c.type}:${c.content}`).join(','),
+    );
+    expect(kinds).toContain('text:a,hardbreak:,text:b');
+    expect(kinds).toContain('text:c,hardbreak:,text:d');
+  });
+
+  it('leaves <br> outside table cells as plain text', () => {
+    const tokens = createBaseMarkdownTokenizer()
+      .use(tableTokenizer)
+      .parse('para with <br> text', {});
+    const inline = tokens.find((t) => t.type === 'inline');
+    expect(inline?.children?.some((c) => c.type === 'hardbreak')).toBe(false);
+    expect(inline?.content).toBe('para with <br> text');
+  });
+
+  it('does not convert escaped or entity <br> forms inside cells', () => {
+    // `\<br>` and `&lt;br&gt;` arrive as text_special tokens at the time
+    // the rule runs (before text_join), so only raw `<br>` text converts.
+    const tokens = createBaseMarkdownTokenizer()
+      .use(tableTokenizer)
+      .parse('| a\\<br>b | c&lt;br&gt;d |\n| --- | --- |', {});
+    const cellInlines = tokens.filter((t) => t.type === 'inline');
+    for (const inline of cellInlines) {
+      expect(inline.children?.some((c) => c.type === 'hardbreak')).toBe(false);
+    }
+  });
+});

--- a/packages/js-lib/markdown-syntax/src/index.ts
+++ b/packages/js-lib/markdown-syntax/src/index.ts
@@ -1,4 +1,10 @@
 export { frontmatterTokenizer } from './frontmatter-syntax';
+export {
+  LIST_KIND_ATTR,
+  type ListKind,
+  listTokenizer,
+  TASK_CHECKED_ATTR,
+} from './list-syntax';
 export { createBaseMarkdownTokenizer } from './tokenizer';
 export {
   parseWikiLinkContent,

--- a/packages/js-lib/markdown-syntax/src/index.ts
+++ b/packages/js-lib/markdown-syntax/src/index.ts
@@ -5,6 +5,7 @@ export {
   listTokenizer,
   TASK_CHECKED_ATTR,
 } from './list-syntax';
+export { tableTokenizer } from './table-syntax';
 export { createBaseMarkdownTokenizer } from './tokenizer';
 export {
   parseWikiLinkContent,

--- a/packages/js-lib/markdown-syntax/src/list-syntax.ts
+++ b/packages/js-lib/markdown-syntax/src/list-syntax.ts
@@ -1,0 +1,109 @@
+import type MarkdownIt from 'markdown-it';
+import type Token from 'markdown-it/lib/token.mjs';
+
+/**
+ * Token attribute carrying a list item's kind. Set on `list_item_open`
+ * tokens (and, for `bullet`/`ordered`, on the enclosing `*_list_open`
+ * token). This is the engine-neutral meaning of the syntax: both editor
+ * engines' codecs read these attributes instead of re-deriving list
+ * semantics themselves.
+ */
+export const LIST_KIND_ATTR = 'data-bangle-list-kind';
+
+/** Token attribute carrying a task item's checked state (`'true'`/`'false'`). */
+export const TASK_CHECKED_ATTR = 'data-bangle-task-checked';
+
+export type ListKind = 'bullet' | 'ordered' | 'task';
+
+/**
+ * Task markers GFM recognizes at the very start of a list item's first
+ * paragraph: `[ ]`, `[x]`, or `[X]`, either followed by a space or ending
+ * the paragraph (an empty task). Anywhere else, `[ ]` is literal text.
+ */
+const TASK_MARKER = /^\[([ xX])\](?: |$)/;
+
+/**
+ * markdown-it plugin defining what list syntax *means* for every consumer
+ * of the shared tokenizer: it stamps {@link LIST_KIND_ATTR} on list tokens
+ * and detects GFM task items (`- [ ] …` / `- [x] …`), recording the checked
+ * state in {@link TASK_CHECKED_ATTR} and removing the marker from the
+ * item's inline content.
+ *
+ * Task detection has to run as a core rule *after* inline parsing — whether
+ * `[ ]` is a checkbox or literal text depends on it sitting at the very
+ * start of a list item's first paragraph, which the inline tokenizer alone
+ * cannot know. Mutating the token stream there is the standard markdown-it
+ * technique for GFM task lists (`markdown-it-task-lists` works the same
+ * way). An escaped marker (`\[ ]`) never matches: the escape becomes a
+ * `text_special` child, so the leading text child no longer starts with
+ * `[`.
+ *
+ * Adapted from a prior in-house ProseMirror-stack plugin, minus behavior no
+ * consumer ever read (a `tight` attribute that was always `"false"`, an
+ * ordered-list `order` attribute both engines deliberately ignore, and an
+ * HTML renderer override).
+ */
+export function listTokenizer(md: MarkdownIt): void {
+  md.core.ruler.after('inline', 'bangle-list-syntax', (state) => {
+    const tokens = state.tokens;
+
+    // Pass 1: stamp bullet/ordered kinds from the enclosing list.
+    const kindStack: Array<'bullet' | 'ordered'> = [];
+    for (const token of tokens) {
+      switch (token.type) {
+        case 'bullet_list_open':
+        case 'ordered_list_open': {
+          const kind = token.type === 'bullet_list_open' ? 'bullet' : 'ordered';
+          kindStack.push(kind);
+          token.attrSet(LIST_KIND_ATTR, kind);
+          break;
+        }
+        case 'bullet_list_close':
+        case 'ordered_list_close':
+          kindStack.pop();
+          break;
+        case 'list_item_open': {
+          const kind = kindStack[kindStack.length - 1];
+          if (kind) token.attrSet(LIST_KIND_ATTR, kind);
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    // Pass 2: upgrade items whose first paragraph starts with a task
+    // marker. The token shape is always `list_item_open`, `paragraph_open`,
+    // `inline`; an item that starts with any other block cannot be a task.
+    for (let i = 2; i < tokens.length; i++) {
+      const inline = tokens[i];
+      const paragraph = tokens[i - 1];
+      const item = tokens[i - 2];
+      if (
+        !inline ||
+        inline.type !== 'inline' ||
+        paragraph?.type !== 'paragraph_open' ||
+        item?.type !== 'list_item_open'
+      ) {
+        continue;
+      }
+      const first = inline.children?.[0];
+      if (!first || first.type !== 'text') continue;
+      const match = TASK_MARKER.exec(first.content);
+      if (!match) continue;
+
+      item.attrSet(LIST_KIND_ATTR, 'task');
+      item.attrSet(TASK_CHECKED_ATTR, match[1] === ' ' ? 'false' : 'true');
+
+      // Remove the marker from both the child and the inline token's own
+      // `content` so the stream stays self-consistent for any consumer.
+      first.content = first.content.slice(match[0].length);
+      inline.content = inline.content.slice(match[0].length);
+      if (first.content === '') {
+        inline.children?.shift();
+      }
+    }
+
+    return false;
+  });
+}

--- a/packages/js-lib/markdown-syntax/src/table-syntax.ts
+++ b/packages/js-lib/markdown-syntax/src/table-syntax.ts
@@ -1,0 +1,70 @@
+import type MarkdownIt from 'markdown-it';
+import type Token from 'markdown-it/lib/token.mjs';
+
+/**
+ * Opt-in markdown-it plugin defining what GFM pipe tables *mean* for every
+ * consumer that supports them. Not part of
+ * {@link createBaseMarkdownTokenizer}: an engine must not receive table
+ * tokens before it has table handling, or a note containing a table would
+ * fail to parse outright — engines opt in with `.use(tableTokenizer)` the
+ * same way they opt into {@link wikiLinkTokenizer}. The ProseMirror engine
+ * consumes this today; the Wordgard engine adopts it when table parity
+ * lands (plan 011, M3).
+ *
+ * Beyond enabling markdown-it's `table` rule, this converts literal `<br>`
+ * text inside table cells into `hardbreak` tokens: GFM cells hold line
+ * breaks as literal `<br>`, and the tokenizer runs with html disabled, so
+ * `<br>` arrives as plain text. The conversion is scoped to cells so `<br>`
+ * text in normal paragraphs keeps round-tripping as text.
+ *
+ * The rule must run before `text_join`: at that point escaped (`\<br>`) and
+ * entity (`&lt;br&gt;`) forms are still separate `text_special` tokens, so
+ * matching only `text` tokens converts exactly the raw occurrences and
+ * leaves intentional literals alone.
+ */
+export function tableTokenizer(md: MarkdownIt): void {
+  md.enable('table');
+  md.core.ruler.before('text_join', 'bangle-table-cell-br', (state) => {
+    let cellDepth = 0;
+    for (const token of state.tokens) {
+      if (token.type === 'th_open' || token.type === 'td_open') {
+        cellDepth++;
+      } else if (token.type === 'th_close' || token.type === 'td_close') {
+        cellDepth--;
+      } else if (cellDepth > 0 && token.type === 'inline' && token.children) {
+        token.children = splitBrIntoHardbreaks(token.children, state.Token);
+      }
+    }
+    return false;
+  });
+}
+
+const CELL_BR_RE = /<br\s*\/?>/i;
+
+function splitBrIntoHardbreaks(
+  children: Token[],
+  TokenCtor: new (type: string, tag: string, nesting: 0) => Token,
+): Token[] {
+  const result: Token[] = [];
+  for (const child of children) {
+    if (child.type !== 'text' || !CELL_BR_RE.test(child.content)) {
+      result.push(child);
+      continue;
+    }
+    const parts = child.content.split(new RegExp(CELL_BR_RE.source, 'gi'));
+    parts.forEach((part, index) => {
+      if (part) {
+        const text = new TokenCtor('text', '', 0);
+        text.content = part;
+        text.level = child.level;
+        result.push(text);
+      }
+      if (index < parts.length - 1) {
+        const br = new TokenCtor('hardbreak', 'br', 0);
+        br.level = child.level;
+        result.push(br);
+      }
+    });
+  }
+  return result;
+}

--- a/packages/js-lib/markdown-syntax/src/tokenizer.ts
+++ b/packages/js-lib/markdown-syntax/src/tokenizer.ts
@@ -1,5 +1,5 @@
-import { listMarkdownPlugin } from '@bangle.dev/pm-markdown/list-markdown';
 import markdownIt from 'markdown-it';
+import { listTokenizer } from './list-syntax';
 
 /**
  * Builds the engine-neutral base Markdown tokenizer that every editor engine —
@@ -10,18 +10,16 @@ import markdownIt from 'markdown-it';
  * ProseMirror or Wordgard document is the codec's job, not the tokenizer's.
  * Both engines MUST tokenize with the same base configuration, or they would
  * disagree about what a stored note means (e.g. whether `~~x~~` is a
- * strikethrough) — the single fidelity invariant this package exists to
- * protect. Feature-specific inline syntax (such as {@link wikiLinkTokenizer})
- * is layered on top with `.use(...)` so each consumer opts into exactly the
- * constructs it understands.
+ * strikethrough, or whether `- [ ] x` is a task item) — the single fidelity
+ * invariant this package exists to protect. Feature-specific inline syntax
+ * (such as {@link wikiLinkTokenizer}) is layered on top with `.use(...)` so
+ * each consumer opts into exactly the constructs it understands.
  *
  * Every call returns a fresh instance so callers never mutate shared parser
- * state. Keep this in lockstep with `@bangle.dev/pm-markdown`'s default
- * tokenizers; `listMarkdownPlugin` is consumed purely as a markdown-it plugin
- * (engine-neutral tokenization), not for any ProseMirror behavior.
+ * state.
  */
 export function createBaseMarkdownTokenizer() {
   return markdownIt('commonmark', { html: false, breaks: false })
     .enable('strikethrough')
-    .use(listMarkdownPlugin);
+    .use(listTokenizer);
 }

--- a/packages/js-lib/wordgard-markdown/package.json
+++ b/packages/js-lib/wordgard-markdown/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@bangle.io/wordgard-markdown",
+  "description": "Editor-free Markdown codec for Wordgard documents: markdown-it token stream to Wordgard doc and back, extensible via type-keyed MarkdownSpec entries.",
+  "license": "AGPL-3.0-or-later",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bangle-io/bangle-io.git",
+    "directory": "packages/js-lib/wordgard-markdown"
+  },
+  "authors": [
+    {
+      "name": "Kushan Joshi",
+      "email": "0o3ko0@gmail.com",
+      "web": "http://github.com/kepta"
+    }
+  ],
+  "homepage": "https://bangle.io",
+  "bugs": "https://github.com/bangle-io/bangle-io/issues",
+  "banglePackageConfig": {
+    "env": "universal",
+    "kind": "library"
+  },
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {},
+  "dependencies": {
+    "@bangle.io/markdown-syntax": "workspace:*",
+    "@bangle.io/wordgard-utils": "workspace:*",
+    "markdown-it": "14.3.0"
+  },
+  "devDependencies": {
+    "@bangle.io/test-utils": "workspace:*",
+    "@types/markdown-it": "^14.1.2"
+  }
+}

--- a/packages/js-lib/wordgard-markdown/src/__tests__/codec.spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/__tests__/codec.spec.ts
@@ -1,0 +1,110 @@
+import {
+  Doc,
+  Emphasis,
+  Heading,
+  Leaf,
+  Link,
+  LinkTitle,
+  Paragraph,
+  Schema,
+  Strong,
+} from '@bangle.io/wordgard-utils';
+import { describe, expect, it } from 'vitest';
+import { createMarkdownCodec, createNoteMarkdownCodec } from '../codec';
+import { defaultMarkdownSpecs } from '../default-specs';
+
+describe('createMarkdownCodec failure paths', () => {
+  it('throws a descriptive error for a markdown-it token type with no registered spec', () => {
+    // A schema/spec set that never registers a `heading` parse handler:
+    // parsing a heading must fail loudly rather than silently drop it.
+    const schema = Schema.define([Doc, Paragraph]);
+    const specs = defaultMarkdownSpecs.filter(
+      (spec) => !('node' in spec) || spec.node !== Heading,
+    );
+    const codec = createMarkdownCodec({ schema, specs });
+
+    expect(() => codec.parse('# A heading')).toThrow(
+      /Token type `heading_open` not supported by Markdown parser/,
+    );
+  });
+
+  it('throws a descriptive error naming the node type when serializing an unsupported node', () => {
+    // A schema that includes Strong (so parsing succeeds) but a spec set
+    // with no serializer registered for it: serializing must name the type.
+    const schema = Schema.define([Doc, Paragraph, Strong]);
+    const specs = defaultMarkdownSpecs.filter(
+      (spec) => !('mark' in spec) || spec.mark !== Strong,
+    );
+    const codec = createMarkdownCodec({ schema, specs });
+
+    const doc = schema.doc([Paragraph.create([Leaf.text('bold', [Strong])])]);
+
+    expect(() => codec.serialize(doc)).toThrow(
+      /Mark type `Strong` not supported by Markdown renderer/,
+    );
+  });
+
+  it('throws a descriptive error naming the plot type when serializing an unsupported plot', () => {
+    const schema = Schema.define([Doc, Paragraph, Emphasis]);
+    const specs = defaultMarkdownSpecs.filter(
+      (spec) => !('node' in spec) || spec.node !== Paragraph,
+    );
+    const codec = createMarkdownCodec({ schema, specs });
+
+    const doc = schema.doc([Paragraph.create([Leaf.text('hi')])]);
+
+    expect(() => codec.serialize(doc)).toThrow(
+      /Node type `Paragraph` not supported by Markdown serializer/,
+    );
+  });
+});
+
+describe('createNoteMarkdownCodec', () => {
+  it('exposes its schema', () => {
+    const codec = createNoteMarkdownCodec();
+    expect(codec.schema).toBeInstanceOf(Schema);
+  });
+
+  it('does not leak a titled link’s LinkTitle mark onto trailing text', () => {
+    // `link_close` tokens carry no attributes, so the parser must remember
+    // which marks the matching `link_open` added (Link + LinkTitle) instead
+    // of recomputing them from the close token — recomputing would remove
+    // only Link and leave LinkTitle active for the rest of the paragraph.
+    const codec = createNoteMarkdownCodec();
+    const doc = codec.parse('[a](b "c") more text');
+
+    const paragraph = doc.content[0];
+    if (!paragraph || !paragraph.isPlot) throw new Error('expected paragraph');
+    const trailing = paragraph.content[paragraph.content.length - 1];
+    if (!trailing) throw new Error('expected trailing text');
+
+    expect(trailing.isText).toBe(true);
+    expect(trailing.mark(LinkTitle)).toBeUndefined();
+    expect(trailing.mark(Link)).toBeUndefined();
+    expect(codec.serialize(doc)).toBe('[a](b "c") more text');
+  });
+
+  it('expels enclosing whitespace from a Strong-marked text node', () => {
+    // CommonMark forbids whitespace just inside `**`/`_` delimiters, so
+    // `** bold **` never parses into a Strong mark in the first place (it
+    // stays literal text) — this case can only be exercised by constructing
+    // the marked node directly, mirroring how a Wordgard editing command
+    // (not the Markdown parser) could produce this document shape.
+    const codec = createNoteMarkdownCodec();
+    const { schema } = codec;
+
+    // A lone marked node: there is no following node for the trailing
+    // whitespace to be expelled past, so (matching the ProseMirror engine
+    // exactly) only the leading whitespace moves outside the delimiters.
+    const lone = schema.doc([
+      Paragraph.create([Leaf.text(' bold ', [Strong])]),
+    ]);
+    expect(codec.serialize(lone)).toBe(' **bold** ');
+
+    // With a following sibling, both sides expel.
+    const withSibling = schema.doc([
+      Paragraph.create([Leaf.text(' bold ', [Strong]), Leaf.text('after')]),
+    ]);
+    expect(codec.serialize(withSibling)).toBe(' **bold** after');
+  });
+});

--- a/packages/js-lib/wordgard-markdown/src/__tests__/codec.spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/__tests__/codec.spec.ts
@@ -3,6 +3,7 @@ import {
   Emphasis,
   Heading,
   Leaf,
+  LineBreak,
   Link,
   LinkTitle,
   Paragraph,
@@ -106,5 +107,89 @@ describe('createNoteMarkdownCodec', () => {
       Paragraph.create([Leaf.text(' bold ', [Strong]), Leaf.text('after')]),
     ]);
     expect(codec.serialize(withSibling)).toBe(' **bold** after');
+  });
+});
+
+/**
+ * Serialize-only cases over directly constructed documents, ported from
+ * prosemirror-markdown's own test suite: these document shapes cannot be
+ * produced by parsing Markdown (the parser never yields them), only by
+ * editing commands, so the round-trip corpus cannot cover them.
+ */
+describe('serializing constructed documents', () => {
+  const codec = createNoteMarkdownCodec();
+  const { schema } = codec;
+
+  it('drops trailing hard breaks', () => {
+    const doc = schema.doc([
+      Paragraph.create([Leaf.text('a'), LineBreak, LineBreak]),
+    ]);
+    expect(codec.serialize(doc)).toBe('a');
+  });
+
+  it('does not crash when a block ends in a hard break', () => {
+    const doc = schema.doc([
+      Paragraph.create([
+        Leaf.text('foo', [Strong]),
+        LineBreak.withMarks([Strong]),
+      ]),
+    ]);
+    expect(codec.serialize(doc)).toBe('**foo**');
+  });
+
+  it('expels whitespace before a hard break outside the mark', () => {
+    const doc = schema.doc([
+      Paragraph.create([
+        Leaf.text('foo ', [Strong]),
+        LineBreak.withMarks([Strong]),
+        Leaf.text('bar'),
+      ]),
+    ]);
+    expect(codec.serialize(doc)).toBe('**foo** \\\nbar');
+  });
+
+  it('drops marks whose entire text is expelled whitespace', () => {
+    const doc = schema.doc([
+      Paragraph.create([
+        Leaf.text('Text with', []),
+        Leaf.text(' ', [Emphasis]),
+        Leaf.text('an emphasized space'),
+      ]),
+    ]);
+    expect(codec.serialize(doc)).toBe('Text with an emphasized space');
+  });
+
+  it('expels whitespace from emphasis around a nested link', () => {
+    const link = Link.of('https://x');
+    const doc = schema.doc([
+      Paragraph.create([
+        Leaf.text('One', []),
+        Leaf.text(' two ', [Emphasis]),
+        Leaf.text('three', [Emphasis, link]),
+        Leaf.text(' four ', [Emphasis]),
+        Leaf.text('five'),
+      ]),
+    ]);
+    expect(codec.serialize(doc)).toBe('One _two [three](https://x) four_ five');
+  });
+
+  it('keeps a newline inside an inline mark intact', () => {
+    // A text leaf containing a raw newline can only be constructed
+    // programmatically. prosemirror-markdown emits the newline as-is inside
+    // the delimiters; so does this serializer.
+    const doc = schema.doc([
+      Paragraph.create([Leaf.text('text1\ntext2', [Strong])]),
+    ]);
+    expect(codec.serialize(doc)).toBe('**text1\ntext2**');
+  });
+
+  it('orders overlapping mark delimiters by spec registration, not mark rank', () => {
+    // Wordgard's own mark-set order ranks Link (20) before Strong (60), but
+    // serialization must nest Strong outside Link to match the ProseMirror
+    // engine — `serializationMarks` re-sorts by the mark specs' order.
+    const doc = schema.doc([
+      Paragraph.create([Leaf.text('x', [Link.of('https://u'), Strong])]),
+    ]);
+    expect(codec.serialize(doc)).toBe('**[x](https://u)**');
   });
 });

--- a/packages/js-lib/wordgard-markdown/src/__tests__/markdown-golden-corpus.spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/__tests__/markdown-golden-corpus.spec.ts
@@ -6,23 +6,30 @@ import { createNoteMarkdownCodec } from '../codec';
  * Cross-engine parity contract test (see
  * `plans/011-wordgard-editor-w-migration.md`, milestone M1): every fixture in
  * `@bangle.io/test-utils`'s `MARKDOWN_CORPUS` whose `engines` includes
- * `'wordgard'` must round-trip byte-identically through this package's
- * `createNoteMarkdownCodec()`. The ProseMirror engine asserts the same
- * contract in `packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts`
+ * `'wordgard'` must serialize to its expected bytes (`canonical` for
+ * normalization fixtures, the input itself otherwise) through this package's
+ * `createNoteMarkdownCodec()`, and that expected form must be a fixed point
+ * of the round trip. The ProseMirror engine asserts the same contract in
+ * `packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts`
  * against the same corpus — a failure here means this engine has drifted
  * from the shared fixed point, not that the fixture itself is wrong.
  */
 describe('golden corpus (wordgard)', () => {
   const codec = createNoteMarkdownCodec();
+  const roundTrip = (input: string) => codec.serialize(codec.parse(input));
   const wordgardFixtures = MARKDOWN_CORPUS.filter((f) =>
     f.engines.includes('wordgard'),
   );
 
   it.each(
-    wordgardFixtures.map((f) => [f.name, f.markdown] as const),
-  )('%s', (_name, markdown) => {
-    const doc = codec.parse(markdown);
-    const out = codec.serialize(doc);
-    expect(out).toBe(markdown);
+    wordgardFixtures.map((f) => [f.name, f] as const),
+  )('%s', (_name, fixture) => {
+    const expected = fixture.canonical ?? fixture.markdown;
+    expect(roundTrip(fixture.markdown)).toBe(expected);
+    if (fixture.canonical !== undefined) {
+      // The canonical form must itself be stable, or the "normalization"
+      // never converges and every save would rewrite the note.
+      expect(roundTrip(fixture.canonical)).toBe(fixture.canonical);
+    }
   });
 });

--- a/packages/js-lib/wordgard-markdown/src/__tests__/markdown-golden-corpus.spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/__tests__/markdown-golden-corpus.spec.ts
@@ -1,0 +1,28 @@
+import { MARKDOWN_CORPUS } from '@bangle.io/test-utils';
+import { describe, expect, it } from 'vitest';
+import { createNoteMarkdownCodec } from '../codec';
+
+/**
+ * Cross-engine parity contract test (see
+ * `plans/011-wordgard-editor-w-migration.md`, milestone M1): every fixture in
+ * `@bangle.io/test-utils`'s `MARKDOWN_CORPUS` whose `engines` includes
+ * `'wordgard'` must round-trip byte-identically through this package's
+ * `createNoteMarkdownCodec()`. The ProseMirror engine asserts the same
+ * contract in `packages/core/editor/src/__tests__/markdown-golden-corpus.spec.ts`
+ * against the same corpus — a failure here means this engine has drifted
+ * from the shared fixed point, not that the fixture itself is wrong.
+ */
+describe('golden corpus (wordgard)', () => {
+  const codec = createNoteMarkdownCodec();
+  const wordgardFixtures = MARKDOWN_CORPUS.filter((f) =>
+    f.engines.includes('wordgard'),
+  );
+
+  it.each(
+    wordgardFixtures.map((f) => [f.name, f.markdown] as const),
+  )('%s', (_name, markdown) => {
+    const doc = codec.parse(markdown);
+    const out = codec.serialize(doc);
+    expect(out).toBe(markdown);
+  });
+});

--- a/packages/js-lib/wordgard-markdown/src/__tests__/round-trip.spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/__tests__/round-trip.spec.ts
@@ -133,6 +133,19 @@ describe('createNoteMarkdownCodec parse shape', () => {
     expect(heading && !heading.isLeaf ? heading.tag.param : undefined).toBe(3);
   });
 
+  it('frontmatter parses to a leading Frontmatter plot with raw text', () => {
+    const doc = codec.parse('---\ntitle: Hello\ntags:\n  - a\n---\n\nbody');
+    const frontmatter = doc.content[0];
+    if (!frontmatter?.isPlot) throw new Error('expected a plot');
+    expect(frontmatter.name).toBe('Frontmatter');
+    expect(frontmatter.textContent()).toBe('title: Hello\ntags:\n  - a');
+    // Raw YAML text: `[[..]]`-like or emphasis-like content must stay text.
+    const withSyntax = codec.parse('---\nlink: [[not a link]]\n---');
+    const fm = withSyntax.content[0];
+    if (!fm?.isPlot) throw new Error('expected a plot');
+    expect(fm.content.every((n) => n.isText)).toBe(true);
+  });
+
   it('a task item inside an ordered list parses without failing', () => {
     // GFM allows `1. [ ] x`; the schema admits the transient
     // OrderedList > TaskItem shape (see `taskListContentOverrides`) so a

--- a/packages/js-lib/wordgard-markdown/src/__tests__/round-trip.spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/__tests__/round-trip.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { createNoteMarkdownCodec } from '../codec';
+
+/**
+ * Round-trip fixtures: `serialize(parse(md)) === md` for every construct the
+ * note schema supports. These assert byte parity with the ProseMirror
+ * engine's own Markdown conventions (see `default-specs.ts`), which is the
+ * whole point of this package — a silent divergence here would mean two
+ * editor engines disagree about what a stored note's Markdown means.
+ */
+describe('createNoteMarkdownCodec round-trip', () => {
+  const codec = createNoteMarkdownCodec();
+  const roundTrip = (md: string) => codec.serialize(codec.parse(md));
+
+  it.each([
+    ['single paragraph', 'Hello world'],
+    ['multiple paragraphs', 'First paragraph\n\nSecond paragraph'],
+    ['heading 1', '# Heading one'],
+    ['heading 2', '## Heading two'],
+    ['heading 3', '### Heading three'],
+    ['heading 4', '#### Heading four'],
+    ['heading 5', '##### Heading five'],
+    ['heading 6', '###### Heading six'],
+    ['blockquote', '> quoted text'],
+    ['nested blockquote', '> outer\n>\n> > inner'],
+    ['horizontal rule', 'above\n\n---\n\nbelow'],
+    ['hard break', 'line one\\\nline two'],
+    ['multiple hard breaks', 'a\\\n\\\nb'],
+    ['bold spanning a hard break', '**bold line one\\\nbold line two**'],
+    ['bold ending right before a hard break', '**bold**\\\nplain text'],
+    ['bold', '**bold text**'],
+    ['italic', '_italic text_'],
+    ['strikethrough', '~~struck text~~'],
+    ['inline code', 'some `code` here'],
+    [
+      'inline code with backticks inside',
+      'some `` code with ` backtick `` here',
+    ],
+    ['bold+italic mixable', '**bold _both_**'],
+    ['image no title', '![alt text](./image.png)'],
+    ['image with title', '![alt text](./image.png "a title")'],
+    ['image empty alt', '![](./image.png)'],
+    ['link with title', '[link text](https://example.com "a title")'],
+    ['link relative url', '[relative](../notes/other.md)'],
+    ['autolink', '<https://example.com/path>'],
+    ['escaped emphasis', '\\*not em\\*'],
+    ['wiki link target only', '[[target-note]]'],
+    ['wiki link with label', '[[target-note|Display Label]]'],
+    ['wiki link unicode', '[[日本語ノート|ラベル]]'],
+    ['empty code block', '```\n```'],
+    ['code block with language', '```js\nconst x = 1;\n```'],
+    ['code block with backticks inside', '````\n```\nnested fence\n```\n````'],
+  ])('%s', (_name, md) => {
+    expect(roundTrip(md)).toBe(md);
+  });
+
+  it('empty document round-trips to empty string', () => {
+    expect(roundTrip('')).toBe('');
+  });
+
+  it('an escaped wiki-link opener parses as plain text, not a wiki link', () => {
+    // `\[[..]]` escapes only the first `[`, so the wikiLinkTokenizer (which
+    // runs before markdown-it's `escape` rule) never sees a `[[` opener —
+    // the whole thing becomes plain text. Escaping isn't guaranteed to be
+    // byte-identical on round-trip (unescaped brackets that happen to need
+    // escaping look identical to originally-escaped ones after parsing);
+    // what matters is that it re-parses back to the same plain text, with
+    // no wiki link node created.
+    const md = '\\[[not a wiki link]]';
+    const doc = createNoteMarkdownCodec().parse(md);
+    const paragraph = doc.content[0];
+    if (!paragraph?.isPlot) throw new Error('expected a paragraph plot');
+    expect(paragraph.content.some((n) => n.name === 'WikiLink')).toBe(false);
+    expect(paragraph.textContent()).toBe('[[not a wiki link]]');
+
+    const out = roundTrip(md);
+    expect(out).toBe('\\[\\[not a wiki link\\]\\]');
+    // Re-parsing the serialized form must still not produce a wiki link,
+    // and must preserve the same literal text.
+    const reparsed = createNoteMarkdownCodec().parse(out);
+    const reparsedParagraph = reparsed.content[0];
+    if (!reparsedParagraph?.isPlot)
+      throw new Error('expected a paragraph plot');
+    expect(reparsedParagraph.textContent()).toBe('[[not a wiki link]]');
+  });
+
+  describe('lists', () => {
+    it.each([
+      ['bullet list single item', '- one'],
+      ['bullet list multiple items', '- one\n\n- two\n\n- three'],
+      ['ordered list', '1. first\n\n1. second\n\n1. third'],
+      ['task list', '- [ ] todo one\n\n- [x] todo two'],
+      [
+        'nested bullet list',
+        '- one\n\n- two\n\n  - nested a\n\n  - nested b\n\n- three',
+      ],
+      [
+        'mixed nested list kinds',
+        '- one\n\n  1. nested ordered a\n\n  1. nested ordered b\n\n- two',
+      ],
+      ['multi-paragraph list item', '- one\n\n  more text\n\n- two'],
+    ])('%s', (_name, md) => {
+      expect(roundTrip(md)).toBe(md);
+    });
+  });
+
+  describe('constructs combined inside lists', () => {
+    it.each([
+      ['bold inside list item', '- **bold item**'],
+      ['wiki link inside list item', '- item with [[a-note]]'],
+      ['wiki link inside bold', '**bold [[a-note|label]] text**'],
+    ])('%s', (_name, md) => {
+      expect(roundTrip(md)).toBe(md);
+    });
+  });
+
+  it('an empty blockquote is filled with a default paragraph, not rejected', () => {
+    // `>` with no content is valid Markdown, but Wordgard's Blockquote plot
+    // requires at least one block child. `Schema.createAndFill` supplies an
+    // empty default paragraph (see `parser.ts`'s `closeNode`), matching the
+    // ProseMirror engine's own `"> "` output for the same input.
+    expect(roundTrip('>')).toBe('> ');
+  });
+});
+
+describe('createNoteMarkdownCodec parse shape', () => {
+  const codec = createNoteMarkdownCodec();
+
+  it('heading level is stored as the plot tag param', () => {
+    const doc = codec.parse('### Level three');
+    const heading = doc.content[0];
+    expect(heading?.isPlot).toBe(true);
+    expect(heading && !heading.isLeaf ? heading.tag.param : undefined).toBe(3);
+  });
+
+  it('task item checked state is stored as the plot tag param', () => {
+    const doc = codec.parse('- [x] done\n\n- [ ] not done');
+    const list = doc.content[0];
+    expect(list?.isPlot).toBe(true);
+    if (!list?.isPlot) throw new Error('expected a plot');
+    const [doneItem, notDoneItem] = list.content;
+    expect(
+      doneItem?.isPlot && !doneItem.isLeaf ? doneItem.tag.param : undefined,
+    ).toBe(true);
+    expect(
+      notDoneItem?.isPlot && !notDoneItem.isLeaf
+        ? notDoneItem.tag.param
+        : undefined,
+    ).toBe(false);
+  });
+
+  it('wiki link target is the leaf param and label is a mark', () => {
+    const doc = codec.parse('[[my-target|My Label]]');
+    const paragraph = doc.content[0];
+    if (!paragraph?.isPlot) throw new Error('expected a paragraph plot');
+    const wikiLink = paragraph.content[0];
+    expect(wikiLink?.isLeaf).toBe(true);
+    if (!wikiLink?.isLeaf) throw new Error('expected a leaf');
+    expect(wikiLink.param).toBe('my-target');
+    const labelMark = wikiLink.marks.find((m) => m.name === 'WikiLinkLabel');
+    expect(labelMark?.value).toBe('My Label');
+  });
+
+  it('code block language is stored as a CodeBlockLanguage mark on the plot', () => {
+    const doc = codec.parse('```typescript\nconst x = 1;\n```');
+    const codeBlock = doc.content[0];
+    expect(codeBlock?.isPlot).toBe(true);
+    if (!codeBlock?.isPlot) throw new Error('expected a plot');
+    const languageMark = codeBlock.tag.marks.find(
+      (m) => m.name === 'CodeBlockLanguage',
+    );
+    expect(languageMark?.value).toBe('typescript');
+  });
+});

--- a/packages/js-lib/wordgard-markdown/src/__tests__/round-trip.spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/__tests__/round-trip.spec.ts
@@ -133,6 +133,20 @@ describe('createNoteMarkdownCodec parse shape', () => {
     expect(heading && !heading.isLeaf ? heading.tag.param : undefined).toBe(3);
   });
 
+  it('a task item inside an ordered list parses without failing', () => {
+    // GFM allows `1. [ ] x`; the schema admits the transient
+    // OrderedList > TaskItem shape (see `taskListContentOverrides`) so a
+    // legal note never turns into a load failure. Serialization normalizes
+    // the item back to a `- [ ]` bullet, matching the ProseMirror engine.
+    const doc = codec.parse('1. [ ] task');
+    const list = doc.content[0];
+    if (!list?.isPlot) throw new Error('expected a plot');
+    expect(list.tag.type.name).toBe('OrderedList');
+    const [item] = list.content;
+    expect(item?.isPlot && item.name).toBe('TaskItem');
+    expect(codec.serialize(doc)).toBe('- [ ] task');
+  });
+
   it('task item checked state is stored as the plot tag param', () => {
     const doc = codec.parse('- [x] done\n\n- [ ] not done');
     const list = doc.content[0];

--- a/packages/js-lib/wordgard-markdown/src/codec.ts
+++ b/packages/js-lib/wordgard-markdown/src/codec.ts
@@ -28,7 +28,7 @@ import {
   Strikethrough,
   Strong,
   TaskItem,
-  taskListContentOverride,
+  taskListContentOverrides,
   WikiLink,
   WikiLinkLabel,
 } from '@bangle.io/wordgard-utils';
@@ -168,7 +168,7 @@ export function createNoteMarkdownCodec(): MarkdownCodec {
     OrderedList,
     ListItem,
     TaskItem,
-    taskListContentOverride,
+    ...taskListContentOverrides,
     HorizontalRule,
     LineBreak,
     Image,

--- a/packages/js-lib/wordgard-markdown/src/codec.ts
+++ b/packages/js-lib/wordgard-markdown/src/codec.ts
@@ -53,6 +53,11 @@ export interface MarkdownCodec {
 
 export interface MarkdownCodecOptions {
   readonly schema: Schema;
+  /**
+   * The node/mark markdown specs. The relative order of MARK specs defines
+   * the serialization nesting order for overlapping marks (earlier =
+   * outermost); see `MarkdownSerializerState.serializationMarks`.
+   */
   readonly specs: readonly MarkdownSpec[];
   readonly tokenizer?: MarkdownIt;
 }

--- a/packages/js-lib/wordgard-markdown/src/codec.ts
+++ b/packages/js-lib/wordgard-markdown/src/codec.ts
@@ -1,5 +1,6 @@
 import {
   createBaseMarkdownTokenizer,
+  frontmatterTokenizer,
   wikiLinkTokenizer,
 } from '@bangle.io/markdown-syntax';
 import {
@@ -10,6 +11,8 @@ import {
   CodeBlockLanguage,
   Doc,
   Emphasis,
+  Frontmatter,
+  frontmatterDocContentOverride,
   Heading,
   HorizontalRule,
   Image,
@@ -162,6 +165,8 @@ export function createNoteMarkdownCodec(): MarkdownCodec {
     Paragraph,
     Heading,
     Blockquote,
+    Frontmatter,
+    frontmatterDocContentOverride,
     CodeBlock,
     CodeBlockLanguage,
     BulletList,
@@ -184,7 +189,9 @@ export function createNoteMarkdownCodec(): MarkdownCodec {
     WikiLinkLabel,
   ]);
 
-  const tokenizer = createBaseMarkdownTokenizer().use(wikiLinkTokenizer);
+  const tokenizer = createBaseMarkdownTokenizer()
+    .use(wikiLinkTokenizer)
+    .use(frontmatterTokenizer);
 
   return createMarkdownCodec({
     schema,

--- a/packages/js-lib/wordgard-markdown/src/codec.ts
+++ b/packages/js-lib/wordgard-markdown/src/codec.ts
@@ -1,0 +1,189 @@
+import {
+  createBaseMarkdownTokenizer,
+  wikiLinkTokenizer,
+} from '@bangle.io/markdown-syntax';
+import {
+  Blockquote,
+  BulletList,
+  Code,
+  CodeBlock,
+  CodeBlockLanguage,
+  Doc,
+  Emphasis,
+  Heading,
+  HorizontalRule,
+  Image,
+  ImageAlt,
+  ImageTitle,
+  LineBreak,
+  Link,
+  LinkTitle,
+  ListItem,
+  Mark,
+  Node,
+  OrderedList,
+  Paragraph,
+  type Plot,
+  Schema,
+  Strikethrough,
+  Strong,
+  TaskItem,
+  taskListContentOverride,
+  WikiLink,
+  WikiLinkLabel,
+} from '@bangle.io/wordgard-utils';
+import type MarkdownIt from 'markdown-it';
+import { defaultMarkdownSpecs } from './default-specs';
+import { parseTokens } from './parser';
+import {
+  isMarkMarkdownSpec,
+  isNodeMarkdownSpec,
+  type MarkdownSpec,
+  type MarkMarkdownSpec,
+  type MarkTypeRef,
+} from './spec';
+import { MarkdownSerializerState } from './state';
+
+/** A headless Markdown string <-> Wordgard `Plot.Doc` codec. */
+export interface MarkdownCodec {
+  readonly schema: Schema;
+  parse(markdown: string): Plot.Doc;
+  serialize(doc: Plot.Doc): string;
+}
+
+export interface MarkdownCodecOptions {
+  readonly schema: Schema;
+  readonly specs: readonly MarkdownSpec[];
+  readonly tokenizer?: MarkdownIt;
+}
+
+/** Canonicalizes a {@link MarkTypeRef} (a `Mark.Type` or singleton `Mark`) to its `Mark.Type`. */
+function markTypeOf(ref: MarkTypeRef): Mark.Type {
+  return ref instanceof Mark ? ref.type : ref;
+}
+
+/**
+ * Builds a Markdown codec from an explicit schema, spec set, and (optional)
+ * tokenizer. Node/mark type identity — not string names — is the lookup key
+ * for the serializer dispatch table, matching how specs are keyed (see
+ * `spec.ts`): `Node.Type.get` and {@link markTypeOf} canonicalize a spec's
+ * type-or-singleton-tag reference the same way regardless of which shape a
+ * spec author used to register it.
+ */
+export function createMarkdownCodec(
+  options: MarkdownCodecOptions,
+): MarkdownCodec {
+  const { schema, specs } = options;
+  const tokenizer = options.tokenizer ?? createBaseMarkdownTokenizer();
+
+  const nodeSerializers = new Map<
+    Node.Type,
+    Extract<MarkdownSpec, { node: unknown }>['serialize']
+  >();
+  const markSerializers = new Map<Mark.Type, MarkMarkdownSpec['serialize']>();
+
+  for (const spec of specs) {
+    if (isNodeMarkdownSpec(spec)) {
+      nodeSerializers.set(Node.Type.get(spec.node), spec.serialize);
+    } else if (isMarkMarkdownSpec(spec)) {
+      markSerializers.set(markTypeOf(spec.mark), spec.serialize);
+    }
+  }
+
+  const renderNode = (
+    state: MarkdownSerializerState,
+    node: Node,
+    parent: Plot,
+    index: number,
+  ): void => {
+    const key = node.isLeaf ? node.type : node.tag.type;
+    const serialize = nodeSerializers.get(key);
+    if (!serialize) {
+      throw new Error(
+        `Node type \`${node.name}\` not supported by Markdown serializer`,
+      );
+    }
+    serialize(state, node, parent, index);
+  };
+
+  return {
+    schema,
+    parse(markdown: string): Plot.Doc {
+      const tokens = tokenizer.parse(markdown, {});
+      const content = parseTokens(schema, specs, tokens);
+      return schema.doc(ensureNonEmptyDoc(schema, content));
+    },
+    serialize(doc: Plot.Doc): string {
+      // A fresh state per call: the serializer accumulates output on
+      // `this`, so reusing one instance across calls would leak content
+      // and the delimiter stack between unrelated `serialize()` calls.
+      const state = new MarkdownSerializerState(markSerializers, renderNode);
+      state.renderContent(doc);
+      return state.out;
+    },
+  };
+}
+
+/**
+ * `Doc` requires at least one block child (see `Plot.defineDoc`'s
+ * `canBeEmpty` default of `false`). An empty markdown string produces no
+ * tokens, so we fill it with a single empty paragraph — the only place the
+ * parser invents content, and it round-trips back to `''` (an empty
+ * paragraph serializes to nothing).
+ */
+function ensureNonEmptyDoc(
+  schema: Schema,
+  content: readonly Node[],
+): readonly Node[] {
+  if (content.length > 0) return content;
+  const fallback = schema.defaultContentPlot(schema.docTag.type);
+  if (!fallback) {
+    throw new Error(
+      'Schema has no default block content to fill an empty document',
+    );
+  }
+  return [schema.createAndFill(fallback)];
+}
+
+/**
+ * The batteries-included codec for Bangle notes: the schema and Markdown
+ * specs that every note's Wordgard document must round-trip through, kept
+ * in one factory so `editor-w` and this package's own tests build the exact
+ * same schema/tokenizer pairing.
+ */
+export function createNoteMarkdownCodec(): MarkdownCodec {
+  const schema = Schema.define([
+    Doc,
+    Paragraph,
+    Heading,
+    Blockquote,
+    CodeBlock,
+    CodeBlockLanguage,
+    BulletList,
+    OrderedList,
+    ListItem,
+    TaskItem,
+    taskListContentOverride,
+    HorizontalRule,
+    LineBreak,
+    Image,
+    ImageAlt,
+    ImageTitle,
+    LinkTitle,
+    Strong,
+    Emphasis,
+    Strikethrough,
+    Code,
+    Link,
+    WikiLink,
+    WikiLinkLabel,
+  ]);
+
+  const tokenizer = createBaseMarkdownTokenizer().use(wikiLinkTokenizer);
+
+  return createMarkdownCodec({
+    schema,
+    specs: defaultMarkdownSpecs,
+    tokenizer,
+  });
+}

--- a/packages/js-lib/wordgard-markdown/src/default-specs.ts
+++ b/packages/js-lib/wordgard-markdown/src/default-specs.ts
@@ -1,0 +1,621 @@
+// Portions adapted from prosemirror-markdown (MIT © Marijn Haverbeke).
+// The per-construct string conventions below (heading `#` prefixes, fence
+// backtick-length adaptation, hard-break lookahead, list indentation, the
+// autolink heuristic, adaptive inline-code backticks, ...) are ported from
+// `@bangle.io/banger-editor`'s ProseMirror markdown specs (which themselves
+// port prosemirror-markdown), onto Wordgard's plot/leaf/mark model. Byte
+// parity with the ProseMirror engine's output is the whole point of this
+// file — see the package-level round-trip corpus.
+import {
+  serializeWikiLinkAttrs,
+  type WikiLinkAttrs,
+} from '@bangle.io/markdown-syntax';
+import {
+  Blockquote,
+  BulletList,
+  Code,
+  CodeBlock,
+  CodeBlockLanguage,
+  Emphasis,
+  Heading,
+  HorizontalRule,
+  Image,
+  ImageAlt,
+  ImageTitle,
+  Leaf,
+  LineBreak,
+  Link,
+  LinkTitle,
+  ListItem,
+  type Mark,
+  type Node,
+  OrderedList,
+  Paragraph,
+  type Plot,
+  Strikethrough,
+  Strong,
+  TaskItem,
+  WikiLink,
+  WikiLinkLabel,
+} from '@bangle.io/wordgard-utils';
+import type Token from 'markdown-it/lib/token.mjs';
+import type { MarkdownSpec, MarkMarkdownSpec, NodeMarkdownSpec } from './spec';
+import type { MarkdownSerializerState } from './state';
+
+/**
+ * Quote helper for link/image titles, matching `banger-editor`'s local
+ * `quote()` (not `MarkdownSerializerState.quote`, which uses PM's
+ * `""`/`''`/`()` fallback chain) — this is the byte-parity target since the
+ * ProseMirror engine's own markdown specs define and use this exact
+ * function for titles.
+ */
+function quote(str: string): string {
+  const wrap = str.includes('"') ? "'" : '"';
+  return wrap + str + wrap;
+}
+
+// ---------------------------------------------------------------------------
+// Paragraph
+// ---------------------------------------------------------------------------
+
+const paragraphSpec: NodeMarkdownSpec = {
+  node: Paragraph,
+  parse: {
+    paragraph: { block: Paragraph },
+  },
+  serialize(state, node) {
+    assertPlot(node, 'paragraph');
+    state.renderInline(node);
+    state.closeBlock(node);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Heading
+// ---------------------------------------------------------------------------
+
+function parseHeadingLevel(tok: Token): number {
+  const level = Number.parseInt(tok.tag.slice(1), 10);
+  return Number.isNaN(level) ? 1 : level;
+}
+
+const headingSpec: NodeMarkdownSpec = {
+  node: Heading,
+  parse: {
+    heading: { block: (tok) => Heading.of(parseHeadingLevel(tok)) },
+  },
+  serialize(state, node) {
+    assertPlot(node, 'heading');
+    const level = node.tag.is(Heading) ? node.tag.param : 1;
+    state.write(`${state.repeat('#', level)} `);
+    // banger-editor's heading calls `renderInline(node)` with the default
+    // `fromBlockStart = true`, so start-of-line constructs at the head of a
+    // heading's text get escaped (`## 1\. x`) — byte parity requires the
+    // same here, even though prosemirror-markdown's own heading passes
+    // `false`.
+    state.renderInline(node);
+    state.closeBlock(node);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Blockquote
+// ---------------------------------------------------------------------------
+
+const blockquoteSpec: NodeMarkdownSpec = {
+  node: Blockquote,
+  parse: {
+    blockquote: { block: Blockquote },
+  },
+  serialize(state, node) {
+    assertPlot(node, 'blockquote');
+    state.wrapBlock('> ', null, node, () => state.renderContent(node));
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Horizontal rule
+// ---------------------------------------------------------------------------
+
+const horizontalRuleSpec: NodeMarkdownSpec = {
+  node: HorizontalRule,
+  parse: {
+    hr: { node: () => HorizontalRule },
+  },
+  serialize(state, node) {
+    state.write('---');
+    state.closeBlock(node);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Hard break
+// ---------------------------------------------------------------------------
+
+const hardBreakSpec: NodeMarkdownSpec = {
+  node: LineBreak,
+  parse: {
+    hardbreak: { node: (_tok, marks) => LineBreak.withMarks(marks) },
+  },
+  serialize(state, node, parent, index) {
+    for (let i = index + 1; i < parent.content.length; i++) {
+      const sibling = parent.content[i];
+      if (!sibling || sibling.tag.type !== node.tag.type) {
+        state.write('\\\n');
+        return;
+      }
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Code block
+// ---------------------------------------------------------------------------
+
+function longestFenceMarkerRun(text: string, marker: '`' | '~'): number {
+  let longest = 0;
+  let current = 0;
+  for (const char of text) {
+    if (char === marker) {
+      current += 1;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+  return longest;
+}
+
+function createCodeFence(text: string, info: string): string {
+  const marker = info.includes('`') ? '~' : '`';
+  const longestRun = longestFenceMarkerRun(text, marker);
+  return marker.repeat(Math.max(3, longestRun + 1));
+}
+
+const codeBlockSpec: NodeMarkdownSpec = {
+  node: CodeBlock,
+  parse: {
+    code_block: {
+      block: () => CodeBlock,
+      noCloseToken: true,
+    },
+    fence: {
+      block: (tok) => {
+        const language = tok.info || '';
+        return language
+          ? CodeBlock.withMarks([CodeBlockLanguage.of(language)])
+          : CodeBlock;
+      },
+      noCloseToken: true,
+    },
+  },
+  serialize(state, node) {
+    assertPlot(node, 'code_block');
+    const language = node.mark(CodeBlockLanguage) ?? '';
+    const text = node.textContent();
+    const fence = createCodeFence(text, language);
+    state.write(`${fence}${language}\n`);
+    state.write(text);
+    if (text) {
+      state.write('\n');
+    }
+    state.write(fence);
+    state.closeBlock(node);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Image
+// ---------------------------------------------------------------------------
+
+function imageAlt(tok: Token): string {
+  const first = tok.children?.[0];
+  return first?.content || '';
+}
+
+const imageSpec: NodeMarkdownSpec = {
+  node: Image,
+  parse: {
+    image: {
+      // Merge `ImageAlt`/`ImageTitle` (attribute marks private to this
+      // leaf) into the currently-active spanning marks, rather than
+      // replacing them — an image typed inside `**bold**` must stay bold.
+      node: (tok, marks) => {
+        const src = tok.attrGet('src') ?? '';
+        const title = tok.attrGet('title');
+        const alt = imageAlt(tok);
+        let withAttrs = marks;
+        if (alt) withAttrs = ImageAlt.of(alt).addToSet(withAttrs);
+        if (title) withAttrs = ImageTitle.of(title).addToSet(withAttrs);
+        return Image.of(src, withAttrs);
+      },
+    },
+  },
+  serialize(state, node) {
+    assertLeaf(node, 'image');
+    if (!node.is(Image)) throw new Error('Expected an `image` leaf');
+    const alt = node.mark(ImageAlt) ?? '';
+    const title = node.mark(ImageTitle);
+    const text = state.esc(alt);
+    const url = state.esc(node.param) + (title ? ` ${quote(title)}` : '');
+    state.write(`![${text}](${url})`);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Text
+// ---------------------------------------------------------------------------
+
+const textSpec: NodeMarkdownSpec = {
+  node: Leaf.Text,
+  parse: {
+    // `text` and `inline` are handled directly by the parser (`parser.ts`),
+    // not through a spec — a text leaf never arrives via its own markdown-it
+    // token type the way block/mark specs do.
+  },
+  serialize(state, node) {
+    assertLeaf(node, 'text');
+    if (typeof node.param !== 'string') throw new Error('Expected a text leaf');
+    state.text(node.param);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Lists — Wordgard nests BulletList/OrderedList -> ListItem/TaskItem, with a
+// nested list living inside its parent item's content. The ProseMirror
+// engine's `flatListToMarkdown` (banger-editor's list.ts) works over a flat
+// list model instead. Byte parity means reproducing that flat algorithm's
+// output (unconditional tight lists, fixed "1." markers, 2-space nesting
+// indent) on top of the nested structure, which the block content walk
+// gives us for free.
+// ---------------------------------------------------------------------------
+
+function listItemMarker(node: Plot): string {
+  if (node.tag.is(TaskItem)) {
+    return node.tag.param ? '- [x]' : '- [ ]';
+  }
+  return '-';
+}
+
+function serializeListItem(
+  state: MarkdownSerializerState,
+  node: Plot,
+  level: number,
+  marker: string,
+): void {
+  const baseIndent = '  '.repeat(level);
+  const firstDelim = `${baseIndent}${marker} `;
+  const continuationDelim = ' '.repeat(firstDelim.length);
+
+  const isNestedList = (child: Node): child is Plot =>
+    child.isPlot &&
+    (child.tag.is(BulletList.type) || child.tag.is(OrderedList));
+
+  // Mirrors `flatListToMarkdown`: non-list children render inside the
+  // item's wrapBlock (keeping their original parent/index so sibling-aware
+  // serializers see the true document shape), nested lists render after it
+  // at the next indent level.
+  state.wrapBlock(continuationDelim, firstDelim, node, () => {
+    for (let i = 0; i < node.content.length; i++) {
+      const child = node.content[i];
+      if (child && !isNestedList(child)) state.render(child, node, i);
+    }
+  });
+
+  for (const child of node.content) {
+    if (isNestedList(child)) serializeList(state, child, level + 1);
+  }
+}
+
+/**
+ * Renders a list's items in document order. Unlike prosemirror-markdown's
+ * `renderList` (which primes `flushClose(1)` for tight lists to suppress
+ * the blank line `write()` would otherwise insert), the ProseMirror engine's
+ * `flatListToMarkdown` never primes — its `tight` flag only ever short-
+ * circuits `maybeAddBlankLine`, so `write()`'s default `flushClose(2)`
+ * always fires between items. The observable (and byte-parity) result is a
+ * blank line between every sibling item, and between an item and its nested
+ * sub-list — confirmed against the real ProseMirror engine's output, not
+ * assumed from reading `list.ts` alone.
+ */
+function serializeList(
+  state: MarkdownSerializerState,
+  node: Plot,
+  level: number,
+): void {
+  for (let i = 0; i < node.content.length; i++) {
+    const child = node.content[i];
+    if (!child?.isPlot) continue;
+    const marker = node.tag.is(OrderedList) ? '1.' : listItemMarker(child);
+    serializeListItem(state, child, level, marker);
+  }
+}
+
+const bulletListSpec: NodeMarkdownSpec = {
+  node: BulletList,
+  parse: {
+    bullet_list: { block: BulletList },
+  },
+  serialize(state, node) {
+    assertPlot(node, 'bullet_list');
+    serializeList(state, node, 0);
+  },
+};
+
+const orderedListSpec: NodeMarkdownSpec = {
+  node: OrderedList,
+  parse: {
+    // Markdown-it's `start` attribute is dropped: the ProseMirror engine
+    // normalizes every ordered list to render with `1.` regardless of its
+    // source start value, so parity means never reading `order`/`start`
+    // back in (see `flatListToMarkdown`'s fixed `"1."` marker).
+    ordered_list: { block: () => OrderedList.of(1) },
+  },
+  serialize(state, node) {
+    assertPlot(node, 'ordered_list');
+    serializeList(state, node, 0);
+  },
+};
+
+function listItemKind(tok: Token): 'task' | 'ordered' | 'bullet' {
+  const kind = tok.attrGet('data-bangle-list-kind');
+  return kind === 'task' || kind === 'ordered' ? kind : 'bullet';
+}
+
+const listItemSpec: NodeMarkdownSpec = {
+  node: ListItem,
+  parse: {
+    list_item: {
+      block: (tok) => {
+        if (listItemKind(tok) === 'task') {
+          const checked = tok.attrGet('data-bangle-task-checked') === 'true';
+          return TaskItem.of(checked);
+        }
+        return ListItem;
+      },
+    },
+  },
+  serialize() {
+    // Never reached directly: `serializeList`/`serializeListItem` render
+    // list items as part of their parent list's own serializer, the same
+    // way `renderList`'s per-item callback owns rendering in PM. The spec
+    // still needs to exist so `TaskItem`/`ListItem` have a registered
+    // Markdown identity (e.g. for schema completeness checks).
+    throw new Error(
+      'list_item should be serialized by its parent list, not directly',
+    );
+  },
+};
+
+const taskItemSpec: NodeMarkdownSpec = {
+  node: TaskItem,
+  parse: {},
+  serialize: listItemSpec.serialize,
+};
+
+// ---------------------------------------------------------------------------
+// Marks: bold / italic / strike / code
+// ---------------------------------------------------------------------------
+
+const strongSpec: MarkMarkdownSpec = {
+  mark: Strong,
+  parse: {
+    strong: { mark: () => [Strong] },
+  },
+  serialize: {
+    open: '**',
+    close: '**',
+    mixable: true,
+    expelEnclosingWhitespace: true,
+  },
+};
+
+const emphasisSpec: MarkMarkdownSpec = {
+  mark: Emphasis,
+  parse: {
+    em: { mark: () => [Emphasis] },
+  },
+  serialize: {
+    open: '_',
+    close: '_',
+    mixable: true,
+    expelEnclosingWhitespace: true,
+  },
+};
+
+const strikethroughSpec: MarkMarkdownSpec = {
+  mark: Strikethrough,
+  parse: {
+    s: { mark: () => [Strikethrough] },
+  },
+  serialize: {
+    open: '~~',
+    close: '~~',
+    mixable: true,
+    expelEnclosingWhitespace: true,
+  },
+};
+
+function backticksFor(node: Node | undefined, side: number): string {
+  const param = node?.isLeaf ? node.param : undefined;
+  const text = typeof param === 'string' ? param : '';
+  const ticks = /`+/g;
+  let len = 0;
+  let m: RegExpExecArray | null = ticks.exec(text);
+  while (m) {
+    len = Math.max(len, m[0].length);
+    m = ticks.exec(text);
+  }
+  let result = len > 0 && side > 0 ? ' `' : '`';
+  for (let i = 0; i < len; i++) result += '`';
+  if (len > 0 && side < 0) result += ' ';
+  return result;
+}
+
+const codeSpec: MarkMarkdownSpec = {
+  mark: Code,
+  parse: {
+    code_inline: { mark: () => [Code], noCloseToken: true },
+  },
+  serialize: {
+    open: (_state, _mark, parent, index) =>
+      backticksFor(parent.content[index], -1),
+    close: (_state, _mark, parent, index) =>
+      backticksFor(parent.content[index - 1], 1),
+    escape: false,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Link
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors `link/link.ts`'s `isPlainURL(link, parent, index, side)`: a link
+ * mark serializes to the `<href>` autolink form only when it has no title,
+ * its href looks like a URL, and it exactly and solely covers one
+ * plain-text run adjacent to `index` on the given side.
+ */
+function isPlainUrl(
+  link: Mark,
+  parent: Plot,
+  index: number,
+  side: number,
+): boolean {
+  const href = typeof link.value === 'string' ? link.value : '';
+  const title = titleOnNode(parent.content[index + (side < 0 ? -1 : 0)]);
+  if (title || !/^\w+:/.test(href)) return false;
+
+  const contentIndex = index + (side < 0 ? -1 : 0);
+  const nextIndex = index + (side < 0 ? -2 : 1);
+  if (contentIndex < 0 || contentIndex >= parent.content.length) return false;
+  const content = parent.content[contentIndex];
+  if (
+    !content ||
+    !content.isLeaf ||
+    !content.isText ||
+    content.param !== href
+  ) {
+    return false;
+  }
+  const lastMark = content.marks[content.marks.length - 1];
+  if (!lastMark?.eq(link)) return false;
+  if (index === (side < 0 ? 1 : parent.content.length - 1)) return true;
+
+  if (nextIndex < 0 || nextIndex >= parent.content.length) return false;
+  const next = parent.content[nextIndex];
+  return !next?.marks.some((m) => m.eq(lastMark));
+}
+
+function titleOnNode(node: Node | undefined): string | undefined {
+  return node?.mark(LinkTitle);
+}
+
+const linkSpec: MarkMarkdownSpec = {
+  mark: Link,
+  parse: {
+    link: {
+      mark: (tok) => {
+        const href = tok.attrGet('href') ?? '';
+        const title = tok.attrGet('title');
+        return [Link.of(href), ...(title ? [LinkTitle.of(title)] : [])];
+      },
+    },
+  },
+  serialize: {
+    open: (_state, mark, parent, index) =>
+      isPlainUrl(mark, parent, index, 1) ? '<' : '[',
+    close: (state, mark, parent, index) => {
+      if (isPlainUrl(mark, parent, index, -1)) return '>';
+      const href = typeof mark.value === 'string' ? mark.value : '';
+      const title = titleOnNode(parent.content[index - 1]);
+      const titleAttr = title ? ` ${quote(title)}` : '';
+      return `](${state.esc(href)}${titleAttr})`;
+    },
+    mixable: true,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Wiki link
+// ---------------------------------------------------------------------------
+
+function asWikiLinkAttrs(meta: unknown): WikiLinkAttrs | null {
+  if (
+    typeof meta === 'object' &&
+    meta !== null &&
+    'target' in meta &&
+    typeof (meta as { target: unknown }).target === 'string'
+  ) {
+    const label = (meta as { label?: unknown }).label;
+    return {
+      target: (meta as { target: string }).target,
+      label: typeof label === 'string' ? label : null,
+    };
+  }
+  return null;
+}
+
+function wikiLinkText(attrs: WikiLinkAttrs): string {
+  return serializeWikiLinkAttrs(attrs) ?? attrs.label ?? attrs.target;
+}
+
+const wikiLinkSpec: NodeMarkdownSpec = {
+  node: WikiLink,
+  parse: {
+    wiki_link: {
+      // `marks` carries the currently-active spanning marks (e.g. a `[[..]]`
+      // typed inside `**bold**`) — merge in `WikiLinkLabel`, an attribute
+      // mark private to this leaf, rather than replacing them.
+      node: (tok, marks) => {
+        const attrs = asWikiLinkAttrs(tok.meta);
+        if (!attrs) {
+          throw new Error('wiki_link token missing valid WikiLinkAttrs meta');
+        }
+        const withLabel =
+          attrs.label !== null
+            ? WikiLinkLabel.of(attrs.label).addToSet(marks)
+            : marks;
+        return WikiLink.of(attrs.target, withLabel);
+      },
+    },
+  },
+  serialize(state, node) {
+    assertLeaf(node, 'wiki_link');
+    if (!node.is(WikiLink)) throw new Error('Expected a `wiki_link` leaf');
+    const label = node.mark(WikiLinkLabel) ?? null;
+    const attrs: WikiLinkAttrs = { target: node.param, label };
+    state.text(wikiLinkText(attrs), false);
+  },
+};
+
+// ---------------------------------------------------------------------------
+
+function assertPlot(node: Node, name: string): asserts node is Plot {
+  if (!node.isPlot) throw new Error(`Expected a plot for \`${name}\``);
+}
+
+function assertLeaf(node: Node, name: string): asserts node is Leaf {
+  if (!node.isLeaf) throw new Error(`Expected a leaf for \`${name}\``);
+}
+
+export const defaultMarkdownSpecs: readonly MarkdownSpec[] = [
+  paragraphSpec,
+  headingSpec,
+  blockquoteSpec,
+  horizontalRuleSpec,
+  hardBreakSpec,
+  codeBlockSpec,
+  imageSpec,
+  textSpec,
+  bulletListSpec,
+  orderedListSpec,
+  listItemSpec,
+  taskItemSpec,
+  wikiLinkSpec,
+  strongSpec,
+  emphasisSpec,
+  strikethroughSpec,
+  codeSpec,
+  linkSpec,
+];

--- a/packages/js-lib/wordgard-markdown/src/default-specs.ts
+++ b/packages/js-lib/wordgard-markdown/src/default-specs.ts
@@ -20,6 +20,7 @@ import {
   CodeBlock,
   CodeBlockLanguage,
   Emphasis,
+  Frontmatter,
   Heading,
   HorizontalRule,
   Image,
@@ -125,7 +126,34 @@ const horizontalRuleSpec: NodeMarkdownSpec = {
   parse: {
     hr: { node: () => HorizontalRule },
   },
+  serialize(state, node, parent, index) {
+    // A `---` on the first line of a document is a frontmatter fence, so a
+    // doc-leading rule must use a different thematic-break marker to
+    // survive a parse round trip — mirroring the ProseMirror engine's
+    // horizontal-rule serializer byte for byte.
+    const isDocStart = parent.isDoc && index === 0;
+    state.write(isDocStart ? '***' : '---');
+    state.closeBlock(node);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Frontmatter
+// ---------------------------------------------------------------------------
+
+const frontmatterSpec: NodeMarkdownSpec = {
+  node: Frontmatter,
+  parse: {
+    frontmatter: { block: Frontmatter, noCloseToken: true },
+  },
   serialize(state, node) {
+    assertPlot(node, 'frontmatter');
+    const text = node.textContent();
+    state.write('---\n');
+    if (text) {
+      state.write(text);
+      state.write('\n');
+    }
     state.write('---');
     state.closeBlock(node);
   },
@@ -653,6 +681,7 @@ export const defaultMarkdownSpecs: readonly MarkdownSpec[] = [
   headingSpec,
   blockquoteSpec,
   horizontalRuleSpec,
+  frontmatterSpec,
   hardBreakSpec,
   codeBlockSpec,
   imageSpec,

--- a/packages/js-lib/wordgard-markdown/src/default-specs.ts
+++ b/packages/js-lib/wordgard-markdown/src/default-specs.ts
@@ -7,7 +7,10 @@
 // parity with the ProseMirror engine's output is the whole point of this
 // file — see the package-level round-trip corpus.
 import {
+  LIST_KIND_ATTR,
+  type ListKind,
   serializeWikiLinkAttrs,
+  TASK_CHECKED_ATTR,
   type WikiLinkAttrs,
 } from '@bangle.io/markdown-syntax';
 import {
@@ -44,10 +47,10 @@ import type { MarkdownSerializerState } from './state';
 
 /**
  * Quote helper for link/image titles, matching `banger-editor`'s local
- * `quote()` (not `MarkdownSerializerState.quote`, which uses PM's
- * `""`/`''`/`()` fallback chain) — this is the byte-parity target since the
- * ProseMirror engine's own markdown specs define and use this exact
- * function for titles.
+ * `quote()` (deliberately not prosemirror-markdown's `""`/`''`/`()`
+ * fallback chain) — this is the byte-parity target since the ProseMirror
+ * engine's own markdown specs define and use this exact function for
+ * titles.
  */
 function quote(str: string): string {
   const wrap = str.includes('"') ? "'" : '"';
@@ -278,11 +281,18 @@ const textSpec: NodeMarkdownSpec = {
 // gives us for free.
 // ---------------------------------------------------------------------------
 
-function listItemMarker(node: Plot): string {
+/**
+ * A task item's marker always wins over the enclosing list's own marker:
+ * GFM allows `1. [ ] x` (a task inside an ordered list), and both engines
+ * normalize that shape to a `- [ ]` bullet on serialize — the ProseMirror
+ * flat-list model does this implicitly (item kind beats wrapper kind), so
+ * byte parity requires the same here.
+ */
+function listItemMarker(node: Plot, parentIsOrdered: boolean): string {
   if (node.tag.is(TaskItem)) {
     return node.tag.param ? '- [x]' : '- [ ]';
   }
-  return '-';
+  return parentIsOrdered ? '1.' : '-';
 }
 
 function serializeListItem(
@@ -331,11 +341,16 @@ function serializeList(
   node: Plot,
   level: number,
 ): void {
+  const parentIsOrdered = node.tag.is(OrderedList);
   for (let i = 0; i < node.content.length; i++) {
     const child = node.content[i];
     if (!child?.isPlot) continue;
-    const marker = node.tag.is(OrderedList) ? '1.' : listItemMarker(child);
-    serializeListItem(state, child, level, marker);
+    serializeListItem(
+      state,
+      child,
+      level,
+      listItemMarker(child, parentIsOrdered),
+    );
   }
 }
 
@@ -365,8 +380,8 @@ const orderedListSpec: NodeMarkdownSpec = {
   },
 };
 
-function listItemKind(tok: Token): 'task' | 'ordered' | 'bullet' {
-  const kind = tok.attrGet('data-bangle-list-kind');
+function listItemKind(tok: Token): ListKind {
+  const kind = tok.attrGet(LIST_KIND_ATTR);
   return kind === 'task' || kind === 'ordered' ? kind : 'bullet';
 }
 
@@ -376,7 +391,7 @@ const listItemSpec: NodeMarkdownSpec = {
     list_item: {
       block: (tok) => {
         if (listItemKind(tok) === 'task') {
-          const checked = tok.attrGet('data-bangle-task-checked') === 'true';
+          const checked = tok.attrGet(TASK_CHECKED_ATTR) === 'true';
           return TaskItem.of(checked);
         }
         return ListItem;

--- a/packages/js-lib/wordgard-markdown/src/default-specs.ts
+++ b/packages/js-lib/wordgard-markdown/src/default-specs.ts
@@ -208,9 +208,15 @@ const codeBlockSpec: NodeMarkdownSpec = {
 // Image
 // ---------------------------------------------------------------------------
 
+/**
+ * The full alt text of an `image` token. markdown-it splits the alt into
+ * multiple child tokens when it contains escapes (`![a\]b](x)` becomes
+ * `text "a"`, `text_special "]"`, `text "b"`) or inline markup, so joining
+ * every child's content is required for fidelity. (prosemirror-markdown
+ * reads only `children[0].content` and silently truncates such alt text.)
+ */
 function imageAlt(tok: Token): string {
-  const first = tok.children?.[0];
-  return first?.content || '';
+  return (tok.children ?? []).map((child) => child.content).join('');
 }
 
 const imageSpec: NodeMarkdownSpec = {
@@ -256,7 +262,9 @@ const textSpec: NodeMarkdownSpec = {
   serialize(state, node) {
     assertLeaf(node, 'text');
     if (typeof node.param !== 'string') throw new Error('Expected a text leaf');
-    state.text(node.param);
+    // Inside an autolink the URL is written raw — see
+    // `MarkdownSerializerState.inAutolink`.
+    state.text(node.param, !state.inAutolink);
   },
 };
 
@@ -475,8 +483,17 @@ const codeSpec: MarkMarkdownSpec = {
  * mark serializes to the `<href>` autolink form only when it has no title,
  * its href looks like a URL, and it exactly and solely covers one
  * plain-text run adjacent to `index` on the given side.
+ *
+ * "Solely covers" is the innermost check: the link must be the innermost
+ * mark rendered around the text, otherwise another mark's delimiters would
+ * end up inside the `<...>`. The ProseMirror engine checks
+ * `content.marks[last] === link` (its schema ranks link innermost); the
+ * equivalent here is the last entry of the state's serialization-ordered
+ * spanning marks, since Wordgard's own mark-set order differs from the
+ * order marks are rendered in.
  */
 function isPlainUrl(
+  state: MarkdownSerializerState,
   link: Mark,
   parent: Plot,
   index: number,
@@ -498,13 +515,14 @@ function isPlainUrl(
   ) {
     return false;
   }
-  const lastMark = content.marks[content.marks.length - 1];
-  if (!lastMark?.eq(link)) return false;
+  const renderedMarks = state.serializationMarks(content);
+  const innermost = renderedMarks[renderedMarks.length - 1];
+  if (!innermost?.eq(link)) return false;
   if (index === (side < 0 ? 1 : parent.content.length - 1)) return true;
 
   if (nextIndex < 0 || nextIndex >= parent.content.length) return false;
   const next = parent.content[nextIndex];
-  return !next?.marks.some((m) => m.eq(lastMark));
+  return !next?.marks.some((m) => m.eq(link));
 }
 
 function titleOnNode(node: Node | undefined): string | undefined {
@@ -523,15 +541,25 @@ const linkSpec: MarkMarkdownSpec = {
     },
   },
   serialize: {
-    open: (_state, mark, parent, index) =>
-      isPlainUrl(mark, parent, index, 1) ? '<' : '[',
+    open: (state, mark, parent, index) => {
+      state.inAutolink = isPlainUrl(state, mark, parent, index, 1);
+      return state.inAutolink ? '<' : '[';
+    },
     close: (state, mark, parent, index) => {
-      if (isPlainUrl(mark, parent, index, -1)) return '>';
+      state.inAutolink = undefined;
+      if (isPlainUrl(state, mark, parent, index, -1)) return '>';
       const href = typeof mark.value === 'string' ? mark.value : '';
       const title = titleOnNode(parent.content[index - 1]);
       const titleAttr = title ? ` ${quote(title)}` : '';
       return `](${state.esc(href)}${titleAttr})`;
     },
+    // Deliberate divergence from the ProseMirror engine, whose link mark is
+    // not mixable: without `mixable`, a mark that opens inside a link
+    // (`[link _foo **bar**_](x)`) forces the serializer to close and reopen
+    // the link around it, splitting one link into several — output that is
+    // not even a fixed point of that engine's own round trip. Marking the
+    // link mixable keeps it intact; every shared golden-corpus fixture still
+    // serializes byte-identically in both engines.
     mixable: true,
   },
 };
@@ -599,6 +627,12 @@ function assertLeaf(node: Node, name: string): asserts node is Leaf {
   if (!node.isLeaf) throw new Error(`Expected a leaf for \`${name}\``);
 }
 
+// The relative order of MARK specs is load-bearing: it defines the
+// serialization nesting order for overlapping marks (outermost first — see
+// `MarkdownSerializerState.serializationMarks`). This order matches the
+// ProseMirror engine's schema mark order (bold, strike, italic, link), so
+// both engines emit the same bytes for text carrying several marks, with
+// `Code` last because a non-escaping mark must always be innermost.
 export const defaultMarkdownSpecs: readonly MarkdownSpec[] = [
   paragraphSpec,
   headingSpec,
@@ -614,8 +648,8 @@ export const defaultMarkdownSpecs: readonly MarkdownSpec[] = [
   taskItemSpec,
   wikiLinkSpec,
   strongSpec,
-  emphasisSpec,
   strikethroughSpec,
-  codeSpec,
+  emphasisSpec,
   linkSpec,
+  codeSpec,
 ];

--- a/packages/js-lib/wordgard-markdown/src/index.ts
+++ b/packages/js-lib/wordgard-markdown/src/index.ts
@@ -1,0 +1,36 @@
+/**
+ * `@bangle.io/wordgard-markdown` is the ProseMirror-free
+ * `markdown string <-> Wordgard Plot.Doc` codec: it plays the same role
+ * for the Wordgard editor engine that `prosemirror-markdown` plays for the
+ * ProseMirror engine, built on the shared `@bangle.io/markdown-syntax`
+ * tokenizer so both engines agree on what a stored note's Markdown means.
+ *
+ * This package is intentionally editor-free (no DOM, no Wordgard editor
+ * state) — it only knows about `Plot.Doc` values, so it can run in a
+ * worker, a test, or a headless indexer exactly like it runs inside
+ * `editor-w`.
+ *
+ * Use {@link createNoteMarkdownCodec} for the batteries-included Bangle
+ * note schema/spec set. Use {@link createMarkdownCodec} directly to build a
+ * codec over a custom schema and/or spec set (e.g. for a reduced schema, or
+ * to add a new construct's `MarkdownSpec` before it's promoted into the
+ * default set).
+ */
+export {
+  createMarkdownCodec,
+  createNoteMarkdownCodec,
+  type MarkdownCodec,
+  type MarkdownCodecOptions,
+} from './codec';
+export { defaultMarkdownSpecs } from './default-specs';
+export {
+  isMarkMarkdownSpec,
+  isNodeMarkdownSpec,
+  type MarkdownSpec,
+  type MarkMarkdownSpec,
+  type MarkTypeRef,
+  type NodeMarkdownSpec,
+  type NodeTypeRef,
+  type TokenParseSpec,
+} from './spec';
+export { MarkdownSerializerState } from './state';

--- a/packages/js-lib/wordgard-markdown/src/parser.ts
+++ b/packages/js-lib/wordgard-markdown/src/parser.ts
@@ -1,0 +1,308 @@
+// Portions adapted from prosemirror-markdown (MIT © Marijn Haverbeke).
+// This is a port of `MarkdownParseState`/`tokenHandlers` from
+// prosemirror-markdown's `from_markdown.ts` onto Wordgard's node model: PM's
+// `NodeType.createAndFill(attrs, content, marks)` becomes
+// `Plot.Tag.create(content)` (Wordgard's tag already carries `param` +
+// `marks`), and PM's flat mark stack becomes a `Mark.Set` stack. Token-walk
+// order, `noCloseToken` handling, `ignore`, and the default
+// `softbreak -> addText(" ")` behavor are kept identical to PM's
+// implementation.
+import {
+  Leaf,
+  type Mark,
+  type Node,
+  type Plot,
+  type Schema,
+} from '@bangle.io/wordgard-utils';
+import type Token from 'markdown-it/lib/token.mjs';
+import type { MarkdownSpec, TokenParseSpec } from './spec';
+
+type StackFrame = {
+  readonly tag: Plot.Tag | null;
+  content: Node[];
+  marks: Mark.Set;
+};
+
+function maybeMergeText(a: Node, b: Node): Node | undefined {
+  if (
+    a.isLeaf &&
+    a.isText &&
+    b.isLeaf &&
+    b.isText &&
+    typeof a.param === 'string' &&
+    typeof b.param === 'string' &&
+    sameMarkSet(a.marks, b.marks)
+  ) {
+    return Leaf.text(a.param + b.param, a.marks);
+  }
+  return undefined;
+}
+
+function sameMarkSet(a: Mark.Set, b: Mark.Set): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((mark, i) => mark.eq(b[i] as Mark));
+}
+
+/**
+ * Tracks the running parse of a markdown-it token stream into a Wordgard
+ * document: a stack of open plots (each with its own accumulated content and
+ * active mark set), mirroring prosemirror-markdown's `MarkdownParseState`.
+ */
+class MarkdownParseState {
+  private readonly stack: StackFrame[] = [
+    { tag: null, content: [], marks: [] },
+  ];
+
+  constructor(
+    private readonly schema: Schema,
+    private readonly tokenHandlers: Readonly<
+      Record<
+        string,
+        (
+          state: MarkdownParseState,
+          token: Token,
+          tokens: readonly Token[],
+          i: number,
+        ) => void
+      >
+    >,
+  ) {}
+
+  private top(): StackFrame {
+    const frame = this.stack[this.stack.length - 1];
+    if (!frame) throw new Error('Markdown parse stack is empty');
+    return frame;
+  }
+
+  /** The mark set currently active at the top of the parse stack. */
+  get activeMarks(): Mark.Set {
+    return this.top().marks;
+  }
+
+  push(node: Node): void {
+    this.top().content.push(node);
+  }
+
+  /** Add text at the current position, using the currently active marks. */
+  addText(text: string): void {
+    if (!text) return;
+    const top = this.top();
+    const nodes = top.content;
+    const last = nodes[nodes.length - 1];
+    const node = Leaf.text(text, top.marks);
+    const merged = last && maybeMergeText(last, node);
+    if (merged) {
+      nodes[nodes.length - 1] = merged;
+    } else {
+      nodes.push(node);
+    }
+  }
+
+  /** Add the given mark(s) to the set of active marks. */
+  openMark(mark: Mark): void {
+    const top = this.top();
+    top.marks = mark.addToSet(top.marks);
+  }
+
+  /** Remove the given mark type from the set of active marks. */
+  closeMark(mark: Mark): void {
+    const top = this.top();
+    top.marks = mark.removeFromSet(top.marks);
+  }
+
+  parseTokens(tokens: readonly Token[]): void {
+    for (let i = 0; i < tokens.length; i++) {
+      const tok = tokens[i];
+      if (!tok) continue;
+      const handler = this.tokenHandlers[tok.type];
+      if (!handler) {
+        throw new Error(
+          `Token type \`${tok.type}\` not supported by Markdown parser`,
+        );
+      }
+      handler(this, tok, tokens, i);
+    }
+  }
+
+  /** Add one or more nodes at the current position. */
+  addNode(node: Node | readonly Node[]): void {
+    if (Array.isArray(node)) {
+      for (const n of node) this.push(n);
+    } else {
+      this.push(node as Node);
+    }
+  }
+
+  /** Open a new plot, subsequent content is added inside it. */
+  openNode(tag: Plot.Tag): void {
+    this.stack.push({ tag, content: [], marks: [] });
+  }
+
+  /**
+   * Close and return the plot currently on top of the stack.
+   *
+   * Markdown constructs that Wordgard models as block-content plots
+   * (`Blockquote`, `ListItem`) can legally be empty in Markdown (`>` with no
+   * text, an empty `- ` item) even though their Wordgard plot type requires
+   * at least one child. Rather than let that throw a `ValidationError` and
+   * turn a load into a hard failure, fill with the schema's default block
+   * (typically an empty paragraph) — the same recovery `schema.doc()` would
+   * need to do internally, made explicit here so parsing never surfaces an
+   * error for markup real Markdown allows.
+   */
+  closeNode(): Node {
+    const info = this.stack.pop();
+    if (!info?.tag) {
+      throw new Error('No open plot to close');
+    }
+    const node =
+      info.content.length === 0 && !info.tag.type.canBeEmpty
+        ? this.schema.createAndFill(info.tag)
+        : info.tag.create(info.content);
+    this.push(node);
+    return node;
+  }
+
+  /** Finish the parse, closing any still-open plots, and return the doc content. */
+  finish(): readonly Node[] {
+    while (this.stack.length > 1) {
+      this.closeNode();
+    }
+    return this.top().content;
+  }
+}
+
+function withoutTrailingNewline(str: string): string {
+  return str.endsWith('\n') ? str.slice(0, -1) : str;
+}
+
+function isNoCloseToken(spec: TokenParseSpec, type: string): boolean {
+  return (
+    ('noCloseToken' in spec && spec.noCloseToken === true) ||
+    type === 'code_inline' ||
+    type === 'code_block' ||
+    type === 'fence'
+  );
+}
+
+type TokenHandler = (
+  state: MarkdownParseState,
+  token: Token,
+  tokens: readonly Token[],
+  i: number,
+) => void;
+
+function resolveBlockTag(
+  spec: Extract<TokenParseSpec, { block: unknown }>,
+  token: Token,
+): Plot.Tag {
+  return typeof spec.block === 'function' ? spec.block(token) : spec.block;
+}
+
+/**
+ * Builds the markdown-it token type -> handler map from a set of
+ * {@link MarkdownSpec}s, one handler per token type across all specs. This
+ * is the parse-side counterpart of the serializer's per-type dispatch table.
+ */
+function buildTokenHandlers(
+  specs: readonly MarkdownSpec[],
+): Record<string, TokenHandler> {
+  const handlers: Record<string, TokenHandler> = Object.create(null);
+
+  const register = (type: string, handler: TokenHandler): void => {
+    if (handlers[type]) {
+      throw new Error(
+        `Token type \`${type}\` is registered by more than one MarkdownSpec`,
+      );
+    }
+    handlers[type] = handler;
+  };
+
+  for (const spec of specs) {
+    for (const [type, tokenSpec] of Object.entries(spec.parse)) {
+      if ('block' in tokenSpec) {
+        if (isNoCloseToken(tokenSpec, type)) {
+          register(type, (state, tok) => {
+            state.openNode(resolveBlockTag(tokenSpec, tok));
+            state.addText(withoutTrailingNewline(tok.content));
+            state.closeNode();
+          });
+        } else {
+          register(`${type}_open`, (state, tok) =>
+            state.openNode(resolveBlockTag(tokenSpec, tok)),
+          );
+          register(`${type}_close`, (state) => {
+            state.closeNode();
+          });
+        }
+      } else if ('node' in tokenSpec) {
+        register(type, (state, tok) => {
+          state.addNode(tokenSpec.node(tok, state.activeMarks));
+        });
+      } else if ('mark' in tokenSpec) {
+        if (isNoCloseToken(tokenSpec, type)) {
+          register(type, (state, tok) => {
+            const marks = tokenSpec.mark(tok);
+            for (const mark of marks) state.openMark(mark);
+            state.addText(withoutTrailingNewline(tok.content));
+            for (const mark of marks) state.closeMark(mark);
+          });
+        } else {
+          // The `_close` token carries no attributes (e.g. `link_close` has
+          // no href/title), so re-running `spec.mark(closeToken)` cannot
+          // reconstruct what `_open` added — a titled link would leak its
+          // `LinkTitle` mark past the close. Instead, remember exactly which
+          // marks each `_open` produced and close those. markdown-it
+          // guarantees balanced open/close pairs per token type, and the
+          // handler map (with this stack) is built fresh for every parse.
+          const opened: (readonly Mark[])[] = [];
+          register(`${type}_open`, (state, tok) => {
+            const marks = tokenSpec.mark(tok);
+            opened.push(marks);
+            for (const mark of marks) state.openMark(mark);
+          });
+          register(`${type}_close`, (state) => {
+            const marks = opened.pop();
+            if (!marks) {
+              throw new Error(`Unbalanced \`${type}_close\` token`);
+            }
+            for (const mark of marks) state.closeMark(mark);
+          });
+        }
+      } else if ('ignore' in tokenSpec) {
+        if (isNoCloseToken(tokenSpec, type)) {
+          register(type, () => {});
+        } else {
+          register(`${type}_open`, () => {});
+          register(`${type}_close`, () => {});
+        }
+      }
+    }
+  }
+
+  handlers.text = (state, tok) => state.addText(tok.content);
+  handlers.inline = (state, tok) => state.parseTokens(tok.children ?? []);
+  if (!handlers.softbreak) {
+    handlers.softbreak = (state) => state.addText(' ');
+  }
+
+  return handlers;
+}
+
+/**
+ * Parses a markdown-it token stream into a Wordgard document, per the given
+ * specs. Throws for token types with no registered handler, matching
+ * prosemirror-markdown's default (non-lenient) behavior — this is what
+ * makes an unsupported construct in a note fail loudly instead of silently
+ * dropping content.
+ */
+export function parseTokens(
+  schema: Schema,
+  specs: readonly MarkdownSpec[],
+  tokens: readonly Token[],
+): readonly Node[] {
+  const handlers = buildTokenHandlers(specs);
+  const state = new MarkdownParseState(schema, handlers);
+  state.parseTokens(tokens);
+  return state.finish();
+}

--- a/packages/js-lib/wordgard-markdown/src/parser.ts
+++ b/packages/js-lib/wordgard-markdown/src/parser.ts
@@ -9,7 +9,7 @@
 // implementation.
 import {
   Leaf,
-  type Mark,
+  Mark,
   type Node,
   type Plot,
   type Schema,
@@ -31,16 +31,11 @@ function maybeMergeText(a: Node, b: Node): Node | undefined {
     b.isText &&
     typeof a.param === 'string' &&
     typeof b.param === 'string' &&
-    sameMarkSet(a.marks, b.marks)
+    Mark.sameSet(a.marks, b.marks)
   ) {
     return Leaf.text(a.param + b.param, a.marks);
   }
   return undefined;
-}
-
-function sameMarkSet(a: Mark.Set, b: Mark.Set): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((mark, i) => mark.eq(b[i] as Mark));
 }
 
 /**

--- a/packages/js-lib/wordgard-markdown/src/spec.ts
+++ b/packages/js-lib/wordgard-markdown/src/spec.ts
@@ -1,0 +1,131 @@
+import type { Mark, Node, Plot } from '@bangle.io/wordgard-utils';
+import type Token from 'markdown-it/lib/token.mjs';
+import type { MarkdownSerializerState } from './state';
+
+/**
+ * Reference to whatever a {@link NodeMarkdownSpec} describes: either a
+ * parameterized type (`Plot.Type<P>`/`Leaf.Type<P>`) or a singleton tag (a
+ * parameter-less `Plot.Tag`/`Leaf`, e.g. `HorizontalRule`). Specs are keyed
+ * by this object (never by string name) so the codec never has to guess a
+ * schema element's name back from Wordgard; `Node.Type.get` resolves either
+ * shape to the same canonical `Node.Type` for map lookups.
+ */
+export type NodeTypeRef = Node.Type.Ref<unknown>;
+
+/**
+ * Mirrors {@link NodeTypeRef} for marks: a `Mark.Type<P>` or a singleton
+ * `Mark<null>` (e.g. `Strong`).
+ */
+export type MarkTypeRef = Mark.Type<unknown> | Mark<unknown>;
+
+/**
+ * Describes how one markdown-it token type feeds the parser. This mirrors
+ * prosemirror-markdown's `ParseSpec` kinds one-for-one so the port of
+ * `MarkdownParseState` (see `src/parser.ts`) can stay a faithful translation:
+ *
+ * - `block`: token comes in `_open`/`_close` pairs (unless `noCloseToken`)
+ *   and wraps a plot. `tag` may be a fixed plot tag/type or a function of
+ *   the opening token (e.g. heading level, code fence language).
+ * - `node`: token maps to a leaf, or (rarely) more than one sibling node —
+ *   the array form lets a single token expand into several document nodes.
+ * - `mark`: token wraps its content in one or more marks. The array return
+ *   is what lets `link_open` add both `Link` and `LinkTitle` from one token.
+ * - `ignore`: token contributes no node/mark of its own (its children, if
+ *   any, are still walked) — used for PM-flat-list tokens whose structure
+ *   the nested Wordgard list model gets for free from token nesting.
+ */
+export type TokenParseSpec =
+  | {
+      readonly block: Plot.Tag | ((token: Token) => Plot.Tag);
+      readonly noCloseToken?: boolean;
+    }
+  | {
+      readonly node: (token: Token, marks: Mark.Set) => Node | readonly Node[];
+    }
+  | {
+      readonly mark: (token: Token) => readonly Mark[];
+    }
+  | {
+      readonly ignore: true;
+    };
+
+/**
+ * Serializer + parser pairing for one Wordgard plot or leaf type. Keyed by
+ * the `node` field (a type or singleton tag object, per the plan's "specs
+ * are keyed by the type object" rule) so `createMarkdownCodec` can build its
+ * serializer dispatch table with `===` identity instead of fragile string
+ * names, matching how Wordgard schemas are themselves type-object based.
+ */
+export interface NodeMarkdownSpec {
+  readonly node: NodeTypeRef;
+  /** Keyed by markdown-it token type (e.g. `"heading"`, `"fence"`). */
+  readonly parse: Readonly<Record<string, TokenParseSpec>>;
+  readonly serialize: (
+    state: MarkdownSerializerState,
+    node: Node,
+    parent: Plot,
+    index: number,
+  ) => void;
+}
+
+/**
+ * Serializer + parser pairing for one Wordgard mark type. `serialize.open`/
+ * `close` may be a fixed delimiter string or computed per-occurrence (e.g.
+ * the adaptive inline-code backticks, or the link mark's autolink form) —
+ * ported verbatim from prosemirror-markdown's `MarkSerializerSpec`.
+ */
+export interface MarkMarkdownSpec {
+  readonly mark: MarkTypeRef;
+  readonly parse: Readonly<Record<string, TokenParseSpec>>;
+  readonly serialize: {
+    readonly open:
+      | string
+      | ((
+          state: MarkdownSerializerState,
+          mark: Mark,
+          parent: Plot,
+          index: number,
+        ) => string);
+    readonly close:
+      | string
+      | ((
+          state: MarkdownSerializerState,
+          mark: Mark,
+          parent: Plot,
+          index: number,
+        ) => string);
+    /**
+     * Whether this mark's open/close order relative to other mixable marks
+     * may be reordered to match already-open marks (e.g. `**bold _both_**`
+     * vs `*a **b***`). See `MarkdownSerializerState.renderInline`.
+     */
+    readonly mixable?: boolean;
+    /**
+     * CommonMark forbids whitespace just inside emphasis-like delimiters
+     * (`** bold **` is not valid emphasis). When set, leading/trailing
+     * whitespace is moved outside the mark's delimiters at serialize time.
+     */
+    readonly expelEnclosingWhitespace?: boolean;
+    /**
+     * Set to `false` for marks whose content must not be escaped (inline
+     * code): the mark becomes the innermost/highest-precedence mark on the
+     * node, and its text is written raw.
+     */
+    readonly escape?: boolean;
+  };
+}
+
+/** Either kind of markdown spec, as accepted by `createMarkdownCodec`. */
+export type MarkdownSpec = NodeMarkdownSpec | MarkMarkdownSpec;
+
+export function isNodeMarkdownSpec(
+  spec: MarkdownSpec,
+): spec is NodeMarkdownSpec {
+  return 'node' in spec;
+}
+
+export function isMarkMarkdownSpec(
+  spec: MarkdownSpec,
+): spec is MarkMarkdownSpec {
+  return 'mark' in spec;
+}

--- a/packages/js-lib/wordgard-markdown/src/state.ts
+++ b/packages/js-lib/wordgard-markdown/src/state.ts
@@ -1,0 +1,401 @@
+// Portions adapted from prosemirror-markdown (MIT © Marijn Haverbeke).
+// This is a port of `MarkdownSerializerState` from prosemirror-markdown's
+// `to_markdown.ts` onto Wordgard's node model: PM `Node` (block/inline,
+// content walked with `forEach`) becomes Wordgard `Plot`/`Leaf` (content
+// walked as a plain array), and PM node/mark `attrs` become Wordgard node
+// `param` + `marks`. The escaping regexes, delimiter/whitespace-expulsion
+// logic, and mixable-mark reordering are kept byte-identical to PM's
+// implementation because the golden-corpus round-trip gate compares output
+// byte-for-byte against the ProseMirror engine.
+import {
+  Leaf,
+  LineBreak,
+  type Mark,
+  type Node,
+  type Plot,
+} from '@bangle.io/wordgard-utils';
+import type { MarkMarkdownSpec } from './spec';
+
+/** True for the node type this schema uses to represent hard line breaks. */
+function isLineBreak(node: Node): boolean {
+  return node.isLeaf && node.type === LineBreak.type;
+}
+
+/**
+ * Tracks output-so-far and pending block delimiters while walking a Wordgard
+ * document, and exposes the same primitive operations
+ * (`write`/`text`/`esc`/`wrapBlock`/`closeBlock`/`renderInline`/...) that
+ * prosemirror-markdown's node/mark `serialize` functions are written
+ * against. Keeping these primitives identical is what lets the ported
+ * per-construct serializers (headings, lists, marks, ...) reuse PM's exact
+ * string-level conventions.
+ */
+export class MarkdownSerializerState {
+  /** @internal */
+  delim = '';
+  /** Accumulated output. */
+  out = '';
+  /** @internal */
+  closed: Node | null = null;
+  /** @internal */
+  inAutolink: boolean | undefined = undefined;
+  /** @internal */
+  atBlockStart = false;
+  /** @internal */
+  inTightList = false;
+
+  constructor(
+    private readonly marks: ReadonlyMap<
+      Mark.Type,
+      MarkMarkdownSpec['serialize']
+    >,
+    private readonly renderNode: (
+      state: MarkdownSerializerState,
+      node: Node,
+      parent: Plot,
+      index: number,
+    ) => void,
+  ) {}
+
+  /** @internal */
+  flushClose(size = 2): void {
+    if (this.closed) {
+      if (!this.atBlank()) this.out += '\n';
+      if (size > 1) {
+        let delimMin = this.delim;
+        const trim = /\s+$/.exec(delimMin);
+        if (trim)
+          delimMin = delimMin.slice(0, delimMin.length - trim[0].length);
+        for (let i = 1; i < size; i++) this.out += `${delimMin}\n`;
+      }
+      this.closed = null;
+    }
+  }
+
+  private getMark(type: Mark.Type): MarkMarkdownSpec['serialize'] {
+    const info = this.marks.get(type);
+    if (!info) {
+      throw new Error(
+        `Mark type \`${type.name}\` not supported by Markdown renderer`,
+      );
+    }
+    return info;
+  }
+
+  /**
+   * Render a block, prefixing each line with `delim` and the first line
+   * with `firstDelim`. `node` is the node that gets closed at the end of
+   * the block.
+   */
+  wrapBlock(
+    delim: string,
+    firstDelim: string | null,
+    node: Node,
+    f: () => void,
+  ): void {
+    const old = this.delim;
+    this.write(firstDelim ?? delim);
+    this.delim += delim;
+    f();
+    this.delim = old;
+    this.closeBlock(node);
+  }
+
+  /** @internal */
+  atBlank(): boolean {
+    return /(^|\n)$/.test(this.out);
+  }
+
+  /** Ensure the current content ends with a newline. */
+  ensureNewLine(): void {
+    if (!this.atBlank()) this.out += '\n';
+  }
+
+  /**
+   * Prepare the state for writing output (closing closed blocks, adding
+   * delimiters), and then optionally add unescaped content.
+   */
+  write(content?: string): void {
+    this.flushClose();
+    if (this.delim && this.atBlank()) this.out += this.delim;
+    if (content) this.out += content;
+  }
+
+  /** Close the block for the given node. */
+  closeBlock(node: Node): void {
+    this.closed = node;
+  }
+
+  /** Add text to the document, escaping it unless `shouldEscape` is `false`. */
+  text(input: string, shouldEscape = true): void {
+    const lines = input.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i] ?? '';
+      this.write();
+      // Escape exclamation marks in front of links.
+      if (!shouldEscape && line[0] === '[' && /(^|[^\\])!$/.test(this.out)) {
+        this.out = `${this.out.slice(0, this.out.length - 1)}\\!`;
+      }
+      this.out += shouldEscape ? this.esc(line, this.atBlockStart) : line;
+      if (i !== lines.length - 1) this.out += '\n';
+    }
+  }
+
+  /** Render the given node as a block. */
+  render(node: Node, parent: Plot, index: number): void {
+    this.renderNode(this, node, parent, index);
+  }
+
+  /** Render the contents of `parent` as block nodes. */
+  renderContent(parent: Plot): void {
+    for (let i = 0; i < parent.content.length; i++) {
+      const node = parent.content[i];
+      if (node) this.render(node, parent, i);
+    }
+  }
+
+  /** Render the contents of `parent` as inline content. */
+  renderInline(parent: Plot, fromBlockStart = true): void {
+    this.atBlockStart = fromBlockStart;
+    const active: Mark[] = [];
+    let trailing = '';
+    const content = parent.content;
+
+    const progress = (nodeIn: Node | null, index: number): void => {
+      let node = nodeIn;
+      // Non-spanning marks (e.g. `ImageAlt`, `LinkTitle`, `WikiLinkLabel`,
+      // `CodeBlockLanguage`) are Wordgard's "attribute" marks — metadata
+      // read directly by the owning node's own serializer (see
+      // `default-specs.ts`), not delimiter pairs to open/close here. Only
+      // spanning marks (`Strong`, `Emphasis`, `Strikethrough`, `Code`,
+      // `Link`) participate in this open/close walk.
+      let marks: Mark.Set = node
+        ? node.marks.filter((mark) => mark.type.spanning)
+        : [];
+
+      // Marks are never left open across a hard break unless they also
+      // cover the very next node (and that next node has non-whitespace
+      // text, or isn't text at all) — otherwise a mark's closing delimiter
+      // would land right after `\` + newline, which markdown-it would not
+      // parse back as still being inside the mark.
+      if (node && isLineBreak(node)) {
+        marks = marks.filter((mark) => {
+          if (index + 1 === content.length) return false;
+          const next = content[index + 1];
+          if (!next) return false;
+          const nextText = textOf(next);
+          return (
+            isMarkInSet(mark, next.marks) &&
+            (nextText === null || /\S/.test(nextText))
+          );
+        });
+      }
+
+      let leading = trailing;
+      trailing = '';
+
+      // Expel leading whitespace from marks that request it.
+      const textBefore = node && textOf(node);
+      if (
+        textBefore !== null &&
+        marks.some((mark) => {
+          const info = this.getMark(mark.type);
+          return info.expelEnclosingWhitespace && !isMarkInSet(mark, active);
+        })
+      ) {
+        const match = /^(\s*)([\s\S]*)$/m.exec(textBefore);
+        const lead = match?.[1] ?? '';
+        const rest = match?.[2] ?? '';
+        if (lead) {
+          leading += lead;
+          node = rest ? Leaf.text(rest, node?.marks) : null;
+          if (!node) marks = active;
+        }
+      }
+
+      // Expel trailing whitespace from marks that request it.
+      const textAfter = node && textOf(node);
+      if (
+        textAfter !== null &&
+        marks.some((mark) => {
+          const info = this.getMark(mark.type);
+          return (
+            info.expelEnclosingWhitespace &&
+            !this.isMarkAhead(content, index + 1, mark)
+          );
+        })
+      ) {
+        const match = /^([\s\S]*?)(\s*)$/m.exec(textAfter);
+        const rest = match?.[1] ?? '';
+        const trail = match?.[2] ?? '';
+        if (trail) {
+          trailing = trail;
+          node = rest ? Leaf.text(rest, node?.marks) : null;
+          if (!node) marks = active;
+        }
+      }
+
+      const inner = marks.length ? marks[marks.length - 1] : null;
+      const noEsc = inner ? this.getMark(inner.type).escape === false : false;
+      const len = marks.length - (noEsc ? 1 : 0);
+
+      // Reorder mixable marks so their order matches `active` where possible.
+      outer: for (let i = 0; i < len; i++) {
+        const mark = marks[i];
+        if (!mark || !this.getMark(mark.type).mixable) break;
+        for (let j = 0; j < active.length; j++) {
+          const other = active[j];
+          if (!other || !this.getMark(other.type).mixable) break;
+          if (mark.eq(other)) {
+            if (i > j) {
+              marks = marks
+                .slice(0, j)
+                .concat(mark)
+                .concat(marks.slice(j, i))
+                .concat(marks.slice(i + 1, len));
+            } else if (j > i) {
+              marks = marks
+                .slice(0, i)
+                .concat(marks.slice(i + 1, j))
+                .concat(mark)
+                .concat(marks.slice(j, len));
+            }
+            continue outer;
+          }
+        }
+      }
+
+      // Find the unchanged prefix of the active mark set.
+      let keep = 0;
+      while (
+        keep < Math.min(active.length, len) &&
+        marks[keep] &&
+        active[keep] &&
+        marks[keep]?.eq(active[keep] as Mark)
+      ) {
+        keep++;
+      }
+
+      // Close marks that need to be closed.
+      while (keep < active.length) {
+        const popped = active.pop();
+        if (popped)
+          this.text(this.markString(popped, false, parent, index), false);
+      }
+
+      // Output previously expelled trailing whitespace outside the marks.
+      if (leading) this.text(leading);
+
+      if (node) {
+        // Open marks that need to be opened.
+        while (active.length < len) {
+          const add = marks[active.length];
+          if (!add) break;
+          active.push(add);
+          this.text(this.markString(add, true, parent, index), false);
+          this.atBlockStart = false;
+        }
+
+        const innerText = textOf(node);
+        if (noEsc && inner && innerText !== null) {
+          this.text(
+            this.markString(inner, true, parent, index) +
+              innerText +
+              this.markString(inner, false, parent, index + 1),
+            false,
+          );
+        } else {
+          this.render(node, parent, index);
+        }
+        this.atBlockStart = false;
+      }
+
+      if (node && textOf(node) !== null && node.length > 0) {
+        this.atBlockStart = false;
+      }
+    };
+
+    for (let i = 0; i < content.length; i++) {
+      progress(content[i] ?? null, i);
+    }
+    progress(null, content.length);
+    this.atBlockStart = false;
+  }
+
+  /**
+   * Escape a string so it can safely appear in Markdown content. When
+   * `startOfLine` is true, also escape constructs that are only special at
+   * the start of a line (bullets, headings, ordered-list markers).
+   */
+  esc(str: string, startOfLine = false): string {
+    let out = str.replace(/[`*\\~[\]_]/g, (m, i: number) =>
+      m === '_' &&
+      i > 0 &&
+      i + 1 < str.length &&
+      /\w/.test(str[i - 1] ?? '') &&
+      /\w/.test(str[i + 1] ?? '')
+        ? m
+        : `\\${m}`,
+    );
+    if (startOfLine) {
+      out = out
+        .replace(/^(\+[ ]|[-*>])/, '\\$&')
+        .replace(/^(\s*)(#{1,6})(\s|$)/, '$1\\$2$3')
+        .replace(/^(\s*\d+)\.\s/, '$1\\. ');
+    }
+    return out;
+  }
+
+  /** @internal */
+  quote(str: string): string {
+    const wrap =
+      str.indexOf('"') === -1 ? '""' : str.indexOf("'") === -1 ? "''" : '()';
+    return wrap[0] + str + wrap[1];
+  }
+
+  /** Repeat `str` `n` times. */
+  repeat(str: string, n: number): string {
+    let out = '';
+    for (let i = 0; i < n; i++) out += str;
+    return out;
+  }
+
+  /** Get the markdown string for a given opening or closing mark. */
+  markString(mark: Mark, open: boolean, parent: Plot, index: number): string {
+    const info = this.getMark(mark.type);
+    const value = open ? info.open : info.close;
+    return typeof value === 'string' ? value : value(this, mark, parent, index);
+  }
+
+  /** @internal */
+  isMarkAhead(content: readonly Node[], index: number, mark: Mark): boolean {
+    // Skip over hard breaks, same as PM: whether a mark is "ahead" of a
+    // break shouldn't depend on the break itself carrying the mark.
+    let i = index;
+    for (;;) {
+      const next = content[i];
+      if (!next) return false;
+      if (!isLineBreak(next)) return isMarkInSet(mark, next.marks);
+      i++;
+    }
+  }
+}
+
+function isMarkInSet(mark: Mark, set: Mark.Set): boolean {
+  return set.some((m) => m.eq(mark));
+}
+
+/**
+ * Returns a text leaf's string content, or `null` for anything else (plots,
+ * non-text leaves). `Node.isText` is a plain boolean on the shared node
+ * interface (not a type-narrowing discriminant), so this centralizes the
+ * "is this actually a text leaf" check in one place that also narrows to a
+ * concrete `string` for callers, mirroring PM's `node.isText` + `node.text!`.
+ */
+function textOf(node: Node): string | null {
+  if (!node.isLeaf || !node.isText) return null;
+  // `Leaf.Text`'s param is documented as the leaf's string content; `isText`
+  // is a runtime check (not a type-level discriminant on `Param`), so this
+  // is the one place that needs to trust that invariant.
+  return typeof node.param === 'string' ? node.param : null;
+}

--- a/packages/js-lib/wordgard-markdown/src/state.ts
+++ b/packages/js-lib/wordgard-markdown/src/state.ts
@@ -37,12 +37,23 @@ export class MarkdownSerializerState {
   out = '';
   /** @internal */
   closed: Node | null = null;
-  /** @internal */
+  /**
+   * Set by the link mark's serializer while emitting the `<url>` autolink
+   * form; the text serializer checks it to leave the URL unescaped (an
+   * escaped `<https://x/\_file>` would corrupt the URL).
+   */
   inAutolink: boolean | undefined = undefined;
   /** @internal */
   atBlockStart = false;
   /** @internal */
   inTightList = false;
+
+  /**
+   * Serialization nesting order per mark type (lower = outermost), taken
+   * from the registration order of the mark specs. See
+   * {@link serializationMarks} for why this exists.
+   */
+  private readonly markPrecedence: ReadonlyMap<Mark.Type, number>;
 
   constructor(
     private readonly marks: ReadonlyMap<
@@ -55,7 +66,11 @@ export class MarkdownSerializerState {
       parent: Plot,
       index: number,
     ) => void,
-  ) {}
+  ) {
+    this.markPrecedence = new Map(
+      [...marks.keys()].map((type, index) => [type, index]),
+    );
+  }
 
   /** @internal */
   flushClose(size = 2): void {
@@ -70,6 +85,32 @@ export class MarkdownSerializerState {
       }
       this.closed = null;
     }
+  }
+
+  /**
+   * The marks of `node` that serialize as delimiter pairs, in nesting order
+   * (outermost first).
+   *
+   * Two filters happen here. Non-spanning marks (`ImageAlt`, `LinkTitle`,
+   * `WikiLinkLabel`, `CodeBlockLanguage`) are Wordgard's "attribute" marks —
+   * metadata read directly by the owning node's own serializer (see
+   * `default-specs.ts`), not delimiter pairs to open/close, so they are
+   * dropped. The remaining spanning marks are then sorted by the mark specs'
+   * registration order rather than Wordgard's own mark-set order: Wordgard
+   * ranks its built-in marks `Link < Strikethrough < Emphasis < Strong <
+   * Code`, nearly the reverse of the ProseMirror engine's schema order, and
+   * serializing in that order emits broken Markdown for overlapping marks
+   * (`**bold [link](x)**` would become `[**link**](x)** ...**`). Sorting by
+   * spec registration order both fixes that and is what keeps this engine's
+   * canonical output byte-identical to the ProseMirror engine's for
+   * overlapping marks (e.g. `**_both_**`, never `_**both**_`).
+   */
+  serializationMarks(node: Node): Mark[] {
+    const precedence = (mark: Mark): number =>
+      this.markPrecedence.get(mark.type) ?? Number.MAX_SAFE_INTEGER;
+    return node.marks
+      .filter((mark) => mark.type.spanning)
+      .sort((a, b) => precedence(a) - precedence(b));
   }
 
   private getMark(type: Mark.Type): MarkMarkdownSpec['serialize'] {
@@ -163,15 +204,7 @@ export class MarkdownSerializerState {
 
     const progress = (nodeIn: Node | null, index: number): void => {
       let node = nodeIn;
-      // Non-spanning marks (e.g. `ImageAlt`, `LinkTitle`, `WikiLinkLabel`,
-      // `CodeBlockLanguage`) are Wordgard's "attribute" marks — metadata
-      // read directly by the owning node's own serializer (see
-      // `default-specs.ts`), not delimiter pairs to open/close here. Only
-      // spanning marks (`Strong`, `Emphasis`, `Strikethrough`, `Code`,
-      // `Link`) participate in this open/close walk.
-      let marks: Mark.Set = node
-        ? node.marks.filter((mark) => mark.type.spanning)
-        : [];
+      let marks: Mark[] = node ? this.serializationMarks(node) : [];
 
       // Marks are never left open across a hard break unless they also
       // cover the very next node (and that next node has non-whitespace
@@ -344,13 +377,6 @@ export class MarkdownSerializerState {
         .replace(/^(\s*\d+)\.\s/, '$1\\. ');
     }
     return out;
-  }
-
-  /** @internal */
-  quote(str: string): string {
-    const wrap =
-      str.indexOf('"') === -1 ? '""' : str.indexOf("'") === -1 ? "''" : '()';
-    return wrap[0] + str + wrap[1];
   }
 
   /** Repeat `str` `n` times. */

--- a/packages/js-lib/wordgard-utils/package.json
+++ b/packages/js-lib/wordgard-utils/package.json
@@ -29,5 +29,6 @@
   "scripts": {},
   "dependencies": {
     "wordgard": "0.1.1"
-  }
+  },
+  "devDependencies": {}
 }

--- a/packages/js-lib/wordgard-utils/package.json
+++ b/packages/js-lib/wordgard-utils/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@bangle.io/wordgard-utils",
+  "description": "The single import chokepoint for the wordgard editor system: re-exports of wordgard/* subpath modules plus reusable, app-agnostic Wordgard extensions.",
+  "license": "AGPL-3.0-or-later",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bangle-io/bangle-io.git",
+    "directory": "packages/js-lib/wordgard-utils"
+  },
+  "authors": [
+    {
+      "name": "Kushan Joshi",
+      "email": "0o3ko0@gmail.com",
+      "web": "http://github.com/kepta"
+    }
+  ],
+  "homepage": "https://bangle.io",
+  "bugs": "https://github.com/bangle-io/bangle-io/issues",
+  "banglePackageConfig": {
+    "env": "universal",
+    "kind": "library"
+  },
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {},
+  "dependencies": {
+    "wordgard": "0.1.1"
+  }
+}

--- a/packages/js-lib/wordgard-utils/src/frontmatter.ts
+++ b/packages/js-lib/wordgard-utils/src/frontmatter.ts
@@ -1,0 +1,33 @@
+import { Node, Plot, Schema } from 'wordgard/doc';
+import { Doc } from 'wordgard/types';
+
+/**
+ * A YAML frontmatter block: raw text between `---` fences at the very top
+ * of a note. It shares a code block's raw-text feel (inline text content,
+ * {@link Node.Role.Code} so marks stay out) but is its own type and
+ * deliberately NOT part of the `Content` group — it is only valid where a
+ * schema explicitly admits it via {@link frontmatterDocContentOverride}.
+ *
+ * The shared tokenizer (`frontmatterTokenizer` in
+ * `@bangle.io/markdown-syntax`) only ever produces a frontmatter token for
+ * the first line of a document, so parsed frontmatter always sits first;
+ * editor-side invariants (single instance, top position under editing
+ * commands) are corrections for the editor milestone, not schema rules.
+ */
+export const Frontmatter: Plot.Tag<null> = Plot.define('Frontmatter', {
+  inlineContent: true,
+  role: Node.Role.Code,
+  shape: {
+    element: 'pre',
+    selector: 'pre[data-frontmatter]',
+    attributes: () => ({ 'data-frontmatter': '' }),
+  },
+});
+
+/**
+ * Schema override admitting {@link Frontmatter} into the built-in
+ * {@link Doc} plot's content. Include this alongside `Frontmatter` when
+ * defining a schema.
+ */
+export const frontmatterDocContentOverride: Schema.Override =
+  Schema.Override.plotContent(Doc, (content) => [content, Frontmatter.type]);

--- a/packages/js-lib/wordgard-utils/src/index.ts
+++ b/packages/js-lib/wordgard-utils/src/index.ts
@@ -67,6 +67,10 @@ export {
   TableRow,
   Underline,
 } from 'wordgard/types';
+export {
+  Frontmatter,
+  frontmatterDocContentOverride,
+} from './frontmatter';
 export { TaskItem, taskListContentOverrides } from './task-item';
 export { ImageTitle, LinkTitle } from './title-marks';
 export { WikiLink, WikiLinkLabel } from './wiki-link';

--- a/packages/js-lib/wordgard-utils/src/index.ts
+++ b/packages/js-lib/wordgard-utils/src/index.ts
@@ -67,6 +67,6 @@ export {
   TableRow,
   Underline,
 } from 'wordgard/types';
-export { TaskItem, taskListContentOverride } from './task-item';
+export { TaskItem, taskListContentOverrides } from './task-item';
 export { ImageTitle, LinkTitle } from './title-marks';
 export { WikiLink, WikiLinkLabel } from './wiki-link';

--- a/packages/js-lib/wordgard-utils/src/index.ts
+++ b/packages/js-lib/wordgard-utils/src/index.ts
@@ -1,0 +1,72 @@
+/**
+ * The single import chokepoint for the `wordgard` editor system. Nothing else
+ * in the repo may import `wordgard/*` directly (mirroring how banger-editor
+ * re-exports `prosemirror-*`): wordgard is pre-1.0 with deliberate breaking
+ * changes, and funneling every import through this package makes each upgrade
+ * a one-package problem and gives us a place to patch over upstream changes.
+ *
+ * Only the subpath modules that current milestones consume are re-exported;
+ * grow this surface as `editor-w` milestones need more (state, editor,
+ * command, history, table, phrases).
+ */
+export {
+  Attributes,
+  ChangeSet,
+  Elt,
+  Leaf,
+  Mark,
+  Node,
+  Plot,
+  Pos,
+  parse,
+  Schema,
+  SchemaError,
+  type Shape,
+  Slice,
+  serialize,
+  type Token,
+  ValidationError,
+} from 'wordgard/doc';
+export {
+  Alignment,
+  BackgroundColor,
+  BlockCell,
+  BlockHeaderCell,
+  Blockquote,
+  BulletList,
+  CaptionedFigure,
+  Cell,
+  Code,
+  CodeBlock,
+  CodeBlockLanguage,
+  Color,
+  ColSpan,
+  Direction,
+  Doc,
+  Emphasis,
+  Figure,
+  HeaderCell,
+  Heading,
+  HorizontalRule,
+  Image,
+  ImageAlt,
+  ImageSize,
+  InlineDoc,
+  InlineListItem,
+  LineBreak,
+  Link,
+  ListItem,
+  OrderedList,
+  Paragraph,
+  RowSpan,
+  Strikethrough,
+  Strong,
+  Subscript,
+  Superscript,
+  Table,
+  TableRow,
+  Underline,
+} from 'wordgard/types';
+export { TaskItem, taskListContentOverride } from './task-item';
+export { ImageTitle, LinkTitle } from './title-marks';
+export { WikiLink, WikiLinkLabel } from './wiki-link';

--- a/packages/js-lib/wordgard-utils/src/task-item.ts
+++ b/packages/js-lib/wordgard-utils/src/task-item.ts
@@ -1,12 +1,13 @@
 import { Node, Plot, Schema } from 'wordgard/doc';
-import { BulletList } from 'wordgard/types';
+import { BulletList, OrderedList } from 'wordgard/types';
 
 /**
  * A task ("todo") list item. The boolean parameter is the checked state —
  * Wordgard's one-param model replaces the ProseMirror flat-list
- * `{kind: 'task', checked}` attrs. Task items live inside a {@link BulletList}
- * (they serialize to Markdown as `- [ ]` / `- [x]` bullets), which requires
- * {@link taskListContentOverride} in any schema that uses them.
+ * `{kind: 'task', checked}` attrs. Task items normally live inside a
+ * {@link BulletList} (they serialize to Markdown as `- [ ]` / `- [x]`
+ * bullets), which requires {@link taskListContentOverrides} in any schema
+ * that uses them.
  */
 export const TaskItem = Plot.Type.define<boolean>('TaskItem', {
   defaultParam: false,
@@ -21,9 +22,17 @@ export const TaskItem = Plot.Type.define<boolean>('TaskItem', {
 });
 
 /**
- * Schema override allowing {@link TaskItem} inside the built-in
- * {@link BulletList} (whose content query is otherwise fixed to the stock
- * list items). Include this alongside `TaskItem` when defining a schema.
+ * Schema overrides allowing {@link TaskItem} inside the built-in list plots
+ * (whose content queries are otherwise fixed to the stock list items).
+ * Include these alongside `TaskItem` when defining a schema.
+ *
+ * {@link OrderedList} is included deliberately: GFM recognizes `1. [ ] x` as
+ * a task item inside an ordered list, so the Markdown parser can produce
+ * that shape — a schema that rejects it would turn a legal note into a load
+ * failure. Serialization normalizes such items back to `- [ ]` bullets
+ * (matching the ProseMirror engine), so the shape is transient.
  */
-export const taskListContentOverride: Schema.Override =
-  Schema.Override.plotContent(BulletList, (content) => [content, TaskItem]);
+export const taskListContentOverrides: readonly Schema.Override[] = [
+  Schema.Override.plotContent(BulletList, (content) => [content, TaskItem]),
+  Schema.Override.plotContent(OrderedList, (content) => [content, TaskItem]),
+];

--- a/packages/js-lib/wordgard-utils/src/task-item.ts
+++ b/packages/js-lib/wordgard-utils/src/task-item.ts
@@ -1,0 +1,29 @@
+import { Node, Plot, Schema } from 'wordgard/doc';
+import { BulletList } from 'wordgard/types';
+
+/**
+ * A task ("todo") list item. The boolean parameter is the checked state —
+ * Wordgard's one-param model replaces the ProseMirror flat-list
+ * `{kind: 'task', checked}` attrs. Task items live inside a {@link BulletList}
+ * (they serialize to Markdown as `- [ ]` / `- [x]` bullets), which requires
+ * {@link taskListContentOverride} in any schema that uses them.
+ */
+export const TaskItem = Plot.Type.define<boolean>('TaskItem', {
+  defaultParam: false,
+  validate: 'boolean',
+  blockContent: Node.Group.Content,
+  defining: true,
+  shape: {
+    element: 'li',
+    attributes: (checked) => ({ 'data-task-checked': String(checked) }),
+    readElement: (elt) => elt.getAttribute('data-task-checked') === 'true',
+  },
+});
+
+/**
+ * Schema override allowing {@link TaskItem} inside the built-in
+ * {@link BulletList} (whose content query is otherwise fixed to the stock
+ * list items). Include this alongside `TaskItem` when defining a schema.
+ */
+export const taskListContentOverride: Schema.Override =
+  Schema.Override.plotContent(BulletList, (content) => [content, TaskItem]);

--- a/packages/js-lib/wordgard-utils/src/title-marks.ts
+++ b/packages/js-lib/wordgard-utils/src/title-marks.ts
@@ -1,0 +1,24 @@
+import { Mark } from 'wordgard/doc';
+import { Image, Link } from 'wordgard/types';
+
+/**
+ * The optional Markdown link title — the quoted part of `[text](href "title")`.
+ * The built-in {@link Link} mark's parameter carries only the href, so the
+ * title travels as a sibling mark applied to the same inline nodes. It exists
+ * purely to preserve Markdown fidelity for notes that use link titles.
+ */
+export const LinkTitle = Mark.Type.define<string>('LinkTitle', {
+  validate: 'string',
+  shape: { attribute: 'data-link-title', value: 0 },
+});
+
+/**
+ * The optional Markdown image title — the quoted part of
+ * `![alt](src "title")`. Like {@link LinkTitle}, kept as a mark on the
+ * {@link Image} leaf (whose parameter is the src) for Markdown fidelity.
+ */
+export const ImageTitle = Mark.Type.define<string>('ImageTitle', {
+  target: Image,
+  validate: 'string',
+  shape: { attribute: 'data-image-title', value: 0, preferTarget: 'img' },
+});

--- a/packages/js-lib/wordgard-utils/src/wiki-link.ts
+++ b/packages/js-lib/wordgard-utils/src/wiki-link.ts
@@ -1,0 +1,39 @@
+import { Leaf, Mark } from 'wordgard/doc';
+
+/**
+ * A `[[wiki link]]` — an atomic inline leaf whose string parameter is the link
+ * target (the linked note). The optional display label (`[[target|label]]`)
+ * is the {@link WikiLinkLabel} mark, following Wordgard's one-param-plus-marks
+ * model. Target resolution and navigation are app concerns and live in
+ * `editor-w`, not here.
+ */
+export const WikiLink: Leaf.Type<string> = Leaf.Type.define<string>(
+  'WikiLink',
+  {
+    inline: true,
+    validate: 'string',
+    selectable: true,
+    toText: (leaf) => {
+      const label = leaf.mark(WikiLinkLabel);
+      return typeof label === 'string' ? label : String(leaf.param);
+    },
+    shape: {
+      element: 'a',
+      selector: 'a[data-wiki-link-target]',
+      attributes: (target) => ({ 'data-wiki-link-target': target }),
+      readElement: (elt) => elt.getAttribute('data-wiki-link-target') ?? '',
+    },
+  },
+);
+
+/**
+ * Optional display label for a {@link WikiLink} (`[[target|label]]`).
+ */
+export const WikiLinkLabel: Mark.Type<string> = Mark.Type.define<string>(
+  'WikiLinkLabel',
+  {
+    target: WikiLink,
+    validate: 'string',
+    shape: { attribute: 'data-wiki-link-label', value: 0 },
+  },
+);

--- a/packages/tooling/test-utils/index.ts
+++ b/packages/tooling/test-utils/index.ts
@@ -11,6 +11,8 @@ export {
   sleep,
   waitForExpect,
 } from './common-opts';
+export type { MarkdownCorpusFixture } from './markdown-corpus';
+export { MARKDOWN_CORPUS } from './markdown-corpus';
 export type { TestCommandHandlerReturnType } from './test-command-handler';
 export { testCommandHandler } from './test-command-handler';
 export { renderWithServices } from './test-component-setup';

--- a/packages/tooling/test-utils/markdown-corpus.ts
+++ b/packages/tooling/test-utils/markdown-corpus.ts
@@ -1,0 +1,495 @@
+/**
+ * The golden Markdown corpus: the cross-engine parity contract for the
+ * ProseMirror and Wordgard editor engines (see `plans/011-wordgard-editor-w-migration.md`,
+ * milestone M1).
+ *
+ * Every fixture below is written in the *canonical form* a compliant engine
+ * emits: `serialize(parse(fixture.markdown)) === fixture.markdown` must hold
+ * for byte identity for every engine listed in `fixture.engines`. Fixtures are
+ * not meant to be "valid-looking" Markdown; they are fixed points of the
+ * parse/serialize round trip, including exact whitespace, escaping, and list
+ * indentation.
+ *
+ * Rules for extending this corpus:
+ * - Every new editor construct (a new mark, node, or Markdown syntax) that
+ *   ships in either engine must land with fixtures here that exercise it.
+ * - A gate failure (an engine that cannot yet round-trip some construct)
+ *   becomes a fixture first: add it with the engines that already pass in
+ *   `engines`, and only add the missing engine once its round trip is proven
+ *   byte-identical. Do not silently shrink coverage by leaving a construct
+ *   out of the corpus.
+ * - If a construct empirically has NO stable fixed point in an engine today
+ *   (parsing it never reproduces the same bytes, e.g. because the engine
+ *   normalizes it further on every parse/serialize pass), it does not belong
+ *   in the corpus as a fixture. Leave it out and explain why in a comment
+ *   near the related fixtures instead of adding a fixture that would fail.
+ */
+export type MarkdownCorpusFixture = {
+  name: string;
+  markdown: string;
+  /** Which engines must round-trip this fixture byte-identically today. */
+  engines: ReadonlyArray<'prosemirror' | 'wordgard'>;
+};
+
+const BOTH_ENGINES: ReadonlyArray<'prosemirror' | 'wordgard'> = [
+  'prosemirror',
+  'wordgard',
+];
+
+// GFM tables are not implemented in the Wordgard engine yet; table parity
+// lands in M3. Flagging these as `['prosemirror']` keeps the parity worklist
+// visible instead of silently shrinking coverage once wordgard adds tables.
+const PROSEMIRROR_ONLY: ReadonlyArray<'prosemirror' | 'wordgard'> = [
+  'prosemirror',
+];
+
+export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
+  // --- Plain text -----------------------------------------------------
+  {
+    name: 'empty document',
+    markdown: '',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'plain paragraph',
+    markdown: 'Hello world',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'multiple paragraphs',
+    markdown: 'Paragraph one.\n\nParagraph two.',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'unicode text',
+    markdown: 'Unicode: café naïve 日本語 😀',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Headings ---------------------------------------------------------
+  {
+    name: 'heading level 1',
+    markdown: '# Heading 1',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading level 2',
+    markdown: '## Heading 2',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading level 3',
+    markdown: '### Heading 3',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading level 4',
+    markdown: '#### Heading 4',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading level 5',
+    markdown: '##### Heading 5',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading level 6',
+    markdown: '###### Heading 6',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading with inline marks',
+    markdown: '# Heading with **bold** and _italic_',
+    engines: BOTH_ENGINES,
+  },
+  {
+    // The PM engine's heading serializer renders inline content with
+    // start-of-line escaping active (banger-editor passes renderInline's
+    // default `fromBlockStart = true`), so heading text that begins with an
+    // ordered-list-like marker keeps its escape.
+    name: 'heading text starting with an ordered-list marker stays escaped',
+    markdown: '## 1\\. not a list',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Marks: bold, italic, strike, code, combinations -------------------
+  {
+    name: 'bold',
+    markdown: '**bold text**',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'italic',
+    markdown: '_italic text_',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'strike',
+    markdown: '~~strike text~~',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'inline code',
+    markdown: '`inline code`',
+    engines: BOTH_ENGINES,
+  },
+  // A code span whose content itself contains a backtick (double-backtick
+  // fence, e.g. ``` ``code containing ` backtick`` ```) is NOT a stable
+  // fixed point in the PM engine: the serializer inserts padding spaces
+  // next to the inner backtick on serialize (`` `` code containing ` `` ``
+  // backtick `` ``, with added leading/trailing spaces inside the fence) to
+  // keep the span from closing early, so `serialize(parse(x)) !== x` on the
+  // very first pass. Excluded rather than included as a failing fixture.
+  {
+    name: 'bold containing italic',
+    markdown: '**bold _and italic_**',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'bold italic strike code combined in one paragraph',
+    markdown: '**bold**, _italic_, ~~strike~~, and `code`',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'mark adjacent to punctuation with no surrounding space',
+    markdown: 'word**bold**word',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Escaped constructs that must not be reinterpreted -----------------
+  {
+    name: 'escaped literal asterisks are not emphasis',
+    markdown: '\\*not bold\\*',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped literal brackets are not a link',
+    markdown: 'Escaped bracket \\[not a link\\]',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped leading hash is not a heading',
+    markdown: '\\# not a heading',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped leading dash is not a bullet',
+    markdown: '\\- not a bullet',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'trailing double backslash stays a literal backslash',
+    markdown: 'Trailing backslash literal \\\\',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'literal asterisk surrounded by spaces is not emphasis',
+    markdown: 'literal asterisk in text 5 \\* 3',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'hash mid-line is not a heading marker',
+    markdown: '# Escaped hash mid text is fine # not heading',
+    engines: BOTH_ENGINES,
+  },
+  // `\_` inside a word (e.g. `file\_name`) is NOT a stable fixed point: `_`
+  // mid-word is never emphasis under CommonMark's intraword-underscore rule,
+  // so the serializer's escaper drops the now-unnecessary backslash on
+  // serialize, producing `file_name`. Excluded rather than included as a
+  // fixture that would fail `serialize(parse(x)) === x`.
+  //
+  // Similarly, an escaped backtick placed *inside* an already-open code span
+  // (e.g. `` `code with \` backslash` ``) is not stable: the parser treats
+  // the backslash as literal code content, but the serializer must then
+  // re-escape the span's closing backtick, changing the byte length on
+  // serialize. Excluded for the same reason.
+  //
+  // `\1.` at a line start (escaping an ordered-list marker) is also not
+  // stable: markdown-it's escape handling doubles the backslash on
+  // serialize (`\\1.`). Excluded.
+
+  // --- Links --------------------------------------------------------------
+  {
+    name: 'standard link',
+    markdown: '[a link](https://example.com)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'link with title',
+    markdown: '[a link](https://example.com "a title")',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'autolink',
+    markdown: '<https://example.com/>',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'relative link',
+    markdown: '[relative](../other.md)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'mailto link',
+    markdown: '[email](mailto:user@example.com)',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Images ---------------------------------------------------------------
+  {
+    name: 'image',
+    markdown: '![alt text](./image.png)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'image with title',
+    markdown: '![alt text](./image.png "a title")',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Blockquotes ------------------------------------------------------
+  {
+    name: 'simple blockquote',
+    markdown: '> a simple quote',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'multi-paragraph blockquote',
+    markdown: '> line one\n>\n> line two',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'nested blockquote',
+    markdown: '> > nested quote',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'blockquote containing a list',
+    markdown: '> - item one\n>\n> - item two',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Bullet lists -------------------------------------------------------
+  // The PM serializer always renders lists TIGHT at the item level (see
+  // `packages/js-lib/banger-editor/src/list.ts`'s `toMarkdown`, which calls
+  // `flatListToMarkdown` with `tight` hardcoded to `true`), but a blank line
+  // still separates top-level sibling items because each item's trailing
+  // paragraph closes its own block. So the canonical, stable form for
+  // sibling top-level list items has a blank line between them; this is
+  // NOT "loose list" Markdown semantics reappearing, it is simply how the
+  // block serializer closes each item. Verified empirically against
+  // `packages/core/editor/src/__tests__/copy-selection-markdown.spec.ts`.
+  {
+    name: 'flat bullet list, two items',
+    markdown: '- one\n\n- two',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'nested bullet list, three levels',
+    markdown: '- level0\n\n  - level1\n\n    - level2',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'bullet list item with a second paragraph',
+    markdown: '- item one\n\n  more text in same item\n\n- item two',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'bullet list items carrying inline marks',
+    markdown: '- **bold item**\n\n- _italic item_',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Ordered lists -------------------------------------------------------
+  // The PM serializer normalizes every ordered-list marker to the literal
+  // `1.` regardless of the source numbering or the node's `order` attribute
+  // (see `flatListToMarkdown` in list.ts: `marker = '1.'`, unconditionally).
+  // Canonical fixtures must therefore use `1.` for every item; a fixture
+  // using `1. / 2. / 3.` would not be a fixed point.
+  {
+    name: 'ordered list, canonical "1." markers',
+    markdown: '1. item one\n\n1. item two\n\n1. item three',
+    engines: BOTH_ENGINES,
+  },
+
+  // A list nested under an ORDERED item does NOT survive round-trip: the
+  // serializer indents nested content by exactly 2 spaces per level
+  // regardless of the parent marker's width (`'  '.repeat(level)`), but a
+  // 2-space indent under a 3-character `1. ` marker does not parse back as
+  // nested content under CommonMark's list-item content-indent rule. Empirically:
+  //   input:  "1. item\n\n  - nested under ordered"
+  //   output: "1. item\n\n- nested under ordered"   (promoted to a sibling
+  //           top-level list, not nested)
+  // This is a known PM engine quirk, not a corpus gap; left out of the
+  // corpus rather than included as a failing fixture.
+
+  // --- Task lists ----------------------------------------------------------
+  {
+    name: 'task list, unchecked',
+    markdown: '- [ ] unchecked task',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'task list, checked',
+    markdown: '- [x] checked task',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'nested task list',
+    markdown: '- [ ] task one\n\n  - [x] nested task',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'task list item mixed with a plain bullet item',
+    markdown: '- [ ] task\n\n- plain item',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Code blocks -----------------------------------------------------
+  {
+    name: 'fenced code block with language',
+    markdown: '```js\nconsole.log("ok");\n```',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'fenced code block without language',
+    markdown: '```\nno language\n```',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'empty fenced code block',
+    markdown: '```js\n```',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'fenced code block containing markdown-like text',
+    markdown: '```md\n# not a heading\n- not a list\n**not bold**\n```',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'fenced code block containing backticks, uses a longer fence',
+    markdown: '````markdown\n```js\nconst nestedFence = true;\n```\n````',
+    engines: BOTH_ENGINES,
+  },
+  // Indented (4-space) code blocks are not a stable fixed point: the PM
+  // parser accepts them as `code_block` on parse, but the serializer's only
+  // `code_block` output form is a fenced block, so the canonical/stable form
+  // is the fenced one above, not the indented source. An indented-code-block
+  // *input* string is therefore never returned unchanged by `serialize`.
+
+  // --- Horizontal rule ---------------------------------------------------
+  // All three CommonMark thematic-break markers (`---`, `***`, `___`)
+  // normalize to `---` on first serialize UNLESS the parser attaches the
+  // original `markup` attr, which it does — so `---` is the only stable
+  // fixed point to include; `***`/`___` still parse fine but do not
+  // round-trip byte-identically on this corpus's first pass because the
+  // fixture must already equal its own serialization.
+  {
+    name: 'horizontal rule',
+    markdown: '---',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Hard breaks and soft breaks -----------------------------------------
+  // A hard break serializes as a trailing backslash + newline. Soft line
+  // breaks (a single `\n` inside a paragraph) normalize to a single space on
+  // serialize, so canonical fixtures must never contain a bare `\n` inside a
+  // paragraph — every multi-line paragraph fixture in this corpus either
+  // uses `\n\n` (a real paragraph break) or `\\\n` (an explicit hard break).
+  {
+    name: 'hard break inside a paragraph',
+    markdown: 'line one\\\nline two',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'multiple hard breaks in one paragraph',
+    markdown: 'a\\\nb\\\nc',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Wiki links --------------------------------------------------------
+  {
+    name: 'wiki link, bare target',
+    markdown: '[[target]]',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wiki link with label',
+    markdown: '[[target|label]]',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wiki link with unicode target and label',
+    markdown: 'Unicode [[日本語|表示名]]',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wiki link adjacent to surrounding text with no space',
+    markdown: 'before[[bangle.io]]after',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wiki links inside bold and italic marks',
+    markdown: '**bold [[target]]** and _italic [[target|label]]_',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wiki link inside a bullet list item',
+    markdown: '- item [[target]]',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wiki link inside an ordered list item',
+    markdown: '1. item [[target|label]]',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wiki link inside a task list item',
+    markdown: '- [ ] task [[target]]',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped wiki syntax is not reinterpreted as a link',
+    markdown: String.raw`\[\[target\]\] and \\[[actual]]`,
+    engines: BOTH_ENGINES,
+  },
+
+  // --- GFM tables (prosemirror only until M3) -----------------------------
+  {
+    name: 'simple table',
+    markdown: '| Name | Status |\n| --- | --- |\n| Alpha | Done |',
+    engines: PROSEMIRROR_ONLY,
+  },
+  {
+    name: 'table with column alignment',
+    markdown:
+      '| Left | Center | Right | None |\n| :--- | :---: | ---: | --- |\n| a | b | c | d |',
+    engines: PROSEMIRROR_ONLY,
+  },
+  {
+    name: 'table with inline marks in cells',
+    markdown: '| _em_ and **strong** |\n| --- |\n| plain |',
+    engines: PROSEMIRROR_ONLY,
+  },
+  {
+    name: 'table between paragraphs',
+    markdown: 'before\n\n| a |\n| --- |\n| b |\n\nafter',
+    engines: PROSEMIRROR_ONLY,
+  },
+
+  // --- Raw / unsupported constructs ---------------------------------------
+  // The tokenizer runs with `html: false`, so raw HTML tags are never parsed
+  // as HTML nodes; they fall through as plain inline/block text. Both forms
+  // below are empirically byte-stable, so they are included; this documents
+  // that HTML is inert text under the current engine rather than dropped.
+  {
+    name: 'raw HTML tag round-trips as inert text',
+    markdown: '<div>x</div>',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'HTML comment round-trips as inert text',
+    markdown: '<!-- comment -->',
+    engines: BOTH_ENGINES,
+  },
+];

--- a/packages/tooling/test-utils/markdown-corpus.ts
+++ b/packages/tooling/test-utils/markdown-corpus.ts
@@ -709,6 +709,57 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '- [x] task **bold**',
     engines: BOTH_ENGINES,
   },
+  {
+    name: 'task item containing a link',
+    markdown: '- [ ] [a link](https://x)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'empty unchecked task keeps its marker',
+    markdown: '- [ ]',
+    canonical: '- [ ] ',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'empty checked task keeps its marker',
+    markdown: '- [x]',
+    canonical: '- [x] ',
+    engines: BOTH_ENGINES,
+  },
+  {
+    // GFM recognizes task markers inside ordered lists; both engines
+    // normalize the item to a `- [ ]` bullet (the checkbox wins over the
+    // ordered marker). Before this was pinned, the Wordgard codec crashed
+    // on this input outright.
+    name: 'task marker inside an ordered list normalizes to a bullet task',
+    markdown: '1. [ ] task marker in ordered list',
+    canonical: '- [ ] task marker in ordered list',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'bracket without a following space is not a task marker',
+    markdown: '- [ ]no space after bracket',
+    canonical: '- \\[ \\]no space after bracket',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'bracket past the start of the item is not a task marker',
+    markdown: '- a [ ] mid-item marker',
+    canonical: '- a \\[ \\] mid-item marker',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'non-checkbox bracket content is not a task marker',
+    markdown: '- [y] not a checkbox',
+    canonical: '- \\[y\\] not a checkbox',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped bracket is never a task marker',
+    markdown: '- \\[ ] escaped bracket',
+    canonical: '- \\[ \\] escaped bracket',
+    engines: BOTH_ENGINES,
+  },
   // A task item with a continuation paragraph has NO stable fixed point in
   // either engine: the `- [x] ` marker makes the continuation indent six
   // spaces, which CommonMark reads back as an indented code block. Both

--- a/packages/tooling/test-utils/markdown-corpus.ts
+++ b/packages/tooling/test-utils/markdown-corpus.ts
@@ -801,27 +801,72 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
   },
 
   // --- Horizontal rule ---------------------------------------------------
+  // A `---` on the FIRST line of a document is a frontmatter fence, so a
+  // doc-leading thematic break must serialize with a different marker
+  // (`***`) to survive re-parsing; anywhere else the canonical marker is
+  // `---`.
   {
-    name: 'horizontal rule',
-    markdown: '---',
+    name: 'thematic break after content keeps dashes',
+    markdown: 'before\n\n---\n\nafter',
     engines: BOTH_ENGINES,
   },
   {
-    name: 'star thematic break normalizes to dashes',
+    name: 'doc-leading thematic break uses stars',
     markdown: '***',
-    canonical: '---',
     engines: BOTH_ENGINES,
   },
   {
-    name: 'underscore thematic break normalizes to dashes',
+    name: 'doc-leading dash thematic break normalizes to stars',
+    markdown: '---',
+    canonical: '***',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'doc-leading underscore thematic break normalizes to stars',
     markdown: '___',
-    canonical: '---',
+    canonical: '***',
     engines: BOTH_ENGINES,
   },
   {
-    name: 'spaced thematic break normalizes to dashes',
+    name: 'doc-leading spaced thematic break normalizes to stars',
     markdown: '- - -',
-    canonical: '---',
+    canonical: '***',
+    engines: BOTH_ENGINES,
+  },
+
+  // --- Frontmatter ---------------------------------------------------------
+  {
+    name: 'frontmatter with body',
+    markdown: '---\ntitle: Hello\ntags:\n  - a\n---\n\n# Heading',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'frontmatter alone',
+    markdown: '---\ntitle: x\n---',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'empty frontmatter',
+    markdown: '---\n---',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'YAML document-end closing fence normalizes to dashes',
+    markdown: '---\ntitle: x\n...\n\nbody',
+    canonical: '---\ntitle: x\n---\n\nbody',
+    engines: BOTH_ENGINES,
+  },
+  {
+    // No closing fence means it is NOT frontmatter: the `---` keeps its
+    // thematic-break meaning (and, being doc-leading, normalizes to `***`).
+    name: 'unclosed frontmatter fence stays a thematic break',
+    markdown: '---\ntitle: x',
+    canonical: '***\n\ntitle: x',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'dashes fence later in the document is not frontmatter',
+    markdown: 'text\n\n---\n\nmore: text',
     engines: BOTH_ENGINES,
   },
 

--- a/packages/tooling/test-utils/markdown-corpus.ts
+++ b/packages/tooling/test-utils/markdown-corpus.ts
@@ -3,12 +3,19 @@
  * ProseMirror and Wordgard editor engines (see `plans/011-wordgard-editor-w-migration.md`,
  * milestone M1).
  *
- * Every fixture below is written in the *canonical form* a compliant engine
- * emits: `serialize(parse(fixture.markdown)) === fixture.markdown` must hold
- * for byte identity for every engine listed in `fixture.engines`. Fixtures are
- * not meant to be "valid-looking" Markdown; they are fixed points of the
- * parse/serialize round trip, including exact whitespace, escaping, and list
- * indentation.
+ * Every fixture asserts, for every engine listed in `fixture.engines`:
+ *
+ * 1. `serialize(parse(fixture.markdown)) === (fixture.canonical ?? fixture.markdown)`
+ *    byte-for-byte, and
+ * 2. the expected output is itself a fixed point:
+ *    `serialize(parse(expected)) === expected`.
+ *
+ * Fixtures without `canonical` are written in the *canonical form* a
+ * compliant engine emits — fixed points of the parse/serialize round trip,
+ * including exact whitespace, escaping, and list indentation. Fixtures with
+ * `canonical` document intentional, cross-engine-identical normalization
+ * (e.g. `*em*` -> `_em_`): the input is legal Markdown that every engine
+ * must rewrite to the same canonical bytes.
  *
  * Rules for extending this corpus:
  * - Every new editor construct (a new mark, node, or Markdown syntax) that
@@ -18,16 +25,22 @@
  *   `engines`, and only add the missing engine once its round trip is proven
  *   byte-identical. Do not silently shrink coverage by leaving a construct
  *   out of the corpus.
- * - If a construct empirically has NO stable fixed point in an engine today
- *   (parsing it never reproduces the same bytes, e.g. because the engine
- *   normalizes it further on every parse/serialize pass), it does not belong
- *   in the corpus as a fixture. Leave it out and explain why in a comment
- *   near the related fixtures instead of adding a fixture that would fail.
+ * - An input the engines normalize *identically* belongs here with
+ *   `canonical` set, not excluded. Only constructs where the engines
+ *   genuinely disagree (or never converge) stay out — leave a comment near
+ *   the related fixtures explaining the divergence instead of adding a
+ *   fixture that would fail.
  */
 export type MarkdownCorpusFixture = {
   name: string;
   markdown: string;
-  /** Which engines must round-trip this fixture byte-identically today. */
+  /**
+   * Expected serialization when it differs from `markdown` (an intentional
+   * normalization). Must itself round-trip byte-identically. Omit for
+   * fixtures already written in canonical form.
+   */
+  canonical?: string;
+  /** Which engines must satisfy this fixture's contract today. */
   engines: ReadonlyArray<'prosemirror' | 'wordgard'>;
 };
 
@@ -63,6 +76,30 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
   {
     name: 'unicode text',
     markdown: 'Unicode: café naïve 日本語 😀',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'soft line break normalizes to a space',
+    markdown: 'foo\nbar',
+    canonical: 'foo bar',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'extra blank lines between paragraphs collapse',
+    markdown: 'para one\n\n\n\npara two',
+    canonical: 'para one\n\npara two',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'leading paragraph indentation is dropped',
+    markdown: '   leading spaces',
+    canonical: 'leading spaces',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'HTML entities decode to their character',
+    markdown: '&amp; entity',
+    canonical: '& entity',
     engines: BOTH_ENGINES,
   },
 
@@ -111,6 +148,40 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '## 1\\. not a list',
     engines: BOTH_ENGINES,
   },
+  {
+    name: 'setext heading normalizes to ATX',
+    markdown: 'setext\n======',
+    canonical: '# setext',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'setext level-2 heading normalizes to ATX',
+    markdown: 'setext two\n----------',
+    canonical: '## setext two',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'closing hashes on an ATX heading are dropped',
+    markdown: '# heading with trailing hash #',
+    canonical: '# heading with trailing hash',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'tab after heading marker normalizes to a space',
+    markdown: '#\ttab after hash',
+    canonical: '# tab after hash',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading inside a list item',
+    markdown: '- # Foo',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'heading inside a blockquote',
+    markdown: '> ## heading in quote',
+    engines: BOTH_ENGINES,
+  },
 
   // --- Marks: bold, italic, strike, code, combinations -------------------
   {
@@ -133,6 +204,18 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '`inline code`',
     engines: BOTH_ENGINES,
   },
+  {
+    name: 'star emphasis normalizes to underscore',
+    markdown: '*asterisk emphasis*',
+    canonical: '_asterisk emphasis_',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'underscore strong normalizes to asterisks',
+    markdown: '__underscore strong__',
+    canonical: '**underscore strong**',
+    engines: BOTH_ENGINES,
+  },
   // A code span whose content itself contains a backtick (double-backtick
   // fence, e.g. ``` ``code containing ` backtick`` ```) is NOT a stable
   // fixed point in the PM engine: the serializer inserts padding spaces
@@ -145,6 +228,37 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '**bold _and italic_**',
     engines: BOTH_ENGINES,
   },
+  // Overlapping-mark delimiter nesting is rank-driven and must match across
+  // engines: strong outside italic, strike outside italic, strong outside
+  // strike. The `canonical` fixtures pin the normalization of the other
+  // nesting order.
+  {
+    name: 'fully overlapping bold and italic',
+    markdown: '**_bold italic_**',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'italic-outside-bold normalizes to bold-outside-italic',
+    markdown: '_**both**_',
+    canonical: '**_both_**',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'fully overlapping bold and strike',
+    markdown: '**~~bold strike~~**',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'fully overlapping strike and italic',
+    markdown: '~~_strike italic_~~',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'italic-outside-strike normalizes to strike-outside-italic',
+    markdown: '_~~both~~_',
+    canonical: '~~_both_~~',
+    engines: BOTH_ENGINES,
+  },
   {
     name: 'bold italic strike code combined in one paragraph',
     markdown: '**bold**, _italic_, ~~strike~~, and `code`',
@@ -155,6 +269,24 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: 'word**bold**word',
     engines: BOTH_ENGINES,
   },
+  {
+    name: 'code mark content is not escaped',
+    markdown: 'foo`*`',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'whitespace-only code span',
+    markdown: 'Three spaces: ` `',
+    engines: BOTH_ENGINES,
+  },
+  // A code span INSIDE another mark (`**bold `code`**`) has no shared fixed
+  // point: the PM engine's `code` mark excludes all other marks
+  // (banger-editor `excludes: '_'`), so it strips the bold and emits
+  // `**bold** `code``, while the Wordgard engine preserves the combination
+  // byte-for-byte. Wordgard's behavior is the more faithful one (no
+  // information loss), so it is deliberately NOT changed to match; the
+  // construct stays out of the shared corpus until the PM engine drops the
+  // exclusion.
 
   // --- Escaped constructs that must not be reinterpreted -----------------
   {
@@ -178,6 +310,16 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     engines: BOTH_ENGINES,
   },
   {
+    name: 'escaped leading plus is not a bullet',
+    markdown: '\\+ not a list',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped leading angle bracket is not a blockquote',
+    markdown: '\\> not a quote',
+    engines: BOTH_ENGINES,
+  },
+  {
     name: 'trailing double backslash stays a literal backslash',
     markdown: 'Trailing backslash literal \\\\',
     engines: BOTH_ENGINES,
@@ -192,17 +334,98 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '# Escaped hash mid text is fine # not heading',
     engines: BOTH_ENGINES,
   },
-  // `\_` inside a word (e.g. `file\_name`) is NOT a stable fixed point: `_`
-  // mid-word is never emphasis under CommonMark's intraword-underscore rule,
-  // so the serializer's escaper drops the now-unnecessary backslash on
-  // serialize, producing `file_name`. Excluded rather than included as a
-  // fixture that would fail `serialize(parse(x)) === x`.
-  //
-  // Similarly, an escaped backtick placed *inside* an already-open code span
+  {
+    name: 'escaped ordered-list marker is not a list',
+    markdown: '1\\. foo',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped ordered-list marker inside a list item',
+    markdown: '- 1\\. hi\n\n- x',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'list-marker-like text mid-paragraph is not escaped',
+    markdown: '123 [0. com](https://x)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'number followed by dot without a space is not escaped',
+    markdown: '1.2kg',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'underscores at word boundaries stay escaped',
+    markdown: '\\_abc\\_',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'underscores surrounded by non-word characters stay escaped',
+    markdown: '/\\_abc\\_)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'intraword underscore is not escaped',
+    markdown: 'abc_def',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'intraword underscore run is not escaped',
+    markdown: 'abc___def',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped intraword underscore drops its now-redundant escape',
+    markdown: 'file\\_name',
+    canonical: 'file_name',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'hashtag-like text is not escaped',
+    markdown: '#hashtag',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'more than six hashes is not a heading',
+    markdown: '#######',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped heading marker before unicode space',
+    markdown: '\\#　こんにちは',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped ATX heading marker with text',
+    markdown: '\\### text',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'escaped ATX heading marker at end of line',
+    markdown: '\\###',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'plus runs are not a list or rule',
+    markdown: '+++',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'tildes around text are escaped, not strikethrough',
+    markdown: '~single tilde~',
+    canonical: '\\~single tilde\\~',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'em-dash-like run mid-sentence is untouched',
+    markdown: 'em dash --- text',
+    engines: BOTH_ENGINES,
+  },
+  // An escaped backtick placed *inside* an already-open code span
   // (e.g. `` `code with \` backslash` ``) is not stable: the parser treats
   // the backslash as literal code content, but the serializer must then
   // re-escape the span's closing backtick, changing the byte length on
-  // serialize. Excluded for the same reason.
+  // serialize. Excluded.
   //
   // `\1.` at a line start (escaping an ordered-list marker) is also not
   // stable: markdown-it's escape handling doubles the backslash on
@@ -220,8 +443,28 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     engines: BOTH_ENGINES,
   },
   {
+    name: 'link with single-quoted title keeps its quoting style',
+    markdown: '[a](x.html \'title "quoted"\')',
+    engines: BOTH_ENGINES,
+  },
+  {
     name: 'autolink',
     markdown: '<https://example.com/>',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'autolink with characters the escaper would otherwise touch',
+    markdown: '<https://example.com/_file/#~anchor>',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'autolink inside emphasis',
+    markdown: 'Link to _<https://example.com/_file>_ here',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'autolink inside bold',
+    markdown: '**<https://example.com/~x>**',
     engines: BOTH_ENGINES,
   },
   {
@@ -234,6 +477,43 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '[email](mailto:user@example.com)',
     engines: BOTH_ENGINES,
   },
+  {
+    name: 'link inside bold text',
+    markdown: '**[link](https://x) is bold**',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'exclamation mark before a link stays escaped',
+    markdown: '\\![text](https://x)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'link href with balanced parentheses',
+    markdown: '[l](https://x/(a))',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'bare URL in text is not autolinked',
+    markdown: 'https://bare-url.example.com',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'reference link resolves to an inline link',
+    markdown: '[ref link][1]\n\n[1]: https://example.com',
+    canonical: '[ref link](https://example.com)',
+    engines: BOTH_ENGINES,
+  },
+  // A link with an empty label (`[](x)`) parses to a link mark over zero
+  // text nodes in both engines and serializes to an empty string — the href
+  // is lost. Both engines agree, but that agreement is data loss, so it is
+  // documented here rather than blessed as a fixture.
+  //
+  // A link whose text carries a nested mark run (`[link _foo **bar**_](x)`)
+  // has no shared fixed point: the PM engine's link mark is not mixable, so
+  // it splits the link into several adjacent links (output that fails even
+  // its own round trip), while the Wordgard engine keeps the link whole and
+  // converges to `[link _foo _**_bar_**](x)`. Wordgard's lossless behavior
+  // is deliberately kept; excluded from the shared corpus.
 
   // --- Images ---------------------------------------------------------------
   {
@@ -244,6 +524,26 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
   {
     name: 'image with title',
     markdown: '![alt text](./image.png "a title")',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'image with empty alt',
+    markdown: '![](empty-alt.png)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'image alt containing an escaped bracket',
+    markdown: '![a\\]b](x.png)',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'image between marked text runs',
+    markdown: 'a **b** ![i](x.png) c',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'image carrying a bold mark',
+    markdown: '**![i](x.png)**',
     engines: BOTH_ENGINES,
   },
 
@@ -266,6 +566,22 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
   {
     name: 'blockquote containing a list',
     markdown: '> - item one\n>\n> - item two',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'blockquote containing a nested list',
+    markdown: '> - a\n>\n>   - b',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'blockquote containing a code block',
+    markdown: '> ```\n> code\n> ```',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'empty blockquote keeps a marker line',
+    markdown: '>',
+    canonical: '> ',
     engines: BOTH_ENGINES,
   },
 
@@ -299,16 +615,54 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '- **bold item**\n\n- _italic item_',
     engines: BOTH_ENGINES,
   },
+  {
+    name: 'empty bullet list item keeps its marker',
+    markdown: '- ',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'star bullet normalizes to dash',
+    markdown: '* star bullet',
+    canonical: '- star bullet',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'plus bullet normalizes to dash',
+    markdown: '+ plus bullet',
+    canonical: '- plus bullet',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'wide bullet marker spacing normalizes to one space',
+    markdown: '-   wide marker spacing',
+    canonical: '- wide marker spacing',
+    engines: BOTH_ENGINES,
+  },
 
   // --- Ordered lists -------------------------------------------------------
   // The PM serializer normalizes every ordered-list marker to the literal
   // `1.` regardless of the source numbering or the node's `order` attribute
   // (see `flatListToMarkdown` in list.ts: `marker = '1.'`, unconditionally).
-  // Canonical fixtures must therefore use `1.` for every item; a fixture
-  // using `1. / 2. / 3.` would not be a fixed point.
   {
     name: 'ordered list, canonical "1." markers',
     markdown: '1. item one\n\n1. item two\n\n1. item three',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'ordered list numbering normalizes to "1." markers',
+    markdown: '3. third\n4. fourth',
+    canonical: '1. third\n\n1. fourth',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'paren ordered marker normalizes to dot',
+    markdown: '1) paren ordered',
+    canonical: '1. paren ordered',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'ordered list item with a continuation paragraph',
+    markdown: '1. one\n\n   two',
     engines: BOTH_ENGINES,
   },
 
@@ -335,6 +689,12 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     engines: BOTH_ENGINES,
   },
   {
+    name: 'uppercase checked marker normalizes to lowercase',
+    markdown: '- [X] uppercase checked',
+    canonical: '- [x] uppercase checked',
+    engines: BOTH_ENGINES,
+  },
+  {
     name: 'nested task list',
     markdown: '- [ ] task one\n\n  - [x] nested task',
     engines: BOTH_ENGINES,
@@ -344,6 +704,17 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '- [ ] task\n\n- plain item',
     engines: BOTH_ENGINES,
   },
+  {
+    name: 'task list item with inline marks',
+    markdown: '- [x] task **bold**',
+    engines: BOTH_ENGINES,
+  },
+  // A task item with a continuation paragraph has NO stable fixed point in
+  // either engine: the `- [x] ` marker makes the continuation indent six
+  // spaces, which CommonMark reads back as an indented code block. Both
+  // engines agree on the (mangled) output, but it never converges to the
+  // input, so it stays out of the corpus. Fixing this requires a different
+  // continuation-indent rule in both engines, tracked for a later milestone.
 
   // --- Code blocks -----------------------------------------------------
   {
@@ -371,31 +742,43 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
     markdown: '````markdown\n```js\nconst nestedFence = true;\n```\n````',
     engines: BOTH_ENGINES,
   },
-  // Indented (4-space) code blocks are not a stable fixed point: the PM
-  // parser accepts them as `code_block` on parse, but the serializer's only
-  // `code_block` output form is a fenced block, so the canonical/stable form
-  // is the fenced one above, not the indented source. An indented-code-block
-  // *input* string is therefore never returned unchanged by `serialize`.
+  {
+    name: 'indented code block normalizes to a fenced block',
+    markdown: '    indented code',
+    canonical: '```\nindented code\n```',
+    engines: BOTH_ENGINES,
+  },
 
   // --- Horizontal rule ---------------------------------------------------
-  // All three CommonMark thematic-break markers (`---`, `***`, `___`)
-  // normalize to `---` on first serialize UNLESS the parser attaches the
-  // original `markup` attr, which it does — so `---` is the only stable
-  // fixed point to include; `***`/`___` still parse fine but do not
-  // round-trip byte-identically on this corpus's first pass because the
-  // fixture must already equal its own serialization.
   {
     name: 'horizontal rule',
     markdown: '---',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'star thematic break normalizes to dashes',
+    markdown: '***',
+    canonical: '---',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'underscore thematic break normalizes to dashes',
+    markdown: '___',
+    canonical: '---',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'spaced thematic break normalizes to dashes',
+    markdown: '- - -',
+    canonical: '---',
     engines: BOTH_ENGINES,
   },
 
   // --- Hard breaks and soft breaks -----------------------------------------
   // A hard break serializes as a trailing backslash + newline. Soft line
   // breaks (a single `\n` inside a paragraph) normalize to a single space on
-  // serialize, so canonical fixtures must never contain a bare `\n` inside a
-  // paragraph — every multi-line paragraph fixture in this corpus either
-  // uses `\n\n` (a real paragraph break) or `\\\n` (an explicit hard break).
+  // serialize (see the 'soft line break normalizes to a space' fixture), so
+  // canonical fixtures must never contain a bare `\n` inside a paragraph.
   {
     name: 'hard break inside a paragraph',
     markdown: 'line one\\\nline two',
@@ -404,6 +787,22 @@ export const MARKDOWN_CORPUS: readonly MarkdownCorpusFixture[] = [
   {
     name: 'multiple hard breaks in one paragraph',
     markdown: 'a\\\nb\\\nc',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'two-space hard break normalizes to backslash form',
+    markdown: 'a  \nb',
+    canonical: 'a\\\nb',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'hard break inside emphasis',
+    markdown: '_foo\\\nbar_',
+    engines: BOTH_ENGINES,
+  },
+  {
+    name: 'hard break directly after a bold run',
+    markdown: '**foo**\\\nbar',
     engines: BOTH_ENGINES,
   },
 

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -95,12 +95,40 @@ exists):
   green, and the new package ships headless tokenizer + wiki-link syntax
   tests. Verified with `lint:ci`, `typecheck`, `knip:ci`, and `test:ci`
   (1416 passed).
-- Still open in M1: the `wordgard-markdown` codec (parse + serialize for the
-  full schema) built on this shared tokenizer; moving the table markdown-it
-  plugin (`banger-editor/table/table-markdown.ts`) down into the shared layer
-  when the second engine needs table parity (M3); and the golden corpus in
-  `@bangle.io/test-utils` with both-engine round-trip contract tests. The
-  codec lands once `wordgard` / `wordgard-utils` scaffold.
+### M1 essentially complete — codec, packages, and golden corpus landed
+
+- **`@bangle.io/wordgard-utils`** (js-lib, universal) scaffolded with
+  `wordgard` exact-pinned at `0.1.1`: the single `wordgard/*` import
+  chokepoint (currently re-exporting `wordgard/doc` + `wordgard/types`;
+  grows per milestone), plus the first custom schema elements — `TaskItem`
+  (`Plot.Type<boolean>`, param = checked, with a `Schema.Override` slotting
+  it into the built-in `BulletList`), `WikiLink` (`Leaf.Type<string>`,
+  param = target) + `WikiLinkLabel` mark, and `LinkTitle`/`ImageTitle` marks
+  preserving Markdown title fidelity.
+- **`@bangle.io/wordgard-markdown`** (js-lib, universal) — the headless
+  codec. `MarkdownSpec`s keyed by node/mark type objects; parser and
+  serializer state are faithful ports of prosemirror-markdown's
+  `MarkdownParseState`/`MarkdownSerializerState` (MIT, attributed) onto
+  Wordgard's plot/leaf/mark model, consuming the shared
+  `@bangle.io/markdown-syntax` tokenizer. `createNoteMarkdownCodec()` is the
+  batteries-included bangle-note assembly. Byte-parity subtleties ported
+  deliberately: loose (blank-line-separated) list items, fixed `1.` ordered
+  markers, 2-space nesting indent, banger's heading start-of-line escaping,
+  autolink heuristic, adaptive code fences/backticks, hard-break lookahead.
+- **Golden corpus** in `@bangle.io/test-utils` (`markdown-corpus.ts`,
+  ~69 canonical-form fixtures) with both-engine contract tests:
+  `core/editor/src/__tests__/markdown-golden-corpus.spec.ts` (ProseMirror)
+  and `wordgard-markdown/src/__tests__/markdown-golden-corpus.spec.ts`
+  (Wordgard). Table fixtures are `engines: ['prosemirror']` until M3.
+  Constructs with no byte-stable fixed point in the PM engine are documented
+  in the corpus file instead of included (lists nested under ordered items,
+  indented code blocks, mid-word escaped underscores, and similar).
+- **M1 exit met for the non-table schema:** the corpus round-trips
+  byte-identically through both engines headlessly. Verified with `lint:ci`
+  and `test:ci` (1611 passed).
+- Still open in M1 scope: moving the table markdown-it plugin
+  (`banger-editor/table/table-markdown.ts`) into the shared layer and adding
+  Wordgard table specs when the second engine needs table parity (M3).
 
 ## Guiding principles
 
@@ -597,13 +625,15 @@ None. M0 can start immediately.
 
 ## Next steps
 
-1. Shared syntax layer: **done** (`@bangle.io/markdown-syntax`). Next, scaffold
-   `@bangle.io/wordgard-utils` + `@bangle.io/wordgard-markdown` (js-lib) with
-   `wordgard` pinned to an exact version, then build the `wordgard-markdown`
-   codec on top of the shared `@bangle.io/markdown-syntax` tokenizer and add
-   the golden corpus.
-2. M0b alongside it: stub `@bangle.io/editor-w` package + persisted engine
+1. Shared syntax layer: **done** (`@bangle.io/markdown-syntax`).
+2. Scaffold `wordgard-utils` + `wordgard-markdown`, build the codec, add the
+   golden corpus with both-engine contract tests: **done** (see "M1
+   essentially complete" above).
+3. M0b next: stub `@bangle.io/editor-w` package + persisted engine
    preference + omni-search switch command + composition-root selection +
    boot guard + e2e switch coverage.
-3. Extract `editor-common` (save queue, load-status, `<Editor>` shell) when
+4. Extract `editor-common` (save queue, load-status, `<Editor>` shell) when
    editor-w first needs it (M2).
+5. Table parity (M3): move `banger-editor/table/table-markdown.ts` into the
+   shared layer, add Wordgard table specs, and flip the corpus table
+   fixtures to both engines.

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -117,16 +117,48 @@ exists):
   markers, 2-space nesting indent, banger's heading start-of-line escaping,
   autolink heuristic, adaptive code fences/backticks, hard-break lookahead.
 - **Golden corpus** in `@bangle.io/test-utils` (`markdown-corpus.ts`,
-  ~69 canonical-form fixtures) with both-engine contract tests:
+  ~140 fixtures) with both-engine contract tests:
   `core/editor/src/__tests__/markdown-golden-corpus.spec.ts` (ProseMirror)
   and `wordgard-markdown/src/__tests__/markdown-golden-corpus.spec.ts`
   (Wordgard). Table fixtures are `engines: ['prosemirror']` until M3.
-  Constructs with no byte-stable fixed point in the PM engine are documented
-  in the corpus file instead of included (lists nested under ordered items,
-  indented code blocks, mid-word escaped underscores, and similar).
-- **M1 exit met for the non-table schema:** the corpus round-trips
-  byte-identically through both engines headlessly. Verified with `lint:ci`
-  and `test:ci` (1611 passed).
+  Fixtures come in two contract shapes: canonical-form fixed points, and
+  `canonical`-carrying normalization fixtures (`*em*` -> `_em_`, setext ->
+  ATX, indented -> fenced code, reference -> inline links, ...) asserting
+  both engines normalize legal-but-non-canonical Markdown to the same bytes
+  AND that the canonical form is itself stable. Constructs with no shared
+  fixed point stay out, each documented in the corpus file (lists nested
+  under ordered items, task-item continuation paragraphs, code spans inside
+  other marks, link text carrying nested mark runs, empty-label links).
+- **M1 review hardening (post-scaffold):** empirical A/B probing of both
+  engines surfaced and fixed real divergences —
+  - Wordgard serializer now sorts spanning marks by mark-spec registration
+    order (`MarkdownSerializerState.serializationMarks`), because Wordgard's
+    built-in mark ranks (`Link 20 < Strike 42 < Em 50 < Strong 60 < Code
+    80`) are nearly the reverse of the PM schema's and produced broken
+    output for overlapping marks (`**[link](x) is bold**` serialized as
+    `[**link**](x)** is bold**`). The mark-spec order in
+    `defaultMarkdownSpecs` is therefore load-bearing (outermost first,
+    `Code` last since a non-escaping mark must be innermost).
+  - The PM corpus test's extension registration order now mirrors the app's
+    `setupExtensions` (bold, strike, code, italic, link) — PM mark rank
+    follows schema insertion order and decides delimiter nesting, so the
+    old test order blessed canonical forms the real app never emits.
+  - Autolink URL corruption fixed in BOTH engines (`<https://x/_f>` used to
+    serialize as `<https://x/\_f>`): banger-editor's link/text serializers
+    now implement prosemirror-markdown's `inAutolink` protocol, and the
+    Wordgard codec does the same.
+  - Image alt-text truncation fixed in BOTH engines (`![a\]b](x)` lost
+    everything after the escape): alt is now joined across all markdown-it
+    children instead of `children[0].content`.
+  - Deliberate divergences from the PM engine, kept because they preserve
+    data: the Wordgard link mark is `mixable` (PM's splits
+    `[link _foo **bar**_](x)` into three links, output that fails even PM's
+    own round trip), and Wordgard does not copy the PM `code` mark's
+    exclude-all-marks rule (PM silently unbolts `**bold `code`**`).
+- **M1 exit met for the non-table schema:** the corpus (round-trip +
+  normalization contracts) passes byte-identically through both engines
+  headlessly, plus serialize-only constructed-doc tests ported from
+  prosemirror-markdown's suite for shapes parsing cannot produce.
 - Still open in M1 scope: moving the table markdown-it plugin
   (`banger-editor/table/table-markdown.ts`) into the shared layer and adding
   Wordgard table specs when the second engine needs table parity (M3).

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -252,9 +252,13 @@ bangle-agnostic, the `banger-editor` analog)
   each feature is one extension bundle combining schema elements, key
   bindings, input rules, commands, corrections, menu items, and styles.
   Initial roster (built across milestones): task lists, wiki-link node +
-  syntax, trigger/suggestion machinery (the `/`, `[[`, `$date` engine),
-  placeholder, trailing block, drag handle, active-node highlight,
-  collapsible headings, shiki code-highlight bridge.
+  syntax, placeholder, trailing block, active-node highlight, collapsible
+  headings, shiki code-highlight bridge. Strictly **headless** — anything
+  that renders React or positions floating DOM lives in `wordgard-plus`
+  (see "Floating UI" and the wordgard-plus section); the trigger/suggestion
+  machinery is split accordingly (minimal trigger core here or in
+  wordgard-plus behind a thin seam, UI in wordgard-plus — pending upstream
+  autocompletion, issue #13).
 - Carries zero Bangle imports. Long term this is publishable as
   `wordgard-utils` (name reserved); publishing itself is out of scope here.
 
@@ -294,16 +298,29 @@ bangle-agnostic — the missing `prosemirror-markdown` equivalent)
   the same contract with the same `static deps` (`fileSystem`, `navigation`,
   `workbenchState`, `workspaceState`) and the same save-queue semantics.
 - Its React surface (slash menu, link menu, table menu, selection menu, date
-  picker) is **rebuilt on Wordgard primitives**, not ported: Wordgard's
-  panel/tooltip/dialog/menu facets replace the hand-rolled PM plugin + jotai
-  atom plumbing where they fit; where we want our ShadCN look, the service
-  bridges Wordgard state fields/facets into jotai atoms that the existing
-  presentational components consume. Decide per feature; do not force either
-  direction.
+  picker) is **rebuilt on Wordgard primitives**, not ported — composed from
+  `@bangle.io/wordgard-plus` components (which own the tooltip-portal, menu
+  resolution, and Jotai bridge; see the wordgard-plus section) plus
+  editor-w-local wiring for app concerns (wiki-link target resolution,
+  commands, workspace state). `@floating-ui/dom` and the hand-rolled
+  plugin→jotai plumbing do not carry over.
 - Bridges Bangle's `t` translations into Wordgard `PhraseSet`s so built-in UI
   (menus, dialogs, table controls) is localized consistently.
 
-**4. `@bangle.io/editor-common`** (`packages/core/editor-common`, extracted
+**4. `@bangle.io/wordgard-plus`** (`packages/js-lib/wordgard-plus`,
+bangle-agnostic — opinionated plug-and-play Wordgard surfaces)
+
+- The shadcn-posture component layer: React chrome (selection toolbar,
+  link popover, suggest listbox, dialog helpers) + the Jotai/tooltip/menu
+  bridge, complementing a consumer's own Wordgard setup — never wrapping
+  or owning the editor instance. Full philosophy, invariants, module
+  roster, and upstream-coordination policy in the "Floating UI" and
+  "`@bangle.io/wordgard-plus`" sections (after the feature parity
+  matrix).
+- First consumer is editor-w; carries zero Bangle imports so later
+  extraction is mechanical (an explicit non-goal for now).
+
+**5. `@bangle.io/editor-common`** (`packages/core/editor-common`, extracted
 at M2 — not before)
 
 - The engine-agnostic editor kernel, pulled out of `core/editor` once
@@ -495,16 +512,16 @@ From the current extension inventory (`core/editor/src/extensions.ts`).
 | bullet/ordered lists | Built-in list extensions; build indent/dedent commands (M2-L1/M2-L2, see Lists section) | M2 |
 | code block + language | Built-in (`CodeBlock` + `CodeBlockLanguage` mark) | M2 |
 | undo/redo history | Built-in (`wordgard/history`) | M2 |
-| link mark + link menu | Built-in link + dialog; restyle/bridge to our UI | M3–M4 |
+| link mark + link menu | Built-in link mark; popover is wordgard-plus `link-popover` (M4-P2) | M3–M4 |
 | image node, local-image node view, resize | Built-in image/figure/`imageResizing`; asset resolution is ours | M5 |
 | tables + table menu | Built-in `wordgard/table` (cell selection, commands, rectangularity corrections) + our markdown | M3 |
 | task lists (flat-list `kind: task`, checked; toggle/collapsed dropped) | `TaskItem` plot landed in M1; commands/input rule/checkbox are M3-T1..T3 (see Lists section) | M3 |
 | wiki link node + `[[` suggestions | Build in wordgard-utils (syntax + node) / editor-w (target resolution) | M3 |
 | markdown parse/serialize (pm-markdown) | **Build: `wordgard-markdown`** — the critical path | M1 |
-| slash commands, date picker suggestions | Build: trigger machinery in wordgard-utils; UI in editor-w | M4 |
-| selection menu (floating toolbar) | Build on Wordgard tooltip/menu facets | M4 |
+| slash commands, date picker suggestions | wordgard-plus `suggest` UI over a thin trigger seam (upstream #13); consumers in editor-w (M4-P3) | M4 |
+| selection menu (floating toolbar) | wordgard-plus `selection-toolbar`: Tooltip facet + resolved 1p menu items in React (M4-P1) | M4 |
 | placeholder, trailing node | Build (small decorations/corrections) | M4 |
-| drag handle, drop gap cursor | Build; note Wordgard owns selection/cursor drawing — verify native DnD behavior first | M4 |
+| drag handle, drop gap cursor | Build (UI in wordgard-plus); Wordgard owns selection/cursor drawing — verify native DnD behavior first (M4-P4) | M4 |
 | active-node highlight | Build (decorations + state field) | M4 |
 | collapsible headings | Build (state field + point/range decorations); collapse state stays out of the document | M5 |
 | code syntax highlight (shiki) | Build (range decorations from a state field) | M5 |
@@ -624,6 +641,138 @@ output is itself a fixed point AND the PM engine produces identical bytes"
 — which may open editable behind an explicit "this note will be
 normalized on first save" notice. Never silently widen the gate.
 
+### Floating UI: Wordgard positions, React renders, Jotai holds UI state
+
+Today's PM chrome hand-rolls the hard part: `core/editor` positions React
+menus with `@floating-ui/dom`, and `banger-editor` smuggles a Jotai store
+through a PM plugin (`store/store.ts`) to expose plugin state to React.
+Wordgard makes that middle layer first-party, and we should stop owning
+it. Division of labor for every floating surface in editor-w:
+
+- **Wordgard owns geometry and lifecycle.** `Tooltip.show` (a facet) and
+  `Tooltip.hover` anchor DOM to *document positions* — mapped through
+  changes, flipped/clipped/overlap-managed, repositioned on RAF, with
+  `Tooltip.View`'s `connect`/`disconnect`/`positioned` hooks. `Panel` owns
+  docked top/bottom chrome; `Dialog.show` gives promise-based form prompts
+  on top of panels. `@floating-ui/dom` does not come along to editor-w:
+  anything anchored to editor content rides the Tooltip facet.
+- **React owns content.** A tooltip/panel's `dom` is a plain element; we
+  portal React into it (`createPortal` into `View.dom`, mounted on
+  `connect`, released on `disconnect`). Wordgard never knows React exists.
+- **Jotai owns UI state.** Chrome state (which surface is open, active
+  item, query text) lives in per-editor Jotai atoms — the repo's one state
+  mechanism — fed by a single `updateListener`-driven bridge (below). The
+  document and selection are never mirrored into atoms; atoms hold derived
+  read models and UI-local state only, and the write path is always
+  "React → dispatch a command/transaction", never atom→editor sync.
+- **The menu MODEL stays first-party even where the menu UI is ours.**
+  Wordgard menu items (`Menu.Button.define`, submenus, groups, ranks,
+  `select`/`enable`/`active` predicates) are extension values that feature
+  bundles already declare — `bulletList.toggleButton` et al. — and the
+  guide explicitly blesses custom renderers: resolve the `Menu.Item.source`
+  facet with `Menu.resolve` and display the result "maybe as a React
+  component". So our toolbars consume resolved 1p menu items rendered with
+  our components; we never fork a parallel menu-item registry. The stock
+  `menuBar` remains available for barebones/dev setups.
+
+### `@bangle.io/wordgard-plus` — components that complement, never wrap
+
+A new package of opinionated, plug-and-play Wordgard surfaces — the
+shadcn posture, not the tiptap posture. Tiptap wraps the engine: it owns
+the editor instance, re-exports the API, and you live inside its
+abstraction. wordgard-plus does the opposite and holds these invariants:
+
+- **Never owns the editor.** No `<WordgardPlusEditor>`, no config factory,
+  no lifecycle management. Every deliverable is (a) an extension bundle
+  you add to *your* Wordgard config, or (b) a React component you render
+  in *your* tree, connected to an existing `Wordgard` instance you pass
+  in. Deleting wordgard-plus from an app must leave a working editor.
+- **Never re-exports Wordgard.** Consumers import wordgard themselves;
+  wordgard-plus types accept wordgard values at the boundary.
+- **Opinionated by Bangle's priorities** (markdown-serializable behavior,
+  local-first, keyboard-first, a11y non-negotiable — icon buttons carry
+  `description` for screen readers per the Wordgard menu guide). It is
+  fine for v0 to say "this is how Bangle does it".
+- **Bangle-free.** First consumer is editor-w, but the package carries
+  zero `@bangle.io` app imports so extraction later is mechanical.
+  User-visible strings arrive via props/PhraseSets, never the global `t`.
+
+**Placement and boundaries.** `packages/js-lib/wordgard-plus`, following
+the `banger-editor` precedent (js-lib already hosts React+Jotai editor
+chrome). It depends on `@bangle.io/wordgard-utils` (the wordgard import
+chokepoint, which grows `editor`/`command`/`menu`/`view` re-exports in
+M2/M4), `jotai`, and `react` — and NOT on `packages/ui/*` (js-lib cannot;
+this is also what keeps it extractable). Components ship working default
+markup styled with theme-variable-driven CSS (dark/light via Wordgard's
+`&dark`/`&light` for editor-internal styles) plus `className`/slot
+overrides; editor-w composes them with our base-ui look. The dividing
+line against its sibling: **wordgard-utils = headless** (schema elements,
+commands, corrections, input rules, markdown specs — e.g. the TaskItem
+checkbox decoration from M3-T3), **wordgard-plus = chrome** (anything
+that renders React or positions floating DOM). In-repo module first;
+extraction is a later, separate decision.
+
+**v0 module roster (bangle-priority order):**
+
+1. `bridge` — the foundation everything else uses:
+   - `createEditorAtoms(wg)`: one `updateListener` subscription feeding a
+     per-editor Jotai store scope; exposes read atoms (selection summary,
+     active marks/blocks via `listIsActive`-style predicates, canUndo/
+     canRedo, focus state) with equality guards so a keystroke doesn't
+     re-render every consumer. Per-editor scoping is mandatory — split
+     view / side-by-side must never share chrome state.
+   - `useResolvedMenu(wg, template?)`: resolves `Menu.Item.source` items
+     through `Menu.resolve` into plain data (label/icon/run/active/
+     enabled/description), re-evaluated per the items' `updateFor`
+     predicates, exposed as an atom.
+   - `reactTooltip(...)` / `<TooltipHost>`: the portal glue that lets a
+     `Tooltip.View` render a React subtree (mount on `connect`, unmount
+     on `disconnect`).
+2. `selection-toolbar` — floating toolbar over non-empty selections
+   (extension: state field + `Tooltip.show` value; component: toolbar
+   rendering the resolved inline menu group). Parity target:
+   `core/editor`'s `inline-selection-menu`.
+3. `link-popover` — hover + cursor-in-link popover (`Tooltip.hover`
+   source + edit form component). Parity target: `link-menu`.
+4. `suggest` — trigger-based autocomplete UI (`[[`, `/`, `$date`):
+   listbox component + keyboard navigation over a minimal trigger-state
+   extension. **Upstream-sensitive — see coordination note below**: the
+   trigger-detection/matching core is deliberately a thin, replaceable
+   seam because upstream is considering 1p autocompletion.
+5. `dialogs` — thin styled helpers over 1p `Dialog.show` for
+   editor-scoped prompts. App-level dialogs stay in Bangle's dialog
+   service; the boundary is "does it prompt about editor content at the
+   cursor, or about the workspace".
+6. Later candidates as their milestones arrive: table menu (M3), drag
+   handle (M4), code-block language picker (M5 — upstream-sensitive,
+   #11).
+
+**Upstream coordination — build, wait, or thin-seam.** Marijn's tracker
+(`code.haverbeke.berlin/wordgard/wordgard/issues`) already lists several
+of these as candidate first-party features. Policy: where upstream has
+*stated intent*, we either wait or build behind a deliberately thin seam
+we can re-base; we never build a rival core.
+
+- **#13 autocompletion in core** — the big one; overlaps our `suggest`
+  module. M3 needs wiki-link `[[` suggestions regardless, so build the
+  *UI* (listbox, keyboard model, Jotai atoms) now, keep the
+  trigger/matching core minimal and private, and re-base it on 1p
+  autocomplete when it ships. Do not polish or generalize our core.
+- **#11 CodeBlockLanguage UI** — defer ours (language picker is M5
+  anyway); adopt or restyle upstream's.
+- **#14 menu bar top container** — watch; affects `Panel` placement
+  options wordgard-plus relies on.
+- **#12 collaborative editing** — out of scope for this migration either
+  way; note only that wordgard-plus components must not assume
+  single-client state shapes that would fight `wordgard/collab` later.
+- **#10/#9 (CodeMirror-in-code-block, footnote examples)** — upstream
+  examples to crib from when M5 reaches code blocks; not blockers.
+- **#8 iOS autocorrect / #4 Android voice-typing cursor bugs** — not
+  wordgard-plus items, but they gate the M6 flip: add "mobile IME
+  behavior acceptable on real devices" to the M6 exit checklist and
+  track both issues there. Do not flip defaults while either reproduces
+  on a supported device.
+
 ## Milestones
 
 Each milestone is a stream of small PRs, merged continuously, full CI green.
@@ -679,10 +828,35 @@ checkbox rendering + click — specified in the Lists section), wiki links +
 existing Bangle note passes the round-trip gate and is fully editable,
 including checking a task with the mouse.
 
-**M4 — Interaction chrome**
-Slash commands, date picker, selection/link/table menus, placeholder,
-trailing block, drag handle, active-node highlight. Exit: muscle-memory
-parity — a PM user switching engines loses no workflow.
+**M4 — Interaction chrome (built as `wordgard-plus`)**
+The floating/menu surfaces land as wordgard-plus modules composed by
+editor-w (see the "Floating UI" and wordgard-plus architecture sections):
+
+- *M4-P0 — package scaffold + bridge:* `createEditorAtoms(wg)` (one
+  updateListener → per-editor Jotai atoms with equality guards),
+  `useResolvedMenu` (`Menu.resolve` over the `Menu.Item.source` facet),
+  and the `<TooltipHost>` React-portal glue for `Tooltip.View`s. Exit:
+  a story/demo page shows a toolbar of resolved 1p menu items rendered
+  in React, updating live, on a plain Wordgard setup with zero Bangle
+  imports.
+- *M4-P1 — selection toolbar* (parity: `inline-selection-menu`): state
+  field + `Tooltip.show` extension, React toolbar over the resolved
+  inline menu group. Keyboard accessible; e2e-covered.
+- *M4-P2 — link popover* (parity: `link-menu`): `Tooltip.hover` source +
+  cursor-in-link tracking, edit form, open/copy/remove actions.
+- *M4-P3 — suggest UI + consumers:* generic listbox/keyboard model in
+  wordgard-plus over a deliberately thin trigger core (upstream #13
+  seam); slash menu and date picker in editor-w composed from it. (The
+  wiki `[[` consumer lands earlier, in M3, on the same seam — build the
+  seam with M3, polish the generic UI here.)
+- *M4-P4 — remaining chrome:* placeholder, trailing block, active-node
+  highlight (headless → wordgard-utils); drag handle (UI portion in
+  wordgard-plus; verify against Wordgard's native DnD/selection drawing
+  first).
+
+Exit: muscle-memory parity — a PM user switching engines loses no
+workflow — and `@floating-ui/dom` is absent from the editor-w dependency
+graph.
 
 **M5 — Assets and long-tail**
 Image/asset paste-drop, asset links, shiki highlighting, collapsible
@@ -691,12 +865,15 @@ recompute, load time) against the PM baseline on the same corpus.
 
 **M6 — Confidence and flip**
 Full e2e suite runs against both engines (engine-parameterized fixture);
-maintainer dogfoods editor-w as personal default; then flip stages: default
-for new users → default for all (PM reachable via the same switch command)
-→ finally, as a **separate decision**, retire the PM stack (delete
-`core/editor`, `prosemirror-plugins`, banger dependency) once editor-w has
-soaked. The switch machinery itself is cheap and can outlive the flip as a
-safety valve.
+maintainer dogfoods editor-w as personal default; **mobile IME check**:
+upstream wordgard issues #8 (iOS autocorrect removes words) and #4
+(Android voice-typing cursor mismatch) must be fixed or verified
+non-reproducing on real devices before any default flips. Then flip
+stages: default for new users → default for all (PM reachable via the
+same switch command) → finally, as a **separate decision**, retire the PM
+stack (delete `core/editor`, `prosemirror-plugins`, banger dependency)
+once editor-w has soaked. The switch machinery itself is cheap and can
+outlive the flip as a safety valve.
 
 ## Testing strategy
 

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -159,6 +159,25 @@ exists):
   normalization contracts) passes byte-identically through both engines
   headlessly, plus serialize-only constructed-doc tests ported from
   prosemirror-markdown's suite for shapes parsing cannot produce.
+- **List/task syntax now lives in the shared layer:** the markdown-it list
+  plugin (kind stamping + GFM task detection) is vendored into
+  `@bangle.io/markdown-syntax` (`list-syntax.ts`, replacing the
+  `@bangle.dev/pm-markdown/list-markdown` import), with exported
+  `LIST_KIND_ATTR`/`TASK_CHECKED_ATTR` constants both codecs now use. The
+  rewrite dropped dead behavior no consumer read (a `tight` attr that was
+  always `"false"`, an ordered `order` attr both engines ignore, an HTML
+  renderer override) and fixed real gaps, each pinned by tokenizer tests
+  and corpus fixtures:
+  - Empty tasks (`- [ ]` / `- [x]`) are now recognized, matching GitHub;
+    canonical form `- [ ] `.
+  - `1. [ ] x` (task inside an ordered list — GFM-legal) used to CRASH the
+    Wordgard codec (`OrderedList cannot contain child TaskItem`), i.e. a
+    legal note would fail to load. `taskListContentOverrides` now admits
+    the transient shape and serialization normalizes to `- [ ] x`,
+    byte-identical with the PM engine.
+  - The inline token's own `content` is kept in sync when the marker is
+    sliced off (it used to go stale), and the emptied text child is
+    removed.
 - Still open in M1 scope: moving the table markdown-it plugin
   (`banger-editor/table/table-markdown.ts`) into the shared layer and adding
   Wordgard table specs when the second engine needs table parity (M3).
@@ -501,6 +520,38 @@ with `Elt` shapes*; plugin props become *facets*; transaction meta becomes
 *annotations/effects*; feature flags inside the editor become
 *compartments*; DOM work batches on RAF, so bulk operations dispatch one
 coherent transaction.
+
+### Lists: Wordgard's built-in nested model, NOT a flat-list port
+
+The PM engine uses `prosemirror-flat-list` (one flat `list` node with a
+`kind` attr) because PM's own nested `ul > li` stack made list manipulation
+genuinely painful — strict content expressions, lift/sink commands that
+drag unselected content along, and position surgery for every structural
+edit. Those are PM pains, and Wordgard was designed around them: loose
+content queries + corrections, multi-change specs addressed in original
+coordinates, and first-party `toggleList`/`splitTextblock`/`joinListItems`
+commands over the nested `BulletList`/`OrderedList`/`ListItem` model.
+
+Decision: editor-w stays on the built-in nested model. Porting a flat-list
+design would orphan us from Wordgard's 1p commands, menu buttons, input
+rules, and future upstream fixes — recreating on the Wordgard side the 3p
+coupling we're trying to leave behind on the PM side. The nested model is
+also what the markdown codec is built on: markdown-it's token nesting maps
+onto it 1:1 (the flat model is precisely why the PM engine needs the
+list_item-only parse with `ignore`d wrapper tokens and the
+`flatListToMarkdown` reconstruction). Flat-list features we consciously do
+NOT carry: toggle lists (never had markdown serialization; effectively
+unused) and arbitrary same-line indentation (unrepresentable in markdown —
+supporting it would fight the fidelity invariant). Documents are stored as
+markdown, so no `migrateDocJSON`-style model migration exists between the
+engines.
+
+Known 1p gaps to budget in M2/M3, all extension-level work (not model
+work): list indent/dedent commands (Wordgard core ships none; build on
+`wrapBlockRange`/`unwrapBlock` with flat-list's only-move-the-selected-range
+semantics as the behavior bar), the `[ ] ` task input rule, checkbox click
+handling via `TaskItem` tag decorations, and a toggle-checked command +
+keybinding.
 
 ## Milestones
 

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -188,6 +188,32 @@ exists):
   that invariant). The PM table extension consumes it; the Wordgard codec
   adopts it with table specs in M3. That closes M1 entirely except for
   the M3-scheduled Wordgard table specs themselves.
+- **Frontmatter parity (integrated after PR #615 landed on main):** the
+  Wordgard codec now supports YAML frontmatter — `Frontmatter` plot in
+  wordgard-utils (inline text content, `Node.Role.Code`, admitted into
+  `Doc` via `frontmatterDocContentOverride`; the shared tokenizer only
+  produces the token at line 0, so position/single-instance invariants
+  are editor-milestone corrections, not schema rules), a `MarkdownSpec`
+  byte-matching the PM serializer, and `frontmatterTokenizer` wired into
+  `createNoteMarkdownCodec`. The PM engine's new doc-leading
+  thematic-break rule (`---` at document start serializes as `***` so it
+  cannot re-parse as a frontmatter fence) is mirrored in the Wordgard hr
+  spec. Corpus: frontmatter fixtures (with body, alone, empty, `...`
+  closing-fence normalization, unclosed-fence stays a thematic break,
+  mid-document `---` untouched) plus the reworked thematic-break
+  fixtures are all BOTH_ENGINES.
+- **Coordination rule with plan 012 (markdown feature parity):** every
+  012 construct changes what a note's bytes mean, so each 012 milestone
+  must either land the Wordgard `MarkdownSpec` + BOTH_ENGINES corpus
+  fixtures in the same stream, or explicitly add its fixtures as
+  `engines: ['prosemirror']` so the parity worklist stays visible. Two
+  012 items are load-bearing here: enabling `linkify` in the BASE
+  tokenizer (012-M2) changes the shared token stream and would make the
+  Wordgard parser throw on every bare URL unless its handler ships
+  simultaneously; and 012-M5/M6 normalization decisions (reference
+  links, entities) are already pinned as cross-engine `canonical` corpus
+  fixtures — changing them means updating the corpus contract, not just
+  PM specs.
 
 ## Guiding principles
 
@@ -518,6 +544,7 @@ From the current extension inventory (`core/editor/src/extensions.ts`).
 | bold, italic, strike, inline code, underline | Built-in marks | M2 |
 | bullet/ordered lists | Built-in list extensions; build indent/dedent commands (M2-L1/M2-L2, see Lists section) | M2 |
 | code block + language | Built-in (`CodeBlock` + `CodeBlockLanguage` mark) | M2 |
+| YAML frontmatter | `Frontmatter` plot + codec spec landed (M1 hardening); editing chrome/corrections with M2 | done (codec) |
 | undo/redo history | Built-in (`wordgard/history`) | M2 |
 | link mark + link menu | Built-in link mark; popover is wordgard-plus `link-popover` (M4-P2) | M3–M4 |
 | image node, local-image node view, resize | Built-in image/figure/`imageResizing`; asset resolution is ours | M5 |

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -10,6 +10,7 @@ owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/609
   - https://github.com/bangle-io/bangle-io/pull/613
+  - https://github.com/bangle-io/bangle-io/pull/616
 related_issues: []
 ---
 

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -178,9 +178,16 @@ exists):
   - The inline token's own `content` is kept in sync when the marker is
     sliced off (it used to go stale), and the emptied text child is
     removed.
-- Still open in M1 scope: moving the table markdown-it plugin
-  (`banger-editor/table/table-markdown.ts`) into the shared layer and adding
-  Wordgard table specs when the second engine needs table parity (M3).
+- **Table syntax now lives in the shared layer too:** the GFM table
+  markdown-it plugin (enable `table` + the `<br>`-in-cell → hardbreak
+  rule) moved from `banger-editor/table/table-markdown.ts` into
+  `@bangle.io/markdown-syntax` as the opt-in `tableTokenizer` (same
+  posture as `wikiLinkTokenizer` — deliberately NOT part of the base
+  tokenizer, because an engine without table handling must not receive
+  table tokens or table notes would fail to parse; a tokenizer test pins
+  that invariant). The PM table extension consumes it; the Wordgard codec
+  adopts it with table specs in M3. That closes M1 entirely except for
+  the M3-scheduled Wordgard table specs themselves.
 
 ## Guiding principles
 

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -492,13 +492,13 @@ From the current extension inventory (`core/editor/src/extensions.ts`).
 | --- | --- | --- |
 | doc/paragraph/text, heading, blockquote, hr, hard break | Built-in (`wordgard/types`, `wordgard/schema`) | M2 |
 | bold, italic, strike, inline code, underline | Built-in marks | M2 |
-| bullet/ordered lists | Built-in list extensions | M2 |
+| bullet/ordered lists | Built-in list extensions; build indent/dedent commands (M2-L1/M2-L2, see Lists section) | M2 |
 | code block + language | Built-in (`CodeBlock` + `CodeBlockLanguage` mark) | M2 |
 | undo/redo history | Built-in (`wordgard/history`) | M2 |
 | link mark + link menu | Built-in link + dialog; restyle/bridge to our UI | M3–M4 |
 | image node, local-image node view, resize | Built-in image/figure/`imageResizing`; asset resolution is ours | M5 |
 | tables + table menu | Built-in `wordgard/table` (cell selection, commands, rectangularity corrections) + our markdown | M3 |
-| task lists (flat-list `kind: task`, checked, collapsed) | Build: `TaskItem` plot (param = checked) in wordgard-utils | M3 |
+| task lists (flat-list `kind: task`, checked; toggle/collapsed dropped) | `TaskItem` plot landed in M1; commands/input rule/checkbox are M3-T1..T3 (see Lists section) | M3 |
 | wiki link node + `[[` suggestions | Build in wordgard-utils (syntax + node) / editor-w (target resolution) | M3 |
 | markdown parse/serialize (pm-markdown) | **Build: `wordgard-markdown`** — the critical path | M1 |
 | slash commands, date picker suggestions | Build: trigger machinery in wordgard-utils; UI in editor-w | M4 |
@@ -546,12 +546,83 @@ supporting it would fight the fidelity invariant). Documents are stored as
 markdown, so no `migrateDocJSON`-style model migration exists between the
 engines.
 
-Known 1p gaps to budget in M2/M3, all extension-level work (not model
-work): list indent/dedent commands (Wordgard core ships none; build on
-`wrapBlockRange`/`unwrapBlock` with flat-list's only-move-the-selected-range
-semantics as the behavior bar), the `[ ] ` task input rule, checkbox click
-handling via `TaskItem` tag decorations, and a toggle-checked command +
-keybinding.
+Known 1p gaps, all extension-level work (not model work), broken into
+sub-milestones below. Everything lands as one extension bundle per the
+`wordgard` skill (schema element + commands + keybindings + input rules +
+menu items + styles + MarkdownSpec + corpus fixtures), with the reusable
+parts in `@bangle.io/wordgard-utils` and app wiring in editor-w.
+
+**M2-L1 — list keymap baseline (1p commands only).** Wire what Wordgard
+already ships: `bulletList()`/`orderedList()` bundles (schema, `- `/`1. `
+input rules, menu buttons), `toggleList` on Mod-Shift-8/9 (PM key parity),
+`splitTextblock` on Enter (splits the item), `joinListItems`/`joinBackward`
+on Backspace at item start, `listIsActive` for menu state. No custom code
+beyond keybinding glue. Exit: create/edit/split/join bullet and ordered
+lists; every doc a command produces serializes to corpus-stable markdown.
+
+**M2-L2 — indent/dedent commands (the real gap; build in wordgard-utils).**
+Wordgard core ships no list indent/dedent. Build `indentListItem` /
+`dedentListItem` as spec-returning commands over the nested model, using
+`wrapBlockRange`/`unwrapBlock`/`findWrappable` and multi-change specs in
+original coordinates (no offset surgery). Behavior bar is flat-list's
+"accurate range" semantics — only the selected items move:
+
+- *Indent:* the selected item(s) move into a nested list (same kind as the
+  enclosing list) appended to the previous sibling item's content. No
+  previous sibling → no-op. Tab keybinding, list-scoped.
+- *Dedent:* the selected item(s) move out to the parent list after their
+  containing item; unselected trailing siblings of the dedented item become
+  a nested list inside it (they must not travel up — that is the exact
+  flat-list improvement over `liftListItem`). At top level, dedent unwraps
+  the item into its blocks. Shift-Tab keybinding.
+- Nested-list kind is preserved on both moves (an ordered sub-list stays
+  ordered when its parent chain changes).
+
+Tests: unit specs asserting the exact output document per selection shape
+(single item, range spanning siblings, range spanning nesting levels,
+first/last item, item with trailing siblings), plus a markdown round-trip
+assertion on every produced doc. Exit: Tab/Shift-Tab muscle-memory parity
+with the PM engine for bullet/ordered lists.
+
+**M3-T1 — task commands.** `toggleTaskList` (rewrites the selected items'
+tags between `ListItem` and `TaskItem.of(false)`; wraps unlisted blocks in
+a bullet list of task items first, mirroring PM's toggle) on Mod-Shift-7,
+and `toggleTaskChecked` (flips the containing `TaskItem`'s boolean param)
+on Mod-Enter. Both spec-returning, both keyed by tag objects, both unit
+tested with round-trip assertions.
+
+**M3-T2 — task input rule.** Typing `[ ] ` or `[x] ` at the start of a
+textblock converts it to an (un)checked task item — inside a list it
+retags the item; outside it wraps in a bullet list first (parity with PM's
+`wrappingListInputRule(/^\s*(\[([ |x])\])\s$/)`). Ships in the same
+extension bundle as M3-T1.
+
+**M3-T3 — checkbox rendering + click.** `TaskItem`'s shape already renders
+`li[data-task-checked]`; add the interactive checkbox as a tag decoration
+(never a NodeView — they don't exist) whose click dispatches one coherent
+transaction flipping that item's param by document offset, without moving
+the selection or requiring focus. Styling via `Wordgard.styles` with
+`&dark`/`&light`. E2E covers click-to-check on a real note (checked state
+must survive reload — it is document content).
+
+**Deliberately not built:** toggle/collapsible lists (no markdown
+serialization exists in the PM engine either; the input rule there is
+commented out — carrying them would add an unserializable construct) and a
+correction evicting `TaskItem` from `OrderedList` (the shape only arises
+from parsing `1. [ ] x`, and the serializer already normalizes it to
+`- [ ] x`; add a correction only if editing commands prove able to create
+the shape unintentionally).
+
+**Round-trip gate interaction (decide in M2):** the corpus now
+distinguishes byte-stable fixtures from `canonical` normalization fixtures
+(`1. [ ] x` → `- [ ] x`, `*em*` → `_em_`, ...). A byte-strict gate opens
+every normalizing note read-only, even though the PM engine silently
+rewrites the same notes on save today. Default to strict (read-only is the
+conservative, data-safe choice); if dogfooding shows it fires often,
+extend the gate with a second class — "output differs from source, but the
+output is itself a fixed point AND the PM engine produces identical bytes"
+— which may open editable behind an explicit "this note will be
+normalized on first save" notice. Never silently widen the gate.
 
 ## Milestones
 
@@ -592,15 +663,21 @@ before it.
 Wordgard editor wired in editor-w: schema assembly from wordgard-utils
 bundles, history, keymaps, input rules, styles/theme (dark/light via
 Wordgard's `&dark`/`&light`), `t`→PhraseSet bridge; save pipeline through
-the extracted `editor-common` save queue; round-trip gate live. Exit: you
-can live in editor-w for plain notes (paragraphs/headings/lists/marks/code)
-with durable, gate-protected saves; persistence smoke (create → edit →
-reload → verify) passes on editor-w.
+the extracted `editor-common` save queue; round-trip gate live (including
+the strict-vs-normalizing policy decision — see "Round-trip gate
+interaction" under the Lists section). List editing lands as sub-milestones
+M2-L1 (1p keymap baseline) and M2-L2 (indent/dedent commands — the one
+real 1p gap), specified in the Lists section. Exit: you can live in
+editor-w for plain notes (paragraphs/headings/lists/marks/code) with
+durable, gate-protected saves and Tab/Shift-Tab list parity; persistence
+smoke (create → edit → reload → verify) passes on editor-w.
 
 **M3 — Bangle constructs**
-Task lists, wiki links + `[[` suggestions, tables + markdown, heading
-navigation. Exit: a typical existing Bangle note passes the round-trip gate
-and is fully editable.
+Task lists (sub-milestones M3-T1 commands, M3-T2 input rule, M3-T3
+checkbox rendering + click — specified in the Lists section), wiki links +
+`[[` suggestions, tables + markdown, heading navigation. Exit: a typical
+existing Bangle note passes the round-trip gate and is fully editable,
+including checking a task with the mouse.
 
 **M4 — Interaction chrome**
 Slash commands, date picker, selection/link/table menus, placeholder,

--- a/plans/012-markdown-feature-parity.md
+++ b/plans/012-markdown-feature-parity.md
@@ -115,6 +115,24 @@ reference links exactly like we do today.
    command/keymap specs; exact-string round-trip specs in
    `packages/core/editor/src/__tests__/`; one thin Playwright E2E per
    user-visible feature. Every intentional normalization asserted visibly.
+6. **Cross-engine parity (plan 011 coordination)** — every construct here
+   changes what a note's bytes mean, and two engines read those bytes.
+   Each milestone must either land the Wordgard side in the same stream
+   (`MarkdownSpec` in `wordgard-markdown`, schema element in
+   `wordgard-utils` if needed, BOTH_ENGINES fixtures in the shared golden
+   corpus `@bangle.io/test-utils/markdown-corpus.ts`) or explicitly add
+   its corpus fixtures as `engines: ['prosemirror']` so the parity
+   worklist stays visible. Two hard constraints:
+   - Anything added to the **base** tokenizer (M2 plans to enable
+     `linkify` there) reaches the Wordgard parser immediately, which
+     throws on unknown token types — the Wordgard handler must ship in
+     the same change, or the rule must stay opt-in until it does.
+     Keep new rules opt-in (like `frontmatterTokenizer`/`tableTokenizer`)
+     unless both engines are ready.
+   - The M5 (reference links) and entity normalizations are already
+     pinned as cross-engine `canonical` fixtures in the golden corpus;
+     changing that behavior means updating the shared corpus contract,
+     not just PM specs.
 
 ## Milestones (fidelity first)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,9 +490,6 @@ importers:
 
   packages/js-lib/markdown-syntax:
     dependencies:
-      '@bangle.dev/pm-markdown':
-        specifier: 2.0.0-alpha.18
-        version: 2.0.0-alpha.18(prosemirror-markdown@1.13.4)
       markdown-it:
         specifier: 14.3.0
         version: 14.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,10 @@ importers:
       shiki:
         specifier: ^4.3.0
         version: 4.3.0
+    devDependencies:
+      '@bangle.io/test-utils':
+        specifier: workspace:*
+        version: link:../../tooling/test-utils
 
   packages/core/initialize-services:
     dependencies:
@@ -519,6 +523,31 @@ importers:
       prosemirror-model:
         specifier: ^1.25.9
         version: 1.25.9
+
+  packages/js-lib/wordgard-markdown:
+    dependencies:
+      '@bangle.io/markdown-syntax':
+        specifier: workspace:*
+        version: link:../markdown-syntax
+      '@bangle.io/wordgard-utils':
+        specifier: workspace:*
+        version: link:../wordgard-utils
+      markdown-it:
+        specifier: 14.3.0
+        version: 14.3.0
+    devDependencies:
+      '@bangle.io/test-utils':
+        specifier: workspace:*
+        version: link:../../tooling/test-utils
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
+
+  packages/js-lib/wordgard-utils:
+    dependencies:
+      wordgard:
+        specifier: 0.1.1
+        version: 0.1.1
 
   packages/platform/service-platform:
     dependencies:
@@ -2491,6 +2520,9 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@marijn/find-cluster-break@1.0.3':
+    resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
 
   '@mswjs/interceptors@0.37.6':
     resolution: {integrity: sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==}
@@ -5127,6 +5159,9 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  crelt@1.0.7:
+    resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
@@ -8227,6 +8262,9 @@ packages:
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
@@ -8814,6 +8852,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wordgard@0.1.1:
+    resolution: {integrity: sha512-gmXxOnWPM+OWNkeDMvFgRh6h0CrJKrVRjMroBool0/FUfwZbkEI5GGnwXl0xIhi4vxJLBCYLFlXw7rQrkP1kDA==}
+    engines: {node: '>=22'}
 
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
@@ -10691,6 +10733,8 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@marijn/find-cluster-break@1.0.3': {}
 
   '@mswjs/interceptors@0.37.6':
     dependencies:
@@ -13100,6 +13144,8 @@ snapshots:
 
   create-require@1.1.1:
     optional: true
+
+  crelt@1.0.7: {}
 
   cross-dirname@0.1.0:
     optional: true
@@ -16862,6 +16908,8 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
+  style-mod@4.1.3: {}
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
@@ -17409,6 +17457,12 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wordgard@0.1.1:
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.3
+      crelt: 1.0.7
+      style-mod: 4.1.3
 
   wordwrap@1.0.0: {}
 


### PR DESCRIPTION
## Summary

Completes the core of **M1** of [plan 011](https://github.com/bangle-io/bangle-io/blob/main/plans/011-wordgard-editor-w-migration.md) — the schwerpunkt milestone: nothing writable ships in editor-w before the markdown bridge and its parity contract exist.

- **`@bangle.io/wordgard-utils`** (js-lib, universal): the single `wordgard/*` import chokepoint, with `wordgard` exact-pinned at `0.1.1`. Re-exports `wordgard/doc` + `wordgard/types` (grows per milestone), plus the first custom schema elements written Wordgard-style (one param + marks): `TaskItem` (`Plot.Type<boolean>`, param = checked, with a `Schema.Override` slotting it into the built-in `BulletList`), `WikiLink` (`Leaf.Type<string>`, param = target) + `WikiLinkLabel` mark, and `LinkTitle`/`ImageTitle` marks so `[a](b "title")` fidelity survives.
- **`@bangle.io/wordgard-markdown`** (js-lib, universal): the missing prosemirror-markdown equivalent — a pure, editor-free `markdown ⇄ Plot.Doc` codec on the shared `@bangle.io/markdown-syntax` tokenizer. `MarkdownSpec`s are keyed by node/mark **type objects**, not string names; the parser/serializer state are faithful ports of prosemirror-markdown's `MarkdownParseState`/`MarkdownSerializerState` (MIT, attributed in-file). Byte-parity subtleties were ground-truthed against live ProseMirror-engine output rather than read from source: loose (blank-line-separated) list items, fixed `1.` ordered markers, 2-space nesting indent, heading start-of-line escaping, the autolink heuristic, adaptive code fences/backticks, hard-break mark boundaries.
- **Golden corpus** (`@bangle.io/test-utils/markdown-corpus.ts`, 69 canonical-form fixtures) with per-engine flags and **both-engine round-trip contract tests**: the ProseMirror engine in `core/editor` and the Wordgard codec in `wordgard-markdown` must each round-trip every applicable fixture byte-identically. Table fixtures are `['prosemirror']` until M3, which keeps the parity worklist visible. Constructs with no byte-stable PM fixed point (lists nested under ordered items, indented code blocks, mid-word escaped underscores, …) are documented in the corpus with exact diffs instead of silently omitted.
- Plan 011 updated: M1 exit (corpus green on both engines headlessly) met for the non-table schema; table markdown moves shared in M3.

## Verification

- `pnpm lint:ci` ✅ (workspace validation + tsgo + Biome)
- `pnpm knip:ci` ✅
- `pnpm test:ci` ✅ — 1611 passed (≈195 new: 122 codec tests incl. 64 corpus fixtures on Wordgard, 69 corpus fixtures on ProseMirror)
- `pnpm e2e:ci` ✅ (full Playwright E2E + component suite, worktree ports)
- `pnpm desktop:ci` ✅
- No app runtime behavior changes: headless libraries + tests only (the only production-adjacent edit is a `core/editor` devDependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review hardening (second commit)

Adversarial A/B probing of both engines against identical inputs (compared byte-for-byte against prosemirror-markdown's own source and test suite) surfaced real gaps the first pass missed; all fixed and re-verified:

- **Wordgard mark-nesting bug (data-mangling):** Wordgard's built-in mark ranks (`Link 20 < Strike 42 < Em 50 < Strong 60 < Code 80`) are nearly the reverse of the PM schema's, so `**[link](x) is bold**` serialized as `[**link**](x)** is bold**` — invalid markdown that corrupts on re-parse. The serializer now orders spanning marks by mark-spec registration order (`serializationMarks`), making `defaultMarkdownSpecs` mark order load-bearing (outermost first, `Code` innermost).
- **Autolink URL corruption in BOTH engines:** `<https://x/_f>` serialized as `<https://x/\_f>`. Both engines now implement prosemirror-markdown's `inAutolink` protocol (banger-editor `base.ts`/`link.ts`, wordgard codec).
- **Image alt truncation in BOTH engines:** `![a\]b](x)` lost everything after the escape (upstream prosemirror-markdown reads only `children[0]`); alt now joins all markdown-it children.
- **Corpus test didn't match the shipping app:** the PM corpus test registered extensions in a different order than `setupExtensions`, blessing canonical forms (`_~~x~~_`) the real app never emits (`~~_x_~~`). Now mirrors the app's relative mark order.
- **Corpus contract extended:** optional `canonical` field for inputs both engines normalize identically (star emphasis, setext headings, indented code, reference links, thematic-break variants, two-space hard breaks, …), each asserted to be a fixed point itself. Fixture set grew 69 → ~140; constructs with no shared fixed point are documented in place (code spans inside marks, task-item continuation paragraphs, empty-label links, nested marks inside link text).
- **Serialize-only tests ported from prosemirror-markdown's suite** for doc shapes the parser can't produce (trailing hard breaks, whitespace expulsion, mark-order pinning), plus small cleanups (`Mark.sameSet`, dead `state.quote` removed).

Deliberate, documented divergences kept because they preserve user data and cost no shared-corpus parity: Wordgard's link mark is `mixable` (PM splits `[link _foo **bar**_](x)` into three links — output that fails even PM's own round trip), and Wordgard does not copy PM's code-mark exclude-all rule (PM silently unbolts `**bold `code`**`).

Re-verified after hardening: `pnpm lint:ci` ✅ · `pnpm knip:ci` ✅ · `pnpm test:ci` ✅ (1758 passed) · `pnpm e2e:ci` ✅

## List/task syntax hardening (third commit)

The markdown-it list plugin (kind stamping + GFM task detection) is vendored from `@bangle.dev/pm-markdown` into `@bangle.io/markdown-syntax` — the engine-neutral layer it defines semantics for — with shared `LIST_KIND_ATTR`/`TASK_CHECKED_ATTR` constants now used by both codecs. The rewrite drops dead code (a `tight` attr that was always `"false"`, an unused ordered `order` attr, an HTML renderer override) and fixes gaps found by A/B probing, each pinned by tokenizer tests + corpus fixtures:

- **Crash fixed:** `1. [ ] x` (GFM-legal task inside an ordered list) crashed the Wordgard codec (`OrderedList cannot contain child TaskItem`) — a legal note would fail to load. The schema now admits the transient shape; serialization normalizes to `- [ ] x`, byte-identical with PM.
- **Empty tasks** (`- [ ]`, `- [x]`) now recognized, matching GitHub.
- Token-stream hygiene: inline `content` stays in sync after marker stripping; emptied text children removed; non-task lookalikes pinned as fixtures.

Plan 011 also records the list-model decision: editor-w stays on Wordgard's built-in nested list model (no `prosemirror-flat-list`-style port), with the M2/M3 gap list (indent/dedent commands, task input rule, checkbox interaction).

Re-verified: `pnpm lint:ci` ✅ · `knip:ci` ✅ · `test:ci` ✅ (1790 passed) · `e2e:ci` ✅ (113 + 7 passed, 1 flaky-passed-on-retry)
