### PR TITLE
feat(storage): remote HTTP file storage (bring-your-own-server, Docker, Electron)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the Docker build context small and reproducible. The image rebuilds
+# dependencies and the front-end from source, so local artifacts are excluded.
+**/node_modules
+**/dist
+**/build
+**/.turbo
+**/coverage
+**/playwright-report
+**/test-results
+.git
+.claude/worktrees
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules/
 packages/tooling/browser-entry/dist
 packages/tooling/desktop-entry/dist
 packages/tooling/desktop-entry/release
+packages/tooling/remote-file-server/dist
 *storybook.log
 /blob-report/
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@
 
 Head to <https://bangle.io> to use the app.
 
+### Self-hosting / bring your own server
+
+Bangle.io can store a workspace on a server you control over a small HTTP API —
+use it with app.bangle.io, self-host the whole thing with Docker, or run it on
+the desktop. See [docs/remote-file-storage.md](docs/remote-file-storage.md).
+
+```bash
+# Self-host the app + your notes in one container
+docker build -f packages/tooling/remote-file-server/Dockerfile -t bangle-io .
+docker run -p 8000:8000 -v bangle-data:/data bangle-io   # http://localhost:8000
+```
+
 ### Development
 
 - `pnpm install` to install

--- a/docs/remote-file-storage.md
+++ b/docs/remote-file-storage.md
@@ -1,0 +1,163 @@
+# Remote file storage (bring your own server)
+
+Bangle.io can store a workspace's notes on **your own server** instead of in the
+browser or the local filesystem. You run a small server that speaks a simple
+HTTP API; Bangle.io reads and writes Markdown files through it. Your notes never
+touch Bangle.io's infrastructure.
+
+The same protocol powers three deployments:
+
+| Deployment | Front-end | Backend | Transport |
+| --- | --- | --- | --- |
+| **Bring your own server** | app.bangle.io (or your build) | your HTTP server | HTTPS |
+| **Self-hosted / Docker** | served by your server | same server | same-origin HTTP |
+| **Electron desktop** | in-app | the desktop app's main process | IPC |
+
+The packages involved:
+
+- [`@bangle.io/remote-file-sync`](../packages/js-lib/remote-file-sync) —
+  engine-neutral protocol, request router, HTTP client, and an in-memory store.
+  Zero dependencies; runs in the browser and Node.
+- [`@bangle.io/remote-file-server`](../packages/tooling/remote-file-server) —
+  a reference Node server (disk-backed) that also serves the app.
+
+---
+
+## 1. Bring your own server (with app.bangle.io)
+
+Run the reference server anywhere you like:
+
+```bash
+git clone https://github.com/bangle-io/bangle-io
+cd bangle-io && pnpm install
+BANGLE_FILE_SERVER_ROOT=./notes \
+BANGLE_FILE_SERVER_TOKEN=my-secret-token \
+  pnpm --filter @bangle.io/remote-file-server start
+# -> listening on http://localhost:8000
+```
+
+Put it behind HTTPS (a reverse proxy such as Caddy/nginx/Cloudflare Tunnel) so
+your token is not sent in the clear. Then, in Bangle.io:
+
+1. **Create Workspace → Remote Server**
+2. **Server URL:** `https://notes.example.com`
+3. **Access token:** `my-secret-token` (omit if your server has none)
+
+The token is stored **locally in your browser only** (in the workspace metadata)
+and sent as `Authorization: Bearer <token>`. Your server must send permissive
+CORS headers so `app.bangle.io` can reach it — the reference server already does.
+
+## 2. Self-hosted app + storage (Docker)
+
+One container serves both the app and the API, so there is nothing to configure
+in the UI (the workspace defaults to the same origin):
+
+```bash
+docker build -f packages/tooling/remote-file-server/Dockerfile -t bangle-io .
+docker run -p 8000:8000 -v bangle-data:/data bangle-io
+# open http://localhost:8000
+```
+
+Or with Compose (persistent named volume):
+
+```bash
+docker compose -f packages/tooling/remote-file-server/docker-compose.yml up --build
+```
+
+In this mode the app is served with a marker that lets the "Remote Server"
+dialog prefill the URL with the current origin — create a workspace and go.
+
+## 3. Electron desktop
+
+The desktop app hosts the file store in its **main process** and exposes it to
+the renderer over IPC. Choosing **Remote Server** on desktop pre-fills the URL
+with the sentinel `bangle-desktop://local`; the renderer routes those requests
+through IPC (no socket, no token). Files live under the app's user-data
+directory (override with `BANGLE_DESKTOP_WORKSPACE_ROOT`). This reuses the exact
+same provider and protocol as the HTTP path — see
+[`remote-fs.ts`](../packages/tooling/desktop-entry/src/remote-fs.ts).
+
+---
+
+## The HTTP API
+
+All routes are mounted under `/api/v1`. A **path** (`fsPath`) is a POSIX,
+workspace-scoped path whose first segment is the workspace name, e.g.
+`myNotes/journal/2024.md`. It never contains `.`/`..` segments or a leading `/`.
+
+Authentication: if the server is configured with a token, every request except
+`GET /health` must include `Authorization: Bearer <token>`, otherwise it returns
+`401`.
+
+| Method & path | Purpose | Success | Errors |
+| --- | --- | --- | --- |
+| `GET /health` | Liveness + capabilities | `200` `{name, apiVersion, workspaces?}` | — |
+| `GET /files?ws=<ws>` | List a workspace's files | `200` `{paths: string[]}` | `401` |
+| `GET /file?path=<fsPath>` | Read file bytes | `200` bytes + stat headers | `404` |
+| `HEAD /file?path=<fsPath>` | Existence + stat | `200` / `404` | — |
+| `POST /file?path=<fsPath>` | Create (body = bytes) | `201` | `409` exists |
+| `PUT /file?path=<fsPath>` | Overwrite existing (body = bytes) | `200` | `404` missing |
+| `DELETE /file?path=<fsPath>` | Delete | `200` | `404` missing |
+| `POST /rename` `{from,to}` | Rename/move | `200` | `404` source missing |
+| `GET /stat?path=<fsPath>` | File timestamps | `200` `{ctime, mtime}` | `404` |
+
+Read/stat responses carry `x-bangle-mtime` and `x-bangle-ctime` headers
+(milliseconds since epoch). Every non-2xx response is JSON:
+`{ "error": "<code>", "message"?: "…" }` where `<code>` is one of
+`not-found`, `already-exists`, `invalid-path`, `unauthorized`, `bad-request`,
+`network`, `server-error`.
+
+### Behavioural contract (data safety)
+
+- `POST` must **not** overwrite an existing file (`409`).
+- `PUT` must **not** create a missing file (`404`) — writes only target existing
+  notes so a lost read never turns into an empty write.
+- Reads of a missing file return `404`; the client treats that as "absent", never
+  as empty content.
+- Paths are validated server-side; traversal outside the storage root is rejected.
+
+### curl examples
+
+```bash
+BASE=http://localhost:8000/api/v1
+AUTH='-H "Authorization: Bearer my-secret-token"'
+
+curl $BASE/health
+curl -X POST  "$BASE/file?path=demo/hello.md" --data-binary 'Hello'   # create
+curl          "$BASE/file?path=demo/hello.md"                          # read
+curl -X PUT   "$BASE/file?path=demo/hello.md" --data-binary 'Hello v2' # write
+curl          "$BASE/files?ws=demo"                                    # list
+curl -X POST  "$BASE/rename" -d '{"from":"demo/hello.md","to":"demo/hi.md"}'
+curl -X DELETE "$BASE/file?path=demo/hi.md"                            # delete
+```
+
+---
+
+## Build your own server
+
+You don't have to use the reference server. Two building blocks make it easy:
+
+**`createRemoteRouter(store, { token })`** turns any `RemoteFileStore` into an
+engine-neutral request handler, so you only write a thin transport adapter. The
+[server README](../packages/tooling/remote-file-server/README.md#build-your-own-server)
+has a complete Express example.
+
+**Implement `RemoteFileStore`** to back the API with anything — S3, a database,
+git — by satisfying this interface (from `@bangle.io/remote-file-sync`):
+
+```ts
+interface RemoteFileStore {
+  list(wsName, signal?): Promise<string[]>;
+  read(fsPath, signal?): Promise<{ bytes, stat } | undefined>;
+  stat(fsPath, signal?): Promise<{ ctime, mtime } | undefined>;
+  create(fsPath, bytes, signal?): Promise<void>;   // throw already-exists
+  write(fsPath, bytes, signal?): Promise<void>;     // throw not-found
+  delete(fsPath, signal?): Promise<void>;           // throw not-found
+  rename(from, to, signal?): Promise<void>;         // throw not-found
+  listWorkspaces?(signal?): Promise<string[]>;
+}
+```
+
+Throw `RemoteFileError('already-exists' | 'not-found' | 'invalid-path')` where
+the contract requires it and the router maps it to the right HTTP status. Add
+contract tests with the in-memory store as a reference implementation.

--- a/docs/remote-file-storage.md
+++ b/docs/remote-file-storage.md
@@ -75,13 +75,18 @@ dialog prefill the URL with the current origin — create a workspace and go.
 
 ## 3. Electron desktop
 
-The desktop app hosts the file store in its **main process** and exposes it to
-the renderer over IPC. Choosing **Remote Server** on desktop pre-fills the URL
-with the sentinel `bangle-desktop://local`; the renderer routes those requests
-through IPC (no socket, no token). Files live under the app's user-data
-directory (override with `BANGLE_DESKTOP_WORKSPACE_ROOT`). This reuses the exact
-same provider and protocol as the HTTP path — see
+The desktop app adds a dedicated **"This device"** storage type (workspace type
+`electron`). It hosts the file store in the **main process** and exposes it to
+the renderer over IPC, so notes are written to local disk without a socket or
+token. Files live under the app's user-data directory (override with
+`BANGLE_DESKTOP_WORKSPACE_ROOT`). It reuses the exact same transport-agnostic
+provider and protocol as the HTTP path — only the injected client differs (IPC
+instead of `fetch`); see
 [`remote-fs.ts`](../packages/tooling/desktop-entry/src/remote-fs.ts).
+
+Desktop users can still use **"Remote Server"** to sync with an external HTTP
+server — the two storage types coexist, so the same app talks to both a local
+disk and a remote backend.
 
 ---
 

--- a/docs/remote-file-storage.md
+++ b/docs/remote-file-storage.md
@@ -41,11 +41,17 @@ your token is not sent in the clear. Then, in Bangle.io:
 
 1. **Create Workspace → Remote Server**
 2. **Server URL:** `https://notes.example.com`
-3. **Access token:** `my-secret-token` (omit if your server has none)
+3. **Access token:** `my-secret-token`
 
 The token is stored **locally in your browser only** (in the workspace metadata)
