### PR TITLE
feat(wordgard-plus): scaffold + editor/menu bridge + tooltip host (M4-P0)

### DIFF
--- a/packages/js-lib/wordgard-plus/package.json
+++ b/packages/js-lib/wordgard-plus/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@bangle.io/wordgard-plus",
+  "description": "Opinionated plug-and-play Wordgard surfaces: React chrome and the Jotai/tooltip/menu bridge that complement a consumer's own Wordgard setup \u2014 never wrapping or owning the editor instance.",
+  "license": "AGPL-3.0-or-later",
+  "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bangle-io/bangle-io.git",
+    "directory": "packages/js-lib/wordgard-plus"
+  },
+  "authors": [
+    {
+      "name": "Kushan Joshi",
+      "email": "0o3ko0@gmail.com",
+      "web": "http://github.com/kepta"
+    }
+  ],
+  "homepage": "https://bangle.io",
+  "bugs": "https://github.com/bangle-io/bangle-io/issues",
+  "banglePackageConfig": {
+    "env": "browser",
+    "kind": "library"
+  },
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {},
+  "dependencies": {
+    "@bangle.io/wordgard-utils": "workspace:*",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "jotai": "^2.20.1",
+    "react": "19.2.7",
+    "react-dom": "19.2.7"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2"
+  }
+}

