### PR TITLE
fix(asset): harden PDF preview + address review feedback (follow-up to #618)

### DIFF
--- a/packages/core/app/src/pages/page-asset.tsx
+++ b/packages/core/app/src/pages/page-asset.tsx
@@ -53,13 +53,16 @@ export function PageAsset() {
       return;
     }
 
+    const controller = new AbortController();
     let objectUrl: string | undefined;
     let disposed = false;
     setState({ status: 'loading' });
 
     void (async () => {
       try {
-        const file = await fileSystem.readFile(wsPath);
+        const file = await fileSystem.readFile(wsPath, {
+          signal: controller.signal,
+        });
         if (disposed) {
           return;
         }
@@ -72,9 +75,17 @@ export function PageAsset() {
         let textContent: string | undefined;
         if (kind === 'text') {
           if (file.size <= TEXT_PREVIEW_MAX_BYTES) {
-            textContent = await file.text();
+            const decoded = await file.text();
             if (disposed) {
               return;
+            }
+            if (decoded.includes('\u0000')) {
+              // A NUL byte means the bytes are not really text (a binary file
+              // misnamed with a text extension); fall back to download rather
+              // than render replacement-character mojibake.
+              kind = undefined;
+            } else {
+              textContent = decoded;
             }
           } else {
             // Too large to render as a single string; offer download instead.
@@ -82,7 +93,15 @@ export function PageAsset() {
           }
         }
 
-        objectUrl = URL.createObjectURL(file);
+        // Serve PDFs under an explicit application/pdf type. A stored file can
+        // carry an attacker-controlled MIME type (e.g. a text/html file dragged
+        // in from another page and saved as ".pdf"); since a blob: URL inherits
+        // the app origin, letting the iframe honor that type would execute
+        // same-origin script. The other kinds render in inert sinks
+        // (img/video/audio) or as escaped text, so their bytes are used as-is.
+        const previewSource =
+          kind === 'pdf' ? new Blob([file], { type: 'application/pdf' }) : file;
+        objectUrl = URL.createObjectURL(previewSource);
         setState({ status: 'ready', fileName, objectUrl, kind, textContent });
       } catch {
         if (!disposed) {
@@ -93,6 +112,7 @@ export function PageAsset() {
 
     return () => {
       disposed = true;
+      controller.abort();
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl);
       }

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -163,9 +163,9 @@ export const t = {
       loading: 'Asset wird geladen...',
       unavailable: 'Dieses Asset kann nicht geladen werden.',
       noPreview:
-        'Diese Datei kann hier nicht als Vorschau angezeigt werden. Lade sie herunter, um den Inhalt zu sehen.',
-      videoUnsupported: 'Dein Browser kann dieses Videoformat nicht abspielen.',
-      audioUnsupported: 'Dein Browser kann dieses Audioformat nicht abspielen.',
+        'Diese Datei kann hier nicht als Vorschau angezeigt werden. Laden Sie sie herunter, um den Inhalt zu sehen.',
+      videoUnsupported: 'Ihr Browser kann dieses Videoformat nicht abspielen.',
+      audioUnsupported: 'Ihr Browser kann dieses Audioformat nicht abspielen.',
     },
     dialogs: {
       changeTheme: {

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -152,44 +152,26 @@ async function dragTreeItemOntoEditor(
   await page.mouse.up();
 }
 
-// Stores a real (decodable) 1x1 PNG directly in the browser workspace so the
-// asset page can render an actual `<img>` rather than a broken-media fallback.
-async function writeStoredPng(
+// Bytes of a valid (decodable) 1x1 PNG, so the asset page renders an actual
+// `<img>` rather than a broken-media fallback.
+const PNG_1X1_BYTES = [
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0,
+  0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120,
+  156, 99, 248, 15, 4, 0, 9, 251, 3, 253, 167, 186, 48, 251, 0, 0, 0, 0, 73, 69,
+  78, 68, 174, 66, 96, 130,
+];
+
+function writeStoredPng(
   page: Page,
   workspaceName: string,
   relativePath: string,
 ) {
-  await page.evaluate(
-    async ({ workspace, filePath }) => {
-      const pngBytes = Uint8Array.from([
-        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0,
-        1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65,
-        84, 120, 156, 99, 248, 15, 4, 0, 9, 251, 3, 253, 167, 186, 48, 251, 0,
-        0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
-      ]);
-      const request = indexedDB.open('baby-idb-db-3');
-      const database = await new Promise<IDBDatabase>((resolve, reject) => {
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error);
-      });
-      await new Promise<void>((resolve, reject) => {
-        const transaction = database.transaction(
-          'baby-idb-db-store-3',
-          'readwrite',
-        );
-        transaction.oncomplete = () => resolve();
-        transaction.onerror = () => reject(transaction.error);
-        transaction.onabort = () => reject(transaction.error);
-        transaction.objectStore('baby-idb-db-store-3').put(
-          new File([pngBytes], filePath.split('/').at(-1) ?? filePath, {
-            type: 'image/png',
-          }),
-          `${workspace}/${filePath}`,
-        );
-      });
-      database.close();
-    },
-    { workspace: workspaceName, filePath: relativePath },
+  return writeStoredFile(
+    page,
+    workspaceName,
+    relativePath,
+    PNG_1X1_BYTES,
+    'image/png',
   );
 }
 
@@ -722,5 +704,80 @@ test('renders a text asset inline when the asset URL is opened directly', async 
   await expect(page.getByRole('link', { name: 'Download' })).toHaveAttribute(
     'download',
     'config.json',
+  );
+});
+
+test('does not execute script from a PDF asset stored with a mismatched MIME type', async ({
+  page,
+}, testInfo) => {
+  const workspaceName = `asset-pdf-safety-${testInfo.workerIndex}-${Date.now()}`;
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'source',
+  });
+  // A file saved as .pdf but whose bytes/MIME are HTML with a script. A blob:
+  // URL inherits the app origin, so if the preview iframe honored the stored
+  // MIME type this would run as same-origin script with access to every
+  // workspace's IndexedDB.
+  await writeStoredFile(
+    page,
+    workspaceName,
+    'assets/trap.pdf',
+    '<script>window.top.__assetPreviewXssRan = true;</script><h1>pwned</h1>',
+    'text/html',
+  );
+
+  await page.goto(
+    `/ws#route=asset&wsPath=${encodeURIComponent(
+      `${workspaceName}:assets/trap.pdf`,
+    )}`,
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  await expect(page.getByRole('heading', { name: 'trap.pdf' })).toBeVisible();
+  // The preview iframe is present (rendered as application/pdf), but the
+  // disguised HTML must never execute. Give any injected script ample time to
+  // run so a false-negative can't slip through, then assert it did not.
+  await expect(page.locator('iframe[title="trap.pdf"]')).toBeVisible();
+  await page.waitForTimeout(750);
+  const xssRan = await page.evaluate(
+    () =>
+      (window as unknown as { __assetPreviewXssRan?: boolean })
+        .__assetPreviewXssRan === true,
+  );
+  expect(xssRan).toBe(false);
+  await expect(page.getByRole('link', { name: 'Download' })).toBeVisible();
+});
+
+test('falls back to download for a binary file misnamed with a text extension', async ({
+  page,
+}, testInfo) => {
+  const workspaceName = `asset-binary-text-${testInfo.workerIndex}-${Date.now()}`;
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'source',
+  });
+  // A NUL byte marks these bytes as non-text; the viewer must not render them
+  // as mojibake in a <pre>.
+  await writeStoredFile(
+    page,
+    workspaceName,
+    'data/blob.txt',
+    [0, 1, 2, 3, 255, 254, 0, 66, 67],
+    'application/octet-stream',
+  );
+
+  await page.goto(
+    `/ws#route=asset&wsPath=${encodeURIComponent(
+      `${workspaceName}:data/blob.txt`,
+    )}`,
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  await expect(page.getByRole('heading', { name: 'blob.txt' })).toBeVisible();
+  await expect(page.locator('pre')).toHaveCount(0);
+  await expect(page.getByRole('link', { name: 'Download' })).toHaveAttribute(
+    'download',
+    'blob.txt',
   );
 });

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -781,3 +781,96 @@ test('falls back to download for a binary file misnamed with a text extension', 
     'blob.txt',
   );
 });
+
+// A minimal but structurally valid single-page PDF ("Hello PDF"). Using real
+// PDF bytes (not a "%PDF" stub) lets the browser's native viewer receive genuine
+// content, so this exercises the actual render path rather than only the iframe.
+const VALID_PDF_BYTES = [
+  37, 80, 68, 70, 45, 49, 46, 52, 10, 49, 32, 48, 32, 111, 98, 106, 10, 60, 60,
+  32, 47, 84, 121, 112, 101, 32, 47, 67, 97, 116, 97, 108, 111, 103, 32, 47, 80,
+  97, 103, 101, 115, 32, 50, 32, 48, 32, 82, 32, 62, 62, 10, 101, 110, 100, 111,
+  98, 106, 10, 50, 32, 48, 32, 111, 98, 106, 10, 60, 60, 32, 47, 84, 121, 112,
+  101, 32, 47, 80, 97, 103, 101, 115, 32, 47, 75, 105, 100, 115, 32, 91, 51, 32,
+  48, 32, 82, 93, 32, 47, 67, 111, 117, 110, 116, 32, 49, 32, 62, 62, 10, 101,
+  110, 100, 111, 98, 106, 10, 51, 32, 48, 32, 111, 98, 106, 10, 60, 60, 32, 47,
+  84, 121, 112, 101, 32, 47, 80, 97, 103, 101, 32, 47, 80, 97, 114, 101, 110,
+  116, 32, 50, 32, 48, 32, 82, 32, 47, 77, 101, 100, 105, 97, 66, 111, 120, 32,
+  91, 48, 32, 48, 32, 50, 48, 48, 32, 50, 48, 48, 93, 32, 47, 67, 111, 110, 116,
+  101, 110, 116, 115, 32, 52, 32, 48, 32, 82, 32, 47, 82, 101, 115, 111, 117,
+  114, 99, 101, 115, 32, 60, 60, 32, 47, 70, 111, 110, 116, 32, 60, 60, 32, 47,
+  70, 49, 32, 53, 32, 48, 32, 82, 32, 62, 62, 32, 62, 62, 32, 62, 62, 10, 101,
+  110, 100, 111, 98, 106, 10, 52, 32, 48, 32, 111, 98, 106, 10, 60, 60, 32, 47,
+  76, 101, 110, 103, 116, 104, 32, 52, 48, 32, 62, 62, 10, 115, 116, 114, 101,
+  97, 109, 10, 66, 84, 32, 47, 70, 49, 32, 50, 52, 32, 84, 102, 32, 52, 48, 32,
+  49, 48, 48, 32, 84, 100, 32, 40, 72, 101, 108, 108, 111, 32, 80, 68, 70, 41,
+  32, 84, 106, 32, 69, 84, 10, 101, 110, 100, 115, 116, 114, 101, 97, 109, 10,
+  101, 110, 100, 111, 98, 106, 10, 53, 32, 48, 32, 111, 98, 106, 10, 60, 60, 32,
+  47, 84, 121, 112, 101, 32, 47, 70, 111, 110, 116, 32, 47, 83, 117, 98, 116,
+  121, 112, 101, 32, 47, 84, 121, 112, 101, 49, 32, 47, 66, 97, 115, 101, 70,
+  111, 110, 116, 32, 47, 72, 101, 108, 118, 101, 116, 105, 99, 97, 32, 62, 62,
+  10, 101, 110, 100, 111, 98, 106, 10, 120, 114, 101, 102, 10, 48, 32, 54, 10,
+  48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 32, 54, 53, 53, 51, 53, 32, 102, 32,
+  10, 48, 48, 48, 48, 48, 48, 48, 48, 48, 57, 32, 48, 48, 48, 48, 48, 32, 110,
+  32, 10, 48, 48, 48, 48, 48, 48, 48, 48, 53, 56, 32, 48, 48, 48, 48, 48, 32,
+  110, 32, 10, 48, 48, 48, 48, 48, 48, 48, 49, 49, 53, 32, 48, 48, 48, 48, 48,
+  32, 110, 32, 10, 48, 48, 48, 48, 48, 48, 48, 50, 52, 49, 32, 48, 48, 48, 48,
+  48, 32, 110, 32, 10, 48, 48, 48, 48, 48, 48, 48, 51, 51, 49, 32, 48, 48, 48,
+  48, 48, 32, 110, 32, 10, 116, 114, 97, 105, 108, 101, 114, 10, 60, 60, 32, 47,
+  83, 105, 122, 101, 32, 54, 32, 47, 82, 111, 111, 116, 32, 49, 32, 48, 32, 82,
+  32, 62, 62, 10, 115, 116, 97, 114, 116, 120, 114, 101, 102, 10, 52, 48, 49,
+  10, 37, 37, 69, 79, 70,
+];
+
+test('serves a real PDF to the native viewer as application/pdf even when stored with a mismatched MIME type', async ({
+  page,
+}, testInfo) => {
+  const workspaceName = `asset-pdf-render-${testInfo.workerIndex}-${Date.now()}`;
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'source',
+  });
+  // Stored with an empty/mismatched MIME type. A blob: URL would otherwise carry
+  // that type into the iframe; the preview must instead hand the browser
+  // application/pdf so it renders (and can never be coerced to text/html).
+  await writeStoredFile(
+    page,
+    workspaceName,
+    'assets/real.pdf',
+    VALID_PDF_BYTES,
+    '',
+  );
+
+  await page.goto(
+    `/ws#route=asset&wsPath=${encodeURIComponent(
+      `${workspaceName}:assets/real.pdf`,
+    )}`,
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  await expect(page.getByRole('heading', { name: 'real.pdf' })).toBeVisible();
+  const frame = page.locator('iframe[title="real.pdf"]');
+  await expect(frame).toBeVisible();
+  await expect(frame).toHaveAttribute('src', /^blob:/);
+
+  // The exact bytes handed to the iframe are an intact PDF under an
+  // application/pdf content type -- which is what the native viewer renders.
+  const delivered = await page.evaluate(async () => {
+    const el = document.querySelector(
+      'iframe[title="real.pdf"]',
+    ) as HTMLIFrameElement | null;
+    if (!el) {
+      return null;
+    }
+    const res = await fetch(el.src);
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    return {
+      contentType: res.headers.get('content-type'),
+      magic: String.fromCharCode(...bytes.slice(0, 5)),
+      size: bytes.length,
+    };
+  });
+  expect(delivered?.contentType).toBe('application/pdf');
+  expect(delivered?.magic).toBe('%PDF-');
+  expect(delivered?.size).toBe(VALID_PDF_BYTES.length);
+  await expect(page.getByRole('link', { name: 'Download' })).toBeVisible();
+});

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -592,11 +592,15 @@ export async function writeStoredFile(
   page: Page,
   workspaceName: string,
   relativePath: string,
-  content: string,
+  // Text content, or raw bytes as a number[] for binary fixtures (e.g. an
+  // actual image). number[] survives Playwright's evaluate serialization.
+  content: string | number[],
   type = 'text/plain',
 ) {
   await page.evaluate(
     async ({ workspace, filePath, content, type }) => {
+      const part =
+        typeof content === 'string' ? content : new Uint8Array(content);
       const request = indexedDB.open('baby-idb-db-3');
       const database = await new Promise<IDBDatabase>((resolve, reject) => {
         request.onsuccess = () => resolve(request.result);
@@ -611,7 +615,7 @@ export async function writeStoredFile(
         transaction.onerror = () => reject(transaction.error);
         transaction.onabort = () => reject(transaction.error);
         transaction.objectStore('baby-idb-db-store-3').put(
-          new File([content], filePath.split('/').at(-1) ?? filePath, {
+          new File([part], filePath.split('/').at(-1) ?? filePath, {
             type,
           }),
           `${workspace}/${filePath}`,


### PR DESCRIPTION
Follow-up to #618, which merged before this review round landed. These are the review fixes for the inline asset viewer; the net diff is only 4 files on top of the merged feature.

## Fixes

- **Security — PDF preview XSS (should-fix):** the preview iframe served the stored blob under its *stored* MIME type. A `blob:` URL inherits the app origin and there is no CSP, so a file saved as `*.pdf` but carrying `text/html` bytes (e.g. dragged in from a hostile page — `safeExtension` keeps the `.pdf` name, the paste/drop plugin accepts attacker-controlled `File.type`) would execute **same-origin script with access to every workspace's IndexedDB**. Fixed by minting the preview URL from `new Blob([file], { type: 'application/pdf' })` for the `pdf` kind, so the iframe can only ever invoke the (sandboxed) built-in PDF viewer. `img`/`video`/`audio` are inert sinks and text is escaped, so only the iframe needed this. Chose forced content-type over an iframe `sandbox` attribute because `sandbox` breaks Chromium's native PDF viewer.
- **AbortSignal:** the asset read now receives an `AbortSignal` that is aborted on unmount / wsPath change.
- **Binary-as-text:** a text-kind file containing a NUL byte (a binary misnamed with a text extension) now falls back to download instead of rendering replacement-character mojibake.
- **German register:** the new `pageAsset` strings now use formal "Sie" to match the rest of `de.ts`.
- **Test dedup:** `writeStoredFile` now accepts raw bytes and the duplicated `writeStoredPng` helper (which had a third hardcoded copy of the IndexedDB store names) is a thin wrapper over it.

## Tests

- New E2E: a `.pdf` stored as `text/html` with an inline `<script>` does **not** execute (asserts the sentinel it would set stays unset), and Download remains available.
- New E2E: a binary file named `.txt` falls back to download (no `<pre>` rendered).

## CI

Tree is identical to the branch state that already passed a full `pnpm local-ci-check` (test:ci 124/124, full e2e 116 + 28 component with 0 failures, lint/knip/desktop green). asset-workflow E2E is 12/12 including the two new safety tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)