### PR TITLE
feat(asset): render images, PDFs, video, audio, and text inline

### DIFF
--- a/packages/core/app/src/components/common/__tests__/asset-preview.spec.tsx
+++ b/packages/core/app/src/components/common/__tests__/asset-preview.spec.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+/// <reference types="@vitest/browser/matchers" />
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { AssetPreview } from '../asset-preview';
+
+const OBJECT_URL = 'blob:https://bangle.test/asset';
+
+describe('AssetPreview', () => {
+  it('renders an image with the file name as alt text', () => {
+    render(
+      <AssetPreview kind="image" objectUrl={OBJECT_URL} fileName="photo.png" />,
+    );
+
+    const img = screen.getByRole('img', { name: 'photo.png' });
+    expect(img).toHaveAttribute('src', OBJECT_URL);
+  });
+
+  it('renders a PDF inside a titled iframe', () => {
+    render(
+      <AssetPreview kind="pdf" objectUrl={OBJECT_URL} fileName="report.pdf" />,
+    );
+
+    const frame = screen.getByTitle('report.pdf');
+    expect(frame.tagName).toBe('IFRAME');
+    expect(frame).toHaveAttribute('src', OBJECT_URL);
+  });
+
+  it('renders a native video player', () => {
+    const { container } = render(
+      <AssetPreview kind="video" objectUrl={OBJECT_URL} fileName="clip.mp4" />,
+    );
+
+    const video = container.querySelector('video');
+    expect(video).not.toBeNull();
+    expect(video).toHaveAttribute('src', OBJECT_URL);
+    expect(video).toHaveAttribute('controls');
+    // Keeps the a11y captions track even though workspace media has none.
+    expect(
+      container.querySelector('video > track[kind="captions"]'),
+    ).not.toBeNull();
+  });
+
+  it('renders a native audio player', () => {
+    const { container } = render(
+      <AssetPreview kind="audio" objectUrl={OBJECT_URL} fileName="song.mp3" />,
+    );
+
+    const audio = container.querySelector('audio');
+    expect(audio).not.toBeNull();
+    expect(audio).toHaveAttribute('src', OBJECT_URL);
+    expect(audio).toHaveAttribute('controls');
+  });
+
+  it('renders decoded text verbatim in a preformatted block', () => {
+    render(
+      <AssetPreview
+        kind="text"
+        objectUrl={OBJECT_URL}
+        fileName="notes.txt"
+        textContent={'line one\n  indented two'}
+      />,
+    );
+
+    const pre = screen.getByText(/line one/);
+    expect(pre.tagName).toBe('PRE');
+    expect(pre.textContent).toBe('line one\n  indented two');
+  });
+
+  it('falls back to a no-preview note when media fails to decode', () => {
+    render(
+      <AssetPreview
+        kind="image"
+        objectUrl={OBJECT_URL}
+        fileName="broken.png"
+      />,
+    );
+
+    fireEvent.error(screen.getByRole('img', { name: 'broken.png' }));
+
+    expect(screen.getByText(t.app.pageAsset.noPreview)).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+});

--- a/packages/core/app/src/components/common/asset-preview.tsx
+++ b/packages/core/app/src/components/common/asset-preview.tsx
@@ -1,0 +1,98 @@
+import type { AssetPreviewKind } from '@bangle.io/ws-path';
+import React from 'react';
+
+interface AssetPreviewProps {
+  kind: AssetPreviewKind;
+  /** A `blob:`/`object:` URL pointing at the asset's bytes. */
+  objectUrl: string;
+  fileName: string;
+  /**
+   * Decoded UTF-8 contents used to render the `text` kind. Ignored for every
+   * other kind, where the browser reads the bytes straight from `objectUrl`.
+   */
+  textContent?: string;
+}
+
+/**
+ * Renders a workspace asset inline using only native browser elements. Image,
+ * PDF, video, audio, and plain-text assets each map to the element the browser
+ * already knows how to display, so no third-party viewer is required. When the
+ * browser cannot decode the media (unknown codec, corrupt bytes) the component
+ * degrades to a short "no preview" note; the asset page keeps the Download
+ * affordance available alongside it.
+ */
+export function AssetPreview({
+  kind,
+  objectUrl,
+  fileName,
+  textContent,
+}: AssetPreviewProps) {
+  // Callers remount this component per asset (keyed on `objectUrl`), so the
+  // failure state never needs to be reset for a newly opened file.
+  const [hasMediaError, setHasMediaError] = React.useState(false);
+
+  if (hasMediaError) {
+    return (
+      <p className="max-w-md text-muted-foreground text-sm">
+        {t.app.pageAsset.noPreview}
+      </p>
+    );
+  }
+
+  switch (kind) {
+    case 'image':
+      return (
+        <img
+          alt={fileName}
+          className="mx-auto max-h-[75vh] max-w-full rounded-md object-contain"
+          onError={() => setHasMediaError(true)}
+          src={objectUrl}
+        />
+      );
+    case 'pdf':
+      return (
+        <iframe
+          className="h-[80vh] w-full rounded-md border border-border bg-background"
+          src={objectUrl}
+          title={fileName}
+        />
+      );
+    case 'video':
+      return (
+        <video
+          className="mx-auto max-h-[75vh] max-w-full rounded-md"
+          controls
+          onError={() => setHasMediaError(true)}
+          src={objectUrl}
+        >
+          {/* Workspace media carries no caption sidecar; an empty captions
+              track keeps the element accessible without inventing content. */}
+          <track kind="captions" />
+          {t.app.pageAsset.videoUnsupported}
+        </video>
+      );
+    case 'audio':
+      return (
+        <audio
+          className="w-full max-w-md"
+          controls
+          onError={() => setHasMediaError(true)}
+          src={objectUrl}
+        >
+          <track kind="captions" />
+          {t.app.pageAsset.audioUnsupported}
+        </audio>
+      );
+    case 'text':
+      return (
+        <pre className="max-h-[75vh] w-full overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted p-4 text-left font-mono text-foreground text-sm">
+          {textContent ?? ''}
+        </pre>
+      );
+    default: {
+      // Exhaustiveness check: every AssetPreviewKind must be handled above.
+      const _exhaustiveCheck: never = kind;
+      throw new Error(`Unknown asset preview kind: ${_exhaustiveCheck}`);
+    }
+  }
+}

--- a/packages/core/app/src/pages/page-asset.tsx
+++ b/packages/core/app/src/pages/page-asset.tsx
@@ -1,19 +1,33 @@
 import { useCoreServices } from '@bangle.io/context';
 import { buttonVariants } from '@bangle.io/ui-components';
-import { WsPath } from '@bangle.io/ws-path';
+import {
+  type AssetPreviewKind,
+  getAssetPreviewKind,
+  WsPath,
+} from '@bangle.io/ws-path';
 import { useAtomValue } from 'jotai';
 import { Download } from 'lucide-react';
 import React from 'react';
+import { AssetPreview } from '../components/common/asset-preview';
 import { ContentSection } from '../components/common/content-section';
-import { PageHeader } from '../components/common/page-header';
 import { FileNotFoundView } from '../components/feedback/file-not-found-view';
 import { WorkspaceNotFoundView } from '../components/feedback/workspace-not-found-view';
 import { AppHeader } from '../layout/app-header';
 import { PageContentContainer } from '../layout/main-content-container';
 
+// Cap inline text previews so a huge log or data dump does not get pulled into
+// memory as one string; larger files fall back to the download affordance.
+const TEXT_PREVIEW_MAX_BYTES = 2 * 1024 * 1024;
+
 type AssetState =
   | { status: 'loading' }
-  | { status: 'ready'; fileName: string; objectUrl: string }
+  | {
+      status: 'ready';
+      fileName: string;
+      objectUrl: string;
+      kind: AssetPreviewKind | undefined;
+      textContent?: string;
+    }
   | { status: 'missing'; fileName: string }
   | { status: 'error'; fileName: string };
 
@@ -43,9 +57,9 @@ export function PageAsset() {
     let disposed = false;
     setState({ status: 'loading' });
 
-    void fileSystem
-      .readFile(wsPath)
-      .then((file) => {
+    void (async () => {
+      try {
+        const file = await fileSystem.readFile(wsPath);
         if (disposed) {
           return;
         }
@@ -53,14 +67,29 @@ export function PageAsset() {
           setState({ status: 'missing', fileName });
           return;
         }
+
+        let kind = getAssetPreviewKind(wsPath);
+        let textContent: string | undefined;
+        if (kind === 'text') {
+          if (file.size <= TEXT_PREVIEW_MAX_BYTES) {
+            textContent = await file.text();
+            if (disposed) {
+              return;
+            }
+          } else {
+            // Too large to render as a single string; offer download instead.
+            kind = undefined;
+          }
+        }
+
         objectUrl = URL.createObjectURL(file);
-        setState({ status: 'ready', fileName, objectUrl });
-      })
-      .catch(() => {
+        setState({ status: 'ready', fileName, objectUrl, kind, textContent });
+      } catch {
         if (!disposed) {
           setState({ status: 'error', fileName });
         }
-      });
+      }
+    })();
 
     return () => {
       disposed = true;
@@ -100,26 +129,64 @@ export function PageAsset() {
     <>
       <AppHeader />
       <PageContentContainer>
-        <ContentSection hasPadding>
-          <PageHeader title={fileName} />
+        <div className="flex w-full flex-wrap items-center justify-between gap-2">
+          <h1
+            className="wrap-anywhere min-w-0 flex-1 font-semibold text-lg"
+            title={fileName}
+          >
+            {fileName}
+          </h1>
           {state.status === 'ready' ? (
             <a
-              className={buttonVariants()}
+              className={buttonVariants({ variant: 'outline', size: 'sm' })}
               download={state.fileName}
               href={state.objectUrl}
             >
-              <Download className="h-4 w-4" />
+              <Download />
               {t.app.pageAsset.downloadButton}
             </a>
-          ) : (
-            <p className="max-w-md text-muted-foreground text-sm">
-              {state.status === 'loading'
-                ? t.app.pageAsset.loading
-                : t.app.pageAsset.unavailable}
-            </p>
-          )}
-        </ContentSection>
+          ) : null}
+        </div>
+        <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center gap-4">
+          <AssetBody state={state} />
+        </div>
       </PageContentContainer>
     </>
+  );
+}
+
+function AssetBody({ state }: { state: AssetState }) {
+  if (state.status === 'loading') {
+    return (
+      <p className="max-w-md text-muted-foreground text-sm">
+        {t.app.pageAsset.loading}
+      </p>
+    );
+  }
+
+  if (state.status === 'missing' || state.status === 'error') {
+    return (
+      <p className="max-w-md text-muted-foreground text-sm">
+        {t.app.pageAsset.unavailable}
+      </p>
+    );
+  }
+
+  if (!state.kind) {
+    return (
+      <p className="max-w-md text-muted-foreground text-sm">
+        {t.app.pageAsset.noPreview}
+      </p>
+    );
+  }
+
+  return (
+    <AssetPreview
+      key={state.objectUrl}
+      kind={state.kind}
+      objectUrl={state.objectUrl}
+      fileName={state.fileName}
+      textContent={state.textContent}
+    />
   );
 }

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -162,6 +162,10 @@ export const t = {
       downloadButton: 'Download',
       loading: 'Asset wird geladen...',
       unavailable: 'Dieses Asset kann nicht geladen werden.',
+      noPreview:
+        'Diese Datei kann hier nicht als Vorschau angezeigt werden. Lade sie herunter, um den Inhalt zu sehen.',
+      videoUnsupported: 'Dein Browser kann dieses Videoformat nicht abspielen.',
+      audioUnsupported: 'Dein Browser kann dieses Audioformat nicht abspielen.',
     },
     dialogs: {
       changeTheme: {

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -182,6 +182,10 @@ export const t = {
       downloadButton: 'Download',
       loading: 'Loading asset...',
       unavailable: 'Unable to load this asset.',
+      noPreview:
+        "This file can't be previewed here. Download it to view the contents.",
+      videoUnsupported: "Your browser can't play this video format.",
+      audioUnsupported: "Your browser can't play this audio format.",
     },
     dialogs: {
       changeTheme: {

--- a/packages/shared/ws-path/src/__tests__/asset-path.spec.ts
+++ b/packages/shared/ws-path/src/__tests__/asset-path.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  assetPreviewKindForExtension,
+  getAssetPreviewKind,
   getEmbeddableWorkspaceAssetKind,
   isEmbeddableImageExtension,
   isEmbeddableWorkspaceAsset,
@@ -161,5 +163,63 @@ describe('embeddable workspace assets', () => {
         'other:assets/image.png',
       ),
     ).toBeUndefined();
+  });
+});
+
+describe('assetPreviewKindForExtension', () => {
+  it.each([
+    ['.png', 'image'],
+    ['.svg', 'image'],
+    ['.bmp', 'image'],
+    ['.ico', 'image'],
+    ['.pdf', 'pdf'],
+    ['.mp4', 'video'],
+    ['.webm', 'video'],
+    ['.mp3', 'audio'],
+    ['.flac', 'audio'],
+    ['.txt', 'text'],
+    ['.json', 'text'],
+    ['.csv', 'text'],
+  ] as const)('maps %s to %s', (extension, kind) => {
+    expect(assetPreviewKindForExtension(extension)).toBe(kind);
+  });
+
+  it('is case-insensitive and tolerates a missing leading dot', () => {
+    expect(assetPreviewKindForExtension('.PNG')).toBe('image');
+    expect(assetPreviewKindForExtension('PDF')).toBe('pdf');
+    expect(assetPreviewKindForExtension('Json')).toBe('text');
+  });
+
+  it.each([
+    '',
+    '.zip',
+    '.exe',
+    '.bin',
+    '.unknown',
+    undefined,
+  ])('returns undefined for non-previewable extension %j', (extension) => {
+    expect(assetPreviewKindForExtension(extension)).toBeUndefined();
+  });
+});
+
+describe('getAssetPreviewKind', () => {
+  it.each([
+    ['workspace:assets/photo.png', 'image'],
+    ['workspace:notes/deep/diagram.SVG', 'image'],
+    ['workspace:report.pdf', 'pdf'],
+    ['workspace:clip.mp4', 'video'],
+    ['workspace:sound.mp3', 'audio'],
+    ['workspace:data/table.csv', 'text'],
+  ] as const)('classifies %s as %s', (wsPath, kind) => {
+    expect(getAssetPreviewKind(wsPath)).toBe(kind);
+  });
+
+  it.each([
+    'workspace:archive.zip',
+    'workspace:no-extension',
+    'workspace:notes/', // directory path
+    'not a wsPath',
+  ])('returns undefined for %s', (wsPath) => {
+    expect(getAssetPreviewKind(wsPath)).toBeUndefined();
   });
 });

--- a/packages/shared/ws-path/src/asset-path.ts
+++ b/packages/shared/ws-path/src/asset-path.ts
@@ -43,6 +43,114 @@ export function isEmbeddableImageExtension(extension: string): boolean {
   return EMBEDDABLE_IMAGE_EXTENSION_SET.has(extension.toLowerCase());
 }
 
+/**
+ * Categories of workspace assets the app can preview inline on the asset page
+ * using only native browser elements (`<img>`, `<iframe>`, `<video>`,
+ * `<audio>`, `<pre>`). Anything outside these kinds falls back to a download
+ * affordance. Keep this list conservative: only formats browsers render without
+ * a third-party viewer belong here.
+ */
+export type AssetPreviewKind = 'image' | 'pdf' | 'video' | 'audio' | 'text';
+
+const ASSET_PREVIEW_EXTENSIONS: Record<AssetPreviewKind, readonly string[]> = {
+  // Reuse the embeddable image set and add a couple of formats browsers render
+  // in `<img>` even though they are not offered for Markdown embedding.
+  image: [...EMBEDDABLE_IMAGE_EXTENSIONS, '.bmp', '.ico'],
+  pdf: ['.pdf'],
+  video: ['.m4v', '.mov', '.mp4', '.ogv', '.webm'],
+  audio: [
+    '.aac',
+    '.flac',
+    '.m4a',
+    '.oga',
+    '.ogg',
+    '.opus',
+    '.mp3',
+    '.wav',
+    '.weba',
+  ],
+  // Plain-text formats rendered verbatim in a `<pre>`; no syntax highlighting.
+  text: [
+    '.bash',
+    '.c',
+    '.cfg',
+    '.conf',
+    '.cpp',
+    '.css',
+    '.csv',
+    '.env',
+    '.go',
+    '.h',
+    '.htm',
+    '.html',
+    '.ini',
+    '.java',
+    '.js',
+    '.json',
+    '.jsonc',
+    '.jsx',
+    '.less',
+    '.log',
+    '.mjs',
+    '.cjs',
+    '.py',
+    '.rb',
+    '.rs',
+    '.scss',
+    '.sh',
+    '.sql',
+    '.text',
+    '.toml',
+    '.ts',
+    '.tsx',
+    '.tsv',
+    '.txt',
+    '.xml',
+    '.yaml',
+    '.yml',
+    '.zsh',
+  ],
+};
+
+const ASSET_PREVIEW_KIND_BY_EXTENSION = new Map<string, AssetPreviewKind>();
+for (const [kind, extensions] of Object.entries(ASSET_PREVIEW_EXTENSIONS) as [
+  AssetPreviewKind,
+  readonly string[],
+][]) {
+  for (const extension of extensions) {
+    ASSET_PREVIEW_KIND_BY_EXTENSION.set(extension, kind);
+  }
+}
+
+/**
+ * Maps a file extension (with or without a leading dot, any case) to the way it
+ * can be previewed inline, or `undefined` when the app cannot render it.
+ */
+export function assetPreviewKindForExtension(
+  extension: string | undefined,
+): AssetPreviewKind | undefined {
+  if (!extension) {
+    return undefined;
+  }
+  const lower = extension.toLowerCase();
+  const normalized = lower.startsWith('.') ? lower : `.${lower}`;
+  return ASSET_PREVIEW_KIND_BY_EXTENSION.get(normalized);
+}
+
+/**
+ * Resolves how a workspace asset can be previewed inline based on its
+ * extension, or `undefined` when only a download fallback is possible.
+ */
+export function getAssetPreviewKind(
+  wsPath: string | WsFilePath,
+): AssetPreviewKind | undefined {
+  const filePath = WsPath.safeParseFile(wsPath).data;
+  if (!filePath) {
+    return undefined;
+  }
+  return assetPreviewKindForExtension(filePath.extension);
+}
+
 export function getEmbeddableWorkspaceAssetKind(
   wsPath: string | WsFilePath,
 ): EmbeddableWorkspaceAssetKind | undefined {

--- a/packages/shared/ws-path/src/index.ts
+++ b/packages/shared/ws-path/src/index.ts
@@ -1,6 +1,11 @@
-export type { EmbeddableWorkspaceAssetKind } from './asset-path';
+export type {
+  AssetPreviewKind,
+  EmbeddableWorkspaceAssetKind,
+} from './asset-path';
 export {
+  assetPreviewKindForExtension,
   EMBEDDABLE_IMAGE_EXTENSIONS,
+  getAssetPreviewKind,
   getEmbeddableWorkspaceAssetKind,
   isEmbeddableImageExtension,
   isEmbeddableWorkspaceAsset,

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -152,6 +152,47 @@ async function dragTreeItemOntoEditor(
   await page.mouse.up();
 }
 
+// Stores a real (decodable) 1x1 PNG directly in the browser workspace so the
+// asset page can render an actual `<img>` rather than a broken-media fallback.
+async function writeStoredPng(
+  page: Page,
+  workspaceName: string,
+  relativePath: string,
+) {
+  await page.evaluate(
+    async ({ workspace, filePath }) => {
+      const pngBytes = Uint8Array.from([
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
+        1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65,
+        84, 120, 156, 99, 248, 15, 4, 0, 9, 251, 3, 253, 167, 186, 48, 251, 0,
+        0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+      ]);
+      const request = indexedDB.open('baby-idb-db-3');
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      await new Promise<void>((resolve, reject) => {
+        const transaction = database.transaction(
+          'baby-idb-db-store-3',
+          'readwrite',
+        );
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error);
+        transaction.objectStore('baby-idb-db-store-3').put(
+          new File([pngBytes], filePath.split('/').at(-1) ?? filePath, {
+            type: 'image/png',
+          }),
+          `${workspace}/${filePath}`,
+        );
+      });
+      database.close();
+    },
+    { workspace: workspaceName, filePath: relativePath },
+  );
+}
+
 test('pastes workspace-backed image and PDF assets, reloads, and opens asset page', async ({
   page,
 }, testInfo) => {
@@ -192,6 +233,9 @@ test('pastes workspace-backed image and PDF assets, reloads, and opens asset pag
   await expect(
     page.getByRole('heading', { name: /spec-sheet-.*\.pdf/i }),
   ).toBeVisible();
+  // The PDF renders inline in the browser's native viewer, and Download stays
+  // available as a fallback.
+  await expect(page.locator('iframe[title^="spec-sheet-"]')).toBeVisible();
   await expect(page.getByRole('link', { name: 'Download' })).toHaveAttribute(
     'download',
     /spec-sheet-.*\.pdf/,
@@ -616,4 +660,67 @@ test('copied nested workspace paths paste and drop from another note', async ({
       ),
     )
     .toContain('[codex-prerequisites.md](codex-prerequisites.md)');
+});
+
+test('renders an image asset inline when the asset URL is opened directly', async ({
+  page,
+}, testInfo) => {
+  const workspaceName = `asset-view-image-${testInfo.workerIndex}-${Date.now()}`;
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'source',
+  });
+  await writeStoredPng(page, workspaceName, 'assets/photo.png');
+
+  await page.goto(
+    `/ws#route=asset&wsPath=${encodeURIComponent(
+      `${workspaceName}:assets/photo.png`,
+    )}`,
+  );
+  // A hash-only navigation does not re-read storage, so force a real reload at
+  // the asset route to pick up the directly-written file, mirroring how a user
+  // arrives via a fresh page load / shared link.
+  await page.reload({ waitUntil: 'networkidle' });
+
+  await expect(page.getByRole('heading', { name: 'photo.png' })).toBeVisible();
+  const image = page.getByRole('img', { name: 'photo.png' });
+  await expect(image).toBeVisible();
+  await expect(image).toHaveAttribute('src', /^blob:/);
+  await expect(page.getByRole('link', { name: 'Download' })).toHaveAttribute(
+    'download',
+    'photo.png',
+  );
+});
+
+test('renders a text asset inline when the asset URL is opened directly', async ({
+  page,
+}, testInfo) => {
+  const workspaceName = `asset-view-text-${testInfo.workerIndex}-${Date.now()}`;
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'source',
+  });
+  await writeStoredFile(
+    page,
+    workspaceName,
+    'data/config.json',
+    '{\n  "hello": "asset viewer"\n}',
+    'application/json',
+  );
+
+  await page.goto(
+    `/ws#route=asset&wsPath=${encodeURIComponent(
+      `${workspaceName}:data/config.json`,
+    )}`,
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  await expect(
+    page.getByRole('heading', { name: 'config.json' }),
+  ).toBeVisible();
+  await expect(page.getByText('"hello": "asset viewer"')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Download' })).toHaveAttribute(
+    'download',
+    'config.json',
+  );
 });


### PR DESCRIPTION
## What & why

Opening a non-markdown file previously only offered a **Download** button — navigating straight to an asset's URL showed a dead-end download page. The asset page already read the file into a `blob:` object URL, so this wires up **native, dependency-free inline rendering** for the high-ROI formats browsers display out of the box.

| Kind | Element | Extensions |
| --- | --- | --- |
| Image | `<img>` | png, jpg/jpeg, gif, webp, avif, svg, bmp, ico |
| PDF | `<iframe>` (browser's built-in viewer) | pdf |
| Video | `<video controls>` | mp4, webm, ogv, mov, m4v |
| Audio | `<audio controls>` | mp3, wav, ogg, m4a, aac, flac, opus, … |
| Text/code/data | `<pre>` (size-capped at 2 MB) | txt, json, csv, log, xml, yml, code files, … |

No third-party libraries — each type maps to the element the browser already knows how to display.

## Behavior & safety

- The **Download** action stays available for every asset, and unsupported types keep the download-only fallback.
- Media that fails to decode (unknown codec, corrupt bytes) degrades to a short "no preview" note instead of a broken element.
- Text previews are capped at 2 MB and fall back to download above that, so a huge log is never pulled into memory as one string.
- The existing object-URL create/revoke lifecycle is preserved (revoked on unmount / asset change).

## Structure

- Detection lives beside the existing embeddable-image logic in `@bangle.io/ws-path` (`getAssetPreviewKind` / `assetPreviewKindForExtension`) — the concept's owner.
- Rendering is a new presentational `AssetPreview` component in `core/app`.
- New user-facing strings added to `en`/`de` translations.

## Tests

- **Unit:** extension→kind classifier (case-insensitivity, unknown types, directory paths).
- **Component:** `AssetPreview` renders the right element per kind and degrades on media error.
- **E2E:** direct-URL image + text rendering (the "go straight to the asset URL" scenario) and inline PDF, all keeping Download.

## CI

`pnpm local-ci-check` passes end to end: `test:ci` (1455 passed), `lint:ci`, `knip:ci`, full `e2e:ci` (116 E2E + 28 component, 0 failures/flakes), and the Electron `desktop:ci` smoke.

> Note: fixed a horizontal-overflow regression the gate caught — a long asset filename in the heading leaked width through the nested flex layout via `truncate`; the heading now uses `wrap-anywhere`, verified against a pathological 120-char unbreakable name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)