--- a/packages/js-lib/wordgard-plus/src/__tests__/bridge.spec.ts
+++ b/packages/js-lib/wordgard-plus/src/__tests__/bridge.spec.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import {
+  basicSchema,
+  bulletList,
+  type GardState,
+  history,
+  Leaf,
+  Wordgard,
+} from '@bangle.io/wordgard-utils';
+import { createStore } from 'jotai';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createEditorAtoms } from '../bridge';
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+/** Wordgard flushes plugin updates on animation frames. */
+function nextFlush(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+function makeEditor(
+  extension: GardState.Extension,
+  doc = '<p>hello world</p>',
+) {
+  const parent = document.createElement('div');
+  document.body.append(parent);
+  const wg = Wordgard.create({
+    parent,
+    doc,
+    config: [basicSchema(), bulletList(), history(), extension],
+  });
+  cleanups.push(() => {
+    wg.dom.remove();
+    parent.remove();
+  });
+  return wg;
+}
+
+describe('createEditorAtoms', () => {
+  test('seeds atoms from the initial state before any update', () => {
+    const store = createStore();
+    const { atoms, extension } = createEditorAtoms({ store });
+    makeEditor(extension);
+
+    expect(store.get(atoms.focused)).toBe(false);
+    // The default selection is a cursor at the start of the document,
+    // which resolves to position 1: inside the first textblock.
+    expect(store.get(atoms.selection)).toEqual({
+      anchor: 1,
+      head: 1,
+      from: 1,
+      to: 1,
+      empty: true,
+    });
+    expect(store.get(atoms.canUndo)).toBe(false);
+    expect(store.get(atoms.canRedo)).toBe(false);
+  });
+
+  test('updates selection and undo depth after transactions', async () => {
+    const store = createStore();
+    const { atoms, extension } = createEditorAtoms({ store });
+    const wg = makeEditor(extension);
+
+    wg.dispatch({
+      changes: { from: 1, to: 1, insert: [Leaf.text('A')], fit: true },
+      selection: { anchor: 2 },
+    });
+    await nextFlush();
+
+    expect(store.get(atoms.selection).anchor).toBe(2);
+    expect(store.get(atoms.canUndo)).toBe(true);
+    expect(store.get(atoms.canRedo)).toBe(false);
+  });
+
+  test('equality guards suppress notifications for irrelevant updates', async () => {
+    const store = createStore();
+    const { atoms, extension } = createEditorAtoms({ store });
+    const wg = makeEditor(extension);
+    await nextFlush();
+
+    const selectionListener = vi.fn();
+    const unsubscribe = store.sub(atoms.selection, selectionListener);
+    cleanups.push(unsubscribe);
+
+    // A transaction that neither moves the selection nor changes the doc.
+    wg.dispatch({});
+    await nextFlush();
+
+    expect(selectionListener).not.toHaveBeenCalled();
+  });
+
+  test('state queries are exposed through the active atom', async () => {
+    const store = createStore();
+    const { atoms, extension } = createEditorAtoms({
+      store,
+      queries: { strongActive: (state) => state.selection.empty },
+    });
+    makeEditor(extension);
+
+    expect(store.get(atoms.active)).toEqual({ strongActive: true });
+  });
+
+  test('two editors never share atom state', async () => {
+    const store = createStore();
+    const first = createEditorAtoms({ store });
+    const second = createEditorAtoms({ store });
+    const wg1 = makeEditor(first.extension);
+    makeEditor(second.extension);
+
+    wg1.dispatch({
+      changes: { from: 1, to: 1, insert: [Leaf.text('A')], fit: true },
+      selection: { anchor: 2 },
+    });
+    await nextFlush();
+
+    expect(store.get(first.atoms.selection).anchor).toBe(2);
+    expect(store.get(second.atoms.selection).anchor).toBe(1);
+  });
+});

--- a/packages/js-lib/wordgard-plus/src/__tests__/resolved-menu.spec.ts
+++ b/packages/js-lib/wordgard-plus/src/__tests__/resolved-menu.spec.ts
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import {
+  basicSchema,
+  bulletList,
+  type GardState,
+  history,
+  Leaf,
+  Wordgard,
+} from '@bangle.io/wordgard-utils';
+import { createStore } from 'jotai';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { ResolvedMenuButton, ResolvedMenuNode } from '../resolved-menu';
+import { createMenuAtoms } from '../resolved-menu';
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+function nextFlush(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+function makeEditor(
+  extension: GardState.Extension,
+  doc = '<p>hello world</p>',
+) {
+  const parent = document.createElement('div');
+  document.body.append(parent);
+  const wg = Wordgard.create({
+    parent,
+    doc,
+    config: [basicSchema(), bulletList(), history(), extension],
+  });
+  cleanups.push(() => {
+    wg.dom.remove();
+    parent.remove();
+  });
+  return wg;
+}
+
+function allButtons(nodes: readonly ResolvedMenuNode[]): ResolvedMenuButton[] {
+  const buttons: ResolvedMenuButton[] = [];
+  for (const node of nodes) {
+    if (node.kind === 'button') {
+      buttons.push(node);
+    } else if (node.kind === 'submenu') {
+      buttons.push(...allButtons(node.items));
+    }
+  }
+  return buttons;
+}
+
+function findButton(
+  nodes: readonly ResolvedMenuNode[],
+  match: RegExp,
+): ResolvedMenuButton {
+  const button = allButtons(nodes).find(
+    (candidate) =>
+      (candidate.description && match.test(candidate.description)) ||
+      (candidate.label && match.test(candidate.label)),
+  );
+  if (!button) {
+    throw new Error(`No menu button matching ${match}`);
+  }
+  return button;
+}
+
+describe('createMenuAtoms', () => {
+  test('projects the first-party menu items registered by extension bundles', () => {
+    const store = createStore();
+    const { atoms, extension } = createMenuAtoms({ store });
+    makeEditor(extension);
+
+    const items = store.get(atoms.items);
+    expect(items.length).toBeGreaterThan(0);
+
+    // Buttons contributed by basicSchema / bulletList / history bundles.
+    expect(() => findButton(items, /strong/i)).not.toThrow();
+    expect(() => findButton(items, /list/i)).not.toThrow();
+    expect(() => findButton(items, /undo/i)).not.toThrow();
+  });
+
+  test('a projected run() dispatches the button command and re-projects state', async () => {
+    const store = createStore();
+    const { atoms, extension } = createMenuAtoms({ store });
+    makeEditor(extension);
+
+    const strongBefore = findButton(store.get(atoms.items), /strong/i);
+    expect(strongBefore.active).toBe(false);
+
+    // Toggling strong at the cursor adds the mark to the active marks.
+    strongBefore.run();
+    await nextFlush();
+
+    const strongAfter = findButton(store.get(atoms.items), /strong/i);
+    expect(strongAfter.active).toBe(true);
+  });
+
+  test('enabled state follows the editor, e.g. undo after a document change', async () => {
+    const store = createStore();
+    const { atoms, extension } = createMenuAtoms({ store });
+    const wg = makeEditor(extension);
+
+    expect(findButton(store.get(atoms.items), /undo/i).enabled).toBe(false);
+
+    wg.dispatch({
+      changes: { from: 1, to: 1, insert: [Leaf.text('A')], fit: true },
+      userEvent: 'input.type',
+    });
+    await nextFlush();
+
+    expect(findButton(store.get(atoms.items), /undo/i).enabled).toBe(true);
+  });
+
+  test('the items atom only notifies when something visible changed', async () => {
+    const store = createStore();
+    const { atoms, extension } = createMenuAtoms({ store });
+    const wg = makeEditor(extension);
+    await nextFlush();
+
+    const listener = vi.fn();
+    cleanups.push(store.sub(atoms.items, listener));
+
+    // No doc/selection change and no updateFor-relevant transaction.
+    wg.dispatch({});
+    await nextFlush();
+    expect(listener).not.toHaveBeenCalled();
+
+    wg.dispatch({
+      changes: { from: 1, to: 1, insert: [Leaf.text('A')], fit: true },
+      userEvent: 'input.type',
+    });
+    await nextFlush();
+    // Undo becomes available -> visible change -> exactly one notification.
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/js-lib/wordgard-plus/src/__tests__/tooltip-host.spec.tsx
+++ b/packages/js-lib/wordgard-plus/src/__tests__/tooltip-host.spec.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment happy-dom
+
+import { basicSchema, Tooltip, Wordgard } from '@bangle.io/wordgard-utils';
+import { act, render } from '@testing-library/react';
+import { createStore } from 'jotai';
+import React from 'react';
+import { afterEach, describe, expect, test } from 'vitest';
+import { createTooltipHost, reactTooltip, TooltipHost } from '../tooltip-host';
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+function nextFlush(): Promise<void> {
+  return act(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve());
+        });
+      }),
+  );
+}
+
+describe('reactTooltip + TooltipHost', () => {
+  test('portals React content into a connected tooltip view and releases it on disconnect', () => {
+    const store = createStore();
+    const host = createTooltipHost(store);
+    const { container } = render(<TooltipHost handle={host} />);
+    cleanups.push(() => {
+      // render() cleanup happens via testing-library auto-cleanup; nothing
+      // editor-side to release in this pure lifecycle test.
+    });
+
+    const tooltip = reactTooltip({
+      host,
+      pos: 1,
+      className: 'my-tooltip',
+      content: () => <span data-testid="tip">TIP</span>,
+    });
+
+    // Drive the Tooltip.View lifecycle directly, as the editor would.
+    const view = tooltip.create(
+      // The content callback receives the editor; this lifecycle test never
+      // dereferences it.
+      undefined as unknown as Wordgard,
+    );
+    expect(view.dom.className).toBe('my-tooltip');
+
+    act(() => {
+      view.connect?.(undefined as unknown as Wordgard);
+    });
+    expect(view.dom.textContent).toBe('TIP');
+    // The portal renders through the host component's React tree.
+    expect(container).toBeDefined();
+
+    act(() => {
+      view.disconnect?.(undefined as unknown as Wordgard);
+    });
+    expect(view.dom.textContent).toBe('');
+  });
+
+  test('a tooltip provided via the Tooltip.show facet renders inside a real editor', async () => {
+    const store = createStore();
+    const host = createTooltipHost(store);
+    render(<TooltipHost handle={host} />);
+
+    const parent = document.createElement('div');
+    document.body.append(parent);
+    const wg = Wordgard.create({
+      parent,
+      doc: '<p>hello</p>',
+      config: [
+        basicSchema(),
+        Tooltip.show.of(
+          reactTooltip({
+            host,
+            pos: 1,
+            content: () => <strong>from-react</strong>,
+          }),
+        ),
+      ],
+    });
+    cleanups.push(() => {
+      wg.dom.remove();
+      parent.remove();
+    });
+
+    await nextFlush();
+
+    expect(wg.dom.textContent).toContain('from-react');
+  });
+
+  test('multiple tooltips keep independent content', () => {
+    const store = createStore();
+    const host = createTooltipHost(store);
+    render(<TooltipHost handle={host} />);
+
+    const first = reactTooltip({
+      host,
+      pos: 1,
+      content: () => <span>one</span>,
+    }).create(undefined as unknown as Wordgard);
+    const second = reactTooltip({
+      host,
+      pos: 2,
+      content: () => <span>two</span>,
+    }).create(undefined as unknown as Wordgard);
+
+    act(() => {
+      first.connect?.(undefined as unknown as Wordgard);
+      second.connect?.(undefined as unknown as Wordgard);
+    });
+    expect(first.dom.textContent).toBe('one');
+    expect(second.dom.textContent).toBe('two');
+
+    act(() => {
+      first.disconnect?.(undefined as unknown as Wordgard);
+    });
+    expect(first.dom.textContent).toBe('');
+    expect(second.dom.textContent).toBe('two');
+  });
+});

--- a/packages/js-lib/wordgard-plus/src/bridge.ts
+++ b/packages/js-lib/wordgard-plus/src/bridge.ts
@@ -1,0 +1,184 @@
+import {
+  type GardState,
+  redoDepth,
+  undoDepth,
+  Wordgard,
+} from '@bangle.io/wordgard-utils';
+import { type Atom, atom, type createStore } from 'jotai';
+
+/**
+ * The Jotai store type wordgard-plus modules share state through. Consumers
+ * pass their own store so chrome state lives wherever the rest of their UI
+ * state does.
+ */
+export type JotaiStore = ReturnType<typeof createStore>;
+
+/** A plain-data snapshot of the selection, safe to hold in UI state. */
+export type SelectionSummary = {
+  anchor: number;
+  head: number;
+  from: number;
+  to: number;
+  empty: boolean;
+};
+
+/**
+ * Boolean state queries evaluated per update, e.g.
+ * `{ bulletList: listIsActive(BulletList.tag) }`. Keys become the keys of
+ * the `active` atom's value.
+ */
+export type StateQueries = Record<string, (state: GardState) => boolean>;
+
+export type EditorAtoms<TQueries extends StateQueries = StateQueries> = {
+  /** Whether the editor currently has focus. */
+  focused: Atom<boolean>;
+  /** The current selection, as plain offsets. */
+  selection: Atom<SelectionSummary>;
+  /** Whether there is anything to undo (requires the history extension). */
+  canUndo: Atom<boolean>;
+  /** Whether there is anything to redo (requires the history extension). */
+  canRedo: Atom<boolean>;
+  /** The result of each configured {@link StateQueries state query}. */
+  active: Atom<{ readonly [K in keyof TQueries]: boolean }>;
+};
+
+function selectionSummary(state: GardState): SelectionSummary {
+  const selection = state.selection;
+  return {
+    anchor: selection.anchor,
+    head: selection.head,
+    from: selection.from,
+    to: selection.to,
+    empty: selection.empty,
+  };
+}
+
+function selectionEqual(a: SelectionSummary, b: SelectionSummary): boolean {
+  return (
+    a.anchor === b.anchor &&
+    a.head === b.head &&
+    a.from === b.from &&
+    a.to === b.to &&
+    a.empty === b.empty
+  );
+}
+
+/**
+ * History depth queries throw when the history extension is absent; a
+ * missing history simply means "nothing to undo" for chrome purposes.
+ */
+function safeDepth(
+  depth: (state: GardState) => number,
+  state: GardState,
+): boolean {
+  try {
+    return depth(state) > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates per-editor Jotai read atoms fed by a single editor plugin.
+ *
+ * Wordgard-idiomatic shape: update hooks are configuration (facets/plugins),
+ * not post-hoc subscriptions on a live instance, so this returns an
+ * `extension` the consumer adds to their own `Wordgard.create` config — the
+ * bridge never owns or wraps the editor. Atoms are created per call, so two
+ * editors never share chrome state; pass one `store` per UI tree.
+ *
+ * The atoms are derived read models only. The write path is always "React
+ * dispatches a command/transaction"; nothing ever syncs an atom back into
+ * the editor.
+ *
+ * Every atom write is equality-guarded so a keystroke that does not change
+ * a value never notifies that atom's subscribers.
+ */
+export function createEditorAtoms<TQueries extends StateQueries>(config: {
+  store: JotaiStore;
+  queries?: TQueries;
+}): {
+  atoms: EditorAtoms<TQueries>;
+  /** Add this to the editor's `Wordgard.create` config. */
+  extension: GardState.Extension;
+} {
+  const { store, queries } = config;
+
+  const $focused = atom(false);
+  const $selection = atom<SelectionSummary>({
+    anchor: 0,
+    head: 0,
+    from: 0,
+    to: 0,
+    empty: true,
+  });
+  const $canUndo = atom(false);
+  const $canRedo = atom(false);
+  const emptyActive = Object.fromEntries(
+    Object.keys(queries ?? {}).map((key) => [key, false]),
+  ) as { readonly [K in keyof TQueries]: boolean };
+  const $active = atom(emptyActive);
+
+  const sync = (state: GardState, focused: boolean) => {
+    if (store.get($focused) !== focused) {
+      store.set($focused, focused);
+    }
+
+    const nextSelection = selectionSummary(state);
+    if (!selectionEqual(store.get($selection), nextSelection)) {
+      store.set($selection, nextSelection);
+    }
+
+    const nextCanUndo = safeDepth(undoDepth, state);
+    if (store.get($canUndo) !== nextCanUndo) {
+      store.set($canUndo, nextCanUndo);
+    }
+    const nextCanRedo = safeDepth(redoDepth, state);
+    if (store.get($canRedo) !== nextCanRedo) {
+      store.set($canRedo, nextCanRedo);
+    }
+
+    if (queries) {
+      const previous = store.get($active);
+      let changed = false;
+      const next: Record<string, boolean> = {};
+      for (const [key, query] of Object.entries(queries)) {
+        const value = query(state);
+        next[key] = value;
+        if (previous[key] !== value) {
+          changed = true;
+        }
+      }
+      if (changed) {
+        store.set($active, next as typeof emptyActive);
+      }
+    }
+  };
+
+  const plugin = Wordgard.Plugin.define((wg) => {
+    // Seed immediately so atoms reflect the initial document/selection
+    // before the first transaction.
+    sync(wg.state, wg.hasFocus);
+    return {
+      update: (update: Wordgard.Update) => {
+        sync(update.state, update.editor.hasFocus);
+      },
+      disconnect: () => {
+        if (store.get($focused)) {
+          store.set($focused, false);
+        }
+      },
+    };
+  });
+
+  return {
+    atoms: {
+      focused: $focused,
+      selection: $selection,
+      canUndo: $canUndo,
+      canRedo: $canRedo,
+      active: $active,
+    },
+    extension: plugin.extension,
+  };
+}

--- a/packages/js-lib/wordgard-plus/src/index.ts
+++ b/packages/js-lib/wordgard-plus/src/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Opinionated plug-and-play Wordgard surfaces (plans/011, M4). The shadcn
+ * posture, not the tiptap posture: every export is either an extension you
+ * add to YOUR `Wordgard.create` config or a React component you render in
+ * YOUR tree — this package never creates, owns, or wraps an editor
+ * instance, and deleting it from an app must leave a working editor.
+ *
+ * Division of labor for floating/menu chrome: Wordgard owns geometry and
+ * lifecycle (tooltip facets, menu model), React owns content (portaled via
+ * {@link TooltipHost}), and Jotai owns UI state (per-editor atoms from
+ * {@link createEditorAtoms} / {@link createMenuAtoms}; the write path is
+ * always "dispatch a command/transaction", never atom→editor sync).
+ *
+ * Bangle-free by design: wordgard is consumed only through the
+ * `@bangle.io/wordgard-utils` chokepoint and user-visible strings arrive
+ * via props/PhraseSets, so later extraction stays mechanical.
+ */
+export {
+  createEditorAtoms,
+  type EditorAtoms,
+  type JotaiStore,
+  type SelectionSummary,
+  type StateQueries,
+} from './bridge';
+export {
+  createMenuAtoms,
+  type MenuAtoms,
+  type ResolvedMenuButton,
+  type ResolvedMenuCustom,
+  type ResolvedMenuNode,
+  type ResolvedMenuSeparator,
+  type ResolvedMenuSubmenu,
+  useResolvedMenu,
+} from './resolved-menu';
+export {
+  createTooltipHost,
+  reactTooltip,
+  TooltipHost,
+  type TooltipHostHandle,
+} from './tooltip-host';

--- a/packages/js-lib/wordgard-plus/src/resolved-menu.ts
+++ b/packages/js-lib/wordgard-plus/src/resolved-menu.ts
@@ -1,0 +1,320 @@
+import {
+  Command,
+  type GardState,
+  Menu,
+  type Transaction,
+  Wordgard,
+} from '@bangle.io/wordgard-utils';
+import { type Atom, atom } from 'jotai';
+import { useAtomValue } from 'jotai/react';
+import type { JotaiStore } from './bridge';
+
+/**
+ * A first-party menu item projected to plain data a React renderer can
+ * consume. `run`/`mount` are the only non-data members; everything else is
+ * comparable so the atom only notifies when something visible changed.
+ */
+export type ResolvedMenuNode =
+  | ResolvedMenuButton
+  | ResolvedMenuSeparator
+  | ResolvedMenuSubmenu
+  | ResolvedMenuCustom;
+
+export type ResolvedMenuButton = {
+  kind: 'button';
+  /** Stable identity derived from the item's position in the menu tree. */
+  key: string;
+  /** Resolved textual label, when the item's label is textual. */
+  label: string | null;
+  /** SVG path (100x100 viewBox) when the item's label is an icon. */
+  icon: string | null;
+  /** Resolved description for tooltips / screen readers. */
+  description: string | null;
+  active: boolean;
+  enabled: boolean;
+  /** Dispatches the button's command against the live editor. */
+  run: () => void;
+};
+
+export type ResolvedMenuSeparator = { kind: 'separator'; key: string };
+
+export type ResolvedMenuSubmenu = {
+  kind: 'submenu';
+  key: string;
+  label: string | null;
+  icon: string | null;
+  description: string | null;
+  enabled: boolean;
+  items: readonly ResolvedMenuNode[];
+};
+
+/**
+ * A {@link Menu.CustomControl} manages its own DOM; the projection exposes
+ * a mount function and leaves rendering to the consumer.
+ */
+export type ResolvedMenuCustom = {
+  kind: 'custom';
+  key: string;
+  description: string | null;
+  enabled: boolean;
+  mount: (done: () => void) => { dom: HTMLElement; focus?: HTMLElement };
+};
+
+type ResolvedLabel = { label: string | null; icon: string | null };
+
+function projectLabel(
+  label: Menu.Label | undefined,
+  state: GardState,
+): ResolvedLabel {
+  if (label === undefined) {
+    return { label: null, icon: null };
+  }
+  if (typeof label === 'string') {
+    return { label, icon: null };
+  }
+  if (typeof label === 'function') {
+    return { label: label(state), icon: null };
+  }
+  return { label: null, icon: label.icon };
+}
+
+function projectDescription(
+  description:
+    | string
+    | ((state: GardState, ...insert: unknown[]) => string)
+    | undefined,
+  fallback: string | null,
+  state: GardState,
+): string | null {
+  if (description === undefined) {
+    return fallback;
+  }
+  return typeof description === 'string' ? description : description(state);
+}
+
+/**
+ * Mirrors the stock renderer's submenu-label behavior: an explicit label
+ * wins, else the first active button child's label, else the default label.
+ */
+function submenuLabel(
+  submenu: Menu.Submenu,
+  content: readonly ResolvedMenuNode[],
+  state: GardState,
+): ResolvedLabel {
+  if (submenu.label !== undefined) {
+    return projectLabel(submenu.label, state);
+  }
+  const activeChild = content.find(
+    (node): node is ResolvedMenuButton => node.kind === 'button' && node.active,
+  );
+  if (activeChild) {
+    return { label: activeChild.label, icon: activeChild.icon };
+  }
+  return projectLabel(submenu.defaultLabel, state);
+}
+
+function projectItems(
+  items: readonly Menu.Item.Resolved[],
+  wg: Wordgard,
+  state: GardState,
+  parentKey: string,
+): readonly ResolvedMenuNode[] {
+  const nodes: ResolvedMenuNode[] = [];
+  items.forEach((item, index) => {
+    const key = parentKey === '' ? `${index}` : `${parentKey}.${index}`;
+    if (item === '|') {
+      nodes.push({ kind: 'separator', key });
+      return;
+    }
+    if (item instanceof Menu.Button) {
+      if (item.select && !item.select(state)) {
+        return;
+      }
+      const { label, icon } = projectLabel(item.label, state);
+      const run = item.run;
+      nodes.push({
+        kind: 'button',
+        key,
+        label,
+        icon,
+        description: projectDescription(item.description, label, state),
+        active: item.active ? item.active(state) : false,
+        enabled: item.enable ? item.enable(state) : true,
+        run: () => {
+          Command.dispatch(wg, run);
+        },
+      });
+      return;
+    }
+    if (item instanceof Menu.CustomControl) {
+      if (item.select && !item.select(state)) {
+        return;
+      }
+      nodes.push({
+        kind: 'custom',
+        key,
+        description: projectDescription(item.description, null, state),
+        enabled: item.enable ? item.enable(state) : true,
+        mount: (done) => item.render(wg, done),
+      });
+      return;
+    }
+    // Menu.Submenu.Resolved
+    if (item.item.select && !item.item.select(state)) {
+      return;
+    }
+    const content = projectItems(item.content, wg, state, key);
+    const { label, icon } = submenuLabel(item.item, content, state);
+    nodes.push({
+      kind: 'submenu',
+      key,
+      label,
+      icon,
+      description: projectDescription(item.item.description, label, state),
+      enabled: item.item.enable ? item.item.enable(state) : true,
+      items: content,
+    });
+  });
+  return nodes;
+}
+
+function nodeEqual(nodeA: ResolvedMenuNode, nodeB: ResolvedMenuNode): boolean {
+  if (nodeA.key !== nodeB.key) {
+    return false;
+  }
+  switch (nodeA.kind) {
+    case 'separator':
+      return nodeB.kind === 'separator';
+    case 'custom':
+      return (
+        nodeB.kind === 'custom' &&
+        nodeA.description === nodeB.description &&
+        nodeA.enabled === nodeB.enabled
+      );
+    case 'button':
+      return (
+        nodeB.kind === 'button' &&
+        nodeA.label === nodeB.label &&
+        nodeA.icon === nodeB.icon &&
+        nodeA.description === nodeB.description &&
+        nodeA.active === nodeB.active &&
+        nodeA.enabled === nodeB.enabled
+      );
+    case 'submenu':
+      return (
+        nodeB.kind === 'submenu' &&
+        nodeA.label === nodeB.label &&
+        nodeA.icon === nodeB.icon &&
+        nodeA.description === nodeB.description &&
+        nodeA.enabled === nodeB.enabled &&
+        nodesEqual(nodeA.items, nodeB.items)
+      );
+  }
+}
+
+function nodesEqual(
+  a: readonly ResolvedMenuNode[],
+  b: readonly ResolvedMenuNode[],
+): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((nodeA, index) => {
+    const nodeB = b[index];
+    return nodeB !== undefined && nodeEqual(nodeA, nodeB);
+  });
+}
+
+function collectUpdateFor(
+  items: readonly Menu.Item.Resolved[],
+  into: Array<(tr: Transaction) => boolean>,
+): void {
+  for (const item of items) {
+    if (item === '|') {
+      continue;
+    }
+    if (item instanceof Menu.Button || item instanceof Menu.CustomControl) {
+      if (item.updateFor) {
+        into.push(item.updateFor);
+      }
+      continue;
+    }
+    if (item.item.updateFor) {
+      into.push(item.item.updateFor);
+    }
+    collectUpdateFor(item.content, into);
+  }
+}
+
+export type MenuAtoms = {
+  /** The resolved menu tree, projected to plain data. */
+  items: Atom<readonly ResolvedMenuNode[]>;
+};
+
+/**
+ * Resolves the first-party menu model — the items feature bundles register
+ * on the {@link Menu.Item.source} facet, shaped by an optional
+ * {@link Menu.Template} — into a Jotai atom of plain data, re-evaluated the
+ * way the stock menu bar does it: on document/selection changes plus any
+ * transaction an item's `updateFor` marks as relevant.
+ *
+ * This never forks a parallel menu-item registry: the tree comes from
+ * `Menu.resolve` over the editor's own configuration, so custom React
+ * toolbars stay in sync with keyboard shortcuts and the stock `menuBar`.
+ *
+ * Like {@link createEditorAtoms}, this returns an `extension` for the
+ * consumer's own `Wordgard.create` config and never wraps the editor.
+ */
+export function createMenuAtoms(config: {
+  store: JotaiStore;
+  template?: Menu.Template | readonly Menu.Template[];
+}): {
+  atoms: MenuAtoms;
+  /** Add this to the editor's `Wordgard.create` config. */
+  extension: GardState.Extension;
+} {
+  const { store, template } = config;
+
+  const $items = atom<readonly ResolvedMenuNode[]>([]);
+
+  const plugin = Wordgard.Plugin.define((wg) => {
+    const resolved = Menu.resolve(wg.state.facet(Menu.Item.source), template);
+    const updateFor: Array<(tr: Transaction) => boolean> = [];
+    collectUpdateFor(resolved, updateFor);
+
+    const project = (state: GardState) => {
+      const next = projectItems(resolved, wg, state, '');
+      if (!nodesEqual(store.get($items), next)) {
+        store.set($items, next);
+      }
+    };
+
+    project(wg.state);
+    return {
+      update: (update: Wordgard.Update) => {
+        const relevant =
+          update.docChanged ||
+          update.selectionSet ||
+          update.transactions.some((tr) =>
+            updateFor.some((predicate) => predicate(tr)),
+          );
+        if (relevant) {
+          project(update.state);
+        }
+      },
+    };
+  });
+
+  return { atoms: { items: $items }, extension: plugin.extension };
+}
+
+/**
+ * Convenience hook over {@link createMenuAtoms}: subscribes to the resolved
+ * menu in the store the atoms were created with.
+ */
+export function useResolvedMenu(
+  menu: MenuAtoms,
+  store: JotaiStore,
+): readonly ResolvedMenuNode[] {
+  return useAtomValue(menu.items, { store });
+}

--- a/packages/js-lib/wordgard-plus/src/tooltip-host.tsx
+++ b/packages/js-lib/wordgard-plus/src/tooltip-host.tsx
@@ -1,0 +1,117 @@
+import type { Tooltip, Wordgard } from '@bangle.io/wordgard-utils';
+import { atom, type PrimitiveAtom } from 'jotai';
+import { useAtomValue } from 'jotai/react';
+import type { ReactNode } from 'react';
+import React from 'react';
+import { createPortal } from 'react-dom';
+import type { JotaiStore } from './bridge';
+
+type PortalEntry = {
+  dom: HTMLElement;
+  content: ReactNode;
+};
+
+/**
+ * Shared registry connecting {@link reactTooltip} views to the
+ * {@link TooltipHost} that portals React into them. Create one per React
+ * tree (per store) and pass it to both sides.
+ */
+export type TooltipHostHandle = {
+  readonly store: JotaiStore;
+  /** @internal */
+  readonly $portals: PrimitiveAtom<ReadonlyMap<number, PortalEntry>>;
+  /** @internal */
+  nextId: number;
+};
+
+export function createTooltipHost(store: JotaiStore): TooltipHostHandle {
+  return {
+    store,
+    $portals: atom<ReadonlyMap<number, PortalEntry>>(new Map()),
+    nextId: 0,
+  };
+}
+
+function addPortal(
+  handle: TooltipHostHandle,
+  id: number,
+  entry: PortalEntry,
+): void {
+  const current = handle.store.get(handle.$portals);
+  const next = new Map(current);
+  next.set(id, entry);
+  handle.store.set(handle.$portals, next);
+}
+
+function removePortal(handle: TooltipHostHandle, id: number): void {
+  const current = handle.store.get(handle.$portals);
+  if (!current.has(id)) {
+    return;
+  }
+  const next = new Map(current);
+  next.delete(id);
+  handle.store.set(handle.$portals, next);
+}
+
+/**
+ * Builds a {@link Tooltip} whose view hosts a React subtree. Wordgard owns
+ * geometry and lifecycle — the tooltip element is anchored to a document
+ * position, flipped/clipped, and repositioned by the editor — while React
+ * owns the content: on `connect` the subtree is portaled into the view's
+ * DOM by the {@link TooltipHost} rendered in the consumer's tree (so
+ * context/providers keep flowing), and on `disconnect` it is released.
+ * Wordgard never knows React exists.
+ *
+ * Provide the returned tooltip through the `Tooltip.show` facet (directly,
+ * computed, or from a state field) in your own editor config.
+ */
+export function reactTooltip(config: {
+  host: TooltipHostHandle;
+  pos: number;
+  end?: number;
+  above?: boolean;
+  strictSide?: boolean;
+  arrow?: boolean;
+  clip?: boolean;
+  /** Extra class for the tooltip element Wordgard positions. */
+  className?: string;
+  content: (wg: Wordgard) => ReactNode;
+}): Tooltip {
+  const { host, content, className, ...tooltip } = config;
+  return {
+    ...tooltip,
+    create: (wg) => {
+      const dom = document.createElement('div');
+      if (className) {
+        dom.className = className;
+      }
+      const id = host.nextId++;
+      return {
+        dom,
+        connect: () => {
+          addPortal(host, id, { dom, content: content(wg) });
+        },
+        disconnect: () => {
+          removePortal(host, id);
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Renders the React subtrees of every currently-connected
+ * {@link reactTooltip} into the DOM elements Wordgard positions. Mount one
+ * per {@link TooltipHostHandle}, anywhere in the tree that has the
+ * providers your tooltip content needs.
+ */
+export function TooltipHost({ handle }: { handle: TooltipHostHandle }) {
+  const portals = useAtomValue(handle.$portals, { store: handle.store });
+  return (
+    <>
+      {[...portals.entries()].map(([id, entry]) =>
+        createPortal(entry.content, entry.dom, `wordgard-plus-tooltip-${id}`),
+      )}
+    </>
+  );
+}

--- a/packages/js-lib/wordgard-utils/src/index.ts
+++ b/packages/js-lib/wordgard-utils/src/index.ts
@@ -9,6 +9,8 @@
  * grow this surface as `editor-w` milestones need more (state, editor,
  * command, history, table, phrases).
  */
+
+export { Command, listIsActive, Menu } from 'wordgard/command';
 export {
   Attributes,
   ChangeSet,
@@ -27,6 +29,22 @@ export {
   type Token,
   ValidationError,
 } from 'wordgard/doc';
+// Editor-side modules, grown for M4-P0 (wordgard-plus bridge): the editor
+// class (with its Update/Plugin/updateListener statics), tooltips, state
+// primitives, the command/menu model, history depth queries, and the
+// built-in schema bundles that carry first-party menu buttons.
+export { Tooltip, Wordgard } from 'wordgard/editor';
+export { history, redoDepth, undoDepth } from 'wordgard/history';
+export {
+  basicSchema,
+  blockquote,
+  bulletList,
+  emphasis,
+  heading,
+  orderedList,
+  strong,
+} from 'wordgard/schema';
+export { GardSelection, GardState, Transaction } from 'wordgard/state';
 export {
   Alignment,
   BackgroundColor,

--- a/packages/tooling/storybook/package.json
+++ b/packages/tooling/storybook/package.json
@@ -42,6 +42,8 @@
     "@bangle.io/browser-entry": "workspace:*",
     "@bangle.io/env-vars": "workspace:*",
     "@bangle.io/translations": "workspace:*",
+    "@bangle.io/wordgard-plus": "workspace:*",
+    "@bangle.io/wordgard-utils": "workspace:*",
     "@chromatic-com/storybook": "^5.2.1",
     "@storybook/addon-links": "^10.4.6",
     "@storybook/addon-onboarding": "^10.4.6",
@@ -51,6 +53,7 @@
     "@tailwindcss/postcss": "^4.3.2",
     "autoprefixer": "^10.5.2",
     "chromatic": "^18.0.1",
+    "jotai": "^2.20.1",
     "storybook": "^10.4.6",
     "vite": "^8.1.3"
   }

--- a/packages/tooling/storybook/src/stories/wordgard-plus-toolbar.stories.tsx
+++ b/packages/tooling/storybook/src/stories/wordgard-plus-toolbar.stories.tsx
@@ -1,0 +1,199 @@
+/**
+ * M4-P0 exit-criterion demo (plans/011): a React toolbar of resolved
+ * first-party Wordgard menu items, updating live, on a plain Wordgard setup
+ * with zero Bangle imports inside the demoed packages. The editor is created
+ * by THIS story — wordgard-plus only contributes extensions and components,
+ * proving the "complement, never wrap" posture.
+ */
+
+import {
+  createEditorAtoms,
+  createMenuAtoms,
+  createTooltipHost,
+  type ResolvedMenuNode,
+  reactTooltip,
+  TooltipHost,
+  useResolvedMenu,
+} from '@bangle.io/wordgard-plus';
+import {
+  basicSchema,
+  bulletList,
+  history,
+  orderedList,
+  Tooltip,
+  Wordgard,
+} from '@bangle.io/wordgard-utils';
+import type { Meta, StoryObj } from '@storybook/react';
+import { createStore } from 'jotai';
+import { useAtomValue } from 'jotai/react';
+import React, { useMemo, useRef, useState } from 'react';
+
+function MenuNode({ node }: { node: ResolvedMenuNode }) {
+  if (node.kind === 'separator') {
+    return <span style={{ width: 1, background: '#ccc', margin: '0 4px' }} />;
+  }
+  if (node.kind === 'custom') {
+    return null;
+  }
+  if (node.kind === 'submenu') {
+    return (
+      <span
+        style={{
+          display: 'inline-flex',
+          gap: 2,
+          border: '1px dashed #bbb',
+          borderRadius: 6,
+          padding: '0 4px',
+          alignItems: 'center',
+        }}
+        title={node.description ?? undefined}
+      >
+        {node.label ? <small>{node.label}</small> : null}
+        {node.items.map((child) => (
+          <MenuNode key={child.key} node={child} />
+        ))}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={node.run}
+      disabled={!node.enabled}
+      aria-pressed={node.active}
+      aria-label={node.description ?? undefined}
+      title={node.description ?? undefined}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minWidth: 28,
+        height: 28,
+        borderRadius: 6,
+        border: '1px solid #ccc',
+        background: node.active ? '#c7d2fe' : 'white',
+        opacity: node.enabled ? 1 : 0.4,
+        cursor: node.enabled ? 'pointer' : 'default',
+      }}
+    >
+      {node.icon ? (
+        <svg viewBox="0 0 100 100" width={16} height={16} aria-hidden="true">
+          <path d={node.icon} fill="currentColor" />
+        </svg>
+      ) : (
+        <small>{node.label}</small>
+      )}
+    </button>
+  );
+}
+
+function WordgardPlusDemo() {
+  const store = useMemo(() => createStore(), []);
+  const [setup] = useState(() => {
+    const editorAtoms = createEditorAtoms({ store });
+    const menuAtoms = createMenuAtoms({ store });
+    const host = createTooltipHost(store);
+    return { editorAtoms, menuAtoms, host };
+  });
+  const editorRef = useRef<Wordgard | null>(null);
+
+  const parentRef = (node: HTMLDivElement | null) => {
+    if (!node || editorRef.current) {
+      return;
+    }
+    editorRef.current = Wordgard.create({
+      parent: node,
+      doc: '<h2>wordgard-plus demo</h2><p>Select some text, toggle marks from the React toolbar, make a list, undo…</p>',
+      config: [
+        Wordgard.label('wordgard-plus demo editor'),
+        basicSchema(),
+        bulletList(),
+        orderedList(),
+        history(),
+        setup.editorAtoms.extension,
+        setup.menuAtoms.extension,
+        // Selection bubble demoing the React tooltip glue: Wordgard
+        // positions it; React renders its content via <TooltipHost>.
+        Tooltip.show.compute((state) =>
+          state.selection.empty
+            ? null
+            : reactTooltip({
+                host: setup.host,
+                pos: state.selection.from,
+                end: state.selection.to,
+                above: true,
+                arrow: true,
+                content: () => (
+                  <span
+                    style={{
+                      background: '#111',
+                      color: 'white',
+                      borderRadius: 4,
+                      padding: '2px 6px',
+                      fontSize: 12,
+                    }}
+                  >
+                    {state.selection.to - state.selection.from} selected
+                  </span>
+                ),
+              }),
+        ),
+      ],
+    });
+  };
+
+  const menu = useResolvedMenu(setup.menuAtoms.atoms, store);
+  const selection = useAtomValue(setup.editorAtoms.atoms.selection, {
+    store,
+  });
+  const focused = useAtomValue(setup.editorAtoms.atoms.focused, { store });
+  const canUndo = useAtomValue(setup.editorAtoms.atoms.canUndo, { store });
+  const canRedo = useAtomValue(setup.editorAtoms.atoms.canRedo, { store });
+
+  return (
+    <div style={{ maxWidth: 640, fontFamily: 'sans-serif' }}>
+      <div
+        role="toolbar"
+        aria-label="Editor toolbar"
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 4,
+          padding: 6,
+          border: '1px solid #ddd',
+          borderRadius: 8,
+          marginBottom: 8,
+        }}
+      >
+        {menu.map((node) => (
+          <MenuNode key={node.key} node={node} />
+        ))}
+      </div>
+      <div
+        ref={parentRef}
+        style={{
+          border: '1px solid #ddd',
+          borderRadius: 8,
+          padding: 8,
+          minHeight: 140,
+        }}
+      />
+      <p style={{ fontSize: 12, color: '#555' }}>
+        focused: {String(focused)} · selection {selection.from}–{selection.to}
+        {selection.empty ? ' (cursor)' : ''} · canUndo: {String(canUndo)} ·
+        canRedo: {String(canRedo)}
+      </p>
+      <TooltipHost handle={setup.host} />
+    </div>
+  );
+}
+
+const meta: Meta<typeof WordgardPlusDemo> = {
+  title: 'wordgard-plus/Toolbar',
+  component: WordgardPlusDemo,
+};
+
+export default meta;
+type Story = StoryObj<typeof WordgardPlusDemo>;
+
+export const Default: Story = {};

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -240,6 +240,49 @@ exists):
   editor-mount-time crashes (a React-render crash lands in the app error
   boundary as before).
 
+### M4-P0 complete — wordgard-plus scaffold + bridge
+
+- **`@bangle.io/wordgard-plus`** (js-lib, browser, bangle-free) scaffolded
+  with the bridge foundation, holding the "complement, never wrap"
+  invariants: every export is an extension for the consumer's own
+  `Wordgard.create` config or a React component for the consumer's tree;
+  wordgard is consumed only via the `wordgard-utils` chokepoint (which grew
+  `editor`/`state`/`command`/`history`/schema-bundle re-exports).
+- **API adaptation discovered against the real 0.1.1 surface** (the plan
+  sketched `createEditorAtoms(wg)` / `useResolvedMenu(wg)` before the API
+  was checked): update hooks are config-time facets/plugins, not post-hoc
+  subscriptions on a live instance, so both bridges return
+  `{ atoms, extension }` and are fed by a `Wordgard.Plugin` (create seeds,
+  `update` syncs, `disconnect` clears focus). This is the Wordgard-idiomatic
+  shape and keeps the no-wrapping invariant by construction.
+- `createEditorAtoms({store, queries?})`: per-editor Jotai read atoms
+  (focused, selection summary, canUndo/canRedo via history depths —
+  gracefully false without the history extension — plus arbitrary
+  `(state) => boolean` queries for `listIsActive`-style predicates), every
+  write equality-guarded.
+- `createMenuAtoms({store, template?})` + `useResolvedMenu`: `Menu.resolve`
+  over the editor's own `Menu.Item.source` facet, projected to plain data
+  (label/icon/description with PhraseSet refs resolved, active/enabled,
+  `run()` dispatching through `Command.dispatch`), re-projected on
+  doc/selection changes plus item `updateFor` transactions, with deep
+  equality so the atom only notifies on visible change. No parallel menu
+  registry — 1p items from feature bundles render in React.
+- `reactTooltip` + `createTooltipHost` + `<TooltipHost>`: `Tooltip.View`s
+  whose DOM hosts a React subtree portaled from the consumer's tree
+  (context keeps flowing), mounted on `connect`, released on `disconnect`;
+  Wordgard owns geometry, React owns content, `@floating-ui/dom` stays out.
+- **Exit criterion met and verified live**: a Storybook story
+  (`tooling/storybook`, so wordgard-plus itself carries no storybook deps)
+  renders a React toolbar of resolved 1p menu items on a plain Wordgard
+  editor — exercised via playwright-cli: typing enables undo, toolbar
+  toggles strong (active state + bold output), block-style submenu shows
+  its active child as label, and a selection bubble demos the tooltip glue.
+- Unit specs (12, vitest + happy-dom — Wordgard runs headless there) cover
+  atom seeding/updates, equality guards, per-editor isolation, menu
+  projection + `run()` dispatch + notification suppression, and the tooltip
+  portal lifecycle including a real editor rendering a `Tooltip.show`
+  tooltip.
+
 - **Coordination rule with plan 012 (markdown feature parity):** every
   012 construct changes what a note's bytes mean, so each 012 milestone
   must either land the Wordgard `MarkdownSpec` + BOTH_ENGINES corpus
@@ -898,13 +941,14 @@ including checking a task with the mouse.
 The floating/menu surfaces land as wordgard-plus modules composed by
 editor-w (see the "Floating UI" and wordgard-plus architecture sections):
 
-- *M4-P0 — package scaffold + bridge:* `createEditorAtoms(wg)` (one
-  updateListener → per-editor Jotai atoms with equality guards),
-  `useResolvedMenu` (`Menu.resolve` over the `Menu.Item.source` facet),
-  and the `<TooltipHost>` React-portal glue for `Tooltip.View`s. Exit:
-  a story/demo page shows a toolbar of resolved 1p menu items rendered
-  in React, updating live, on a plain Wordgard setup with zero Bangle
-  imports.
+- *M4-P0 — package scaffold + bridge — DONE:* `createEditorAtoms` (one
+  editor plugin → per-editor Jotai atoms with equality guards),
+  `createMenuAtoms`/`useResolvedMenu` (`Menu.resolve` over the
+  `Menu.Item.source` facet), and the `<TooltipHost>` React-portal glue
+  for `Tooltip.View`s. Exit (met): a story/demo page shows a toolbar of
+  resolved 1p menu items rendered in React, updating live, on a plain
+  Wordgard setup with zero Bangle imports (see "M4-P0 complete" above,
+  including the config-time-extension API adaptation).
 - *M4-P1 — selection toolbar* (parity: `inline-selection-menu`): state
   field + `Tooltip.show` extension, React toolbar over the resolved
   inline menu group. Keyboard accessible; e2e-covered.

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -5,13 +5,14 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-05
-updated: 2026-07-07
+updated: 2026-07-11
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/609
   - https://github.com/bangle-io/bangle-io/pull/613
   - https://github.com/bangle-io/bangle-io/pull/616
   - https://github.com/bangle-io/bangle-io/pull/620
+  - https://github.com/bangle-io/bangle-io/pull/623
 related_issues: []
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,6 +580,31 @@ importers:
         specifier: ^14.1.2
         version: 14.1.2
 
+  packages/js-lib/wordgard-plus:
+    dependencies:
+      '@bangle.io/wordgard-utils':
+        specifier: workspace:*
+        version: link:../wordgard-utils
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      jotai:
+        specifier: ^2.20.1
+        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.7)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
   packages/js-lib/wordgard-utils:
     dependencies:
       wordgard:
@@ -966,6 +991,12 @@ importers:
       '@bangle.io/translations':
         specifier: workspace:*
         version: link:../../shared/translations
+      '@bangle.io/wordgard-plus':
+        specifier: workspace:*
+        version: link:../../js-lib/wordgard-plus
+      '@bangle.io/wordgard-utils':
+        specifier: workspace:*
+        version: link:../../js-lib/wordgard-utils
       '@chromatic-com/storybook':
         specifier: ^5.2.1
         version: 5.2.1(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))
@@ -993,6 +1024,9 @@ importers:
       chromatic:
         specifier: ^18.0.1
         version: 18.0.1
+      jotai:
+        specifier: ^2.20.1
+        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.7)
       storybook:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7)