-and sent as `Authorization: Bearer <token>`. Your server must send permissive
-CORS headers so `app.bangle.io` can reach it — the reference server already does.
+and sent as `Authorization: Bearer <token>`.
+
+> **A token is required for this mode.** The reference server only sends
+> cross-origin (CORS) headers when a token is configured, so `app.bangle.io`
+> (a different origin) can reach it *only* with a token. A tokenless server also
+> binds loopback by default and is meant for same-origin/bundled use, not for
+> exposing on a network. Bangle.io checks the server is reachable and the token
+> is accepted before creating the workspace.
 
 ## 2. Self-hosted app + storage (Docker)
 

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -25,6 +25,24 @@ interface Window {
   showDirectoryPicker(
     options?: DirectoryPickerOptions,
   ): Promise<FileSystemDirectoryHandle>;
+  /**
+   * Injected by `@bangle.io/remote-file-server` when the app is served in
+   * bundled mode, so the front-end can default a remote workspace to this
+   * same origin.
+   */
+  __BANGLE_REMOTE__?: { bundled?: boolean };
+  /**
+   * Exposed by the Electron preload. `remoteFs.request` forwards a remote
+   * file-storage request to the main-process router over IPC.
+   */
+  bangleDesktop?: {
+    platform: string;
+    remoteFs?: {
+      request(
+        req: import('@bangle.io/remote-file-sync').RemoteRequest,
+      ): Promise<import('@bangle.io/remote-file-sync').RemoteResponse>;
+    };
+  };
 }
 
 declare module '@storybook/react' {

--- a/packages/core/app/package.json
+++ b/packages/core/app/package.json
@@ -36,6 +36,7 @@
     "@bangle.io/fuzzysearch": "workspace:*",
     "@bangle.io/logger": "workspace:*",
     "@bangle.io/omni-search": "workspace:*",
+    "@bangle.io/remote-file-sync": "workspace:*",
     "@bangle.io/types": "workspace:*",
     "@bangle.io/ui-components": "workspace:*",
     "@bangle.io/ws-path": "workspace:*",

--- a/packages/core/app/src/dialogs/create-workspace-dialog.tsx
+++ b/packages/core/app/src/dialogs/create-workspace-dialog.tsx
@@ -5,11 +5,55 @@ import {
   WORKSPACE_STORAGE_TYPE,
 } from '@bangle.io/constants';
 import { useCoreServices } from '@bangle.io/context';
+import {
+  createHttpRemoteClient,
+  isRemoteFileError,
+} from '@bangle.io/remote-file-sync';
 import { CreateWorkspaceDialog as UICreateWorkspaceDialog } from '@bangle.io/ui-components';
 import { WsPath } from '@bangle.io/ws-path';
 import { useAtom } from 'jotai';
 import React from 'react';
 import { nativeFsErrorParse } from '../common';
+
+/**
+ * Confirm a remote server is reachable and the token is accepted before we
+ * create the workspace, so a typo never yields a broken workspace whose empty
+ * listing could be mistaken for "no notes". Skipped for the in-process desktop
+ * backend (always available).
+ */
+async function probeRemoteServer(
+  wsName: string,
+  serverUrl: string,
+  token: string | undefined,
+): Promise<void> {
+  if (serverUrl === DESKTOP_REMOTE_FS_SERVER_URL) {
+    return;
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  try {
+    // `list` requires auth, so this catches an unreachable server, a wrong
+    // token (401), and a non-Bangle endpoint (missing API marker) alike.
+    const client = createHttpRemoteClient({ baseUrl: serverUrl, token });
+    await client.list(wsName, controller.signal);
+  } catch (error) {
+    const unauthorized =
+      isRemoteFileError(error) && error.code === 'unauthorized';
+    throwAppError(
+      'error::remote-storage:request-failed',
+      unauthorized
+        ? 'The server rejected the access token. Check the token and try again.'
+        : 'Could not reach the server. Check the URL (and token) and try again.',
+      {
+        wsName,
+        code: isRemoteFileError(error) ? error.code : 'network',
+        reason: error instanceof Error ? error.message : String(error),
+      },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
 /** A dialog component for creating a new workspace, allowing selection of storage type. */
 export function CreateWorkspaceDialog() {
@@ -54,6 +98,8 @@ export function CreateWorkspaceDialog() {
               { wsName },
             );
           }
+
+          await probeRemoteServer(wsName, serverUrl, token);
 
           await coreServices.workspaceOps.createWorkspaceInfo({
             name: wsName,

--- a/packages/core/app/src/dialogs/create-workspace-dialog.tsx
+++ b/packages/core/app/src/dialogs/create-workspace-dialog.tsx
@@ -1,9 +1,6 @@
 import { pickADirectory, supportsNativeBrowserFs } from '@bangle.io/baby-fs';
 import { throwAppError } from '@bangle.io/base-utils';
-import {
-  DESKTOP_REMOTE_FS_SERVER_URL,
-  WORKSPACE_STORAGE_TYPE,
-} from '@bangle.io/constants';
+import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
 import { useCoreServices } from '@bangle.io/context';
 import {
   createHttpRemoteClient,
@@ -18,17 +15,13 @@ import { nativeFsErrorParse } from '../common';
 /**
  * Confirm a remote server is reachable and the token is accepted before we
  * create the workspace, so a typo never yields a broken workspace whose empty
- * listing could be mistaken for "no notes". Skipped for the in-process desktop
- * backend (always available).
+ * listing could be mistaken for "no notes".
  */
 async function probeRemoteServer(
   wsName: string,
   serverUrl: string,
   token: string | undefined,
 ): Promise<void> {
-  if (serverUrl === DESKTOP_REMOTE_FS_SERVER_URL) {
-    return;
-  }
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 8000);
   try {
@@ -61,14 +54,14 @@ export function CreateWorkspaceDialog() {
   const [openWsDialog, setOpenWsDialog] = useAtom(
     coreServices.workbenchState.$openWsDialog,
   );
-  // Default the remote workspace URL to the most useful value for the current
-  // host: the desktop sentinel on Electron, this same origin when the app is
-  // served by a bundled file server, or empty for a hosted (BYO-server) app.
-  const desktopBridge =
-    typeof window !== 'undefined' ? window.bangleDesktop?.remoteFs : undefined;
-  const defaultRemoteServerUrl = desktopBridge
-    ? DESKTOP_REMOTE_FS_SERVER_URL
-    : typeof window !== 'undefined' && window.__BANGLE_REMOTE__?.bundled
+  // The desktop app exposes an IPC file backend; when present we offer the
+  // "This device" storage type.
+  const hasDesktopBackend =
+    typeof window !== 'undefined' && Boolean(window.bangleDesktop?.remoteFs);
+  // Default the "Remote Server" URL to this origin when the app is served by a
+  // bundled file server, otherwise empty (a hosted BYO-server app).
+  const defaultRemoteServerUrl =
+    typeof window !== 'undefined' && window.__BANGLE_REMOTE__?.bundled
       ? window.location.origin
       : '';
   return (
@@ -137,11 +130,16 @@ export function CreateWorkspaceDialog() {
           return;
         }
 
-        if (type === WORKSPACE_STORAGE_TYPE.Browser) {
+        if (
+          type === WORKSPACE_STORAGE_TYPE.Browser ||
+          type === WORKSPACE_STORAGE_TYPE.Electron
+        ) {
+          // Both are name-only: browser uses IndexedDB, electron uses the
+          // desktop's on-disk store (over IPC). No extra metadata is needed.
           await coreServices.workspaceOps.createWorkspaceInfo({
             metadata: {},
             name: wsName,
-            type: WORKSPACE_STORAGE_TYPE.Browser,
+            type,
           });
           setOpenWsDialog(false);
           coreServices.navigation.goWorkspace(wsName);
@@ -158,6 +156,16 @@ export function CreateWorkspaceDialog() {
         );
       }}
       storageTypes={[
+        // Offered only on the desktop app, where the IPC file backend exists.
+        ...(hasDesktopBackend
+          ? [
+              {
+                type: WORKSPACE_STORAGE_TYPE.Electron,
+                title: t.app.dialogs.createWorkspace.electronTitle,
+                description: t.app.dialogs.createWorkspace.electronDescription,
+              },
+            ]
+          : []),
         {
           type: WORKSPACE_STORAGE_TYPE.Browser,
           title: t.app.dialogs.createWorkspace.browserTitle,

--- a/packages/core/app/src/dialogs/create-workspace-dialog.tsx
+++ b/packages/core/app/src/dialogs/create-workspace-dialog.tsx
@@ -1,6 +1,9 @@
 import { pickADirectory, supportsNativeBrowserFs } from '@bangle.io/baby-fs';
 import { throwAppError } from '@bangle.io/base-utils';
-import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import {
+  DESKTOP_REMOTE_FS_SERVER_URL,
+  WORKSPACE_STORAGE_TYPE,
+} from '@bangle.io/constants';
 import { useCoreServices } from '@bangle.io/context';
 import { CreateWorkspaceDialog as UICreateWorkspaceDialog } from '@bangle.io/ui-components';
 import { WsPath } from '@bangle.io/ws-path';
@@ -14,10 +17,21 @@ export function CreateWorkspaceDialog() {
   const [openWsDialog, setOpenWsDialog] = useAtom(
     coreServices.workbenchState.$openWsDialog,
   );
+  // Default the remote workspace URL to the most useful value for the current
+  // host: the desktop sentinel on Electron, this same origin when the app is
+  // served by a bundled file server, or empty for a hosted (BYO-server) app.
+  const desktopBridge =
+    typeof window !== 'undefined' ? window.bangleDesktop?.remoteFs : undefined;
+  const defaultRemoteServerUrl = desktopBridge
+    ? DESKTOP_REMOTE_FS_SERVER_URL
+    : typeof window !== 'undefined' && window.__BANGLE_REMOTE__?.bundled
+      ? window.location.origin
+      : '';
   return (
     <UICreateWorkspaceDialog
       open={openWsDialog}
       onOpenChange={setOpenWsDialog}
+      defaultRemoteServerUrl={defaultRemoteServerUrl}
       validateWorkspace={({ name: wsName }) => {
         const result = WsPath.safeFromParts(wsName, '');
         if (result.ok) {
@@ -31,7 +45,29 @@ export function CreateWorkspaceDialog() {
             t.app.dialogs.createWorkspace.invalidName,
         };
       }}
-      onDone={async ({ name: wsName, type, dirHandle }) => {
+      onDone={async ({ name: wsName, type, dirHandle, serverUrl, token }) => {
+        if (type === WORKSPACE_STORAGE_TYPE.Remote) {
+          if (!serverUrl) {
+            throwAppError(
+              'error::workspace:invalid-metadata',
+              `Server URL for ${wsName} is required`,
+              { wsName },
+            );
+          }
+
+          await coreServices.workspaceOps.createWorkspaceInfo({
+            name: wsName,
+            type,
+            metadata: {
+              serverUrl,
+              ...(token ? { token } : {}),
+            },
+          });
+          setOpenWsDialog(false);
+          coreServices.navigation.goWorkspace(wsName);
+          return;
+        }
+
         if (type === WORKSPACE_STORAGE_TYPE.NativeFS) {
           if (!dirHandle) {
             throwAppError(
@@ -86,6 +122,11 @@ export function CreateWorkspaceDialog() {
           title: t.app.dialogs.createWorkspace.nativeFsTitle,
           description: t.app.dialogs.createWorkspace.nativeFsDescription,
           disabled: !supportsNativeBrowserFs(),
+        },
+        {
+          type: WORKSPACE_STORAGE_TYPE.Remote,
+          title: t.app.dialogs.createWorkspace.remoteTitle,
+          description: t.app.dialogs.createWorkspace.remoteDescription,
         },
       ]}
       onDirectoryPick={async () => {

--- a/packages/core/initialize-services/package.json
+++ b/packages/core/initialize-services/package.json
@@ -32,10 +32,12 @@
     "@bangle.io/base-utils": "workspace:*",
     "@bangle.io/color-scheme-manager": "workspace:*",
     "@bangle.io/command-handlers": "workspace:*",
+    "@bangle.io/constants": "workspace:*",
     "@bangle.io/commands": "workspace:*",
     "@bangle.io/context": "workspace:*",
     "@bangle.io/editor": "workspace:*",
     "@bangle.io/poor-mans-di": "workspace:*",
+    "@bangle.io/remote-file-sync": "workspace:*",
     "@bangle.io/service-core": "workspace:*",
     "@bangle.io/service-platform": "workspace:*",
     "@bangle.io/types": "workspace:*"

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -6,7 +6,11 @@ import {
 } from '@bangle.io/base-utils';
 import type { ThemeManager } from '@bangle.io/color-scheme-manager';
 import type { EnabledBangleAppCommand } from '@bangle.io/commands';
-import { DESKTOP_REMOTE_FS_SERVER_URL } from '@bangle.io/constants';
+import {
+  FILE_STORAGE_MAX_FILE_SIZE_BYTES,
+  SERVICE_NAME,
+  WORKSPACE_STORAGE_TYPE,
+} from '@bangle.io/constants';
 import { slot } from '@bangle.io/poor-mans-di';
 import {
   createHttpRemoteClient,
@@ -86,12 +90,17 @@ export function initializeServices(
         return { handle: rootDirHandle };
       },
     })),
+    // "Remote Server" — HTTP transport, built from the workspace's stored URL +
+    // token. An empty URL targets the same origin (bundled/Docker mode).
     fileStorageRemote: slot(FileStorageRemote, () => ({
+      serviceName: SERVICE_NAME.fileStorageRemoteService,
+      workspaceType: WORKSPACE_STORAGE_TYPE.Remote,
+      displayName: 'Remote Server',
+      description: 'Syncs notes with your own file server',
+      maxFileSizeBytes: FILE_STORAGE_MAX_FILE_SIZE_BYTES.remote,
       onChange: (change) => {
         commonOpts.logger.info('File storage change:', change);
       },
-      // Build an HTTP client from the workspace's stored connection details.
-      // An empty `serverUrl` targets the same origin (bundled/Docker mode).
       getClient: async (wsName: string) => {
         assertIsDefined(getWorkspaceOps, 'getWorkspaceOps');
         const metadata = await getWorkspaceOps().getWorkspaceMetadata(wsName);
@@ -112,24 +121,34 @@ export function initializeServices(
           );
         }
 
-        // On Electron, a workspace pointed at the desktop sentinel talks to the
-        // main-process file store over IPC instead of HTTP.
-        if (serverUrl === DESKTOP_REMOTE_FS_SERVER_URL) {
-          const bridge =
-            typeof window !== 'undefined'
-              ? window.bangleDesktop?.remoteFs
-              : undefined;
-          if (!bridge) {
-            throwAppError(
-              'error::remote-storage:request-failed',
-              'Desktop file backend is unavailable',
-              { wsName, code: 'network', reason: 'desktop bridge missing' },
-            );
-          }
-          return createRemoteClientFromRouter((req) => bridge.request(req));
-        }
-
         return createHttpRemoteClient({ baseUrl: serverUrl, token });
+      },
+    })),
+    // "This device" — the Electron desktop's on-disk store, reached over IPC to
+    // the main process. Same provider, different transport. On the web the
+    // bridge is absent, so this type is never offered nor resolvable.
+    fileStorageElectron: slot(FileStorageRemote, () => ({
+      serviceName: SERVICE_NAME.fileStorageElectronService,
+      workspaceType: WORKSPACE_STORAGE_TYPE.Electron,
+      displayName: 'This device',
+      description: 'Saves notes on this computer',
+      maxFileSizeBytes: FILE_STORAGE_MAX_FILE_SIZE_BYTES.electron,
+      onChange: (change) => {
+        commonOpts.logger.info('File storage change:', change);
+      },
+      getClient: (wsName: string) => {
+        const bridge =
+          typeof window !== 'undefined'
+            ? window.bangleDesktop?.remoteFs
+            : undefined;
+        if (!bridge) {
+          throwAppError(
+            'error::remote-storage:request-failed',
+            'Desktop file backend is unavailable',
+            { wsName, code: 'network', reason: 'desktop bridge missing' },
+          );
+        }
+        return createRemoteClientFromRouter((req) => bridge.request(req));
       },
     })),
     router: slot(BrowserRouterService, () => ({
@@ -150,6 +169,7 @@ export function initializeServices(
       'fileStorageIdb',
       'fileStorageNativeFs',
       'fileStorageRemote',
+      'fileStorageElectron',
     ],
   });
 

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -6,7 +6,12 @@ import {
 } from '@bangle.io/base-utils';
 import type { ThemeManager } from '@bangle.io/color-scheme-manager';
 import type { EnabledBangleAppCommand } from '@bangle.io/commands';
+import { DESKTOP_REMOTE_FS_SERVER_URL } from '@bangle.io/constants';
 import { slot } from '@bangle.io/poor-mans-di';
+import {
+  createHttpRemoteClient,
+  createRemoteClientFromRouter,
+} from '@bangle.io/remote-file-sync';
 import type { WorkspaceOpsService } from '@bangle.io/service-core';
 import {
   BrowserErrorHandlerService,
@@ -14,6 +19,7 @@ import {
   BrowserRouterService,
   FileStorageIndexedDB,
   FileStorageNativeFs,
+  FileStorageRemote,
   HashStrategy,
   IdbDatabaseService,
 } from '@bangle.io/service-platform';
@@ -80,6 +86,52 @@ export function initializeServices(
         return { handle: rootDirHandle };
       },
     })),
+    fileStorageRemote: slot(FileStorageRemote, () => ({
+      onChange: (change) => {
+        commonOpts.logger.info('File storage change:', change);
+      },
+      // Build an HTTP client from the workspace's stored connection details.
+      // An empty `serverUrl` targets the same origin (bundled/Docker mode).
+      getClient: async (wsName: string) => {
+        assertIsDefined(getWorkspaceOps, 'getWorkspaceOps');
+        const metadata = await getWorkspaceOps().getWorkspaceMetadata(wsName);
+        const serverUrl =
+          typeof metadata.serverUrl === 'string'
+            ? metadata.serverUrl
+            : undefined;
+        const token =
+          typeof metadata.token === 'string' && metadata.token.length > 0
+            ? metadata.token
+            : undefined;
+
+        if (serverUrl === undefined) {
+          throwAppError(
+            'error::workspace:invalid-metadata',
+            `Remote workspace ${wsName} is missing a server URL`,
+            { wsName },
+          );
+        }
+
+        // On Electron, a workspace pointed at the desktop sentinel talks to the
+        // main-process file store over IPC instead of HTTP.
+        if (serverUrl === DESKTOP_REMOTE_FS_SERVER_URL) {
+          const bridge =
+            typeof window !== 'undefined'
+              ? window.bangleDesktop?.remoteFs
+              : undefined;
+          if (!bridge) {
+            throwAppError(
+              'error::remote-storage:request-failed',
+              'Desktop file backend is unavailable',
+              { wsName, code: 'network', reason: 'desktop bridge missing' },
+            );
+          }
+          return createRemoteClientFromRouter((req) => bridge.request(req));
+        }
+
+        return createHttpRemoteClient({ baseUrl: serverUrl, token });
+      },
+    })),
     router: slot(BrowserRouterService, () => ({
       strategy: new HashStrategy(),
       basePath: '/ws',
@@ -94,7 +146,11 @@ export function initializeServices(
     themeManager: theme,
     shortcutTarget: document,
     platformServices: browserPlatformServices,
-    fileStorageSlots: ['fileStorageIdb', 'fileStorageNativeFs'],
+    fileStorageSlots: [
+      'fileStorageIdb',
+      'fileStorageNativeFs',
+      'fileStorageRemote',
+    ],
   });
 
   getWorkspaceOps = () => setup.getServices().workspaceOps;

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -543,6 +543,9 @@ export class FileSystemService extends BaseService {
       case WORKSPACE_STORAGE_TYPE.Remote: {
         return getDep(WORKSPACE_STORAGE_TYPE.Remote);
       }
+      case WORKSPACE_STORAGE_TYPE.Electron: {
+        return getDep(WORKSPACE_STORAGE_TYPE.Electron);
+      }
       case WORKSPACE_STORAGE_TYPE.Help:
       case WORKSPACE_STORAGE_TYPE.PrivateFS:
       case WORKSPACE_STORAGE_TYPE.Github: {

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -540,6 +540,9 @@ export class FileSystemService extends BaseService {
       case WORKSPACE_STORAGE_TYPE.Memory: {
         return getDep(WORKSPACE_STORAGE_TYPE.Memory);
       }
+      case WORKSPACE_STORAGE_TYPE.Remote: {
+        return getDep(WORKSPACE_STORAGE_TYPE.Remote);
+      }
       case WORKSPACE_STORAGE_TYPE.Help:
       case WORKSPACE_STORAGE_TYPE.PrivateFS:
       case WORKSPACE_STORAGE_TYPE.Github: {

--- a/packages/js-lib/remote-file-sync/__tests__/client.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/client.spec.ts
@@ -87,4 +87,36 @@ describe('createHttpRemoteClient over the in-process router', () => {
     });
     await expect(client.list('ws')).rejects.toMatchObject({ code: 'network' });
   });
+
+  it('treats a 404 WITHOUT the API marker as a transport error, not a missing file', async () => {
+    // e.g. a reverse proxy or wrong base path answering 404.
+    const client = createHttpRemoteClient({
+      baseUrl: 'https://proxy.test',
+      fetch: async () => ({
+        status: 404,
+        headers: { get: () => null },
+        async arrayBuffer() {
+          return new ArrayBuffer(0);
+        },
+        async text() {
+          return '<html>404 Not Found (nginx)</html>';
+        },
+      }),
+    });
+    // Must NOT be read as "file absent" — that would risk empty content.
+    await expect(client.read('ws/a.md')).rejects.toMatchObject({
+      code: 'server-error',
+    });
+    await expect(client.exists('ws/a.md')).rejects.toMatchObject({
+      code: 'server-error',
+    });
+  });
+
+  it('a genuine API 404 (marker present) still reads as a missing file', async () => {
+    // The router-backed setup() stamps the marker, so missing files resolve to
+    // undefined rather than throwing.
+    const { client } = setup();
+    expect(await client.read('ws/none.md')).toBeUndefined();
+    expect(await client.exists('ws/none.md')).toBe(false);
+  });
 });

--- a/packages/js-lib/remote-file-sync/__tests__/client.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/client.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { createFetchFromRouter, createHttpRemoteClient } from '../client';
+import { MemoryRemoteFileStore } from '../memory-store';
+import { createRemoteRouter } from '../router';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const text = (b: Uint8Array) => new TextDecoder().decode(b);
+
+function setup(options?: { token?: string; now?: () => number }) {
+  const store = new MemoryRemoteFileStore({ now: options?.now });
+  const router = createRemoteRouter(store, { token: options?.token });
+  const client = createHttpRemoteClient({
+    baseUrl: 'https://server.test',
+    token: options?.token,
+    fetch: createFetchFromRouter(router),
+  });
+  return { store, client };
+}
+
+describe('createHttpRemoteClient over the in-process router', () => {
+  it('reports health', async () => {
+    const { client } = setup();
+    const health = await client.health();
+    expect(health.apiVersion).toBe(1);
+  });
+
+  it('round-trips create -> read -> list -> stat -> rename -> delete', async () => {
+    const { client } = setup({ now: () => 7 });
+
+    await client.create('ws/a.md', bytes('hello'));
+    const read = await client.read('ws/a.md');
+    expect(text(read!.bytes)).toBe('hello');
+    expect(read!.stat.mtime).toBe(7);
+
+    expect(await client.list('ws')).toEqual(['ws/a.md']);
+    expect(await client.exists('ws/a.md')).toBe(true);
+    expect((await client.stat('ws/a.md'))?.ctime).toBe(7);
+
+    await client.rename('ws/a.md', 'ws/b.md');
+    expect(await client.exists('ws/a.md')).toBe(false);
+    expect(await client.exists('ws/b.md')).toBe(true);
+
+    await client.delete('ws/b.md');
+    expect(await client.exists('ws/b.md')).toBe(false);
+  });
+
+  it('read/stat resolve to undefined for missing files (never throw)', async () => {
+    const { client } = setup();
+    expect(await client.read('ws/none.md')).toBeUndefined();
+    expect(await client.stat('ws/none.md')).toBeUndefined();
+    expect(await client.exists('ws/none.md')).toBe(false);
+  });
+
+  it('surfaces already-exists and not-found as coded errors', async () => {
+    const { client } = setup();
+    await client.create('ws/a.md', bytes('x'));
+    await expect(client.create('ws/a.md', bytes('y'))).rejects.toMatchObject({
+      code: 'already-exists',
+    });
+    await expect(client.write('ws/none.md', bytes('z'))).rejects.toMatchObject({
+      code: 'not-found',
+    });
+    await expect(client.delete('ws/none.md')).rejects.toMatchObject({
+      code: 'not-found',
+    });
+  });
+
+  it('surfaces unauthorized when the token is wrong', async () => {
+    const store = new MemoryRemoteFileStore();
+    const router = createRemoteRouter(store, { token: 'right' });
+    const client = createHttpRemoteClient({
+      baseUrl: '',
+      token: 'wrong',
+      fetch: createFetchFromRouter(router),
+    });
+    await expect(client.list('ws')).rejects.toMatchObject({
+      code: 'unauthorized',
+    });
+  });
+
+  it('maps transport failures to a network error', async () => {
+    const client = createHttpRemoteClient({
+      baseUrl: 'https://server.test',
+      fetch: async () => {
+        throw new Error('boom');
+      },
+    });
+    await expect(client.list('ws')).rejects.toMatchObject({ code: 'network' });
+  });
+});

--- a/packages/js-lib/remote-file-sync/__tests__/desktop-transport.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/desktop-transport.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { createRemoteClientFromRouter } from '../client';
+import { MemoryRemoteFileStore } from '../memory-store';
+import { createRemoteRouter, type RemoteRouter } from '../router';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const text = (b: Uint8Array) => new TextDecoder().decode(b);
+
+/**
+ * Simulates the Electron IPC boundary: the renderer serialises a request,
+ * "sends" it to the main-process router, and receives a serialised response.
+ * A JSON round-trip stands in for structured-clone across processes.
+ */
+function ipcBridge(router: RemoteRouter): RemoteRouter {
+  return async (req) => {
+    const cloned = structuredCloneSafe(req);
+    const res = await router(cloned);
+    return structuredCloneSafe(res);
+  };
+}
+
+function structuredCloneSafe<T>(value: T): T {
+  // Uint8Array survives structured clone; emulate that fidelity here.
+  return value;
+}
+
+describe('createRemoteClientFromRouter (desktop IPC shape)', () => {
+  it('round-trips file operations through a router bridge', async () => {
+    const store = new MemoryRemoteFileStore({ now: () => 5 });
+    const router = createRemoteRouter(store);
+    const client = createRemoteClientFromRouter(ipcBridge(router));
+
+    await client.create('desktop/a.md', bytes('local note'));
+    const read = await client.read('desktop/a.md');
+    expect(text(read!.bytes)).toBe('local note');
+    expect(read!.stat.mtime).toBe(5);
+
+    expect(await client.list('desktop')).toEqual(['desktop/a.md']);
+    await client.rename('desktop/a.md', 'desktop/b.md');
+    expect(await client.exists('desktop/b.md')).toBe(true);
+    await client.delete('desktop/b.md');
+    expect(await client.exists('desktop/b.md')).toBe(false);
+  });
+
+  it('preserves error codes across the bridge', async () => {
+    const store = new MemoryRemoteFileStore();
+    const client = createRemoteClientFromRouter(
+      ipcBridge(createRemoteRouter(store)),
+    );
+    await client.create('desktop/a.md', bytes('x'));
+    await expect(
+      client.create('desktop/a.md', bytes('y')),
+    ).rejects.toMatchObject({ code: 'already-exists' });
+  });
+});

--- a/packages/js-lib/remote-file-sync/__tests__/desktop-transport.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/desktop-transport.spec.ts
@@ -13,15 +13,12 @@ const text = (b: Uint8Array) => new TextDecoder().decode(b);
  */
 function ipcBridge(router: RemoteRouter): RemoteRouter {
   return async (req) => {
-    const cloned = structuredCloneSafe(req);
+    // Real structured clone, exactly as Electron IPC serialises across the
+    // process boundary — this proves the Uint8Array bodies survive intact.
+    const cloned = structuredClone(req);
     const res = await router(cloned);
-    return structuredCloneSafe(res);
+    return structuredClone(res);
   };
-}
-
-function structuredCloneSafe<T>(value: T): T {
-  // Uint8Array survives structured clone; emulate that fidelity here.
-  return value;
 }
 
 describe('createRemoteClientFromRouter (desktop IPC shape)', () => {

--- a/packages/js-lib/remote-file-sync/__tests__/memory-store.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/memory-store.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { RemoteFileError } from '../errors';
+import { MemoryRemoteFileStore } from '../memory-store';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const text = (b: Uint8Array) => new TextDecoder().decode(b);
+
+describe('MemoryRemoteFileStore', () => {
+  it('creates and reads a file with stat', async () => {
+    const store = new MemoryRemoteFileStore({ now: () => 1000 });
+    await store.create('ws/a.md', bytes('hello'));
+
+    const read = await store.read('ws/a.md');
+    expect(read).toBeDefined();
+    expect(text(read!.bytes)).toBe('hello');
+    expect(read!.stat).toEqual({ ctime: 1000, mtime: 1000 });
+  });
+
+  it('read/stat return undefined for missing files', async () => {
+    const store = new MemoryRemoteFileStore();
+    expect(await store.read('ws/none.md')).toBeUndefined();
+    expect(await store.stat('ws/none.md')).toBeUndefined();
+  });
+
+  it('create rejects an existing file without overwriting', async () => {
+    const store = new MemoryRemoteFileStore();
+    await store.create('ws/a.md', bytes('original'));
+    await expect(
+      store.create('ws/a.md', bytes('replaced')),
+    ).rejects.toMatchObject({ code: 'already-exists' });
+    expect(text((await store.read('ws/a.md'))!.bytes)).toBe('original');
+  });
+
+  it('write throws not-found for a missing file', async () => {
+    const store = new MemoryRemoteFileStore();
+    await expect(store.write('ws/a.md', bytes('x'))).rejects.toBeInstanceOf(
+      RemoteFileError,
+    );
+    await expect(store.write('ws/a.md', bytes('x'))).rejects.toMatchObject({
+      code: 'not-found',
+    });
+  });
+
+  it('delete throws not-found for a missing file', async () => {
+    const store = new MemoryRemoteFileStore();
+    await expect(store.delete('ws/a.md')).rejects.toMatchObject({
+      code: 'not-found',
+    });
+  });
+
+  it('rename moves content and throws not-found for a missing source', async () => {
+    const store = new MemoryRemoteFileStore();
+    await store.create('ws/a.md', bytes('data'));
+    await store.rename('ws/a.md', 'ws/b.md');
+    expect(await store.read('ws/a.md')).toBeUndefined();
+    expect(text((await store.read('ws/b.md'))!.bytes)).toBe('data');
+
+    await expect(
+      store.rename('ws/missing.md', 'ws/x.md'),
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+
+  it('lists only files under the requested workspace, sorted', async () => {
+    const store = new MemoryRemoteFileStore();
+    await store.create('ws/b.md', bytes('1'));
+    await store.create('ws/a.md', bytes('2'));
+    await store.create('other/c.md', bytes('3'));
+    expect(await store.list('ws')).toEqual(['ws/a.md', 'ws/b.md']);
+    expect(await store.listWorkspaces()).toEqual(['other', 'ws']);
+  });
+
+  it('rejects invalid paths', async () => {
+    const store = new MemoryRemoteFileStore();
+    await expect(store.create('ws/../x', bytes('x'))).rejects.toMatchObject({
+      code: 'invalid-path',
+    });
+  });
+});

--- a/packages/js-lib/remote-file-sync/__tests__/path.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/path.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidFsPath,
+  isValidFsPath,
+  isValidWsName,
+  wsNameOfFsPath,
+} from '../path';
+
+describe('isValidFsPath', () => {
+  it('accepts workspace-scoped file paths', () => {
+    expect(isValidFsPath('ws/a.md')).toBe(true);
+    expect(isValidFsPath('ws/dir/sub/file.md')).toBe(true);
+  });
+
+  it('rejects traversal and unsafe paths', () => {
+    expect(isValidFsPath('')).toBe(false);
+    expect(isValidFsPath('ws')).toBe(false); // no path segment
+    expect(isValidFsPath('/ws/a.md')).toBe(false); // absolute
+    expect(isValidFsPath('ws/../secret')).toBe(false);
+    expect(isValidFsPath('ws/./a.md')).toBe(false);
+    expect(isValidFsPath('ws//a.md')).toBe(false); // empty segment
+    expect(isValidFsPath('ws\\a.md')).toBe(false); // backslash
+    expect(isValidFsPath('ws/a.md/')).toBe(false); // trailing slash
+    expect(isValidFsPath('ws/a\0.md')).toBe(false); // NUL
+    expect(isValidFsPath('../a.md')).toBe(false);
+  });
+});
+
+describe('wsNameOfFsPath', () => {
+  it('returns the first segment', () => {
+    expect(wsNameOfFsPath('myNotes/dir/a.md')).toBe('myNotes');
+  });
+
+  it('throws on invalid paths', () => {
+    expect(() => wsNameOfFsPath('../evil')).toThrowError();
+    expect(() => assertValidFsPath('ws/../x')).toThrowError();
+  });
+});
+
+describe('isValidWsName', () => {
+  it('accepts simple names and rejects separators/traversal', () => {
+    expect(isValidWsName('myNotes')).toBe(true);
+    expect(isValidWsName('')).toBe(false);
+    expect(isValidWsName('..')).toBe(false);
+    expect(isValidWsName('a/b')).toBe(false);
+    expect(isValidWsName('a\\b')).toBe(false);
+  });
+});

--- a/packages/js-lib/remote-file-sync/__tests__/path.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/path.spec.ts
@@ -46,3 +46,17 @@ describe('isValidWsName', () => {
     expect(isValidWsName('a\\b')).toBe(false);
   });
 });
+
+describe('Windows-hostile paths', () => {
+  it('rejects reserved device names (any casing / extension) and ADS colons', () => {
+    expect(isValidFsPath('ws/nul.md')).toBe(false);
+    expect(isValidFsPath('ws/CON')).toBe(false);
+    expect(isValidFsPath('ws/com1.txt')).toBe(false);
+    expect(isValidFsPath('ws/lpt9.md')).toBe(false);
+    expect(isValidFsPath('ws/a:b.md')).toBe(false); // alternate data stream
+    expect(isValidWsName('nul')).toBe(false);
+    // Not reserved — only exact device names are.
+    expect(isValidFsPath('ws/console.md')).toBe(true);
+    expect(isValidFsPath('ws/companion.md')).toBe(true);
+  });
+});

--- a/packages/js-lib/remote-file-sync/__tests__/router.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/router.spec.ts
@@ -147,6 +147,43 @@ describe('createRemoteRouter', () => {
     expect(jsonOf(res).error).toBe('invalid-path');
   });
 
+  it('stamps the API marker and answers unknown routes with bad-request', async () => {
+    const router = createRemoteRouter(new MemoryRemoteFileStore());
+    const res = await router(req({ method: 'GET', path: '/nope' }));
+    // A 404 from this router always means "file missing"; an unknown route is a
+    // client error instead so infra 404s stay distinguishable.
+    expect(res.status).toBe(400);
+    expect(res.headers[REMOTE_HEADERS.api]).toBeDefined();
+
+    const missing = await router(
+      req({
+        method: 'GET',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/x.md' },
+      }),
+    );
+    expect(missing.status).toBe(404);
+    expect(missing.headers[REMOTE_HEADERS.api]).toBeDefined();
+  });
+
+  it('hides workspace names from an unauthorized health probe', async () => {
+    const store = new MemoryRemoteFileStore();
+    await store.create('ws/a.md', bytes('x'));
+    const router = createRemoteRouter(store, { token: 'secret' });
+
+    const anon = await router(req({ path: REMOTE_ROUTES.health }));
+    expect(anon.status).toBe(200);
+    expect(jsonOf(anon).workspaces).toBeUndefined();
+
+    const authed = await router(
+      req({
+        path: REMOTE_ROUTES.health,
+        headers: { [REMOTE_HEADERS.authorization]: 'Bearer secret' },
+      }),
+    );
+    expect(jsonOf(authed).workspaces).toEqual(['ws']);
+  });
+
   it('HEAD returns 200/404 for existence', async () => {
     const store = new MemoryRemoteFileStore();
     await store.create('ws/a.md', bytes('x'));

--- a/packages/js-lib/remote-file-sync/__tests__/router.spec.ts
+++ b/packages/js-lib/remote-file-sync/__tests__/router.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import { MemoryRemoteFileStore } from '../memory-store';
+import { REMOTE_HEADERS, REMOTE_ROUTES } from '../protocol';
+import {
+  createRemoteRouter,
+  type RemoteRequest,
+  type RemoteResponse,
+} from '../router';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const jsonOf = (res: RemoteResponse) =>
+  JSON.parse(new TextDecoder().decode(res.body ?? new Uint8Array()));
+
+function req(
+  partial: Partial<RemoteRequest> & { path: string },
+): RemoteRequest {
+  return {
+    method: 'GET',
+    query: {},
+    headers: {},
+    ...partial,
+  };
+}
+
+describe('createRemoteRouter', () => {
+  it('serves health without auth even when a token is set', async () => {
+    const router = createRemoteRouter(new MemoryRemoteFileStore(), {
+      token: 'secret',
+      name: 'demo',
+    });
+    const res = await router(req({ path: REMOTE_ROUTES.health }));
+    expect(res.status).toBe(200);
+    expect(jsonOf(res)).toMatchObject({ name: 'demo', apiVersion: 1 });
+  });
+
+  it('rejects unauthorized requests when a token is configured', async () => {
+    const router = createRemoteRouter(new MemoryRemoteFileStore(), {
+      token: 'secret',
+    });
+    const res = await router(
+      req({ method: 'GET', path: REMOTE_ROUTES.files, query: { ws: 'ws' } }),
+    );
+    expect(res.status).toBe(401);
+    expect(jsonOf(res).error).toBe('unauthorized');
+  });
+
+  it('accepts requests with the correct bearer token', async () => {
+    const store = new MemoryRemoteFileStore();
+    await store.create('ws/a.md', bytes('x'));
+    const router = createRemoteRouter(store, { token: 'secret' });
+    const res = await router(
+      req({
+        path: REMOTE_ROUTES.files,
+        query: { ws: 'ws' },
+        headers: { [REMOTE_HEADERS.authorization]: 'Bearer secret' },
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(jsonOf(res)).toEqual({ paths: ['ws/a.md'] });
+  });
+
+  it('creates, reads (with stat headers), and 409s on duplicate create', async () => {
+    const store = new MemoryRemoteFileStore({ now: () => 42 });
+    const router = createRemoteRouter(store);
+
+    const created = await router(
+      req({
+        method: 'POST',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/a.md' },
+        body: bytes('hi'),
+      }),
+    );
+    expect(created.status).toBe(201);
+
+    const read = await router(
+      req({
+        method: 'GET',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/a.md' },
+      }),
+    );
+    expect(read.status).toBe(200);
+    expect(new TextDecoder().decode(read.body)).toBe('hi');
+    expect(read.headers[REMOTE_HEADERS.mtime]).toBe('42');
+
+    const dup = await router(
+      req({
+        method: 'POST',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/a.md' },
+        body: bytes('again'),
+      }),
+    );
+    expect(dup.status).toBe(409);
+    expect(jsonOf(dup).error).toBe('already-exists');
+  });
+
+  it('returns 404 for reading and writing a missing file', async () => {
+    const router = createRemoteRouter(new MemoryRemoteFileStore());
+    const read = await router(
+      req({
+        method: 'GET',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/none.md' },
+      }),
+    );
+    expect(read.status).toBe(404);
+
+    const write = await router(
+      req({
+        method: 'PUT',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/none.md' },
+        body: bytes('x'),
+      }),
+    );
+    expect(write.status).toBe(404);
+    expect(jsonOf(write).error).toBe('not-found');
+  });
+
+  it('renames via POST /rename', async () => {
+    const store = new MemoryRemoteFileStore();
+    await store.create('ws/a.md', bytes('data'));
+    const router = createRemoteRouter(store);
+    const res = await router(
+      req({
+        method: 'POST',
+        path: REMOTE_ROUTES.rename,
+        body: bytes(JSON.stringify({ from: 'ws/a.md', to: 'ws/b.md' })),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await store.read('ws/b.md')).toBeDefined();
+  });
+
+  it('maps invalid paths to 400', async () => {
+    const router = createRemoteRouter(new MemoryRemoteFileStore());
+    const res = await router(
+      req({
+        method: 'GET',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/../etc' },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(jsonOf(res).error).toBe('invalid-path');
+  });
+
+  it('HEAD returns 200/404 for existence', async () => {
+    const store = new MemoryRemoteFileStore();
+    await store.create('ws/a.md', bytes('x'));
+    const router = createRemoteRouter(store);
+    const yes = await router(
+      req({
+        method: 'HEAD',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/a.md' },
+      }),
+    );
+    expect(yes.status).toBe(200);
+    const no = await router(
+      req({
+        method: 'HEAD',
+        path: REMOTE_ROUTES.file,
+        query: { path: 'ws/none.md' },
+      }),
+    );
+    expect(no.status).toBe(404);
+  });
+});

--- a/packages/js-lib/remote-file-sync/client.ts
+++ b/packages/js-lib/remote-file-sync/client.ts
@@ -1,0 +1,362 @@
+import { RemoteFileError } from './errors';
+import {
+  type ErrorResponseBody,
+  type HealthResponse,
+  type ListResponse,
+  REMOTE_API_BASE,
+  REMOTE_HEADERS,
+  REMOTE_ROUTES,
+  type RemoteErrorCode,
+  type StatResponse,
+  statusToErrorCode,
+} from './protocol';
+import type { RemoteRouter } from './router';
+import type { RemoteFileStat, RemoteReadResult } from './store';
+
+/**
+ * The client contract consumed by the Bangle.io file-storage provider. The
+ * default implementation talks HTTP; an alternate implementation (e.g. Electron
+ * IPC) can satisfy the same interface so the provider stays transport-agnostic.
+ *
+ * Error contract mirrors the store: `read`/`stat`/`exists` never throw for a
+ * missing file; the mutating methods throw {@link RemoteFileError} with a
+ * meaningful `code` (`already-exists`, `not-found`, `unauthorized`, `network`).
+ */
+export interface RemoteFileStorageClient {
+  health(signal?: AbortSignal): Promise<HealthResponse>;
+  list(wsName: string, signal?: AbortSignal): Promise<string[]>;
+  read(
+    fsPath: string,
+    signal?: AbortSignal,
+  ): Promise<RemoteReadResult | undefined>;
+  stat(
+    fsPath: string,
+    signal?: AbortSignal,
+  ): Promise<RemoteFileStat | undefined>;
+  exists(fsPath: string, signal?: AbortSignal): Promise<boolean>;
+  create(
+    fsPath: string,
+    bytes: Uint8Array,
+    signal?: AbortSignal,
+  ): Promise<void>;
+  write(fsPath: string, bytes: Uint8Array, signal?: AbortSignal): Promise<void>;
+  delete(fsPath: string, signal?: AbortSignal): Promise<void>;
+  rename(from: string, to: string, signal?: AbortSignal): Promise<void>;
+}
+
+/** Minimal subset of `fetch` the client needs; real `fetch` satisfies it. */
+export type RemoteFetchResponse = {
+  status: number;
+  headers: { get(name: string): string | null };
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+};
+
+export type RemoteFetch = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body?: Uint8Array;
+    signal?: AbortSignal;
+  },
+) => Promise<RemoteFetchResponse>;
+
+export interface HttpRemoteClientConfig {
+  /**
+   * Origin the server is reachable at, e.g. `https://notes.example.com`. An
+   * empty string means same-origin (bundled mode), producing relative URLs.
+   */
+  baseUrl: string;
+  /** Bearer token sent as `Authorization: Bearer <token>`. */
+  token?: string;
+  /** Injected transport; defaults to the global `fetch`. */
+  fetch?: RemoteFetch;
+  /** Value sent as the informational `x-bangle-client` header. */
+  clientName?: string;
+}
+
+const defaultFetch: RemoteFetch = (url, init) =>
+  // Cast: the structural subset above is satisfied by the DOM `fetch`.
+  (globalThis.fetch as unknown as RemoteFetch)(url, init);
+
+export function createHttpRemoteClient(
+  config: HttpRemoteClientConfig,
+): RemoteFileStorageClient {
+  const base = config.baseUrl.replace(/\/$/, '') + REMOTE_API_BASE;
+  const doFetch = config.fetch ?? defaultFetch;
+
+  function url(route: string, query?: Record<string, string>): string {
+    const qs = query
+      ? '?' +
+        Object.entries(query)
+          .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+          .join('&')
+      : '';
+    return `${base}${route}${qs}`;
+  }
+
+  function headers(extra?: Record<string, string>): Record<string, string> {
+    const h: Record<string, string> = {
+      [REMOTE_HEADERS.client]: config.clientName ?? 'bangle.io',
+      ...extra,
+    };
+    if (config.token) {
+      h[REMOTE_HEADERS.authorization] = `Bearer ${config.token}`;
+    }
+    return h;
+  }
+
+  async function toError(res: RemoteFetchResponse): Promise<RemoteFileError> {
+    let code: RemoteErrorCode = statusToErrorCode(res.status);
+    let message: string | undefined;
+    try {
+      const text = await res.text();
+      if (text) {
+        const parsed = JSON.parse(text) as ErrorResponseBody;
+        if (parsed?.error) {
+          code = parsed.error;
+        }
+        message = parsed?.message;
+      }
+    } catch {
+      // Non-JSON error body; keep the status-derived code.
+    }
+    return new RemoteFileError(
+      code,
+      message ?? `Request failed (${res.status})`,
+      {
+        status: res.status,
+      },
+    );
+  }
+
+  async function request(
+    route: string,
+    init: {
+      method: string;
+      query?: Record<string, string>;
+      body?: Uint8Array;
+      headers?: Record<string, string>;
+      signal?: AbortSignal;
+    },
+  ): Promise<RemoteFetchResponse> {
+    try {
+      return await doFetch(url(route, init.query), {
+        method: init.method,
+        headers: headers(init.headers),
+        body: init.body,
+        signal: init.signal,
+      });
+    } catch (error) {
+      if (init.signal?.aborted) {
+        throw error;
+      }
+      throw new RemoteFileError(
+        'network',
+        error instanceof Error ? error.message : 'Network request failed',
+        { cause: error },
+      );
+    }
+  }
+
+  function readStat(res: RemoteFetchResponse): RemoteFileStat {
+    const mtime = Number(res.headers.get(REMOTE_HEADERS.mtime));
+    const ctime = Number(res.headers.get(REMOTE_HEADERS.ctime));
+    return {
+      mtime: Number.isFinite(mtime) ? mtime : 0,
+      ctime: Number.isFinite(ctime) ? ctime : 0,
+    };
+  }
+
+  return {
+    async health(signal) {
+      const res = await request(REMOTE_ROUTES.health, {
+        method: 'GET',
+        signal,
+      });
+      if (res.status !== 200) {
+        throw await toError(res);
+      }
+      return JSON.parse(await res.text()) as HealthResponse;
+    },
+
+    async list(wsName, signal) {
+      const res = await request(REMOTE_ROUTES.files, {
+        method: 'GET',
+        query: { ws: wsName },
+        signal,
+      });
+      if (res.status !== 200) {
+        throw await toError(res);
+      }
+      const body = JSON.parse(await res.text()) as ListResponse;
+      return body.paths;
+    },
+
+    async read(fsPath, signal) {
+      const res = await request(REMOTE_ROUTES.file, {
+        method: 'GET',
+        query: { path: fsPath },
+        signal,
+      });
+      if (res.status === 404) {
+        return undefined;
+      }
+      if (res.status !== 200) {
+        throw await toError(res);
+      }
+      return {
+        bytes: new Uint8Array(await res.arrayBuffer()),
+        stat: readStat(res),
+      };
+    },
+
+    async stat(fsPath, signal) {
+      const res = await request(REMOTE_ROUTES.stat, {
+        method: 'GET',
+        query: { path: fsPath },
+        signal,
+      });
+      if (res.status === 404) {
+        return undefined;
+      }
+      if (res.status !== 200) {
+        throw await toError(res);
+      }
+      return JSON.parse(await res.text()) as StatResponse;
+    },
+
+    async exists(fsPath, signal) {
+      const res = await request(REMOTE_ROUTES.file, {
+        method: 'HEAD',
+        query: { path: fsPath },
+        signal,
+      });
+      if (res.status === 200) {
+        return true;
+      }
+      if (res.status === 404) {
+        return false;
+      }
+      throw await toError(res);
+    },
+
+    async create(fsPath, bytes, signal) {
+      const res = await request(REMOTE_ROUTES.file, {
+        method: 'POST',
+        query: { path: fsPath },
+        body: bytes,
+        signal,
+      });
+      if (res.status !== 201 && res.status !== 200) {
+        throw await toError(res);
+      }
+    },
+
+    async write(fsPath, bytes, signal) {
+      const res = await request(REMOTE_ROUTES.file, {
+        method: 'PUT',
+        query: { path: fsPath },
+        body: bytes,
+        signal,
+      });
+      if (res.status !== 200) {
+        throw await toError(res);
+      }
+    },
+
+    async delete(fsPath, signal) {
+      const res = await request(REMOTE_ROUTES.file, {
+        method: 'DELETE',
+        query: { path: fsPath },
+        signal,
+      });
+      if (res.status !== 200) {
+        throw await toError(res);
+      }
+    },
+
+    async rename(from, to, signal) {
+      const res = await request(REMOTE_ROUTES.rename, {
+        method: 'POST',
+        body: new TextEncoder().encode(JSON.stringify({ from, to })),
+        headers: { [REMOTE_HEADERS.contentType]: 'application/json' },
+        signal,
+      });
+      if (res.status !== 200) {
+        throw await toError(res);
+      }
+    },
+  };
+}
+
+/**
+ * Builds a {@link RemoteFileStorageClient} that talks directly to a router
+ * instead of an HTTP server. The router may be in-process (tests) or a bridge
+ * to another process — e.g. Electron's `ipcRenderer.invoke` forwarding requests
+ * to a main-process router. This is how the desktop app reuses the exact same
+ * provider without a listening socket.
+ */
+export function createRemoteClientFromRouter(
+  router: RemoteRouter,
+  config: { token?: string; clientName?: string } = {},
+): RemoteFileStorageClient {
+  return createHttpRemoteClient({
+    baseUrl: '',
+    token: config.token,
+    clientName: config.clientName,
+    fetch: createFetchFromRouter(router),
+  });
+}
+
+/**
+ * Adapts a {@link RemoteRouter} into a {@link RemoteFetch}. This lets the HTTP
+ * client run against an in-process router with no sockets — used by the
+ * contract tests and by the Electron IPC bridge (main-process router).
+ */
+export function createFetchFromRouter(router: RemoteRouter): RemoteFetch {
+  return async function routerFetch(url, init) {
+    const idx = url.indexOf(REMOTE_API_BASE);
+    const rest = idx >= 0 ? url.slice(idx + REMOTE_API_BASE.length) : url;
+    const [path, qs] = rest.split('?');
+    const query: Record<string, string> = {};
+    if (qs) {
+      for (const [k, v] of new URLSearchParams(qs)) {
+        query[k] = v;
+      }
+    }
+    const lowerHeaders: Record<string, string> = {};
+    for (const [k, v] of Object.entries(init.headers)) {
+      lowerHeaders[k.toLowerCase()] = v;
+    }
+    const res = await router(
+      {
+        method: init.method,
+        path: path ?? '',
+        query,
+        headers: lowerHeaders,
+        body: init.body,
+      },
+      init.signal,
+    );
+    const body = res.body ?? new Uint8Array();
+    return {
+      status: res.status,
+      headers: {
+        get(name: string): string | null {
+          return res.headers[name.toLowerCase()] ?? null;
+        },
+      },
+      async arrayBuffer() {
+        return body.buffer.slice(
+          body.byteOffset,
+          body.byteOffset + body.byteLength,
+        ) as ArrayBuffer;
+      },
+      async text() {
+        return new TextDecoder().decode(body);
+      },
+    };
+  };
+}

--- a/packages/js-lib/remote-file-sync/client.ts
+++ b/packages/js-lib/remote-file-sync/client.ts
@@ -107,7 +107,35 @@ export function createHttpRemoteClient(
     return h;
   }
 
+  // A genuine remote-file-storage response carries the API marker header. Its
+  // absence means we reached something else (proxy, wrong URL, captive portal),
+  // so a 404 must never be read as "file absent".
+  function isApiResponse(res: RemoteFetchResponse): boolean {
+    return res.headers.get(REMOTE_HEADERS.api) != null;
+  }
+
+  function parseJson<T>(text: string): T {
+    try {
+      return JSON.parse(text) as T;
+    } catch (error) {
+      throw new RemoteFileError(
+        'server-error',
+        'Malformed response from server',
+        {
+          cause: error,
+        },
+      );
+    }
+  }
+
   async function toError(res: RemoteFetchResponse): Promise<RemoteFileError> {
+    if (!isApiResponse(res)) {
+      return new RemoteFileError(
+        'server-error',
+        `Unexpected response (HTTP ${res.status}); not a Bangle file-storage endpoint`,
+        { status: res.status },
+      );
+    }
     let code: RemoteErrorCode = statusToErrorCode(res.status);
     let message: string | undefined;
     try {
@@ -175,10 +203,10 @@ export function createHttpRemoteClient(
         method: 'GET',
         signal,
       });
-      if (res.status !== 200) {
+      if (res.status !== 200 || !isApiResponse(res)) {
         throw await toError(res);
       }
-      return JSON.parse(await res.text()) as HealthResponse;
+      return parseJson<HealthResponse>(await res.text());
     },
 
     async list(wsName, signal) {
@@ -190,8 +218,8 @@ export function createHttpRemoteClient(
       if (res.status !== 200) {
         throw await toError(res);
       }
-      const body = JSON.parse(await res.text()) as ListResponse;
-      return body.paths;
+      const body = parseJson<ListResponse>(await res.text());
+      return Array.isArray(body.paths) ? body.paths : [];
     },
 
     async read(fsPath, signal) {
@@ -200,7 +228,8 @@ export function createHttpRemoteClient(
         query: { path: fsPath },
         signal,
       });
-      if (res.status === 404) {
+      // Only a genuine API 404 means the file is absent.
+      if (res.status === 404 && isApiResponse(res)) {
         return undefined;
       }
       if (res.status !== 200) {
@@ -218,13 +247,13 @@ export function createHttpRemoteClient(
         query: { path: fsPath },
         signal,
       });
-      if (res.status === 404) {
+      if (res.status === 404 && isApiResponse(res)) {
         return undefined;
       }
       if (res.status !== 200) {
         throw await toError(res);
       }
-      return JSON.parse(await res.text()) as StatResponse;
+      return parseJson<StatResponse>(await res.text());
     },
 
     async exists(fsPath, signal) {
@@ -236,7 +265,7 @@ export function createHttpRemoteClient(
       if (res.status === 200) {
         return true;
       }
-      if (res.status === 404) {
+      if (res.status === 404 && isApiResponse(res)) {
         return false;
       }
       throw await toError(res);

--- a/packages/js-lib/remote-file-sync/errors.ts
+++ b/packages/js-lib/remote-file-sync/errors.ts
@@ -1,0 +1,38 @@
+import type { RemoteErrorCode } from './protocol';
+
+/**
+ * The single error type used across the remote file-storage stack. A store
+ * throws it, the router maps it to an HTTP status, and the client re-throws it
+ * after mapping a status back to a code. Callers switch on {@link code} rather
+ * than parsing messages.
+ */
+export class RemoteFileError extends Error {
+  public readonly code: RemoteErrorCode;
+  /** HTTP status when the error originated from a server response. */
+  public readonly status?: number;
+
+  constructor(
+    code: RemoteErrorCode,
+    message?: string,
+    options?: { status?: number; cause?: unknown },
+  ) {
+    super(
+      message ?? code,
+      options?.cause ? { cause: options.cause } : undefined,
+    );
+    this.name = 'RemoteFileError';
+    this.code = code;
+    this.status = options?.status;
+  }
+}
+
+export function isRemoteFileError(value: unknown): value is RemoteFileError {
+  return value instanceof RemoteFileError;
+}
+
+export function isRemoteFileErrorCode(
+  value: unknown,
+  code: RemoteErrorCode,
+): value is RemoteFileError {
+  return isRemoteFileError(value) && value.code === code;
+}

--- a/packages/js-lib/remote-file-sync/index.ts
+++ b/packages/js-lib/remote-file-sync/index.ts
@@ -1,0 +1,49 @@
+export {
+  createFetchFromRouter,
+  createHttpRemoteClient,
+  createRemoteClientFromRouter,
+  type HttpRemoteClientConfig,
+  type RemoteFetch,
+  type RemoteFetchResponse,
+  type RemoteFileStorageClient,
+} from './client';
+export {
+  isRemoteFileError,
+  isRemoteFileErrorCode,
+  RemoteFileError,
+} from './errors';
+export { MemoryRemoteFileStore } from './memory-store';
+export {
+  assertValidFsPath,
+  assertValidWsName,
+  isValidFsPath,
+  isValidWsName,
+  wsNameOfFsPath,
+} from './path';
+export {
+  type ErrorResponseBody,
+  errorCodeToStatus,
+  type HealthResponse,
+  type ListResponse,
+  REMOTE_API_BASE,
+  REMOTE_API_VERSION,
+  REMOTE_CONTENT_TYPE,
+  REMOTE_HEADERS,
+  REMOTE_ROUTES,
+  type RemoteErrorCode,
+  type RenameRequestBody,
+  type StatResponse,
+  statusToErrorCode,
+} from './protocol';
+export {
+  createRemoteRouter,
+  type RemoteRequest,
+  type RemoteResponse,
+  type RemoteRouter,
+  type RemoteRouterOptions,
+} from './router';
+export type {
+  RemoteFileStat,
+  RemoteFileStore,
+  RemoteReadResult,
+} from './store';

--- a/packages/js-lib/remote-file-sync/memory-store.ts
+++ b/packages/js-lib/remote-file-sync/memory-store.ts
@@ -1,0 +1,105 @@
+import { RemoteFileError } from './errors';
+import { assertValidFsPath, assertValidWsName, wsNameOfFsPath } from './path';
+import type {
+  RemoteFileStat,
+  RemoteFileStore,
+  RemoteReadResult,
+} from './store';
+
+interface Entry {
+  bytes: Uint8Array;
+  ctime: number;
+  mtime: number;
+}
+
+/**
+ * An in-memory {@link RemoteFileStore}. Used by unit tests, the contract-test
+ * harness, and as a zero-config demo backend. `now` is injectable so tests can
+ * make timestamps deterministic.
+ */
+export class MemoryRemoteFileStore implements RemoteFileStore {
+  private entries = new Map<string, Entry>();
+  private now: () => number;
+
+  constructor(options?: { now?: () => number }) {
+    this.now = options?.now ?? (() => Date.now());
+  }
+
+  async list(wsName: string): Promise<string[]> {
+    assertValidWsName(wsName);
+    const prefix = `${wsName}/`;
+    return Array.from(this.entries.keys())
+      .filter((key) => key.startsWith(prefix))
+      .sort((a, b) => a.localeCompare(b));
+  }
+
+  async read(fsPath: string): Promise<RemoteReadResult | undefined> {
+    assertValidFsPath(fsPath);
+    const entry = this.entries.get(fsPath);
+    if (!entry) {
+      return undefined;
+    }
+    return { bytes: entry.bytes, stat: this.toStat(entry) };
+  }
+
+  async stat(fsPath: string): Promise<RemoteFileStat | undefined> {
+    assertValidFsPath(fsPath);
+    const entry = this.entries.get(fsPath);
+    return entry ? this.toStat(entry) : undefined;
+  }
+
+  async create(fsPath: string, bytes: Uint8Array): Promise<void> {
+    assertValidFsPath(fsPath);
+    if (this.entries.has(fsPath)) {
+      throw new RemoteFileError(
+        'already-exists',
+        `File already exists: ${fsPath}`,
+      );
+    }
+    const now = this.now();
+    this.entries.set(fsPath, { bytes, ctime: now, mtime: now });
+  }
+
+  async write(fsPath: string, bytes: Uint8Array): Promise<void> {
+    assertValidFsPath(fsPath);
+    const entry = this.entries.get(fsPath);
+    if (!entry) {
+      throw new RemoteFileError('not-found', `File not found: ${fsPath}`);
+    }
+    entry.bytes = bytes;
+    entry.mtime = this.now();
+  }
+
+  async delete(fsPath: string): Promise<void> {
+    assertValidFsPath(fsPath);
+    if (!this.entries.has(fsPath)) {
+      throw new RemoteFileError('not-found', `File not found: ${fsPath}`);
+    }
+    this.entries.delete(fsPath);
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    assertValidFsPath(from);
+    assertValidFsPath(to);
+    const entry = this.entries.get(from);
+    if (!entry) {
+      throw new RemoteFileError('not-found', `File not found: ${from}`);
+    }
+    this.entries.set(to, { ...entry, mtime: this.now() });
+    if (from !== to) {
+      this.entries.delete(from);
+    }
+  }
+
+  async listWorkspaces(): Promise<string[]> {
+    const names = new Set<string>();
+    for (const key of this.entries.keys()) {
+      names.add(wsNameOfFsPath(key));
+    }
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }
+
+  private toStat(entry: Entry): RemoteFileStat {
+    return { ctime: entry.ctime, mtime: entry.mtime };
+  }
+}

--- a/packages/js-lib/remote-file-sync/package.json
+++ b/packages/js-lib/remote-file-sync/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@bangle.io/remote-file-sync",
+  "description": "Engine-neutral protocol, router and client for the Bangle.io remote file-storage HTTP API.",
+  "license": "AGPL-3.0-or-later",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bangle-io/bangle-io.git",
+    "directory": "packages/js-lib/remote-file-sync"
+  },
+  "authors": [
+    {
+      "name": "Kushan Joshi",
+      "email": "0o3ko0@gmail.com",
+      "web": "http://github.com/kepta"
+    }
+  ],
+  "homepage": "https://bangle.io",
+  "bugs": {
+    "url": "https://github.com/bangle-io/bangle-io/issues"
+  },
+  "banglePackageConfig": {
+    "env": "universal",
+    "kind": "js-util"
+  },
+  "main": "index.ts",
+  "module": "index.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {},
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/js-lib/remote-file-sync/path.ts
+++ b/packages/js-lib/remote-file-sync/path.ts
@@ -1,0 +1,78 @@
+import { RemoteFileError } from './errors';
+
+/**
+ * A workspace-scoped filesystem path used on the wire. The first segment is the
+ * workspace name; the remaining segments are the path within that workspace.
+ *
+ * Validation is a data-safety boundary: a malformed or traversing path must
+ * never be turned into a read/write outside its workspace. Every store and the
+ * router funnel untrusted paths through {@link assertValidFsPath}.
+ */
+
+const SEGMENT_DENYLIST = new Set(['', '.', '..']);
+
+export function isValidFsPath(fsPath: string): boolean {
+  if (typeof fsPath !== 'string' || fsPath.length === 0) {
+    return false;
+  }
+  // Reject Windows separators, control chars, NUL and absolute paths outright.
+  if (fsPath.includes('\\') || fsPath.includes('\0')) {
+    return false;
+  }
+  if (fsPath.startsWith('/')) {
+    return false;
+  }
+  // A file path must not end with a slash (that denotes a directory).
+  if (fsPath.endsWith('/')) {
+    return false;
+  }
+  const segments = fsPath.split('/');
+  // Need at least a workspace segment plus one path segment.
+  if (segments.length < 2) {
+    return false;
+  }
+  for (const segment of segments) {
+    if (SEGMENT_DENYLIST.has(segment)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function assertValidFsPath(fsPath: string): void {
+  if (!isValidFsPath(fsPath)) {
+    throw new RemoteFileError(
+      'invalid-path',
+      `Invalid remote file path: ${JSON.stringify(fsPath)}`,
+    );
+  }
+}
+
+/** Returns the workspace name (first segment) of an fs path. */
+export function wsNameOfFsPath(fsPath: string): string {
+  assertValidFsPath(fsPath);
+  const first = fsPath.split('/')[0];
+  // assertValidFsPath guarantees a non-empty first segment.
+  return first as string;
+}
+
+/** Validates a workspace name used as a listing key. */
+export function isValidWsName(wsName: string): boolean {
+  return (
+    typeof wsName === 'string' &&
+    wsName.length > 0 &&
+    !SEGMENT_DENYLIST.has(wsName) &&
+    !wsName.includes('/') &&
+    !wsName.includes('\\') &&
+    !wsName.includes('\0')
+  );
+}
+
+export function assertValidWsName(wsName: string): void {
+  if (!isValidWsName(wsName)) {
+    throw new RemoteFileError(
+      'invalid-path',
+      `Invalid workspace name: ${JSON.stringify(wsName)}`,
+    );
+  }
+}

--- a/packages/js-lib/remote-file-sync/path.ts
+++ b/packages/js-lib/remote-file-sync/path.ts
@@ -11,6 +11,30 @@ import { RemoteFileError } from './errors';
 
 const SEGMENT_DENYLIST = new Set(['', '.', '..']);
 
+// Windows device names map to hardware, not files — a write "succeeds" and the
+// bytes vanish. Reserved regardless of extension (`nul`, `nul.md`, ...). The
+// desktop disk store can run on Windows, so this guard is universal.
+const RESERVED_WINDOWS_NAMES = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  ...Array.from({ length: 9 }, (_, i) => `com${i + 1}`),
+  ...Array.from({ length: 9 }, (_, i) => `lpt${i + 1}`),
+]);
+
+function isSafeSegment(segment: string): boolean {
+  if (SEGMENT_DENYLIST.has(segment)) {
+    return false;
+  }
+  // `:` denotes an NTFS alternate data stream — reject it everywhere.
+  if (segment.includes(':')) {
+    return false;
+  }
+  const base = (segment.split('.')[0] ?? '').toLowerCase();
+  return !RESERVED_WINDOWS_NAMES.has(base);
+}
+
 export function isValidFsPath(fsPath: string): boolean {
   if (typeof fsPath !== 'string' || fsPath.length === 0) {
     return false;
@@ -31,12 +55,7 @@ export function isValidFsPath(fsPath: string): boolean {
   if (segments.length < 2) {
     return false;
   }
-  for (const segment of segments) {
-    if (SEGMENT_DENYLIST.has(segment)) {
-      return false;
-    }
-  }
-  return true;
+  return segments.every(isSafeSegment);
 }
 
 export function assertValidFsPath(fsPath: string): void {
@@ -61,10 +80,10 @@ export function isValidWsName(wsName: string): boolean {
   return (
     typeof wsName === 'string' &&
     wsName.length > 0 &&
-    !SEGMENT_DENYLIST.has(wsName) &&
     !wsName.includes('/') &&
     !wsName.includes('\\') &&
-    !wsName.includes('\0')
+    !wsName.includes('\0') &&
+    isSafeSegment(wsName)
   );
 }
 

--- a/packages/js-lib/remote-file-sync/protocol.ts
+++ b/packages/js-lib/remote-file-sync/protocol.ts
@@ -16,7 +16,7 @@
  *   POST   {base}/file?path=<fsPath>        -> 201 | 409            (create)
  *   PUT    {base}/file?path=<fsPath>        -> 200 | 404            (write existing)
  *   DELETE {base}/file?path=<fsPath>        -> 200 | 404            (delete)
- *   POST   {base}/rename  {from,to}         -> 200 | 404 | 409      (rename/move)
+ *   POST   {base}/rename  {from,to}         -> 200 | 404            (rename/move; overwrites dest)
  *   GET    {base}/stat?path=<fsPath>        -> StatResponse         (stat)
  *
  * A `<fsPath>` is a POSIX-style, workspace-scoped path whose first segment is
@@ -46,6 +46,13 @@ export const REMOTE_HEADERS = {
   ctime: 'x-bangle-ctime',
   /** Identifies the calling client; informational only. */
   client: 'x-bangle-client',
+  /**
+   * Marks a response as coming from a genuine remote-file-storage endpoint
+   * (value = API version). Lets the client tell a real `404 not-found` from an
+   * infrastructure 404 (proxy misroute, wrong base path) so a transport error
+   * is never mistaken for "file absent".
+   */
+  api: 'x-bangle-api',
   contentType: 'content-type',
 } as const;
 

--- a/packages/js-lib/remote-file-sync/protocol.ts
+++ b/packages/js-lib/remote-file-sync/protocol.ts
@@ -1,0 +1,135 @@
+/**
+ * Wire protocol for the Bangle.io remote file-storage HTTP API.
+ *
+ * This module is the single source of truth for the paths, headers, verbs and
+ * JSON shapes that flow between a Bangle.io client and any server that
+ * implements the API. It is intentionally engine-neutral and dependency-free so
+ * that both the browser client and a Node/Express/other reference server can
+ * import the same contract.
+ *
+ * The API is deliberately small and RESTful:
+ *
+ *   GET    {base}/health                    -> HealthResponse
+ *   GET    {base}/files?ws=<wsName>         -> ListResponse         (list files)
+ *   GET    {base}/file?path=<fsPath>        -> raw bytes            (read)
+ *   HEAD   {base}/file?path=<fsPath>        -> 200/404 + stat headers
+ *   POST   {base}/file?path=<fsPath>        -> 201 | 409            (create)
+ *   PUT    {base}/file?path=<fsPath>        -> 200 | 404            (write existing)
+ *   DELETE {base}/file?path=<fsPath>        -> 200 | 404            (delete)
+ *   POST   {base}/rename  {from,to}         -> 200 | 404 | 409      (rename/move)
+ *   GET    {base}/stat?path=<fsPath>        -> StatResponse         (stat)
+ *
+ * A `<fsPath>` is a POSIX-style, workspace-scoped path whose first segment is
+ * the workspace name, e.g. `myNotes/journal/2024.md`. It never contains `.` or
+ * `..` segments and never starts with `/`.
+ */
+
+/** Bumped when the wire contract changes in a backwards-incompatible way. */
+export const REMOTE_API_VERSION = 1;
+
+/** Default path prefix under which the API is mounted. */
+export const REMOTE_API_BASE = '/api/v1';
+
+export const REMOTE_ROUTES = {
+  health: '/health',
+  files: '/files',
+  file: '/file',
+  rename: '/rename',
+  stat: '/stat',
+} as const;
+
+export const REMOTE_HEADERS = {
+  authorization: 'authorization',
+  /** File modification time (ms since epoch) on read/stat responses. */
+  mtime: 'x-bangle-mtime',
+  /** File creation time (ms since epoch) on read/stat responses. */
+  ctime: 'x-bangle-ctime',
+  /** Identifies the calling client; informational only. */
+  client: 'x-bangle-client',
+  contentType: 'content-type',
+} as const;
+
+export const REMOTE_CONTENT_TYPE = {
+  json: 'application/json',
+  octetStream: 'application/octet-stream',
+} as const;
+
+export interface HealthResponse {
+  name: string;
+  apiVersion: number;
+  /** Optional list of workspaces the server hosts (for management UIs). */
+  workspaces?: string[];
+}
+
+export interface ListResponse {
+  /** Workspace-scoped fs paths, e.g. `myNotes/a.md`. */
+  paths: string[];
+}
+
+export interface StatResponse {
+  ctime: number;
+  mtime: number;
+}
+
+export interface RenameRequestBody {
+  from: string;
+  to: string;
+}
+
+/** JSON error body returned for every non-2xx response. */
+export interface ErrorResponseBody {
+  error: RemoteErrorCode;
+  message?: string;
+}
+
+/**
+ * Stable, transport-independent error codes. They map 1:1 with HTTP status
+ * codes on the wire and with {@link RemoteFileError} in code.
+ */
+export type RemoteErrorCode =
+  | 'not-found'
+  | 'already-exists'
+  | 'invalid-path'
+  | 'unauthorized'
+  | 'bad-request'
+  | 'network'
+  | 'server-error';
+
+/** Maps an error code to the HTTP status a server should respond with. */
+export function errorCodeToStatus(code: RemoteErrorCode): number {
+  switch (code) {
+    case 'not-found':
+      return 404;
+    case 'already-exists':
+      return 409;
+    case 'invalid-path':
+    case 'bad-request':
+      return 400;
+    case 'unauthorized':
+      return 401;
+    case 'network':
+    case 'server-error':
+      return 500;
+    default: {
+      const _exhaustive: never = code;
+      return 500;
+    }
+  }
+}
+
+/** Maps an HTTP status back to a {@link RemoteErrorCode}. */
+export function statusToErrorCode(status: number): RemoteErrorCode {
+  switch (status) {
+    case 404:
+      return 'not-found';
+    case 409:
+      return 'already-exists';
+    case 400:
+      return 'bad-request';
+    case 401:
+    case 403:
+      return 'unauthorized';
+    default:
+      return status >= 500 ? 'server-error' : 'network';
+  }
+}

--- a/packages/js-lib/remote-file-sync/router.ts
+++ b/packages/js-lib/remote-file-sync/router.ts
@@ -1,0 +1,274 @@
+import { RemoteFileError } from './errors';
+import {
+  type ErrorResponseBody,
+  errorCodeToStatus,
+  type HealthResponse,
+  type ListResponse,
+  REMOTE_API_VERSION,
+  REMOTE_CONTENT_TYPE,
+  REMOTE_HEADERS,
+  REMOTE_ROUTES,
+  type RemoteErrorCode,
+  type RenameRequestBody,
+  type StatResponse,
+} from './protocol';
+import type { RemoteFileStore } from './store';
+
+/**
+ * A transport-independent request. HTTP/IPC adapters normalise their native
+ * request into this shape; `headers` keys are lowercased.
+ */
+export interface RemoteRequest {
+  method: string;
+  /** Path relative to the API base, e.g. `/file`, `/files`, `/rename`. */
+  path: string;
+  query: Record<string, string | undefined>;
+  headers: Record<string, string | undefined>;
+  body?: Uint8Array;
+}
+
+export interface RemoteResponse {
+  status: number;
+  headers: Record<string, string>;
+  body?: Uint8Array;
+}
+
+/** The engine-neutral request handler produced by {@link createRemoteRouter}. */
+export type RemoteRouter = (
+  req: RemoteRequest,
+  signal?: AbortSignal,
+) => Promise<RemoteResponse>;
+
+export interface RemoteRouterOptions {
+  /**
+   * Server name reported by `/health`.
+   */
+  name?: string;
+  /**
+   * Bearer token required on every request except `/health`. When omitted the
+   * server is open (suitable for localhost / Electron / trusted networks).
+   */
+  token?: string;
+}
+
+const encoder = new TextEncoder();
+
+function jsonBody(value: unknown): Uint8Array {
+  return encoder.encode(JSON.stringify(value));
+}
+
+function jsonResponse(status: number, value: unknown): RemoteResponse {
+  return {
+    status,
+    headers: { [REMOTE_HEADERS.contentType]: REMOTE_CONTENT_TYPE.json },
+    body: jsonBody(value),
+  };
+}
+
+function errorResponse(
+  code: RemoteErrorCode,
+  message?: string,
+): RemoteResponse {
+  const body: ErrorResponseBody = { error: code, message };
+  return jsonResponse(errorCodeToStatus(code), body);
+}
+
+function statHeaders(stat: StatResponse): Record<string, string> {
+  return {
+    [REMOTE_HEADERS.mtime]: String(stat.mtime),
+    [REMOTE_HEADERS.ctime]: String(stat.ctime),
+  };
+}
+
+function isAuthorized(req: RemoteRequest, token: string): boolean {
+  const header = req.headers[REMOTE_HEADERS.authorization];
+  if (!header) {
+    return false;
+  }
+  const expected = `Bearer ${token}`;
+  // Constant-ish comparison; token secrecy here is best-effort, the real
+  // protection is TLS + a strong token chosen by the operator.
+  return header === expected;
+}
+
+/**
+ * Builds the engine-neutral request handler for the remote file API. The same
+ * router powers the Node reference server and the Electron IPC bridge; only the
+ * transport adapter differs.
+ */
+export function createRemoteRouter(
+  store: RemoteFileStore,
+  options: RemoteRouterOptions = {},
+): (req: RemoteRequest, signal?: AbortSignal) => Promise<RemoteResponse> {
+  const serverName = options.name ?? 'bangle-remote-file-server';
+
+  return async function handle(
+    req: RemoteRequest,
+    signal?: AbortSignal,
+  ): Promise<RemoteResponse> {
+    try {
+      // /health is always reachable so clients can probe connectivity.
+      if (req.path === REMOTE_ROUTES.health && req.method === 'GET') {
+        const workspaces = await store.listWorkspaces?.(signal);
+        const health: HealthResponse = {
+          name: serverName,
+          apiVersion: REMOTE_API_VERSION,
+          ...(workspaces ? { workspaces } : {}),
+        };
+        return jsonResponse(200, health);
+      }
+
+      if (options.token && !isAuthorized(req, options.token)) {
+        return errorResponse('unauthorized', 'Missing or invalid bearer token');
+      }
+
+      switch (req.path) {
+        case REMOTE_ROUTES.files:
+          return await handleFiles(store, req, signal);
+        case REMOTE_ROUTES.file:
+          return await handleFile(store, req, signal);
+        case REMOTE_ROUTES.stat:
+          return await handleStat(store, req, signal);
+        case REMOTE_ROUTES.rename:
+          return await handleRename(store, req, signal);
+        default:
+          return errorResponse('not-found', `Unknown route: ${req.path}`);
+      }
+    } catch (error) {
+      if (error instanceof RemoteFileError) {
+        return errorResponse(error.code, error.message);
+      }
+      // Propagate abort as-is so transports can surface cancellation.
+      if (isAbort(error, signal)) {
+        throw error;
+      }
+      return errorResponse(
+        'server-error',
+        error instanceof Error ? error.message : 'Unknown server error',
+      );
+    }
+  };
+}
+
+async function handleFiles(
+  store: RemoteFileStore,
+  req: RemoteRequest,
+  signal?: AbortSignal,
+): Promise<RemoteResponse> {
+  if (req.method !== 'GET') {
+    return errorResponse('bad-request', 'Only GET is supported for /files');
+  }
+  const wsName = req.query.ws;
+  if (!wsName) {
+    return errorResponse('bad-request', 'Missing ?ws=<workspace>');
+  }
+  const paths = await store.list(wsName, signal);
+  const body: ListResponse = { paths };
+  return jsonResponse(200, body);
+}
+
+async function handleFile(
+  store: RemoteFileStore,
+  req: RemoteRequest,
+  signal?: AbortSignal,
+): Promise<RemoteResponse> {
+  const fsPath = req.query.path;
+  if (!fsPath) {
+    return errorResponse('bad-request', 'Missing ?path=<fsPath>');
+  }
+
+  switch (req.method) {
+    case 'GET': {
+      const result = await store.read(fsPath, signal);
+      if (!result) {
+        return errorResponse('not-found', `File not found: ${fsPath}`);
+      }
+      return {
+        status: 200,
+        headers: {
+          [REMOTE_HEADERS.contentType]: REMOTE_CONTENT_TYPE.octetStream,
+          ...statHeaders(result.stat),
+        },
+        body: result.bytes,
+      };
+    }
+    case 'HEAD': {
+      const stat = await store.stat(fsPath, signal);
+      if (!stat) {
+        return { status: 404, headers: {} };
+      }
+      return { status: 200, headers: statHeaders(stat) };
+    }
+    case 'POST': {
+      await store.create(fsPath, req.body ?? new Uint8Array(), signal);
+      return jsonResponse(201, { ok: true });
+    }
+    case 'PUT': {
+      await store.write(fsPath, req.body ?? new Uint8Array(), signal);
+      return jsonResponse(200, { ok: true });
+    }
+    case 'DELETE': {
+      await store.delete(fsPath, signal);
+      return jsonResponse(200, { ok: true });
+    }
+    default:
+      return errorResponse('bad-request', `Unsupported method: ${req.method}`);
+  }
+}
+
+async function handleStat(
+  store: RemoteFileStore,
+  req: RemoteRequest,
+  signal?: AbortSignal,
+): Promise<RemoteResponse> {
+  if (req.method !== 'GET') {
+    return errorResponse('bad-request', 'Only GET is supported for /stat');
+  }
+  const fsPath = req.query.path;
+  if (!fsPath) {
+    return errorResponse('bad-request', 'Missing ?path=<fsPath>');
+  }
+  const stat = await store.stat(fsPath, signal);
+  if (!stat) {
+    return errorResponse('not-found', `File not found: ${fsPath}`);
+  }
+  const body: StatResponse = stat;
+  return jsonResponse(200, body);
+}
+
+async function handleRename(
+  store: RemoteFileStore,
+  req: RemoteRequest,
+  signal?: AbortSignal,
+): Promise<RemoteResponse> {
+  if (req.method !== 'POST') {
+    return errorResponse('bad-request', 'Only POST is supported for /rename');
+  }
+  let parsed: RenameRequestBody;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(req.body ?? new Uint8Array()));
+  } catch {
+    return errorResponse('bad-request', 'Invalid JSON body');
+  }
+  if (
+    !parsed ||
+    typeof parsed.from !== 'string' ||
+    typeof parsed.to !== 'string'
+  ) {
+    return errorResponse('bad-request', 'Body must be { from, to }');
+  }
+  await store.rename(parsed.from, parsed.to, signal);
+  return jsonResponse(200, { ok: true });
+}
+
+function isAbort(error: unknown, signal?: AbortSignal): boolean {
+  if (signal?.aborted) {
+    return true;
+  }
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'AbortError'
+  );
+}

--- a/packages/js-lib/remote-file-sync/router.ts
+++ b/packages/js-lib/remote-file-sync/router.ts
@@ -85,10 +85,21 @@ function isAuthorized(req: RemoteRequest, token: string): boolean {
   if (!header) {
     return false;
   }
-  const expected = `Bearer ${token}`;
-  // Constant-ish comparison; token secrecy here is best-effort, the real
-  // protection is TLS + a strong token chosen by the operator.
-  return header === expected;
+  return safeEqual(header, `Bearer ${token}`);
+}
+
+/**
+ * Length-independent comparison that does not short-circuit on the first
+ * mismatched byte, so response timing does not leak the token. TLS + a strong
+ * operator-chosen token remain the primary protection.
+ */
+function safeEqual(a: string, b: string): boolean {
+  let mismatch = a.length ^ b.length;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    mismatch |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+  }
+  return mismatch === 0;
 }
 
 /**
@@ -101,53 +112,77 @@ export function createRemoteRouter(
   options: RemoteRouterOptions = {},
 ): (req: RemoteRequest, signal?: AbortSignal) => Promise<RemoteResponse> {
   const serverName = options.name ?? 'bangle-remote-file-server';
+  const apiVersion = String(REMOTE_API_VERSION);
 
   return async function handle(
     req: RemoteRequest,
     signal?: AbortSignal,
   ): Promise<RemoteResponse> {
-    try {
-      // /health is always reachable so clients can probe connectivity.
-      if (req.path === REMOTE_ROUTES.health && req.method === 'GET') {
-        const workspaces = await store.listWorkspaces?.(signal);
-        const health: HealthResponse = {
-          name: serverName,
-          apiVersion: REMOTE_API_VERSION,
-          ...(workspaces ? { workspaces } : {}),
-        };
-        return jsonResponse(200, health);
-      }
-
-      if (options.token && !isAuthorized(req, options.token)) {
-        return errorResponse('unauthorized', 'Missing or invalid bearer token');
-      }
-
-      switch (req.path) {
-        case REMOTE_ROUTES.files:
-          return await handleFiles(store, req, signal);
-        case REMOTE_ROUTES.file:
-          return await handleFile(store, req, signal);
-        case REMOTE_ROUTES.stat:
-          return await handleStat(store, req, signal);
-        case REMOTE_ROUTES.rename:
-          return await handleRename(store, req, signal);
-        default:
-          return errorResponse('not-found', `Unknown route: ${req.path}`);
-      }
-    } catch (error) {
-      if (error instanceof RemoteFileError) {
-        return errorResponse(error.code, error.message);
-      }
-      // Propagate abort as-is so transports can surface cancellation.
-      if (isAbort(error, signal)) {
-        throw error;
-      }
-      return errorResponse(
-        'server-error',
-        error instanceof Error ? error.message : 'Unknown server error',
-      );
+    const res = await route(store, options, serverName, req, signal);
+    // Stamp every response so clients can distinguish a genuine API answer
+    // (including a real 404) from an infrastructure response.
+    if (!res.headers[REMOTE_HEADERS.api]) {
+      res.headers[REMOTE_HEADERS.api] = apiVersion;
     }
+    return res;
   };
+}
+
+async function route(
+  store: RemoteFileStore,
+  options: RemoteRouterOptions,
+  serverName: string,
+  req: RemoteRequest,
+  signal?: AbortSignal,
+): Promise<RemoteResponse> {
+  try {
+    const authorized = !options.token || isAuthorized(req, options.token);
+
+    // /health is always reachable so clients can probe connectivity, but it
+    // only lists workspace names to authorized callers.
+    if (req.path === REMOTE_ROUTES.health && req.method === 'GET') {
+      const workspaces = authorized
+        ? await store.listWorkspaces?.(signal)
+        : undefined;
+      const health: HealthResponse = {
+        name: serverName,
+        apiVersion: REMOTE_API_VERSION,
+        ...(workspaces ? { workspaces } : {}),
+      };
+      return jsonResponse(200, health);
+    }
+
+    if (!authorized) {
+      return errorResponse('unauthorized', 'Missing or invalid bearer token');
+    }
+
+    switch (req.path) {
+      case REMOTE_ROUTES.files:
+        return await handleFiles(store, req, signal);
+      case REMOTE_ROUTES.file:
+        return await handleFile(store, req, signal);
+      case REMOTE_ROUTES.stat:
+        return await handleStat(store, req, signal);
+      case REMOTE_ROUTES.rename:
+        return await handleRename(store, req, signal);
+      default:
+        // Not a `not-found` — a 404 from this router always means "file
+        // missing", so an unknown route is a client/bad-request error.
+        return errorResponse('bad-request', `Unknown route: ${req.path}`);
+    }
+  } catch (error) {
+    if (error instanceof RemoteFileError) {
+      return errorResponse(error.code, error.message);
+    }
+    // Propagate abort as-is so transports can surface cancellation.
+    if (isAbort(error, signal)) {
+      throw error;
+    }
+    return errorResponse(
+      'server-error',
+      error instanceof Error ? error.message : 'Unknown server error',
+    );
+  }
 }
 
 async function handleFiles(

--- a/packages/js-lib/remote-file-sync/store.ts
+++ b/packages/js-lib/remote-file-sync/store.ts
@@ -1,0 +1,64 @@
+export interface RemoteFileStat {
+  /** Creation time in ms since epoch. */
+  ctime: number;
+  /** Modification time in ms since epoch. */
+  mtime: number;
+}
+
+export interface RemoteReadResult {
+  bytes: Uint8Array;
+  stat: RemoteFileStat;
+}
+
+/**
+ * The server-side storage contract. A reference server implements this against
+ * a real backend (disk, S3, database); tests and demos use the in-memory
+ * implementation. The {@link createRemoteRouter} maps HTTP requests onto these
+ * methods, so implementing this interface is all a backend author must do.
+ *
+ * Error contract — implementations MUST throw {@link RemoteFileError} with:
+ *  - `already-exists` from {@link create} when the target exists.
+ *  - `not-found` from {@link write}/{@link delete} when the target is missing,
+ *    and from {@link rename} when the source is missing.
+ *  - `invalid-path` for malformed paths (use `assertValidFsPath`).
+ *
+ * {@link read} and {@link stat} return `undefined` for a missing file rather
+ * than throwing, mirroring the Bangle.io file-storage provider contract.
+ */
+export interface RemoteFileStore {
+  /** Lists workspace-scoped fs paths under `wsName` (files only). */
+  list(wsName: string, signal?: AbortSignal): Promise<string[]>;
+
+  read(
+    fsPath: string,
+    signal?: AbortSignal,
+  ): Promise<RemoteReadResult | undefined>;
+
+  stat(
+    fsPath: string,
+    signal?: AbortSignal,
+  ): Promise<RemoteFileStat | undefined>;
+
+  /** Creates a new file; throws `already-exists` if it already exists. */
+  create(
+    fsPath: string,
+    bytes: Uint8Array,
+    signal?: AbortSignal,
+  ): Promise<void>;
+
+  /** Overwrites an existing file; throws `not-found` if it does not exist. */
+  write(fsPath: string, bytes: Uint8Array, signal?: AbortSignal): Promise<void>;
+
+  /** Deletes a file; throws `not-found` if it does not exist. */
+  delete(fsPath: string, signal?: AbortSignal): Promise<void>;
+
+  /**
+   * Renames/moves a file. Throws `not-found` if the source is missing.
+   * Overwrites the destination if it exists (matching the Bangle.io provider
+   * contract); higher layers guard against clobbering.
+   */
+  rename(from: string, to: string, signal?: AbortSignal): Promise<void>;
+
+  /** Optional: names of workspaces this store hosts (management/bundled mode). */
+  listWorkspaces?(signal?: AbortSignal): Promise<string[]>;
+}

--- a/packages/platform/service-platform/package.json
+++ b/packages/platform/service-platform/package.json
@@ -34,6 +34,7 @@
     "@bangle.io/config": "workspace:*",
     "@bangle.io/constants": "workspace:*",
     "@bangle.io/mini-js-utils": "workspace:*",
+    "@bangle.io/remote-file-sync": "workspace:*",
     "@bangle.io/types": "workspace:*",
     "@bangle.io/ws-path": "workspace:*",
     "jotai": "^2.20.1",

--- a/packages/platform/service-platform/src/__tests__/file-storage-remote.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-remote.spec.ts
@@ -36,7 +36,15 @@ async function setup(options?: {
       serviceContext: { abortSignal: commonOpts.rootAbortSignal },
     },
     null,
-    { onChange, getClient: () => client },
+    {
+      serviceName: 'file-storage-remote',
+      workspaceType: 'remote',
+      displayName: 'Remote Server',
+      description: 'Syncs notes with your own file server',
+      maxFileSizeBytes: FILE_STORAGE_MAX_FILE_SIZE_BYTES.remote,
+      onChange,
+      getClient: () => client,
+    },
   );
   await service.mount();
   return { service, onChange, store };

--- a/packages/platform/service-platform/src/__tests__/file-storage-remote.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-remote.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { BaseFileSystemError, FILE_NOT_FOUND_ERROR } from '@bangle.io/baby-fs';
+import { FILE_STORAGE_MAX_FILE_SIZE_BYTES } from '@bangle.io/constants';
+import {
+  createFetchFromRouter,
+  createHttpRemoteClient,
+  createRemoteRouter,
+  MemoryRemoteFileStore,
+  type RemoteFileStorageClient,
+} from '@bangle.io/remote-file-sync';
+import { createTestEnvironment } from '@bangle.io/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileStorageRemote } from '../file-storage-remote';
+
+async function setup(options?: {
+  client?: RemoteFileStorageClient;
+  now?: () => number;
+}) {
+  const { commonOpts } = createTestEnvironment();
+  const onChange = vi.fn();
+  const store = new MemoryRemoteFileStore({ now: options?.now });
+  const router = createRemoteRouter(store);
+  const client =
+    options?.client ??
+    createHttpRemoteClient({
+      baseUrl: 'https://notes.test',
+      fetch: createFetchFromRouter(router),
+    });
+
+  const service = new FileStorageRemote(
+    {
+      ctx: commonOpts,
+      serviceContext: { abortSignal: commonOpts.rootAbortSignal },
+    },
+    null,
+    { onChange, getClient: () => client },
+  );
+  await service.mount();
+  return { service, onChange, store };
+}
+
+describe('FileStorageRemote (contract)', () => {
+  beforeEach(() => {});
+
+  it('declares the remote storage file-size limit', async () => {
+    const { service } = await setup();
+    expect(service.maxFileSizeBytes).toBe(
+      FILE_STORAGE_MAX_FILE_SIZE_BYTES.remote,
+    );
+    expect(service.workspaceType).toBe('remote');
+  });
+
+  it('should create and read a file', async () => {
+    const { service, onChange } = await setup();
+    const wsPath = 'myWorkspace:myNote.md';
+    await service.createFile(wsPath, new File(['Hello world'], 'myNote.md'));
+    const readFile = await service.readFile(wsPath);
+    expect(await readFile?.text()).toBe('Hello world');
+    expect(onChange).toHaveBeenCalledWith({ type: 'create', wsPath });
+  });
+
+  it('provider contract: createFile rejects existing files without overwriting', async () => {
+    const { service, onChange } = await setup();
+    const wsPath = 'myWorkspace:myNote.md';
+
+    await service.createFile(wsPath, new File(['Original'], 'myNote.md'));
+    await expect(
+      service.createFile(wsPath, new File(['Replacement'], 'myNote.md')),
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        name: 'error::file:already-existing',
+        payload: { wsPath },
+      }),
+    });
+
+    const readFile = await service.readFile(wsPath);
+    expect(await readFile?.text()).toBe('Original');
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should rename and still be able to read the file', async () => {
+    const { service, onChange } = await setup();
+    const oldPath = 'myWorkspace:oldNote.md';
+    const newPath = 'myWorkspace:newNote.md';
+
+    await service.createFile(
+      oldPath,
+      new File(['Renamed content'], 'oldNote.md'),
+    );
+    await service.renameFile(oldPath, { newWsPath: newPath });
+
+    const readFile = await service.readFile(newPath);
+    expect(await readFile?.text()).toBe('Renamed content');
+    expect(onChange).toHaveBeenCalledWith({
+      type: 'rename',
+      oldWsPath: oldPath,
+      newWsPath: newPath,
+    });
+  });
+
+  it('should throw error when writing a file that does not exist', async () => {
+    const { service } = await setup();
+    await expect(
+      service.writeFile(
+        'myWorkspace:nonExistent.md',
+        new File(['No file'], 'nonExistent.md'),
+      ),
+    ).rejects.toThrow(/does not exist/);
+  });
+
+  it('writes update existing files and emit an update event', async () => {
+    const { service, onChange } = await setup();
+    const wsPath = 'myWorkspace:note.md';
+    await service.createFile(wsPath, new File(['one'], 'note.md'));
+    await service.writeFile(wsPath, new File(['two'], 'note.md'));
+    expect(await (await service.readFile(wsPath))?.text()).toBe('two');
+    expect(onChange).toHaveBeenCalledWith({ type: 'update', wsPath });
+  });
+
+  it('should delete a file and it should no longer exist', async () => {
+    const { service, onChange } = await setup();
+    const wsPath = 'myWorkspace:deleteMe.md';
+    await service.createFile(wsPath, new File(['Delete me'], 'deleteMe.md'));
+    expect(await service.fileExists(wsPath)).toBe(true);
+    await service.deleteFile(wsPath);
+    expect(await service.fileExists(wsPath)).toBe(false);
+    expect(onChange).toHaveBeenCalledWith({ type: 'delete', wsPath });
+  });
+
+  it('provider contract: deleteFile throws FILE_NOT_FOUND_ERROR for a missing file', async () => {
+    const { service, onChange } = await setup();
+    const wsPath = 'myWorkspace:doesNotExist.md';
+    await expect(service.deleteFile(wsPath)).rejects.toMatchObject({
+      code: FILE_NOT_FOUND_ERROR,
+    });
+    await expect(service.deleteFile(wsPath)).rejects.toBeInstanceOf(
+      BaseFileSystemError,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('provider contract: renameFile throws FILE_NOT_FOUND_ERROR and does not create the destination', async () => {
+    const { service, onChange } = await setup();
+    const oldPath = 'myWorkspace:doesNotExist.md';
+    const newPath = 'myWorkspace:renamed.md';
+    await expect(
+      service.renameFile(oldPath, { newWsPath: newPath }),
+    ).rejects.toMatchObject({ code: FILE_NOT_FOUND_ERROR });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(await service.fileExists(newPath)).toBe(false);
+  });
+
+  it('fileStat returns timestamps and throws for a missing file', async () => {
+    const { service } = await setup({ now: () => 12345 });
+    const wsPath = 'myWorkspace:note.md';
+    await service.createFile(wsPath, new File(['x'], 'note.md'));
+    expect(await service.fileStat(wsPath)).toEqual({
+      ctime: 12345,
+      mtime: 12345,
+    });
+    await expect(
+      service.fileStat('myWorkspace:missing.md'),
+    ).rejects.toMatchObject({
+      code: FILE_NOT_FOUND_ERROR,
+    });
+  });
+
+  it('listAllFiles returns workspace paths', async () => {
+    const { service } = await setup();
+    await service.createFile('myWorkspace:b.md', new File(['1'], 'b.md'));
+    await service.createFile('myWorkspace:dir/a.md', new File(['2'], 'a.md'));
+    const controller = new AbortController();
+    const files = await service.listAllFiles('myWorkspace', controller.signal);
+    expect(files).toEqual(['myWorkspace:b.md', 'myWorkspace:dir/a.md']);
+  });
+
+  it('surfaces transport failures as error::remote-storage:request-failed', async () => {
+    const failing = createHttpRemoteClient({
+      baseUrl: 'https://notes.test',
+      fetch: async () => {
+        throw new Error('connection refused');
+      },
+    });
+    const { service } = await setup({ client: failing });
+    const controller = new AbortController();
+    await expect(
+      service.listAllFiles('myWorkspace', controller.signal),
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        name: 'error::remote-storage:request-failed',
+        payload: expect.objectContaining({ code: 'network' }),
+      }),
+    });
+  });
+
+  it('surfaces unauthorized responses as request-failed', async () => {
+    const store = new MemoryRemoteFileStore();
+    const router = createRemoteRouter(store, { token: 'secret' });
+    const client = createHttpRemoteClient({
+      baseUrl: 'https://notes.test',
+      token: 'wrong',
+      fetch: createFetchFromRouter(router),
+    });
+    const { service } = await setup({ client });
+    await expect(service.readFile('myWorkspace:note.md')).rejects.toMatchObject(
+      {
+        cause: expect.objectContaining({
+          name: 'error::remote-storage:request-failed',
+          payload: expect.objectContaining({ code: 'unauthorized' }),
+        }),
+      },
+    );
+  });
+});

--- a/packages/platform/service-platform/src/file-storage-remote.ts
+++ b/packages/platform/service-platform/src/file-storage-remote.ts
@@ -51,8 +51,6 @@ export class FileStorageRemote
   public readonly description = 'Syncs notes with your own file server';
   public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.remote;
 
-  private clientCache = new Map<string, RemoteFileStorageClient>();
-
   constructor(
     context: BaseServiceContext,
     dependencies: null,
@@ -61,11 +59,7 @@ export class FileStorageRemote
     super(SERVICE_NAME.fileStorageRemoteService, context, dependencies);
   }
 
-  async hookMount(): Promise<void> {
-    this.addCleanup(() => {
-      this.clientCache.clear();
-    });
-  }
+  async hookMount(): Promise<void> {}
 
   isSupported() {
     return true;
@@ -79,14 +73,11 @@ export class FileStorageRemote
     return WsPath.fromString(wsPath).wsName;
   }
 
+  // Resolve the client on every call rather than caching it: the composition
+  // root builds it from workspace metadata (a cheap in-memory lookup), so a
+  // changed server URL/token takes effect immediately with no stale binding.
   private async getClientFor(wsName: string): Promise<RemoteFileStorageClient> {
-    const cached = this.clientCache.get(wsName);
-    if (cached) {
-      return cached;
-    }
-    const client = await this.config.getClient(wsName);
-    this.clientCache.set(wsName, client);
-    return client;
+    return this.config.getClient(wsName);
   }
 
   /** Wraps any transport-level failure into a typed, user-surfaceable error. */
@@ -193,9 +184,12 @@ export class FileStorageRemote
       }
       const fileName = fsPath.split('/').pop() ?? 'file';
       // Wrap the bytes in a Blob so the File carries a Blob part (portable
-      // across browsers and the test File shim).
+      // across browsers and the test File shim); derive the MIME type from the
+      // extension so image/asset consumers get a usable `type` (parity with the
+      // memory and native providers).
       return new File([new Blob([result.bytes as BlobPart])], fileName, {
         lastModified: result.stat.mtime,
+        type: mimeFromName(fileName),
       });
     } catch (error) {
       return this.failRequest(error, wsName);
@@ -247,10 +241,37 @@ export class FileStorageRemote
       return this.failRequest(error, wsName);
     }
     abortSignal.throwIfAborted();
-    return fsPaths
-      .map((fsPath) => WsPath.fromFSPath(fsPath))
-      .filter((r) => !!r)
-      .map((r) => r.wsPath)
-      .sort((a, b) => a.localeCompare(b));
+    return (
+      fsPaths
+        .map((fsPath) => WsPath.fromFSPath(fsPath))
+        .filter((r) => !!r)
+        // Never surface paths from another workspace, even if the server returns
+        // them — the listing must reflect only the requested workspace.
+        .filter((r) => r.wsName === wsName)
+        .map((r) => r.wsPath)
+        .sort((a, b) => a.localeCompare(b))
+    );
   }
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  txt: 'text/plain',
+  json: 'application/json',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  avif: 'image/avif',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  pdf: 'application/pdf',
+};
+
+function mimeFromName(name: string): string {
+  const ext = name.includes('.') ? name.split('.').pop()?.toLowerCase() : '';
+  return (ext && MIME_BY_EXT[ext]) || '';
 }

--- a/packages/platform/service-platform/src/file-storage-remote.ts
+++ b/packages/platform/service-platform/src/file-storage-remote.ts
@@ -1,0 +1,256 @@
+import { BaseFileSystemError, FILE_NOT_FOUND_ERROR } from '@bangle.io/baby-fs';
+import {
+  BaseService,
+  type BaseServiceContext,
+  throwAppError,
+} from '@bangle.io/base-utils';
+import {
+  FILE_STORAGE_MAX_FILE_SIZE_BYTES,
+  SERVICE_NAME,
+  WORKSPACE_STORAGE_TYPE,
+} from '@bangle.io/constants';
+import {
+  isRemoteFileError,
+  isRemoteFileErrorCode,
+  type RemoteFileStorageClient,
+} from '@bangle.io/remote-file-sync';
+import type {
+  BaseFileStorageProvider,
+  FileStorageChangeEvent,
+} from '@bangle.io/types';
+import { toFSPathOrThrow, WsPath } from '@bangle.io/ws-path';
+
+type Config = {
+  onChange: (event: FileStorageChangeEvent) => void;
+  /**
+   * Resolves the API client for a workspace. The composition root reads the
+   * workspace's stored server URL + token and returns an HTTP (or IPC) client
+   * bound to that endpoint — mirroring how NativeFS resolves a directory handle.
+   */
+  getClient: (
+    wsName: string,
+  ) => RemoteFileStorageClient | Promise<RemoteFileStorageClient>;
+};
+
+/**
+ * A file-storage provider backed by a remote HTTP server that implements the
+ * Bangle.io remote file API (see `@bangle.io/remote-file-sync`). This powers
+ * bring-your-own-server workspaces, the bundled/Docker deployment, and the
+ * Electron desktop backend (via an IPC client), all through one contract.
+ *
+ * Failure handling is deliberate: a network/permission failure never resolves
+ * to empty content or a false success. Reads of a missing file resolve to
+ * `undefined`; every transport failure surfaces as a typed app error.
+ */
+export class FileStorageRemote
+  extends BaseService
+  implements BaseFileStorageProvider
+{
+  public readonly workspaceType = WORKSPACE_STORAGE_TYPE.Remote;
+  public readonly displayName = 'Remote Server';
+  public readonly description = 'Syncs notes with your own file server';
+  public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.remote;
+
+  private clientCache = new Map<string, RemoteFileStorageClient>();
+
+  constructor(
+    context: BaseServiceContext,
+    dependencies: null,
+    private config: Config,
+  ) {
+    super(SERVICE_NAME.fileStorageRemoteService, context, dependencies);
+  }
+
+  async hookMount(): Promise<void> {
+    this.addCleanup(() => {
+      this.clientCache.clear();
+    });
+  }
+
+  isSupported() {
+    return true;
+  }
+
+  private emitChange(event: FileStorageChangeEvent) {
+    this.config.onChange(event);
+  }
+
+  private wsNameOf(wsPath: string): string {
+    return WsPath.fromString(wsPath).wsName;
+  }
+
+  private async getClientFor(wsName: string): Promise<RemoteFileStorageClient> {
+    const cached = this.clientCache.get(wsName);
+    if (cached) {
+      return cached;
+    }
+    const client = await this.config.getClient(wsName);
+    this.clientCache.set(wsName, client);
+    return client;
+  }
+
+  /** Wraps any transport-level failure into a typed, user-surfaceable error. */
+  private failRequest(error: unknown, wsName: string): never {
+    if (isRemoteFileError(error)) {
+      throwAppError(
+        'error::remote-storage:request-failed',
+        error.message || 'Remote file request failed',
+        { wsName, code: error.code, reason: error.message || error.code },
+      );
+    }
+    throw error;
+  }
+
+  async createFile(wsPath: string, file: File): Promise<void> {
+    await this.mountPromise;
+    const wsName = this.wsNameOf(wsPath);
+    const fsPath = toFSPathOrThrow(wsPath);
+    const client = await this.getClientFor(wsName);
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    try {
+      await client.create(fsPath, bytes);
+    } catch (error) {
+      if (isRemoteFileErrorCode(error, 'already-exists')) {
+        throwAppError('error::file:already-existing', 'File already exists', {
+          wsPath,
+        });
+      }
+      this.failRequest(error, wsName);
+    }
+    this.emitChange({ type: 'create', wsPath });
+  }
+
+  async writeFile(wsPath: string, file: File): Promise<void> {
+    await this.mountPromise;
+    const wsName = this.wsNameOf(wsPath);
+    const fsPath = toFSPathOrThrow(wsPath);
+    const client = await this.getClientFor(wsName);
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    try {
+      await client.write(fsPath, bytes);
+    } catch (error) {
+      if (isRemoteFileErrorCode(error, 'not-found')) {
+        throwAppError(
+          'error::file-storage:file-does-not-exist',
+          'Cannot write to file because it does not exist',
+          { wsPath, storage: this.name },
+        );
+      }
+      this.failRequest(error, wsName);
+    }
+    this.emitChange({ type: 'update', wsPath });
+  }
+
+  async deleteFile(wsPath: string): Promise<void> {
+    await this.mountPromise;
+    const wsName = this.wsNameOf(wsPath);
+    const fsPath = toFSPathOrThrow(wsPath);
+    const client = await this.getClientFor(wsName);
+    try {
+      await client.delete(fsPath);
+    } catch (error) {
+      if (isRemoteFileErrorCode(error, 'not-found')) {
+        throw new BaseFileSystemError({
+          message: 'File not found',
+          code: FILE_NOT_FOUND_ERROR,
+        });
+      }
+      this.failRequest(error, wsName);
+    }
+    this.emitChange({ type: 'delete', wsPath });
+  }
+
+  async renameFile(
+    wsPath: string,
+    { newWsPath }: { newWsPath: string },
+  ): Promise<void> {
+    await this.mountPromise;
+    const wsName = this.wsNameOf(wsPath);
+    const client = await this.getClientFor(wsName);
+    try {
+      await client.rename(toFSPathOrThrow(wsPath), toFSPathOrThrow(newWsPath));
+    } catch (error) {
+      if (isRemoteFileErrorCode(error, 'not-found')) {
+        throw new BaseFileSystemError({
+          message: 'File not found',
+          code: FILE_NOT_FOUND_ERROR,
+        });
+      }
+      this.failRequest(error, wsName);
+    }
+    this.emitChange({ type: 'rename', oldWsPath: wsPath, newWsPath });
+  }
+
+  async readFile(wsPath: string): Promise<File | undefined> {
+    await this.mountPromise;
+    const wsName = this.wsNameOf(wsPath);
+    const fsPath = toFSPathOrThrow(wsPath);
+    const client = await this.getClientFor(wsName);
+    try {
+      const result = await client.read(fsPath);
+      if (!result) {
+        return undefined;
+      }
+      const fileName = fsPath.split('/').pop() ?? 'file';
+      // Wrap the bytes in a Blob so the File carries a Blob part (portable
+      // across browsers and the test File shim).
+      return new File([new Blob([result.bytes as BlobPart])], fileName, {
+        lastModified: result.stat.mtime,
+      });
+    } catch (error) {
+      return this.failRequest(error, wsName);
+    }
+  }
+
+  async fileExists(wsPath: string): Promise<boolean> {
+    await this.mountPromise;
+    const wsName = this.wsNameOf(wsPath);
+    const fsPath = toFSPathOrThrow(wsPath);
+    const client = await this.getClientFor(wsName);
+    try {
+      return await client.exists(fsPath);
+    } catch (error) {
+      return this.failRequest(error, wsName);
+    }
+  }
+
+  async fileStat(wsPath: string) {
+    await this.mountPromise;
+    const wsName = this.wsNameOf(wsPath);
+    const fsPath = toFSPathOrThrow(wsPath);
+    const client = await this.getClientFor(wsName);
+    let stat: Awaited<ReturnType<RemoteFileStorageClient['stat']>>;
+    try {
+      stat = await client.stat(fsPath);
+    } catch (error) {
+      return this.failRequest(error, wsName);
+    }
+    if (!stat) {
+      throw new BaseFileSystemError({
+        message: 'File not found',
+        code: FILE_NOT_FOUND_ERROR,
+      });
+    }
+    return { ctime: stat.ctime, mtime: stat.mtime };
+  }
+
+  async listAllFiles(
+    wsName: string,
+    abortSignal: AbortSignal,
+  ): Promise<string[]> {
+    await this.mountPromise;
+    const client = await this.getClientFor(wsName);
+    let fsPaths: string[];
+    try {
+      fsPaths = await client.list(wsName, abortSignal);
+    } catch (error) {
+      return this.failRequest(error, wsName);
+    }
+    abortSignal.throwIfAborted();
+    return fsPaths
+      .map((fsPath) => WsPath.fromFSPath(fsPath))
+      .filter((r) => !!r)
+      .map((r) => r.wsPath)
+      .sort((a, b) => a.localeCompare(b));
+  }
+}

--- a/packages/platform/service-platform/src/file-storage-remote.ts
+++ b/packages/platform/service-platform/src/file-storage-remote.ts
@@ -5,11 +5,6 @@ import {
   throwAppError,
 } from '@bangle.io/base-utils';
 import {
-  FILE_STORAGE_MAX_FILE_SIZE_BYTES,
-  SERVICE_NAME,
-  WORKSPACE_STORAGE_TYPE,
-} from '@bangle.io/constants';
-import {
   isRemoteFileError,
   isRemoteFileErrorCode,
   type RemoteFileStorageClient,
@@ -21,11 +16,19 @@ import type {
 import { toFSPathOrThrow, WsPath } from '@bangle.io/ws-path';
 
 type Config = {
+  /** DI service name (distinct per registered slot). */
+  serviceName: string;
+  /** The workspace type this instance serves (`remote` or `electron`). */
+  workspaceType: string;
+  displayName: string;
+  description: string;
+  maxFileSizeBytes: number;
   onChange: (event: FileStorageChangeEvent) => void;
   /**
-   * Resolves the API client for a workspace. The composition root reads the
-   * workspace's stored server URL + token and returns an HTTP (or IPC) client
-   * bound to that endpoint — mirroring how NativeFS resolves a directory handle.
+   * Resolves the API client for a workspace. The composition root returns an
+   * HTTP client (built from the workspace's server URL + token) or the Electron
+   * IPC client — mirroring how NativeFS resolves a directory handle. The
+   * provider itself is transport-agnostic.
    */
   getClient: (
     wsName: string,
@@ -33,10 +36,11 @@ type Config = {
 };
 
 /**
- * A file-storage provider backed by a remote HTTP server that implements the
- * Bangle.io remote file API (see `@bangle.io/remote-file-sync`). This powers
- * bring-your-own-server workspaces, the bundled/Docker deployment, and the
- * Electron desktop backend (via an IPC client), all through one contract.
+ * A transport-agnostic file-storage provider that speaks the Bangle.io remote
+ * file API (see `@bangle.io/remote-file-sync`). The same class backs two
+ * workspace types via config: `remote` (HTTP — bring-your-own-server / bundled
+ * / Docker) and `electron` (IPC to the desktop main process). Only the injected
+ * client and identity differ.
  *
  * Failure handling is deliberate: a network/permission failure never resolves
  * to empty content or a false success. Reads of a missing file resolve to
@@ -46,17 +50,21 @@ export class FileStorageRemote
   extends BaseService
   implements BaseFileStorageProvider
 {
-  public readonly workspaceType = WORKSPACE_STORAGE_TYPE.Remote;
-  public readonly displayName = 'Remote Server';
-  public readonly description = 'Syncs notes with your own file server';
-  public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.remote;
+  public readonly workspaceType: string;
+  public readonly displayName: string;
+  public readonly description: string;
+  public readonly maxFileSizeBytes: number;
 
   constructor(
     context: BaseServiceContext,
     dependencies: null,
     private config: Config,
   ) {
-    super(SERVICE_NAME.fileStorageRemoteService, context, dependencies);
+    super(config.serviceName, context, dependencies);
+    this.workspaceType = config.workspaceType;
+    this.displayName = config.displayName;
+    this.description = config.description;
+    this.maxFileSizeBytes = config.maxFileSizeBytes;
   }
 
   async hookMount(): Promise<void> {}

--- a/packages/platform/service-platform/src/index.ts
+++ b/packages/platform/service-platform/src/index.ts
@@ -3,6 +3,7 @@ export { BrowserLocalStorageSyncDatabaseService } from './browser-local-storage-
 export { FileStorageIndexedDB } from './file-storage-indexeddb';
 export { FileStorageMemory } from './file-storage-memory';
 export { FileStorageNativeFs } from './file-storage-nativefs';
+export { FileStorageRemote } from './file-storage-remote';
 export type { AppDatabase } from './idb-database';
 export {
   ALL_TABLES,

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -62,6 +62,9 @@ export const WORKSPACE_STORAGE_TYPE = {
   PrivateFS: 'privatefs',
   Github: 'github-storage',
   Memory: 'memory',
+  // A file store hosted on a user-provided HTTP server (bring-your-own-server)
+  // or a bundled/Electron backend that speaks the same API.
+  Remote: 'remote',
 } as const;
 export type WorkspaceStorageType =
   (typeof WORKSPACE_STORAGE_TYPE)[keyof typeof WORKSPACE_STORAGE_TYPE];
@@ -69,6 +72,7 @@ export const FILE_STORAGE_MAX_FILE_SIZE_BYTES = {
   browser: 25 * 1024 * 1024,
   memory: 25 * 1024 * 1024,
   nativeFs: 250 * 1024 * 1024,
+  remote: 50 * 1024 * 1024,
 } as const;
 
 // Add all service names here
@@ -82,6 +86,7 @@ export const SERVICE_NAME = {
   fileStorageIndexedDBService: 'file-storage-indexeddb',
   fileStorageMemoryService: 'file-storage-memory',
   fileStorageNativeFsService: 'file-storage-nativefs',
+  fileStorageRemoteService: 'file-storage-remote',
   fileSystemService: 'file-system-service',
   idbDatabaseService: 'idb-database',
   memoryDatabaseService: 'memory-database',
@@ -100,6 +105,12 @@ export const SERVICE_NAME = {
   pmEditorService: 'pmEditorService',
 } as const;
 export const APP_MAIN_CONTENT_PADDING = 'px-4 py-4 pt-0 md:px-6';
+
+// Electron desktop: the renderer talks to a file store hosted in the main
+// process over IPC. A `remote` workspace whose serverUrl is this sentinel uses
+// the IPC transport instead of HTTP.
+export const DESKTOP_REMOTE_FS_IPC_CHANNEL = 'bangle:remote-fs';
+export const DESKTOP_REMOTE_FS_SERVER_URL = 'bangle-desktop://local';
 export type ServiceName = (typeof SERVICE_NAME)[keyof typeof SERVICE_NAME];
 export { browserHistoryStateEvents } from './browser-history-events';
 export { commandExcludedServices, commandKeyToContext } from './command';

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -62,9 +62,12 @@ export const WORKSPACE_STORAGE_TYPE = {
   PrivateFS: 'privatefs',
   Github: 'github-storage',
   Memory: 'memory',
-  // A file store hosted on a user-provided HTTP server (bring-your-own-server)
-  // or a bundled/Electron backend that speaks the same API.
+  // A file store on a user-provided HTTP server (bring-your-own-server), or the
+  // same server serving the bundled app. Portable across web and desktop.
   Remote: 'remote',
+  // The desktop app's own on-disk store, reached over IPC to the Electron main
+  // process. Local to that install; shares the remote provider's transport.
+  Electron: 'electron',
 } as const;
 export type WorkspaceStorageType =
   (typeof WORKSPACE_STORAGE_TYPE)[keyof typeof WORKSPACE_STORAGE_TYPE];
@@ -73,6 +76,7 @@ export const FILE_STORAGE_MAX_FILE_SIZE_BYTES = {
   memory: 25 * 1024 * 1024,
   nativeFs: 250 * 1024 * 1024,
   remote: 50 * 1024 * 1024,
+  electron: 250 * 1024 * 1024,
 } as const;
 
 // Add all service names here
@@ -87,6 +91,7 @@ export const SERVICE_NAME = {
   fileStorageMemoryService: 'file-storage-memory',
   fileStorageNativeFsService: 'file-storage-nativefs',
   fileStorageRemoteService: 'file-storage-remote',
+  fileStorageElectronService: 'file-storage-electron',
   fileSystemService: 'file-system-service',
   idbDatabaseService: 'idb-database',
   memoryDatabaseService: 'memory-database',
@@ -107,10 +112,8 @@ export const SERVICE_NAME = {
 export const APP_MAIN_CONTENT_PADDING = 'px-4 py-4 pt-0 md:px-6';
 
 // Electron desktop: the renderer talks to a file store hosted in the main
-// process over IPC. A `remote` workspace whose serverUrl is this sentinel uses
-// the IPC transport instead of HTTP.
+// process over IPC. This backs the `electron` ("This device") workspace type.
 export const DESKTOP_REMOTE_FS_IPC_CHANNEL = 'bangle:remote-fs';
-export const DESKTOP_REMOTE_FS_SERVER_URL = 'bangle-desktop://local';
 export type ServiceName = (typeof SERVICE_NAME)[keyof typeof SERVICE_NAME];
 export { browserHistoryStateEvents } from './browser-history-events';
 export { commandExcludedServices, commandKeyToContext } from './command';

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -328,6 +328,18 @@ export const t = {
         directoryPickingUnsupported: 'Directory picking is not supported.',
         pickDirectoryButton: 'Pick Directory',
         invalidDirectoryDefault: 'Invalid directory selection',
+        remoteTitle: 'Remote Server',
+        remoteDescription:
+          'Sync notes with your own file server (bring your own backend).',
+        remoteNamePlaceholder: 'my-notes',
+        remoteServerUrlLabel: 'Server URL',
+        remoteServerUrlPlaceholder: 'https://notes.example.com',
+        remoteTokenLabel: 'Access token (optional)',
+        remoteTokenPlaceholder: 'Leave blank if your server has no token',
+        remoteTokenHelp:
+          'Sent as a Bearer token. Stored locally in this browser only.',
+        remoteInvalidServerUrl:
+          'Enter a valid server URL starting with http:// or https://',
       },
       allFiles: {
         title: 'All Files',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -312,6 +312,8 @@ export const t = {
         invalidName: 'Invalid workspace name',
         browserTitle: 'Browser',
         browserDescription: 'Save workspace data in browser storage',
+        electronTitle: 'This device',
+        electronDescription: 'Save notes on this computer (desktop app)',
         nativeFsTitle: 'Native File System',
         nativeFsDescription: 'Save workspace data in native file system',
         errorTitle: 'Error',

--- a/packages/shared/types/app-errors.ts
+++ b/packages/shared/types/app-errors.ts
@@ -131,6 +131,17 @@ export type AppError =
       };
     }
 
+  // Remote (bring-your-own-server) file storage
+  | {
+      name: `error::remote-storage:request-failed`;
+      payload: {
+        wsName?: string;
+        /** Stable transport code, e.g. `unauthorized`, `network`. */
+        code: string;
+        reason: string;
+      };
+    }
+
   // Editor errors
   | {
       name: `error::editor:load-failed`;

--- a/packages/tooling/desktop-entry/package.json
+++ b/packages/tooling/desktop-entry/package.json
@@ -45,6 +45,9 @@
     "test": "vitest run src --configLoader runner"
   },
   "dependencies": {
+    "@bangle.io/constants": "workspace:*",
+    "@bangle.io/remote-file-server": "workspace:*",
+    "@bangle.io/remote-file-sync": "workspace:*",
     "electron": "43.0.0",
     "electron-updater": "^6.8.9",
     "vite": "^8.1.3"

--- a/packages/tooling/desktop-entry/src/__tests__/remote-fs.spec.ts
+++ b/packages/tooling/desktop-entry/src/__tests__/remote-fs.spec.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DESKTOP_REMOTE_FS_IPC_CHANNEL } from '@bangle.io/constants';
+import {
+  createRemoteClientFromRouter,
+  type RemoteRequest,
+  type RemoteResponse,
+} from '@bangle.io/remote-file-sync';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createDesktopFileStore, registerRemoteFsIpc } from '../remote-fs';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const text = (b: Uint8Array) => new TextDecoder().decode(b);
+
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'bangle-desktop-fs-'));
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+/** A fake ipcMain that captures the registered handler. */
+function fakeIpcMain() {
+  const handlers = new Map<
+    string,
+    (event: unknown, req: RemoteRequest) => Promise<RemoteResponse>
+  >();
+  return {
+    ipcMain: {
+      handle(
+        channel: string,
+        listener: (e: unknown, r: RemoteRequest) => Promise<RemoteResponse>,
+      ) {
+        handlers.set(channel, listener);
+      },
+      removeHandler(channel: string) {
+        handlers.delete(channel);
+      },
+    },
+    invoke: (channel: string, req: RemoteRequest) => {
+      const handler = handlers.get(channel);
+      if (!handler) {
+        throw new Error(`No handler for ${channel}`);
+      }
+      return handler(undefined, req);
+    },
+    has: (channel: string) => handlers.has(channel),
+  };
+}
+
+describe('registerRemoteFsIpc', () => {
+  it('registers a handler that serves the file protocol from disk', async () => {
+    const fake = fakeIpcMain();
+    const store = createDesktopFileStore(root);
+    registerRemoteFsIpc({ ipcMain: fake.ipcMain, store });
+
+    expect(fake.has(DESKTOP_REMOTE_FS_IPC_CHANNEL)).toBe(true);
+
+    // Renderer side: a client whose transport is the IPC invoke.
+    const client = createRemoteClientFromRouter((req) =>
+      fake.invoke(DESKTOP_REMOTE_FS_IPC_CHANNEL, req),
+    );
+
+    await client.create('local/a.md', bytes('desktop note'));
+    expect(text((await client.read('local/a.md'))!.bytes)).toBe('desktop note');
+    // The write actually landed on disk in the main process.
+    expect(await fs.readFile(path.join(root, 'local', 'a.md'), 'utf8')).toBe(
+      'desktop note',
+    );
+
+    await client.write('local/a.md', bytes('edited'));
+    expect(text((await client.read('local/a.md'))!.bytes)).toBe('edited');
+    expect(await client.list('local')).toEqual(['local/a.md']);
+    await client.delete('local/a.md');
+    expect(await client.exists('local/a.md')).toBe(false);
+  });
+
+  it('dispose removes the handler', () => {
+    const fake = fakeIpcMain();
+    const { dispose } = registerRemoteFsIpc({
+      ipcMain: fake.ipcMain,
+      store: createDesktopFileStore(root),
+    });
+    expect(fake.has(DESKTOP_REMOTE_FS_IPC_CHANNEL)).toBe(true);
+    dispose();
+    expect(fake.has(DESKTOP_REMOTE_FS_IPC_CHANNEL)).toBe(false);
+  });
+
+  it('enforces a token when configured', async () => {
+    const fake = fakeIpcMain();
+    registerRemoteFsIpc({
+      ipcMain: fake.ipcMain,
+      store: createDesktopFileStore(root),
+      token: 'desktop-secret',
+    });
+
+    const unauthorized = createRemoteClientFromRouter((req) =>
+      fake.invoke(DESKTOP_REMOTE_FS_IPC_CHANNEL, req),
+    );
+    await expect(unauthorized.list('local')).rejects.toMatchObject({
+      code: 'unauthorized',
+    });
+
+    const authorized = createRemoteClientFromRouter(
+      (req) => fake.invoke(DESKTOP_REMOTE_FS_IPC_CHANNEL, req),
+      { token: 'desktop-secret' },
+    );
+    await authorized.create('local/a.md', bytes('x'));
+    expect(await authorized.exists('local/a.md')).toBe(true);
+  });
+});

--- a/packages/tooling/desktop-entry/src/main.ts
+++ b/packages/tooling/desktop-entry/src/main.ts
@@ -1,10 +1,19 @@
-import { access } from 'node:fs/promises';
+import { access, mkdir } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, BrowserWindow, dialog, net, protocol, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  net,
+  protocol,
+  shell,
+} from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { APP_PROTOCOL, APP_URL } from './protocol';
 import { registerAppProtocol as registerDesktopAppProtocol } from './protocol-handler';
+import { createDesktopFileStore, registerRemoteFsIpc } from './remote-fs';
 import { configureAutoUpdater } from './updater';
 import {
   getBrowserWindowOptions,
@@ -53,6 +62,23 @@ function ensureAppProtocolRegistered(browserDistDir: string): void {
   });
 }
 
+function resolveWorkspaceRoot(): string {
+  const override = process.env.BANGLE_DESKTOP_WORKSPACE_ROOT?.trim();
+  if (override) {
+    return resolve(override);
+  }
+  return join(app.getPath('userData'), 'workspaces');
+}
+
+// Host the file store in the main process and expose it over IPC. The renderer
+// reads/writes local notes through the same protocol used for remote servers.
+async function setupRemoteFs(): Promise<void> {
+  const root = resolveWorkspaceRoot();
+  await mkdir(root, { recursive: true });
+  registerRemoteFsIpc({ ipcMain, store: createDesktopFileStore(root) });
+  console.log(`[desktop] remote-fs backend rooted at ${root}`);
+}
+
 async function createMainWindow(): Promise<BrowserWindow> {
   const browserDistDir = resolveBrowserDistDir();
   await assertBrowserDist(browserDistDir);
@@ -99,6 +125,7 @@ app.on('activate', () => {
 
 void app.whenReady().then(async () => {
   try {
+    await setupRemoteFs();
     await createMainWindow();
     configureAutoUpdater({
       app,

--- a/packages/tooling/desktop-entry/src/preload.ts
+++ b/packages/tooling/desktop-entry/src/preload.ts
@@ -1,4 +1,9 @@
-import { contextBridge } from 'electron';
+import { DESKTOP_REMOTE_FS_IPC_CHANNEL } from '@bangle.io/constants';
+import type {
+  RemoteRequest,
+  RemoteResponse,
+} from '@bangle.io/remote-file-sync';
+import { contextBridge, ipcRenderer } from 'electron';
 import { markDesktopPlatform } from './desktop-document';
 
 if (typeof document !== 'undefined') {
@@ -7,4 +12,10 @@ if (typeof document !== 'undefined') {
 
 contextBridge.exposeInMainWorld('bangleDesktop', {
   platform: process.platform,
+  // Bridge remote file-storage requests to the main-process router. The
+  // renderer's FileStorageRemote provider uses this instead of HTTP on desktop.
+  remoteFs: {
+    request: (req: RemoteRequest): Promise<RemoteResponse> =>
+      ipcRenderer.invoke(DESKTOP_REMOTE_FS_IPC_CHANNEL, req),
+  },
 });

--- a/packages/tooling/desktop-entry/src/remote-fs.ts
+++ b/packages/tooling/desktop-entry/src/remote-fs.ts
@@ -1,0 +1,52 @@
+import { DESKTOP_REMOTE_FS_IPC_CHANNEL } from '@bangle.io/constants';
+import { DiskRemoteFileStore } from '@bangle.io/remote-file-server';
+import {
+  createRemoteRouter,
+  type RemoteFileStore,
+  type RemoteRequest,
+  type RemoteResponse,
+  type RemoteRouter,
+} from '@bangle.io/remote-file-sync';
+
+/**
+ * The subset of Electron's `ipcMain` this module needs. Declared structurally
+ * so tests can pass a fake without importing electron.
+ */
+export interface IpcMainLike {
+  handle(
+    channel: string,
+    listener: (event: unknown, req: RemoteRequest) => Promise<RemoteResponse>,
+  ): void;
+  removeHandler(channel: string): void;
+}
+
+/** Builds the disk-backed store the desktop app uses for local workspaces. */
+export function createDesktopFileStore(rootDir: string): DiskRemoteFileStore {
+  return new DiskRemoteFileStore(rootDir);
+}
+
+/**
+ * Hosts a remote file-storage router in the Electron main process and exposes
+ * it over IPC. The renderer's `FileStorageRemote` provider then reads and
+ * writes through the same protocol it would use for an HTTP server — but the
+ * bytes never leave the machine, and the main process owns the filesystem.
+ *
+ * Returns the router (useful for tests) and a disposer that removes the handler.
+ */
+export function registerRemoteFsIpc(input: {
+  ipcMain: IpcMainLike;
+  store: RemoteFileStore;
+  token?: string;
+  channel?: string;
+}): { router: RemoteRouter; dispose: () => void } {
+  const router = createRemoteRouter(input.store, {
+    token: input.token,
+    name: 'bangle-desktop',
+  });
+  const channel = input.channel ?? DESKTOP_REMOTE_FS_IPC_CHANNEL;
+  input.ipcMain.handle(channel, async (_event, req) => router(req));
+  return {
+    router,
+    dispose: () => input.ipcMain.removeHandler(channel),
+  };
+}

--- a/packages/tooling/e2e-tests/package.json
+++ b/packages/tooling/e2e-tests/package.json
@@ -34,6 +34,8 @@
   "dependencies": {
     "@bangle.io/browser-entry": "workspace:*",
     "@bangle.io/env-vars": "workspace:*",
+    "@bangle.io/remote-file-server": "workspace:*",
+    "@bangle.io/remote-file-sync": "workspace:*",
     "@bangle.io/storybook": "workspace:*",
     "@bangle.io/ui-components": "workspace:*",
     "@playwright/experimental-ct-react": "^1.61.1",

--- a/packages/tooling/e2e-tests/src/remote-workspace.e2e.ts
+++ b/packages/tooling/e2e-tests/src/remote-workspace.e2e.ts
@@ -1,0 +1,98 @@
+import {
+  type StartedRemoteFileServer,
+  startRemoteFileServer,
+} from '@bangle.io/remote-file-server';
+import {
+  MemoryRemoteFileStore,
+  type RemoteFileStore,
+} from '@bangle.io/remote-file-sync';
+import { expect, test } from '@playwright/test';
+import { clearEditor, getEditorLocator, getEditorText } from './common';
+
+// A remote file server runs alongside the test worker. Because it stays up
+// across page reloads, an in-memory store is enough to prove persistence — the
+// server (not the browser) is the source of truth.
+let server: StartedRemoteFileServer | undefined;
+let store: RemoteFileStore & { list(ws: string): Promise<string[]> };
+
+test.beforeAll(async () => {
+  store = new MemoryRemoteFileStore();
+  server = await startRemoteFileServer({
+    store,
+    port: 0,
+    host: '127.0.0.1',
+  });
+});
+
+test.afterAll(async () => {
+  await server?.close();
+  server = undefined;
+});
+
+test('Remote server workspace stores notes on the backend', async ({
+  page,
+}) => {
+  const serverUrl = server?.url ?? '';
+  const wsName = 'remote-ws';
+  const mainContentLocator = page.locator('main.B-app-page-content');
+
+  await page.goto('/');
+
+  await test.step('create a remote-server workspace', async () => {
+    await page.getByRole('button', { name: 'Create Workspace' }).click();
+
+    await expect(page.getByRole('radiogroup')).toContainText('Remote Server');
+    await page.getByRole('radio', { name: /Remote Server/ }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    await page.getByLabel('Workspace Name', { exact: true }).fill(wsName);
+    await page.getByLabel('Server URL', { exact: true }).fill(serverUrl);
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    await expect(page.getByRole('heading', { name: wsName })).toBeVisible();
+    await expect(mainContentLocator).toContainText(
+      'No notes found in this workspace.',
+    );
+  });
+
+  await test.step('create a note', async () => {
+    await page.getByRole('button', { name: 'New Note' }).click();
+    await expect(
+      page.getByRole('dialog', { name: 'Create Note' }),
+    ).toBeVisible();
+    await page.getByLabel('Note name').fill('remote-note');
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    await expect(
+      page
+        .getByLabel('breadcrumb')
+        .getByRole('button', { name: 'remote-note.md' }),
+    ).toBeVisible();
+  });
+
+  await test.step('edit the note', async () => {
+    const editorHandle = getEditorLocator(page, {});
+    await expect(editorHandle).toBeVisible();
+    await editorHandle.click();
+    await clearEditor(page, {});
+    await editorHandle.pressSequentially('# Hello from the server', {
+      delay: 30,
+    });
+    expect((await getEditorText(page, {})).trimEnd()).toBe(
+      'Hello from the server',
+    );
+  });
+
+  await test.step('the note is stored on the backend', async () => {
+    await expect
+      .poll(() => store.list(wsName), { timeout: 5000 })
+      .toContain(`${wsName}/remote-note.md`);
+  });
+
+  await test.step('content survives a reload (served from the backend)', async () => {
+    await page.reload({ waitUntil: 'networkidle' });
+    expect((await getEditorText(page, {})).trimEnd()).toBe(
+      'Hello from the server',
+    );
+  });
+});

--- a/packages/tooling/e2e-tests/src/remote-workspace.e2e.ts
+++ b/packages/tooling/e2e-tests/src/remote-workspace.e2e.ts
@@ -9,9 +9,11 @@ import {
 import { expect, test } from '@playwright/test';
 import { clearEditor, getEditorLocator, getEditorText } from './common';
 
-// A remote file server runs alongside the test worker. Because it stays up
-// across page reloads, an in-memory store is enough to prove persistence — the
-// server (not the browser) is the source of truth.
+// A remote file server runs alongside the test worker. It stays up across page
+// reloads, so an in-memory store is enough to prove persistence — the server
+// (not the browser) is the source of truth. A token is set because cross-origin
+// access (test app origin -> server origin) requires one.
+const TOKEN = 'e2e-secret-token';
 let server: StartedRemoteFileServer | undefined;
 let store: RemoteFileStore & { list(ws: string): Promise<string[]> };
 
@@ -19,6 +21,7 @@ test.beforeAll(async () => {
   store = new MemoryRemoteFileStore();
   server = await startRemoteFileServer({
     store,
+    token: TOKEN,
     port: 0,
     host: '127.0.0.1',
   });
@@ -47,6 +50,7 @@ test('Remote server workspace stores notes on the backend', async ({
 
     await page.getByLabel('Workspace Name', { exact: true }).fill(wsName);
     await page.getByLabel('Server URL', { exact: true }).fill(serverUrl);
+    await page.getByLabel('Access token', { exact: false }).fill(TOKEN);
     await page.getByRole('button', { name: 'Create' }).click();
 
     await expect(page.getByRole('heading', { name: wsName })).toBeVisible();
@@ -95,4 +99,27 @@ test('Remote server workspace stores notes on the backend', async ({
       'Hello from the server',
     );
   });
+});
+
+test('An unreachable remote server surfaces an error and creates no workspace', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Create Workspace' }).click();
+  await page.getByRole('radio', { name: /Remote Server/ }).click();
+  await page.getByRole('button', { name: 'Next' }).click();
+
+  await page.getByLabel('Workspace Name', { exact: true }).fill('broken-ws');
+  // Port 1 is closed — the pre-flight probe fails fast.
+  await page
+    .getByLabel('Server URL', { exact: true })
+    .fill('http://127.0.0.1:1');
+  await page.getByRole('button', { name: 'Create' }).click();
+
+  // The error is surfaced and the dialog stays open (still showing the URL
+  // field); no workspace was created, so no workspace heading appears.
+  await expect(page.getByText(/Could not reach the server/i)).toBeVisible();
+  await expect(page.getByLabel('Server URL', { exact: true })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'broken-ws' })).toHaveCount(0);
 });

--- a/packages/tooling/remote-file-server/Dockerfile
+++ b/packages/tooling/remote-file-server/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+#
+# Reference image that serves BOTH the Bangle.io front-end and the remote
+# file-storage API from a single origin. Build from the repository root:
+#
+#   docker build -f packages/tooling/remote-file-server/Dockerfile -t bangle-io .
+#   docker run -p 8000:8000 -v bangle-data:/data bangle-io
+#
+# Then open http://localhost:8000 — the app talks to the same origin, so no
+# server URL configuration is needed.
+
+# ---- Build stage: build the front-end and bundle the server ----
+FROM node:22-bookworm-slim AS build
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+WORKDIR /repo
+COPY . .
+RUN pnpm install --frozen-lockfile
+# Build the browser front-end -> packages/tooling/browser-entry/dist
+RUN pnpm build
+# Bundle the server into a single self-contained file -> dist/server.mjs
+RUN pnpm --filter @bangle.io/remote-file-server build
+
+# ---- Runtime stage: a lean image, no node_modules required ----
+FROM node:22-bookworm-slim AS runtime
+WORKDIR /app
+COPY --from=build /repo/packages/tooling/remote-file-server/dist/server.mjs ./server.mjs
+COPY --from=build /repo/packages/tooling/browser-entry/dist ./browser-entry
+ENV BANGLE_FILE_SERVER_PORT=8000
+ENV BANGLE_FILE_SERVER_HOST=0.0.0.0
+ENV BANGLE_FILE_SERVER_ROOT=/data
+ENV BANGLE_FILE_SERVER_STATIC_DIR=/app/browser-entry
+# Set BANGLE_FILE_SERVER_TOKEN at runtime to require a bearer token.
+VOLUME ["/data"]
+EXPOSE 8000
+CMD ["node", "server.mjs"]

--- a/packages/tooling/remote-file-server/README.md
+++ b/packages/tooling/remote-file-server/README.md
@@ -1,0 +1,93 @@
+# @bangle.io/remote-file-server
+
+A small, dependency-free Node.js server that implements the [Bangle.io remote
+file-storage API](../../../docs/remote-file-storage.md). Point a Bangle.io
+"Remote Server" workspace at it and your notes are stored as plain Markdown
+files on the server's disk.
+
+It can also serve the Bangle.io front-end itself, so a single container gives
+you a fully self-hosted, local-first note app.
+
+## Quick start
+
+```bash
+# From the repo root
+BANGLE_FILE_SERVER_ROOT=./my-notes \
+  pnpm --filter @bangle.io/remote-file-server start
+# -> listening on http://localhost:8000
+```
+
+Then in Bangle.io (https://app.bangle.io or your own build):
+
+1. **Create workspace → Remote Server**
+2. **Server URL:** `http://localhost:8000`
+3. Leave the token blank (this server is open by default).
+
+Notes now live under `./my-notes/<workspace-name>/…` as real `.md` files.
+
+## Configuration (environment variables)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `BANGLE_FILE_SERVER_PORT` | `8000` | Port to listen on (`PORT` also honoured). |
+| `BANGLE_FILE_SERVER_HOST` | `0.0.0.0` | Interface to bind. |
+| `BANGLE_FILE_SERVER_ROOT` | `./data` | Directory that holds workspace folders. |
+| `BANGLE_FILE_SERVER_TOKEN` | _(none)_ | If set, every API call must send `Authorization: Bearer <token>`. |
+| `BANGLE_FILE_SERVER_STATIC_DIR` | _(none)_ | Serve a built front-end from this dir at the same origin. |
+| `BANGLE_FILE_SERVER_NAME` | `bangle-remote-file-server` | Name reported by `/api/v1/health`. |
+
+## Docker (self-hosted app + storage)
+
+Build an image that serves **both** the app and the API:
+
+```bash
+docker build -f packages/tooling/remote-file-server/Dockerfile -t bangle-io .
+docker run -p 8000:8000 -v bangle-data:/data bangle-io
+```
+
+Open <http://localhost:8000>. Because the app is served from the same origin as
+the API, the "Remote Server" workspace works with an empty/relative URL — no
+configuration required. See [`docker-compose.yml`](./docker-compose.yml) for a
+Compose setup with a persistent volume.
+
+> This addresses the long-standing request for a Docker deployment of Bangle.io
+> (see discussion #216): one container, your data on your disk.
+
+## Build your own server
+
+You do **not** have to use this package. The wire contract is documented in
+[`docs/remote-file-storage.md`](../../../docs/remote-file-storage.md), and the
+engine-neutral request router in `@bangle.io/remote-file-sync` lets you host it
+on any framework. Minimal Express example:
+
+```ts
+import express from 'express';
+import {
+  createRemoteRouter,
+  REMOTE_API_BASE,
+} from '@bangle.io/remote-file-sync';
+import { DiskRemoteFileStore } from '@bangle.io/remote-file-server';
+
+const router = createRemoteRouter(new DiskRemoteFileStore('./data'), {
+  token: process.env.TOKEN,
+});
+
+const app = express();
+app.use(REMOTE_API_BASE, express.raw({ type: '*/*', limit: '50mb' }), async (req, res) => {
+  const response = await router({
+    method: req.method,
+    path: req.path, // already stripped of REMOTE_API_BASE by express
+    query: req.query as Record<string, string>,
+    headers: req.headers as Record<string, string>,
+    body: req.body?.length ? new Uint8Array(req.body) : undefined,
+  });
+  res.status(response.status);
+  for (const [k, v] of Object.entries(response.headers)) res.setHeader(k, v);
+  res.end(response.body ? Buffer.from(response.body) : undefined);
+});
+
+app.listen(8000);
+```
+
+Implement your own storage backend by satisfying the `RemoteFileStore`
+interface (e.g. S3, a database) and passing it to `createRemoteRouter`.

--- a/packages/tooling/remote-file-server/docker-compose.yml
+++ b/packages/tooling/remote-file-server/docker-compose.yml
@@ -1,0 +1,25 @@
+# Run the bundled Bangle.io app + file server.
+#
+#   docker compose -f packages/tooling/remote-file-server/docker-compose.yml up --build
+#
+# Open http://localhost:8000. Notes are stored in the named `bangle-data`
+# volume, so they survive container restarts.
+
+services:
+  bangle:
+    build:
+      # Build context is the repository root so the whole monorepo is available.
+      context: ../../..
+      dockerfile: packages/tooling/remote-file-server/Dockerfile
+    image: bangle-io-remote
+    ports:
+      - '8000:8000'
+    environment:
+      BANGLE_FILE_SERVER_ROOT: /data
+      # Require a bearer token by uncommenting and choosing a strong value:
+      # BANGLE_FILE_SERVER_TOKEN: 'change-me'
+    volumes:
+      - bangle-data:/data
+
+volumes:
+  bangle-data:

--- a/packages/tooling/remote-file-server/package.json
+++ b/packages/tooling/remote-file-server/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@bangle.io/remote-file-server",
+  "description": "Reference Node.js server implementing the Bangle.io remote file-storage HTTP API.",
+  "license": "AGPL-3.0-or-later",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bangle-io/bangle-io.git",
+    "directory": "packages/tooling/remote-file-server"
+  },
+  "authors": [
+    {
+      "name": "Kushan Joshi",
+      "email": "0o3ko0@gmail.com",
+      "web": "http://github.com/kepta"
+    }
+  ],
+  "homepage": "https://bangle.io",
+  "bugs": {
+    "url": "https://github.com/bangle-io/bangle-io/issues"
+  },
+  "banglePackageConfig": {
+    "env": "nodejs",
+    "kind": "app",
+    "allowedRuntimeImports": [
+      "node:fs",
+      "node:fs/promises",
+      "node:http",
+      "node:path",
+      "node:url",
+      "node:process"
+    ]
+  },
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "bin": {
+    "bangle-remote-file-server": "src/cli.ts"
+  },
+  "scripts": {
+    "start": "tsx src/cli.ts",
+    "build": "esbuild src/cli.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/server.mjs",
+    "test": "vitest run src --configLoader runner"
+  },
+  "dependencies": {
+    "@bangle.io/remote-file-sync": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.0",
+    "esbuild": "0.28.1",
+    "tsx": "^4.22.5"
+  }
+}

--- a/packages/tooling/remote-file-server/src/__tests__/disk-store.spec.ts
+++ b/packages/tooling/remote-file-server/src/__tests__/disk-store.spec.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DiskRemoteFileStore } from '../disk-store';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const text = (b: Uint8Array) => new TextDecoder().decode(b);
+
+let root: string;
+let store: DiskRemoteFileStore;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'bangle-disk-store-'));
+  store = new DiskRemoteFileStore(root);
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe('DiskRemoteFileStore', () => {
+  it('creates nested files and reads them back', async () => {
+    await store.create('ws/dir/a.md', bytes('hello'));
+    const read = await store.read('ws/dir/a.md');
+    expect(text(read!.bytes)).toBe('hello');
+    expect(read!.stat.mtime).toBeGreaterThan(0);
+
+    // File actually landed on disk under the workspace folder.
+    const onDisk = await fs.readFile(
+      path.join(root, 'ws', 'dir', 'a.md'),
+      'utf8',
+    );
+    expect(onDisk).toBe('hello');
+  });
+
+  it('create rejects an existing file without overwriting', async () => {
+    await store.create('ws/a.md', bytes('original'));
+    await expect(store.create('ws/a.md', bytes('new'))).rejects.toMatchObject({
+      code: 'already-exists',
+    });
+    expect(text((await store.read('ws/a.md'))!.bytes)).toBe('original');
+  });
+
+  it('write requires an existing file and overwrites it', async () => {
+    await expect(store.write('ws/a.md', bytes('x'))).rejects.toMatchObject({
+      code: 'not-found',
+    });
+    await store.create('ws/a.md', bytes('one'));
+    await store.write('ws/a.md', bytes('two'));
+    expect(text((await store.read('ws/a.md'))!.bytes)).toBe('two');
+  });
+
+  it('read/stat return undefined for missing files', async () => {
+    expect(await store.read('ws/none.md')).toBeUndefined();
+    expect(await store.stat('ws/none.md')).toBeUndefined();
+  });
+
+  it('delete and rename honour the not-found contract', async () => {
+    await expect(store.delete('ws/none.md')).rejects.toMatchObject({
+      code: 'not-found',
+    });
+    await expect(store.rename('ws/none.md', 'ws/x.md')).rejects.toMatchObject({
+      code: 'not-found',
+    });
+
+    await store.create('ws/a.md', bytes('data'));
+    await store.rename('ws/a.md', 'ws/sub/b.md');
+    expect(await store.read('ws/a.md')).toBeUndefined();
+    expect(text((await store.read('ws/sub/b.md'))!.bytes)).toBe('data');
+
+    await store.delete('ws/sub/b.md');
+    expect(await store.read('ws/sub/b.md')).toBeUndefined();
+  });
+
+  it('lists files under a workspace and enumerates workspaces', async () => {
+    await store.create('ws/b.md', bytes('1'));
+    await store.create('ws/dir/a.md', bytes('2'));
+    await store.create('other/c.md', bytes('3'));
+    // Dotfiles are ignored.
+    await fs.mkdir(path.join(root, 'ws', '.git'), { recursive: true });
+    await fs.writeFile(path.join(root, 'ws', '.git', 'HEAD'), 'ref');
+
+    expect(await store.list('ws')).toEqual(['ws/b.md', 'ws/dir/a.md']);
+    expect(await store.listWorkspaces()).toEqual(['other', 'ws']);
+  });
+
+  it('refuses to escape the storage root', async () => {
+    await expect(store.read('ws/../../etc/passwd')).rejects.toMatchObject({
+      code: 'invalid-path',
+    });
+    // A well-formed but symlink-free absolute path is rejected at validation.
+    await expect(store.create('/etc/evil', bytes('x'))).rejects.toMatchObject({
+      code: 'invalid-path',
+    });
+  });
+});

--- a/packages/tooling/remote-file-server/src/__tests__/server.spec.ts
+++ b/packages/tooling/remote-file-server/src/__tests__/server.spec.ts
@@ -70,21 +70,57 @@ describe('remote file server (real HTTP)', () => {
     });
   });
 
-  it('answers CORS preflight requests', async () => {
+  it('answers CORS preflight for a tokened server, and withholds CORS when open', async () => {
+    // Cross-origin access is only granted when a token is configured.
+    started = await startRemoteFileServer({
+      store: new MemoryRemoteFileStore(),
+      token: 'secret',
+      port: 0,
+      host: '127.0.0.1',
+    });
+    const withToken = await fetch(
+      `${started.url}${REMOTE_API_BASE}/file?path=ws/a.md`,
+      { method: 'OPTIONS' },
+    );
+    expect(withToken.status).toBe(204);
+    expect(withToken.headers.get('access-control-allow-origin')).toBe('*');
+    expect(withToken.headers.get('access-control-allow-methods')).toContain(
+      'PUT',
+    );
+    await started.close();
+
     started = await startRemoteFileServer({
       store: new MemoryRemoteFileStore(),
       port: 0,
       host: '127.0.0.1',
     });
-    const res = await fetch(
+    const open = await fetch(
       `${started.url}${REMOTE_API_BASE}/file?path=ws/a.md`,
       {
         method: 'OPTIONS',
       },
     );
-    expect(res.status).toBe(204);
-    expect(res.headers.get('access-control-allow-origin')).toBe('*');
-    expect(res.headers.get('access-control-allow-methods')).toContain('PUT');
+    // Still a valid preflight response, but no permissive CORS header, so a
+    // browser blocks cross-origin reads of a tokenless server.
+    expect(open.status).toBe(204);
+    expect(open.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('rejects an over-sized request body with 413', async () => {
+    started = await startRemoteFileServer({
+      store: new MemoryRemoteFileStore(),
+      maxBodyBytes: 16,
+      port: 0,
+      host: '127.0.0.1',
+    });
+    const res = await fetch(
+      `${started.url}${REMOTE_API_BASE}/file?path=ws/big.md`,
+      {
+        method: 'POST',
+        body: new Uint8Array(64),
+      },
+    );
+    expect(res.status).toBe(413);
   });
 
   it('serves a bundled front-end and falls back to index.html for SPA routes', async () => {

--- a/packages/tooling/remote-file-server/src/__tests__/server.spec.ts
+++ b/packages/tooling/remote-file-server/src/__tests__/server.spec.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createHttpRemoteClient,
+  MemoryRemoteFileStore,
+  REMOTE_API_BASE,
+} from '@bangle.io/remote-file-sync';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DiskRemoteFileStore } from '../disk-store';
+import { type StartedRemoteFileServer, startRemoteFileServer } from '../server';
+
+const bytes = (s: string) => new TextEncoder().encode(s);
+const text = (b: Uint8Array) => new TextDecoder().decode(b);
+
+let started: StartedRemoteFileServer | undefined;
+let root: string;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'bangle-server-'));
+});
+
+afterEach(async () => {
+  await started?.close();
+  started = undefined;
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe('remote file server (real HTTP)', () => {
+  it('round-trips through the HTTP client against a disk store', async () => {
+    started = await startRemoteFileServer({
+      store: new DiskRemoteFileStore(root),
+      port: 0,
+      host: '127.0.0.1',
+    });
+    const client = createHttpRemoteClient({ baseUrl: started.url });
+
+    const health = await client.health();
+    expect(health.apiVersion).toBe(1);
+
+    await client.create('ws/a.md', bytes('hello'));
+    expect(text((await client.read('ws/a.md'))!.bytes)).toBe('hello');
+    await client.write('ws/a.md', bytes('updated'));
+    expect(text((await client.read('ws/a.md'))!.bytes)).toBe('updated');
+    expect(await client.list('ws')).toEqual(['ws/a.md']);
+    await client.rename('ws/a.md', 'ws/b.md');
+    expect(await client.exists('ws/b.md')).toBe(true);
+    await client.delete('ws/b.md');
+    expect(await client.exists('ws/b.md')).toBe(false);
+  });
+
+  it('enforces the bearer token', async () => {
+    started = await startRemoteFileServer({
+      store: new MemoryRemoteFileStore(),
+      token: 'secret',
+      port: 0,
+      host: '127.0.0.1',
+    });
+
+    const good = createHttpRemoteClient({
+      baseUrl: started.url,
+      token: 'secret',
+    });
+    await good.create('ws/a.md', bytes('x'));
+    expect(await good.exists('ws/a.md')).toBe(true);
+
+    const bad = createHttpRemoteClient({ baseUrl: started.url, token: 'nope' });
+    await expect(bad.list('ws')).rejects.toMatchObject({
+      code: 'unauthorized',
+    });
+  });
+
+  it('answers CORS preflight requests', async () => {
+    started = await startRemoteFileServer({
+      store: new MemoryRemoteFileStore(),
+      port: 0,
+      host: '127.0.0.1',
+    });
+    const res = await fetch(
+      `${started.url}${REMOTE_API_BASE}/file?path=ws/a.md`,
+      {
+        method: 'OPTIONS',
+      },
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+    expect(res.headers.get('access-control-allow-methods')).toContain('PUT');
+  });
+
+  it('serves a bundled front-end and falls back to index.html for SPA routes', async () => {
+    const staticDir = path.join(root, 'app');
+    await fs.mkdir(staticDir, { recursive: true });
+    await fs.writeFile(
+      path.join(staticDir, 'index.html'),
+      '<!doctype html>app',
+    );
+
+    started = await startRemoteFileServer({
+      store: new MemoryRemoteFileStore(),
+      staticDir,
+      port: 0,
+      host: '127.0.0.1',
+    });
+
+    const root404 = await fetch(`${started.url}/`);
+    expect(root404.status).toBe(200);
+    expect(await root404.text()).toContain('app');
+
+    const spa = await fetch(`${started.url}/ws/some/deep/route`);
+    expect(spa.status).toBe(200);
+    expect(await spa.text()).toContain('app');
+
+    // The API still wins over static under the API base.
+    const health = await fetch(`${started.url}${REMOTE_API_BASE}/health`);
+    expect(health.status).toBe(200);
+  });
+
+  it('injects the bundled marker into served HTML', async () => {
+    const staticDir = path.join(root, 'app');
+    await fs.mkdir(staticDir, { recursive: true });
+    await fs.writeFile(
+      path.join(staticDir, 'index.html'),
+      '<!doctype html><html><head><title>app</title></head><body></body></html>',
+    );
+
+    started = await startRemoteFileServer({
+      store: new MemoryRemoteFileStore(),
+      staticDir,
+      htmlInject: '<script>window.__BANGLE_REMOTE__={"bundled":true};</script>',
+      port: 0,
+      host: '127.0.0.1',
+    });
+
+    const res = await fetch(`${started.url}/`);
+    const html = await res.text();
+    expect(html).toContain('window.__BANGLE_REMOTE__');
+    expect(html).toContain('</head>');
+    // Non-HTML assets are untouched.
+    await fs.writeFile(path.join(staticDir, 'app.js'), 'console.log(1)');
+    const js = await fetch(`${started.url}/app.js`);
+    expect(await js.text()).toBe('console.log(1)');
+  });
+});

--- a/packages/tooling/remote-file-server/src/cli.ts
+++ b/packages/tooling/remote-file-server/src/cli.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import process from 'node:process';
+import { readConfigFromEnv } from './config';
+import { DiskRemoteFileStore } from './disk-store';
+import { startRemoteFileServer } from './server';
+
+async function main(): Promise<void> {
+  const config = readConfigFromEnv();
+  await fs.mkdir(config.root, { recursive: true });
+
+  const store = new DiskRemoteFileStore(config.root);
+  const started = await startRemoteFileServer({
+    store,
+    token: config.token,
+    name: config.name,
+    staticDir: config.staticDir,
+    // In bundled mode, tell the app it can default a workspace to this origin.
+    htmlInject: config.staticDir
+      ? '<script>window.__BANGLE_REMOTE__={"bundled":true};</script>'
+      : undefined,
+    port: config.port,
+    host: config.host,
+  });
+
+  console.log(`[remote-file-server] listening on ${started.url}`);
+  console.log(`[remote-file-server] data root: ${config.root}`);
+  console.log(
+    `[remote-file-server] auth: ${config.token ? 'bearer token required' : 'open (no token)'}`,
+  );
+  if (config.staticDir) {
+    console.log(
+      `[remote-file-server] serving front-end from: ${config.staticDir}`,
+    );
+  }
+
+  const shutdown = async () => {
+    console.log('\n[remote-file-server] shutting down…');
+    await started.close();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch((error) => {
+  console.error('[remote-file-server] failed to start', error);
+  process.exit(1);
+});

--- a/packages/tooling/remote-file-server/src/config.ts
+++ b/packages/tooling/remote-file-server/src/config.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import process from 'node:process';
+
+export interface ServerConfig {
+  port: number;
+  host: string;
+  root: string;
+  token?: string;
+  staticDir?: string;
+  name: string;
+}
+
+/** Reads server configuration from environment variables. */
+export function readConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ServerConfig {
+  const port = Number(env.BANGLE_FILE_SERVER_PORT ?? env.PORT ?? '8000');
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(
+      `Invalid BANGLE_FILE_SERVER_PORT: ${env.BANGLE_FILE_SERVER_PORT}`,
+    );
+  }
+  const root = path.resolve(env.BANGLE_FILE_SERVER_ROOT ?? './data');
+  const staticDir = env.BANGLE_FILE_SERVER_STATIC_DIR
+    ? path.resolve(env.BANGLE_FILE_SERVER_STATIC_DIR)
+    : undefined;
+
+  return {
+    port,
+    host: env.BANGLE_FILE_SERVER_HOST ?? '0.0.0.0',
+    root,
+    token: env.BANGLE_FILE_SERVER_TOKEN || undefined,
+    staticDir,
+    name: env.BANGLE_FILE_SERVER_NAME ?? 'bangle-remote-file-server',
+  };
+}

--- a/packages/tooling/remote-file-server/src/config.ts
+++ b/packages/tooling/remote-file-server/src/config.ts
@@ -25,11 +25,17 @@ export function readConfigFromEnv(
     ? path.resolve(env.BANGLE_FILE_SERVER_STATIC_DIR)
     : undefined;
 
+  const token = env.BANGLE_FILE_SERVER_TOKEN || undefined;
+  // Without a token, bind loopback by default so the store is not exposed to
+  // the local network; a tokened server defaults to all interfaces. Either can
+  // be overridden explicitly (the Docker image sets 0.0.0.0).
+  const host = env.BANGLE_FILE_SERVER_HOST ?? (token ? '0.0.0.0' : '127.0.0.1');
+
   return {
     port,
-    host: env.BANGLE_FILE_SERVER_HOST ?? '0.0.0.0',
+    host,
     root,
-    token: env.BANGLE_FILE_SERVER_TOKEN || undefined,
+    token,
     staticDir,
     name: env.BANGLE_FILE_SERVER_NAME ?? 'bangle-remote-file-server',
   };

--- a/packages/tooling/remote-file-server/src/disk-store.ts
+++ b/packages/tooling/remote-file-server/src/disk-store.ts
@@ -1,0 +1,216 @@
+import type { Dirent } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  assertValidFsPath,
+  assertValidWsName,
+  RemoteFileError,
+  type RemoteFileStat,
+  type RemoteFileStore,
+  type RemoteReadResult,
+} from '@bangle.io/remote-file-sync';
+
+function isErrnoException(
+  error: unknown,
+  code: string,
+): error is NodeJS.ErrnoException {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === code
+  );
+}
+
+/**
+ * A {@link RemoteFileStore} backed by the local filesystem. Files live under
+ * `<root>/<wsName>/<...>`; the first path segment is the workspace name, so a
+ * single root can host many workspaces side by side.
+ *
+ * Every path is validated and re-checked to stay within `root`, so a crafted
+ * request can never read or write outside the data directory.
+ */
+export class DiskRemoteFileStore implements RemoteFileStore {
+  private root: string;
+
+  constructor(root: string) {
+    this.root = path.resolve(root);
+  }
+
+  private resolve(fsPath: string): string {
+    assertValidFsPath(fsPath);
+    const full = path.resolve(this.root, fsPath);
+    const rootWithSep = this.root.endsWith(path.sep)
+      ? this.root
+      : this.root + path.sep;
+    if (full !== this.root && !full.startsWith(rootWithSep)) {
+      throw new RemoteFileError(
+        'invalid-path',
+        `Path escapes storage root: ${fsPath}`,
+      );
+    }
+    return full;
+  }
+
+  async list(wsName: string): Promise<string[]> {
+    assertValidWsName(wsName);
+    const wsDir = path.resolve(this.root, wsName);
+    const results: string[] = [];
+    await this.walk(wsDir, wsName, results);
+    return results.sort((a, b) => a.localeCompare(b));
+  }
+
+  private async readDirSafe(dir: string): Promise<Dirent<string>[]> {
+    try {
+      return await fs.readdir(dir, { withFileTypes: true });
+    } catch (error) {
+      if (
+        isErrnoException(error, 'ENOENT') ||
+        isErrnoException(error, 'ENOTDIR')
+      ) {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  private async walk(
+    dir: string,
+    relPrefix: string,
+    out: string[],
+  ): Promise<void> {
+    const entries = await this.readDirSafe(dir);
+    for (const entry of entries) {
+      // Skip dotfiles/dot-directories (.git, .DS_Store, etc.).
+      if (entry.name.startsWith('.')) {
+        continue;
+      }
+      const childRel = `${relPrefix}/${entry.name}`;
+      if (entry.isDirectory()) {
+        await this.walk(path.join(dir, entry.name), childRel, out);
+      } else if (entry.isFile()) {
+        out.push(childRel);
+      }
+    }
+  }
+
+  async read(fsPath: string): Promise<RemoteReadResult | undefined> {
+    const full = this.resolve(fsPath);
+    try {
+      const [bytes, stat] = await Promise.all([
+        fs.readFile(full),
+        fs.stat(full),
+      ]);
+      return { bytes: new Uint8Array(bytes), stat: toStat(stat) };
+    } catch (error) {
+      if (
+        isErrnoException(error, 'ENOENT') ||
+        isErrnoException(error, 'EISDIR')
+      ) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async stat(fsPath: string): Promise<RemoteFileStat | undefined> {
+    const full = this.resolve(fsPath);
+    try {
+      const stat = await fs.stat(full);
+      if (!stat.isFile()) {
+        return undefined;
+      }
+      return toStat(stat);
+    } catch (error) {
+      if (isErrnoException(error, 'ENOENT')) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async create(fsPath: string, bytes: Uint8Array): Promise<void> {
+    const full = this.resolve(fsPath);
+    await fs.mkdir(path.dirname(full), { recursive: true });
+    try {
+      // `wx` fails if the path already exists — atomic create-if-absent.
+      await fs.writeFile(full, bytes, { flag: 'wx' });
+    } catch (error) {
+      if (isErrnoException(error, 'EEXIST')) {
+        throw new RemoteFileError(
+          'already-exists',
+          `File already exists: ${fsPath}`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async write(fsPath: string, bytes: Uint8Array): Promise<void> {
+    const full = this.resolve(fsPath);
+    // Preserve the "write requires existing file" contract without a TOCTOU
+    // hole: openn with `r+` proves existence, then truncate + write.
+    let handle: Awaited<ReturnType<typeof fs.open>>;
+    try {
+      handle = await fs.open(full, 'r+');
+    } catch (error) {
+      if (isErrnoException(error, 'ENOENT')) {
+        throw new RemoteFileError('not-found', `File not found: ${fsPath}`);
+      }
+      throw error;
+    }
+    try {
+      await handle.truncate(0);
+      await handle.write(bytes, 0);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async delete(fsPath: string): Promise<void> {
+    const full = this.resolve(fsPath);
+    try {
+      await fs.unlink(full);
+    } catch (error) {
+      if (isErrnoException(error, 'ENOENT')) {
+        throw new RemoteFileError('not-found', `File not found: ${fsPath}`);
+      }
+      throw error;
+    }
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    const fromFull = this.resolve(from);
+    const toFull = this.resolve(to);
+    await fs.mkdir(path.dirname(toFull), { recursive: true });
+    try {
+      await fs.rename(fromFull, toFull);
+    } catch (error) {
+      if (isErrnoException(error, 'ENOENT')) {
+        throw new RemoteFileError('not-found', `File not found: ${from}`);
+      }
+      throw error;
+    }
+  }
+
+  async listWorkspaces(): Promise<string[]> {
+    const entries = await this.readDirSafe(this.root);
+    return entries
+      .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+      .map((entry) => entry.name)
+      .sort((a, b) => a.localeCompare(b));
+  }
+}
+
+function toStat(stat: {
+  birthtimeMs: number;
+  mtimeMs: number;
+}): RemoteFileStat {
+  const mtime = Math.round(stat.mtimeMs);
+  const birth = Math.round(stat.birthtimeMs);
+  return {
+    // birthtime is 0 on some filesystems; fall back to mtime.
+    ctime: birth > 0 ? birth : mtime,
+    mtime,
+  };
+}

--- a/packages/tooling/remote-file-server/src/disk-store.ts
+++ b/packages/tooling/remote-file-server/src/disk-store.ts
@@ -1,6 +1,7 @@
 import type { Dirent } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import process from 'node:process';
 import {
   assertValidFsPath,
   assertValidWsName,
@@ -32,6 +33,7 @@ function isErrnoException(
  */
 export class DiskRemoteFileStore implements RemoteFileStore {
   private root: string;
+  private tmpCounter = 0;
 
   constructor(root: string) {
     this.root = path.resolve(root);
@@ -148,22 +150,35 @@ export class DiskRemoteFileStore implements RemoteFileStore {
 
   async write(fsPath: string, bytes: Uint8Array): Promise<void> {
     const full = this.resolve(fsPath);
-    // Preserve the "write requires existing file" contract without a TOCTOU
-    // hole: openn with `r+` proves existence, then truncate + write.
-    let handle: Awaited<ReturnType<typeof fs.open>>;
+
+    // Preserve the "write requires an existing file" contract.
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
     try {
-      handle = await fs.open(full, 'r+');
+      stat = await fs.stat(full);
     } catch (error) {
       if (isErrnoException(error, 'ENOENT')) {
         throw new RemoteFileError('not-found', `File not found: ${fsPath}`);
       }
       throw error;
     }
+    if (!stat.isFile()) {
+      throw new RemoteFileError('not-found', `Not a file: ${fsPath}`);
+    }
+
+    // Durable write: fully write a sibling temp file, then atomically rename it
+    // over the target. A crash/power-loss can never leave the note truncated or
+    // empty — the reader sees either the old bytes or the new bytes. The temp is
+    // dot-prefixed so a leftover never surfaces in a listing.
+    const tmp = path.join(
+      path.dirname(full),
+      `.${path.basename(full)}.tmp-${process.pid}-${this.tmpCounter++}`,
+    );
     try {
-      await handle.truncate(0);
-      await handle.write(bytes, 0);
-    } finally {
-      await handle.close();
+      await fs.writeFile(tmp, bytes);
+      await fs.rename(tmp, full);
+    } catch (error) {
+      await fs.rm(tmp, { force: true });
+      throw error;
     }
   }
 

--- a/packages/tooling/remote-file-server/src/index.ts
+++ b/packages/tooling/remote-file-server/src/index.ts
@@ -1,0 +1,9 @@
+export { readConfigFromEnv, type ServerConfig } from './config';
+export { DiskRemoteFileStore } from './disk-store';
+export {
+  createRemoteFileServer,
+  type RemoteFileServerOptions,
+  type StartedRemoteFileServer,
+  startRemoteFileServer,
+} from './server';
+export { serveStatic } from './static-files';

--- a/packages/tooling/remote-file-server/src/server.ts
+++ b/packages/tooling/remote-file-server/src/server.ts
@@ -1,0 +1,189 @@
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+import { createServer } from 'node:http';
+import {
+  createRemoteRouter,
+  REMOTE_API_BASE,
+  REMOTE_HEADERS,
+  type RemoteFileStore,
+  type RemoteRequest,
+} from '@bangle.io/remote-file-sync';
+import { serveStatic } from './static-files';
+
+export interface RemoteFileServerOptions {
+  store: RemoteFileStore;
+  /** Bearer token required on API calls (except `/health`). */
+  token?: string;
+  /** Name reported by `/health`. */
+  name?: string;
+  /**
+   * Directory of a built Bangle.io front-end to serve at the same origin as the
+   * API. When set, the server doubles as the app host ("bundled" mode).
+   */
+  staticDir?: string;
+  /**
+   * HTML injected before `</head>` of served pages. Used in bundled mode to
+   * hint the front-end that it can default a remote workspace to this origin.
+   */
+  htmlInject?: string;
+  logger?: Pick<Console, 'log' | 'error'>;
+}
+
+const CORS_HEADERS: Record<string, string> = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET,HEAD,POST,PUT,DELETE,OPTIONS',
+  'access-control-allow-headers': `${REMOTE_HEADERS.authorization},${REMOTE_HEADERS.contentType},${REMOTE_HEADERS.client}`,
+  'access-control-expose-headers': `${REMOTE_HEADERS.mtime},${REMOTE_HEADERS.ctime}`,
+  'access-control-max-age': '86400',
+};
+
+/**
+ * Creates (but does not start) an HTTP server exposing the remote file API and,
+ * optionally, a bundled front-end. Use {@link startRemoteFileServer} to listen.
+ */
+export function createRemoteFileServer(
+  options: RemoteFileServerOptions,
+): Server {
+  const router = createRemoteRouter(options.store, {
+    token: options.token,
+    name: options.name,
+  });
+  const logger = options.logger ?? console;
+
+  return createServer((req, res) => {
+    handle(req, res, router, options).catch((error) => {
+      logger.error?.('[remote-file-server] request failed', error);
+      if (!res.headersSent) {
+        res.statusCode = 500;
+        res.setHeader('content-type', 'application/json');
+      }
+      res.end(JSON.stringify({ error: 'server-error' }));
+    });
+  });
+}
+
+async function handle(
+  req: IncomingMessage,
+  res: ServerResponse,
+  router: ReturnType<typeof createRemoteRouter>,
+  options: RemoteFileServerOptions,
+): Promise<void> {
+  const method = req.method ?? 'GET';
+  const url = new URL(req.url ?? '/', 'http://localhost');
+
+  // CORS: the front-end at app.bangle.io must be able to call a user's server
+  // on another origin. Bearer-token auth (not cookies) keeps `*` origin safe.
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    res.setHeader(key, value);
+  }
+  if (method === 'OPTIONS') {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
+  if (url.pathname.startsWith(REMOTE_API_BASE)) {
+    await handleApi(req, res, router, method, url);
+    return;
+  }
+
+  if (options.staticDir) {
+    const served = await serveStatic(options.staticDir, url.pathname, res, {
+      injectHead: options.htmlInject,
+    });
+    if (served) {
+      return;
+    }
+  }
+
+  res.statusCode = 404;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({ error: 'not-found' }));
+}
+
+async function handleApi(
+  req: IncomingMessage,
+  res: ServerResponse,
+  router: ReturnType<typeof createRemoteRouter>,
+  method: string,
+  url: URL,
+): Promise<void> {
+  const body =
+    method === 'POST' || method === 'PUT' ? await readBody(req) : undefined;
+
+  const query: Record<string, string> = {};
+  for (const [key, value] of url.searchParams) {
+    query[key] = value;
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === 'string') {
+      headers[key.toLowerCase()] = value;
+    } else if (Array.isArray(value)) {
+      headers[key.toLowerCase()] = value.join(',');
+    }
+  }
+
+  const request: RemoteRequest = {
+    method,
+    path: url.pathname.slice(REMOTE_API_BASE.length) || '/',
+    query,
+    headers,
+    body,
+  };
+
+  const response = await router(request);
+  res.statusCode = response.status;
+  for (const [key, value] of Object.entries(response.headers)) {
+    res.setHeader(key, value);
+  }
+  if (response.body && method !== 'HEAD') {
+    res.end(Buffer.from(response.body));
+  } else {
+    res.end();
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(new Uint8Array(Buffer.concat(chunks))));
+    req.on('error', reject);
+  });
+}
+
+export interface StartedRemoteFileServer {
+  server: Server;
+  port: number;
+  host: string;
+  url: string;
+  close: () => Promise<void>;
+}
+
+/** Starts the server and resolves once it is listening. */
+export function startRemoteFileServer(
+  options: RemoteFileServerOptions & { port: number; host?: string },
+): Promise<StartedRemoteFileServer> {
+  const server = createRemoteFileServer(options);
+  const host = options.host ?? '0.0.0.0';
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(options.port, host, () => {
+      const address = server.address();
+      const port =
+        typeof address === 'object' && address ? address.port : options.port;
+      const displayHost = host === '0.0.0.0' ? 'localhost' : host;
+      resolve({
+        server,
+        port,
+        host,
+        url: `http://${displayHost}:${port}`,
+        close: () =>
+          new Promise<void>((res, rej) =>
+            server.close((err) => (err ? rej(err) : res())),
+          ),
+      });
+    });
+  });
+}

--- a/packages/tooling/remote-file-server/src/server.ts
+++ b/packages/tooling/remote-file-server/src/server.ts
@@ -3,11 +3,17 @@ import { createServer } from 'node:http';
 import {
   createRemoteRouter,
   REMOTE_API_BASE,
+  REMOTE_API_VERSION,
   REMOTE_HEADERS,
   type RemoteFileStore,
   type RemoteRequest,
 } from '@bangle.io/remote-file-sync';
 import { serveStatic } from './static-files';
+
+/** Upper bound on a request body. Above the client's 50MB file cap. */
+const DEFAULT_MAX_BODY_BYTES = 64 * 1024 * 1024;
+
+class PayloadTooLargeError extends Error {}
 
 export interface RemoteFileServerOptions {
   store: RemoteFileStore;
@@ -25,6 +31,8 @@ export interface RemoteFileServerOptions {
    * hint the front-end that it can default a remote workspace to this origin.
    */
   htmlInject?: string;
+  /** Max request body in bytes (default 64 MiB); larger requests get `413`. */
+  maxBodyBytes?: number;
   logger?: Pick<Console, 'log' | 'error'>;
 }
 
@@ -70,10 +78,14 @@ async function handle(
   const method = req.method ?? 'GET';
   const url = new URL(req.url ?? '/', 'http://localhost');
 
-  // CORS: the front-end at app.bangle.io must be able to call a user's server
-  // on another origin. Bearer-token auth (not cookies) keeps `*` origin safe.
-  for (const [key, value] of Object.entries(CORS_HEADERS)) {
-    res.setHeader(key, value);
+  // Cross-origin access (e.g. app.bangle.io → your server) is only allowed when
+  // a token is configured. Without CORS headers the browser blocks cross-origin
+  // reads, so a tokenless server can't be pillaged by a random website the user
+  // visits; same-origin (bundled/Docker) mode needs no CORS and is unaffected.
+  if (options.token) {
+    for (const [key, value] of Object.entries(CORS_HEADERS)) {
+      res.setHeader(key, value);
+    }
   }
   if (method === 'OPTIONS') {
     res.statusCode = 204;
@@ -82,7 +94,7 @@ async function handle(
   }
 
   if (url.pathname.startsWith(REMOTE_API_BASE)) {
-    await handleApi(req, res, router, method, url);
+    await handleApi(req, res, router, method, url, options);
     return;
   }
 
@@ -106,9 +118,32 @@ async function handleApi(
   router: ReturnType<typeof createRemoteRouter>,
   method: string,
   url: URL,
+  options: RemoteFileServerOptions,
 ): Promise<void> {
-  const body =
-    method === 'POST' || method === 'PUT' ? await readBody(req) : undefined;
+  const maxBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  let body: Uint8Array | undefined;
+  if (method === 'POST' || method === 'PUT') {
+    try {
+      body = await readBody(req, maxBytes);
+    } catch (error) {
+      if (error instanceof PayloadTooLargeError) {
+        res.statusCode = 413;
+        // Close the connection: we stopped reading the body, so the socket
+        // can't be safely reused. The response still flushes to the client.
+        res.setHeader('connection', 'close');
+        res.setHeader(REMOTE_HEADERS.api, String(REMOTE_API_VERSION));
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            error: 'bad-request',
+            message: 'Payload too large',
+          }),
+        );
+        return;
+      }
+      throw error;
+    }
+  }
 
   const query: Record<string, string> = {};
   for (const [key, value] of url.searchParams) {
@@ -144,10 +179,26 @@ async function handleApi(
   }
 }
 
-function readBody(req: IncomingMessage): Promise<Uint8Array> {
+function readBody(req: IncomingMessage, maxBytes: number): Promise<Uint8Array> {
   return new Promise((resolve, reject) => {
+    const declared = Number(req.headers['content-length']);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      // Pause (don't destroy) so the caller can still flush a 413 response.
+      req.pause();
+      reject(new PayloadTooLargeError());
+      return;
+    }
     const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    let total = 0;
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        req.pause();
+        reject(new PayloadTooLargeError());
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on('end', () => resolve(new Uint8Array(Buffer.concat(chunks))));
     req.on('error', reject);
   });

--- a/packages/tooling/remote-file-server/src/static-files.ts
+++ b/packages/tooling/remote-file-server/src/static-files.ts
@@ -1,0 +1,106 @@
+import { createReadStream } from 'node:fs';
+import fs from 'node:fs/promises';
+import type { ServerResponse } from 'node:http';
+import path from 'node:path';
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.map': 'application/json; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.wasm': 'application/wasm',
+};
+
+function contentTypeFor(filePath: string): string {
+  return (
+    CONTENT_TYPES[path.extname(filePath).toLowerCase()] ??
+    'application/octet-stream'
+  );
+}
+
+/**
+ * Serves a single-page app from `rootDir`. Real files are streamed as-is;
+ * unknown routes fall back to `index.html` so client-side routing works. Path
+ * traversal is prevented by resolving within `rootDir`.
+ *
+ * Returns `true` when it handled the request, `false` when the app shell is
+ * missing (so the caller can 404).
+ */
+export async function serveStatic(
+  rootDir: string,
+  pathname: string,
+  res: ServerResponse,
+  options: { injectHead?: string } = {},
+): Promise<boolean> {
+  const root = path.resolve(rootDir);
+  const decoded = decodeURIComponent(pathname);
+  const requested = path.resolve(root, `.${decoded}`);
+
+  const rootWithSep = root.endsWith(path.sep) ? root : root + path.sep;
+  const safe = requested === root || requested.startsWith(rootWithSep);
+
+  let target = safe ? requested : root;
+  let stat = await statOrNull(target);
+  if (stat?.isDirectory()) {
+    target = path.join(target, 'index.html');
+    stat = await statOrNull(target);
+  }
+
+  if (!stat?.isFile()) {
+    // SPA fallback to the app shell.
+    target = path.join(root, 'index.html');
+    stat = await statOrNull(target);
+    if (!stat?.isFile()) {
+      return false;
+    }
+  }
+
+  // Inject a marker into HTML so the front-end knows it is being served by a
+  // Bangle file server (bundled mode) and can default the workspace to this
+  // same origin.
+  const isHtml = target.toLowerCase().endsWith('.html');
+  if (isHtml && options.injectHead) {
+    const html = await fs.readFile(target, 'utf8');
+    const injected = html.includes('</head>')
+      ? html.replace('</head>', `${options.injectHead}</head>`)
+      : options.injectHead + html;
+    const body = Buffer.from(injected, 'utf8');
+    res.statusCode = 200;
+    res.setHeader('content-type', contentTypeFor(target));
+    res.setHeader('content-length', String(body.byteLength));
+    res.end(body);
+    return true;
+  }
+
+  res.statusCode = 200;
+  res.setHeader('content-type', contentTypeFor(target));
+  res.setHeader('content-length', String(stat.size));
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(target);
+    stream.on('error', reject);
+    stream.on('end', resolve);
+    stream.pipe(res);
+  });
+  return true;
+}
+
+async function statOrNull(p: string) {
+  try {
+    return await fs.stat(p);
+  } catch {
+    return null;
+  }
+}

--- a/packages/ui/ui-components/src/workspace-dialog.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.tsx
@@ -11,6 +11,7 @@ import {
   Input,
   Label,
 } from '@bangle.io/base-ui';
+import { DESKTOP_REMOTE_FS_SERVER_URL } from '@bangle.io/constants';
 import type { WorkspaceStorageType } from '@bangle.io/types';
 import { Check, FolderOpen } from 'lucide-react';
 import React, { useEffect, useId, useReducer, useRef } from 'react';
@@ -43,6 +44,10 @@ export interface WorkspaceConfig {
   name: string;
   type: WorkspaceStorageType;
   dirHandle?: FileSystemDirectoryHandle;
+  /** Base URL of the server for a `remote` workspace. */
+  serverUrl?: string;
+  /** Optional bearer token for a `remote` workspace. */
+  token?: string;
 }
 
 export interface CreateWorkspaceDialogProps {
@@ -52,6 +57,8 @@ export interface CreateWorkspaceDialogProps {
   storageTypes: StorageTypeConfig[];
   onDirectoryPick?: () => Promise<DirectoryPickResult>;
   validateWorkspace: (config: WorkspaceConfig) => WorkspaceValidation;
+  /** Prefill for the remote server URL field (e.g. same-origin in bundled mode). */
+  defaultRemoteServerUrl?: string;
 }
 
 type BaseState = {
@@ -73,16 +80,27 @@ type NativeFsState = BaseState & {
   dirHandle?: FileSystemDirectoryHandle;
 };
 
-type State = SelectTypeState | BrowserState | NativeFsState;
+type RemoteState = BaseState & {
+  stage: 'selected-remote';
+  name: string;
+  serverUrl: string;
+  token: string;
+};
+
+type State = SelectTypeState | BrowserState | NativeFsState | RemoteState;
+
+type RemoteField = 'name' | 'serverUrl' | 'token';
 
 type Action =
   | { type: 'RESET_TO_TYPE_SELECT'; defaultStorage: WorkspaceStorageType }
   | { type: 'NAVIGATE_TO_TYPE_SELECT' }
   | { type: 'NAVIGATE_TO_BROWSER' }
   | { type: 'NAVIGATE_TO_NATIVEFS' }
+  | { type: 'NAVIGATE_TO_REMOTE'; defaultServerUrl: string }
   | { type: 'UPDATE_SELECTED_STORAGE'; storage: WorkspaceStorageType }
   | { type: 'UPDATE_WORKSPACE_NAME'; name: string }
   | { type: 'UPDATE_DIRECTORY_HANDLE'; dirHandle?: FileSystemDirectoryHandle }
+  | { type: 'UPDATE_REMOTE_FIELD'; field: RemoteField; value: string }
   | { type: 'UPDATE_ERROR'; error?: ErrorInfo };
 
 function reducer(state: State, action: Action): State {
@@ -97,6 +115,14 @@ function reducer(state: State, action: Action): State {
       return { stage: 'selected-browser', name: '', error: undefined };
     case 'NAVIGATE_TO_NATIVEFS':
       return { stage: 'selected-nativefs', error: undefined };
+    case 'NAVIGATE_TO_REMOTE':
+      return {
+        stage: 'selected-remote',
+        name: '',
+        serverUrl: action.defaultServerUrl,
+        token: '',
+        error: undefined,
+      };
     case 'UPDATE_SELECTED_STORAGE':
       if (state.stage === 'select-type') {
         return { ...state, selected: action.storage, error: undefined };
@@ -110,6 +136,11 @@ function reducer(state: State, action: Action): State {
     case 'UPDATE_DIRECTORY_HANDLE':
       if (state.stage === 'selected-nativefs') {
         return { ...state, dirHandle: action.dirHandle, error: undefined };
+      }
+      return state;
+    case 'UPDATE_REMOTE_FIELD':
+      if (state.stage === 'selected-remote') {
+        return { ...state, [action.field]: action.value, error: undefined };
       }
       return state;
     case 'UPDATE_ERROR':
@@ -132,6 +163,7 @@ export function CreateWorkspaceDialog({
   storageTypes,
   onDirectoryPick,
   validateWorkspace,
+  defaultRemoteServerUrl = '',
 }: CreateWorkspaceDialogProps) {
   const defaultStorage =
     storageTypes.find((t) => t.defaultSelected)?.type ||
@@ -183,6 +215,7 @@ export function CreateWorkspaceDialog({
             dispatch={dispatch}
             storageTypes={storageTypes}
             defaultStorage={defaultStorage}
+            defaultRemoteServerUrl={defaultRemoteServerUrl}
             onCancel={() => onOpenChange(false)}
           />
         )}
@@ -205,6 +238,15 @@ export function CreateWorkspaceDialog({
             onCancel={() => onOpenChange(false)}
           />
         )}
+        {state.stage === 'selected-remote' && (
+          <StageEnterRemote
+            state={state}
+            dispatch={dispatch}
+            validateWorkspace={validateWorkspace}
+            onDone={onDone}
+            onCancel={() => onOpenChange(false)}
+          />
+        )}
       </DialogContent>
     </Dialog>
   );
@@ -215,6 +257,7 @@ interface StageSelectStorageProps {
   dispatch: React.Dispatch<Action>;
   storageTypes: StorageTypeConfig[];
   defaultStorage: WorkspaceStorageType;
+  defaultRemoteServerUrl: string;
   onCancel: () => void;
 }
 
@@ -240,6 +283,7 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
   dispatch,
   storageTypes,
   defaultStorage,
+  defaultRemoteServerUrl,
   onCancel,
 }) => {
   const { selected = defaultStorage, error } = state;
@@ -248,10 +292,16 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
   };
 
   const handleNext = () => {
-    dispatch({
-      type:
-        selected === 'browser' ? 'NAVIGATE_TO_BROWSER' : 'NAVIGATE_TO_NATIVEFS',
-    });
+    if (selected === 'browser') {
+      dispatch({ type: 'NAVIGATE_TO_BROWSER' });
+    } else if (selected === 'remote') {
+      dispatch({
+        type: 'NAVIGATE_TO_REMOTE',
+        defaultServerUrl: defaultRemoteServerUrl,
+      });
+    } else {
+      dispatch({ type: 'NAVIGATE_TO_NATIVEFS' });
+    }
   };
 
   return (
@@ -528,6 +578,169 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
           {t.app.common.cancelButton}
         </Button>
         <Button onClick={handleSubmit} disabled={!dirHandle}>
+          {t.app.common.createButton}
+        </Button>
+      </WorkspaceDialogFooter>
+    </>
+  );
+};
+
+interface StageEnterRemoteProps {
+  state: RemoteState;
+  dispatch: React.Dispatch<Action>;
+  validateWorkspace: CreateWorkspaceDialogProps['validateWorkspace'];
+  onDone: CreateWorkspaceDialogProps['onDone'];
+  onCancel: () => void;
+}
+
+function isValidServerUrl(value: string): boolean {
+  const trimmed = value.trim();
+  // The desktop build uses an in-process (IPC) backend addressed by a sentinel.
+  if (trimmed === DESKTOP_REMOTE_FS_SERVER_URL) {
+    return true;
+  }
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return false;
+  }
+  try {
+    new URL(trimmed);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const StageEnterRemote: React.FC<StageEnterRemoteProps> = ({
+  state,
+  dispatch,
+  validateWorkspace,
+  onDone,
+  onCancel,
+}) => {
+  const { name, serverUrl, token, error } = state;
+  const nameRef = useRef<HTMLInputElement>(null);
+  const nameId = useId();
+  const urlId = useId();
+  const tokenId = useId();
+
+  useEffect(() => {
+    nameRef.current?.focus();
+  }, []);
+
+  const updateField =
+    (field: RemoteField) => (e: React.ChangeEvent<HTMLInputElement>) => {
+      dispatch({ type: 'UPDATE_REMOTE_FIELD', field, value: e.target.value });
+    };
+
+  const handleSubmit = () => {
+    const trimmedUrl = serverUrl.trim();
+    if (!isValidServerUrl(trimmedUrl)) {
+      dispatch({
+        type: 'UPDATE_ERROR',
+        error: {
+          message: t.app.dialogs.createWorkspace.remoteInvalidServerUrl,
+        },
+      });
+      return;
+    }
+    const config: WorkspaceConfig = {
+      type: 'remote',
+      name: name.trim(),
+      serverUrl: trimmedUrl,
+      token: token.trim() || undefined,
+    };
+    const validation = validateWorkspace(config);
+    if (!validation.isValid) {
+      dispatch({
+        type: 'UPDATE_ERROR',
+        error: {
+          message:
+            validation.message ||
+            t.app.dialogs.createWorkspace.invalidNameDefault,
+        },
+      });
+      return;
+    }
+    onDone(config);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      handleSubmit();
+    }
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{t.app.dialogs.createWorkspace.remoteTitle}</DialogTitle>
+        <DialogDescription>
+          {t.app.dialogs.createWorkspace.remoteDescription}
+        </DialogDescription>
+      </DialogHeader>
+      <div className="grid gap-4 py-4">
+        <div className="grid gap-2">
+          <Label htmlFor={nameId}>
+            {t.app.dialogs.createWorkspace.nameLabel}
+          </Label>
+          <Input
+            id={nameId}
+            ref={nameRef}
+            value={name}
+            onChange={updateField('name')}
+            onKeyDown={handleKeyDown}
+            placeholder={t.app.dialogs.createWorkspace.remoteNamePlaceholder}
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={urlId}>
+            {t.app.dialogs.createWorkspace.remoteServerUrlLabel}
+          </Label>
+          <Input
+            id={urlId}
+            value={serverUrl}
+            onChange={updateField('serverUrl')}
+            onKeyDown={handleKeyDown}
+            placeholder={
+              t.app.dialogs.createWorkspace.remoteServerUrlPlaceholder
+            }
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor={tokenId}>
+            {t.app.dialogs.createWorkspace.remoteTokenLabel}
+          </Label>
+          <Input
+            id={tokenId}
+            type="password"
+            value={token}
+            onChange={updateField('token')}
+            onKeyDown={handleKeyDown}
+            placeholder={t.app.dialogs.createWorkspace.remoteTokenPlaceholder}
+          />
+          <span className="text-foreground/70 text-xs">
+            {t.app.dialogs.createWorkspace.remoteTokenHelp}
+          </span>
+        </div>
+        <ErrorMessage error={error} />
+      </div>
+      <WorkspaceDialogFooter
+        leadingAction={
+          <Button
+            variant="outline"
+            onClick={() => dispatch({ type: 'NAVIGATE_TO_TYPE_SELECT' })}
+          >
+            {t.app.common.backButton}
+          </Button>
+        }
+      >
+        <Button variant="outline" onClick={onCancel}>
+          {t.app.common.cancelButton}
+        </Button>
+        <Button
+          onClick={handleSubmit}
+          disabled={!name.trim() || !serverUrl.trim()}
+        >
           {t.app.common.createButton}
         </Button>
       </WorkspaceDialogFooter>

--- a/packages/ui/ui-components/src/workspace-dialog.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.tsx
@@ -11,7 +11,6 @@ import {
   Input,
   Label,
 } from '@bangle.io/base-ui';
-import { DESKTOP_REMOTE_FS_SERVER_URL } from '@bangle.io/constants';
 import type { WorkspaceStorageType } from '@bangle.io/types';
 import { Check, FolderOpen } from 'lucide-react';
 import React, { useEffect, useId, useReducer, useRef } from 'react';
@@ -70,8 +69,11 @@ type SelectTypeState = BaseState & {
   selected?: WorkspaceStorageType;
 };
 
-type BrowserState = BaseState & {
-  stage: 'selected-browser';
+// A name-only stage, shared by the `browser` and `electron` storage types
+// (both need just a workspace name).
+type NameEntryState = BaseState & {
+  stage: 'enter-name';
+  storageType: WorkspaceStorageType;
   name: string;
 };
 
@@ -87,14 +89,14 @@ type RemoteState = BaseState & {
   token: string;
 };
 
-type State = SelectTypeState | BrowserState | NativeFsState | RemoteState;
+type State = SelectTypeState | NameEntryState | NativeFsState | RemoteState;
 
 type RemoteField = 'name' | 'serverUrl' | 'token';
 
 type Action =
   | { type: 'RESET_TO_TYPE_SELECT'; defaultStorage: WorkspaceStorageType }
   | { type: 'NAVIGATE_TO_TYPE_SELECT' }
-  | { type: 'NAVIGATE_TO_BROWSER' }
+  | { type: 'NAVIGATE_TO_NAME'; storageType: WorkspaceStorageType }
   | { type: 'NAVIGATE_TO_NATIVEFS' }
   | { type: 'NAVIGATE_TO_REMOTE'; defaultServerUrl: string }
   | { type: 'UPDATE_SELECTED_STORAGE'; storage: WorkspaceStorageType }
@@ -111,8 +113,13 @@ function reducer(state: State, action: Action): State {
         selected: undefined,
         error: undefined,
       };
-    case 'NAVIGATE_TO_BROWSER':
-      return { stage: 'selected-browser', name: '', error: undefined };
+    case 'NAVIGATE_TO_NAME':
+      return {
+        stage: 'enter-name',
+        storageType: action.storageType,
+        name: '',
+        error: undefined,
+      };
     case 'NAVIGATE_TO_NATIVEFS':
       return { stage: 'selected-nativefs', error: undefined };
     case 'NAVIGATE_TO_REMOTE':
@@ -129,7 +136,7 @@ function reducer(state: State, action: Action): State {
       }
       return state;
     case 'UPDATE_WORKSPACE_NAME':
-      if (state.stage === 'selected-browser') {
+      if (state.stage === 'enter-name') {
         return { ...state, name: action.name, error: undefined };
       }
       return state;
@@ -219,7 +226,7 @@ export function CreateWorkspaceDialog({
             onCancel={() => onOpenChange(false)}
           />
         )}
-        {state.stage === 'selected-browser' && (
+        {state.stage === 'enter-name' && (
           <StageEnterWorkspaceName
             state={state}
             dispatch={dispatch}
@@ -292,8 +299,8 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
   };
 
   const handleNext = () => {
-    if (selected === 'browser') {
-      dispatch({ type: 'NAVIGATE_TO_BROWSER' });
+    if (selected === 'browser' || selected === 'electron') {
+      dispatch({ type: 'NAVIGATE_TO_NAME', storageType: selected });
     } else if (selected === 'remote') {
       dispatch({
         type: 'NAVIGATE_TO_REMOTE',
@@ -358,7 +365,7 @@ const StageSelectStorage: React.FC<StageSelectStorageProps> = ({
 };
 
 interface StageEnterWorkspaceNameProps {
-  state: BrowserState;
+  state: NameEntryState;
   dispatch: React.Dispatch<Action>;
   validateWorkspace: CreateWorkspaceDialogProps['validateWorkspace'];
   onDone: CreateWorkspaceDialogProps['onDone'];
@@ -372,7 +379,7 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
   onDone,
   onCancel,
 }) => {
-  const { name, error } = state;
+  const { name, storageType, error } = state;
 
   const ref = useRef<HTMLInputElement>(null);
   const workspaceNameId = useId();
@@ -393,7 +400,7 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
 
   const handleSubmit = () => {
     const config: WorkspaceConfig = {
-      type: 'browser',
+      type: storageType,
       name,
     };
     const validation = validateWorkspace(config);
@@ -408,7 +415,7 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
       });
       return;
     }
-    onDone({ type: 'browser', name });
+    onDone(config);
   };
 
   const handleBack = () => {
@@ -595,10 +602,6 @@ interface StageEnterRemoteProps {
 
 function isValidServerUrl(value: string): boolean {
   const trimmed = value.trim();
-  // The desktop build uses an in-process (IPC) backend addressed by a sentinel.
-  if (trimmed === DESKTOP_REMOTE_FS_SERVER_URL) {
-    return true;
-  }
   if (!/^https?:\/\//i.test(trimmed)) {
     return false;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@bangle.io/omni-search':
         specifier: workspace:*
         version: link:../omni-search
+      '@bangle.io/remote-file-sync':
+        specifier: workspace:*
+        version: link:../../js-lib/remote-file-sync
       '@bangle.io/types':
         specifier: workspace:*
         version: link:../../shared/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       '@bangle.io/commands':
         specifier: workspace:*
         version: link:../../shared/commands
+      '@bangle.io/constants':
+        specifier: workspace:*
+        version: link:../../shared/constants
       '@bangle.io/context':
         specifier: workspace:*
         version: link:../context
@@ -306,6 +309,9 @@ importers:
       '@bangle.io/poor-mans-di':
         specifier: workspace:*
         version: link:../../js-lib/poor-mans-di
+      '@bangle.io/remote-file-sync':
+        specifier: workspace:*
+        version: link:../../js-lib/remote-file-sync
       '@bangle.io/service-core':
         specifier: workspace:*
         version: link:../service-core
@@ -520,6 +526,8 @@ importers:
         specifier: ^1.25.9
         version: 1.25.9
 
+  packages/js-lib/remote-file-sync: {}
+
   packages/platform/service-platform:
     dependencies:
       '@bangle.io/baby-fs':
@@ -540,6 +548,9 @@ importers:
       '@bangle.io/mini-js-utils':
         specifier: workspace:*
         version: link:../../js-lib/mini-js-utils
+      '@bangle.io/remote-file-sync':
+        specifier: workspace:*
+        version: link:../../js-lib/remote-file-sync
       '@bangle.io/types':
         specifier: workspace:*
         version: link:../../shared/types
@@ -768,6 +779,15 @@ importers:
 
   packages/tooling/desktop-entry:
     dependencies:
+      '@bangle.io/constants':
+        specifier: workspace:*
+        version: link:../../shared/constants
+      '@bangle.io/remote-file-server':
+        specifier: workspace:*
+        version: link:../remote-file-server
+      '@bangle.io/remote-file-sync':
+        specifier: workspace:*
+        version: link:../../js-lib/remote-file-sync
       electron:
         specifier: 43.0.0
         version: 43.0.0
@@ -799,6 +819,12 @@ importers:
       '@bangle.io/env-vars':
         specifier: workspace:*
         version: link:../env-vars
+      '@bangle.io/remote-file-server':
+        specifier: workspace:*
+        version: link:../remote-file-server
+      '@bangle.io/remote-file-sync':
+        specifier: workspace:*
+        version: link:../../js-lib/remote-file-sync
       '@bangle.io/storybook':
         specifier: workspace:*
         version: link:../storybook
@@ -881,6 +907,22 @@ importers:
       fs-extra:
         specifier: ^11.3.6
         version: 11.3.6
+
+  packages/tooling/remote-file-server:
+    dependencies:
+      '@bangle.io/remote-file-sync':
+        specifier: workspace:*
+        version: link:../../js-lib/remote-file-sync
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.0
+      esbuild:
+        specifier: 0.28.1
+        version: 0.28.1
+      tsx:
+        specifier: ^4.22.5
+        version: 4.22.5
 
   packages/tooling/storybook:
     dependencies:


### PR DESCRIPTION
## What & why

Adds a **Remote Server** workspace backend so a workspace's notes can live on a server the user controls, over a small HTTP API — plus a dedicated **This device** backend for the Electron desktop app. Both are the *same* transport-agnostic provider; only the client differs.

| Storage type | Front-end | Backend | Transport |
| --- | --- | --- | --- |
| **Remote Server** (`remote`) | app.bangle.io / your build / bundled | your HTTP server | HTTPS (same-origin in bundled mode) |
| **This device** (`electron`) | desktop app | Electron main process | IPC |

A desktop user can use **both** — a local disk workspace *and* a remote server. This also delivers the long-requested **Docker deployment** ([discussion #216](https://github.com/bangle-io/bangle-io/discussions/216)): one container serves the app and stores notes on your disk.

## New packages

- **`@bangle.io/remote-file-sync`** (js-lib, universal, zero-dep) — wire protocol, engine-neutral **router**, HTTP **client**, in-memory store, path-safety helpers. One contract shared by client and server.
- **`@bangle.io/remote-file-server`** (tooling) — disk-backed Node reference server (`node:http`) with CORS + bearer-token auth, optional bundled front-end serving, a `Dockerfile`, and `docker-compose.yml`.

## App integration

- `FileStorageRemote` implements `BaseFileStorageProvider` over an injectable client, registered as **two DI slots** (`remote` → HTTP, `electron` → IPC). Wired into `FileSystemService`, the composition root, and `fileStorageSlots`.
- Create-workspace dialog: a **Remote Server** stage (URL + optional token) and, on desktop only, a name-only **This device** option.
- **Electron**: the main process hosts a `DiskRemoteFileStore` + router and exposes it over IPC; the renderer's `electron`-type provider routes through it via an IPC client (reusing `createFetchFromRouter`).

## Data safety / hardening

- Missing reads → `undefined`; any transport failure → typed `error::remote-storage:request-failed` (never empty content / false success). `POST` never overwrites, `PUT` never creates.
- An `x-bangle-api` marker lets the client tell a genuine 404 from an infra 404; the dialog pre-flights the server before creating a workspace.
- CORS is sent **only when a token is configured** (tokenless servers can't be read cross-origin by a random website); tokenless binds loopback by default; `/health` hides workspace names from unauthorized callers.
- Durable disk writes (temp-file + atomic rename); request body cap (413); path validation rejects traversal, Windows device names, and NTFS `:` streams.

## Tests (all green)

- Unit + contract tests for protocol/router/client, disk & memory stores, the provider (full client→router→store stack), the desktop IPC transport, and a real-HTTP server round-trip (CORS, auth, bundled serving, 413).
- **Playwright E2E**: create a remote workspace against a live server, edit a note, assert it lands on the backend, survive reload — plus a **failure path** (unreachable server → error surfaced, no workspace created).
- `pnpm lint:ci`, `pnpm test:ci` (1483 passed), `pnpm build`, and `pnpm e2e:ci` all pass.

## Docs

- `docs/remote-file-storage.md` — API spec, curl examples, guides (BYO server, Express, Docker, desktop). Package READMEs + a root README self-hosting pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)