### PR DESCRIPTION
## Summary

Lands **M4-P0** of [plans/011](https://github.com/bangle-io/bangle-io/blob/main/plans/011-wordgard-editor-w-migration.md): the `@bangle.io/wordgard-plus` package scaffold and its `bridge` foundation — the shadcn posture, not the tiptap posture. Every export is either an extension added to the consumer's own `Wordgard.create` config or a React component rendered in the consumer's tree; the package never creates, owns, or wraps an editor, carries zero Bangle app imports, and consumes wordgard only through the `@bangle.io/wordgard-utils` chokepoint (grown here with `editor`/`state`/`command`/`history`/schema-bundle re-exports).

- **`createEditorAtoms({store, queries?})`** — per-editor Jotai read atoms (focused, selection summary, canUndo/canRedo via history depths, arbitrary `(state) => boolean` queries for `listIsActive`-style predicates), fed by one editor plugin, every write equality-guarded so keystrokes don't fan out spurious renders. Per-editor scoping by construction.
- **`createMenuAtoms` + `useResolvedMenu`** — `Menu.resolve` over the editor's own `Menu.Item.source` facet, projected to plain data (labels/icons with PhraseSet refs resolved, active/enabled/description, `run()` dispatching through `Command.dispatch`), re-projected on doc/selection changes plus item `updateFor` transactions, deep-equality guarded. First-party menu items render in React; no parallel registry is forked.
- **`reactTooltip` + `createTooltipHost` + `<TooltipHost>`** — `Tooltip.View`s whose DOM hosts a React subtree portaled from the consumer's tree (so context/providers keep flowing), mounted on `connect`, released on `disconnect`. Wordgard owns geometry and lifecycle; React owns content; `@floating-ui/dom` stays out.

**API adaptation vs the plan sketch** (recorded in plan 011): the plan wrote `createEditorAtoms(wg)`, but Wordgard's `updateListener`/plugins are config-time facets — there is no post-hoc subscription on a live instance. Both bridges therefore return `{ atoms, extension }`, which is the Wordgard-idiomatic shape and enforces the "never wraps the editor" invariant by construction.

## Demo (M4-P0 exit criterion)

`tooling/storybook` story **wordgard-plus/Toolbar** (kept there so wordgard-plus itself carries no Storybook deps): a React toolbar of resolved 1p menu items over a plain Wordgard editor with zero Bangle imports. Verified interactively with playwright-cli: typing enables Undo, the toolbar's strong button toggles the mark (active state + bold output), the block-style submenu labels itself by its active child, the live status line tracks focus/selection/undo, and selecting text shows a React-rendered "N selected" tooltip positioned by Wordgard.

## Test plan

- 12 unit specs (vitest + happy-dom — Wordgard runs headless there): atom seeding before first update, updates after transactions, notification suppression on irrelevant updates, per-editor isolation, menu projection of bundle-registered items, `run()` dispatch + active-state re-projection, enabled-state tracking, menu-atom notification suppression, tooltip portal connect/disconnect lifecycle, multi-tooltip independence, and a real editor rendering a `Tooltip.show`-provided React tooltip.
- `pnpm local-ci-check` green (lint:ci, test:ci — 1964 passed; re-based and fully re-verified on main after #620 merged, e2e:ci full Playwright + CT suites, build, desktop smoke). This is a library scaffold + demo, not a released user-facing app feature, so component/unit coverage plus the verified Storybook demo is the release bar; app-level e2e arrives with the M4-P1+ surfaces that consume this bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

