### PR TITLE
fix: polish note editing feedback

### DIFF
--- a/packages/core/app/package.json
+++ b/packages/core/app/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@bangle.io/baby-fs": "workspace:*",
     "@bangle.io/base-utils": "workspace:*",
+    "@bangle.io/config": "workspace:*",
     "@bangle.io/constants": "workspace:*",
     "@bangle.io/context": "workspace:*",
     "@bangle.io/editor": "workspace:*",

--- a/packages/core/app/src/index.tsx
+++ b/packages/core/app/src/index.tsx
@@ -52,7 +52,7 @@ export function App({
             <BrowserAppDocumentSetup />
             <AppDialogs />
             <OmniSearch />
-            <Toaster position="top-center" />
+            <Toaster position="top-right" />
             <AppErrorHandler rootEmitter={rootEmitter} />
             <SaveProtection />
             <AppSidebar>

--- a/packages/core/app/src/pages/page-settings.tsx
+++ b/packages/core/app/src/pages/page-settings.tsx
@@ -1,3 +1,4 @@
+import { FRIENDLY_ID } from '@bangle.io/config';
 import {
   ASSET_LOCATION_PREFERENCES,
   isAssetLocationPreference,
@@ -174,10 +175,19 @@ function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
           <SettingsPage.SettingsPageContent>
             {activePage === 'general' ? (
               <>
-                {pwaInstall.canInstall || pwaInstall.isInstalling ? (
-                  <SettingsPage.SettingsSection
-                    title={t.app.settings.general.appSection}
-                  >
+                <SettingsPage.SettingsSection
+                  title={t.app.settings.general.appSection}
+                >
+                  <SettingsPage.SettingsRow
+                    control={
+                      <code className="rounded-md bg-muted px-2.5 py-1 font-mono text-muted-foreground text-sm">
+                        {FRIENDLY_ID}
+                      </code>
+                    }
+                    description={t.app.settings.general.versionDescription}
+                    title={t.app.settings.general.versionTitle}
+                  />
+                  {pwaInstall.canInstall || pwaInstall.isInstalling ? (
                     <SettingsPage.SettingsRow
                       control={
                         <Button
@@ -196,8 +206,8 @@ function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
                       description={t.app.settings.general.installPwaDescription}
                       title={t.app.settings.general.installPwaTitle}
                     />
-                  </SettingsPage.SettingsSection>
-                ) : null}
+                  ) : null}
+                </SettingsPage.SettingsSection>
 
                 <SettingsPage.SettingsSection
                   title={t.app.settings.general.appearanceSection}

--- a/packages/core/app/src/pages/page-settings.tsx
+++ b/packages/core/app/src/pages/page-settings.tsx
@@ -180,7 +180,10 @@ function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
                 >
                   <SettingsPage.SettingsRow
                     control={
-                      <code className="rounded-md bg-muted px-2.5 py-1 font-mono text-muted-foreground text-sm">
+                      <code
+                        className="rounded-md bg-muted px-2.5 py-1 font-mono text-muted-foreground text-sm"
+                        data-testid="app-version"
+                      >
                         {FRIENDLY_ID}
                       </code>
                     }

--- a/packages/core/editor/src/__tests__/remembered-cursor.spec.ts
+++ b/packages/core/editor/src/__tests__/remembered-cursor.spec.ts
@@ -4,9 +4,13 @@ import {
   Schema,
   setupBase,
   setupParagraph,
+  TextSelection,
 } from '@bangle.io/prosemirror-plugins';
 import { describe, expect, it } from 'vitest';
-import { resolveRememberedCursor } from '../pm-editor-service';
+import {
+  getRememberedCursorPosition,
+  resolveRememberedCursor,
+} from '../remembered-cursor';
 
 function parseParagraph(source: string) {
   const extensions = [setupBase(), setupParagraph()];
@@ -20,6 +24,13 @@ function parseParagraph(source: string) {
 }
 
 describe('resolveRememberedCursor', () => {
+  it('remembers the head of a text selection as its cursor position', () => {
+    const doc = parseParagraph('alpha beta');
+    const selection = TextSelection.create(doc, 2, 7);
+
+    expect(getRememberedCursorPosition(selection)).toBe(7);
+  });
+
   it('restores an unchanged text position', () => {
     const doc = parseParagraph('alpha beta');
 

--- a/packages/core/editor/src/__tests__/remembered-cursor.spec.ts
+++ b/packages/core/editor/src/__tests__/remembered-cursor.spec.ts
@@ -1,0 +1,40 @@
+import {
+  markdownLoader,
+  resolve,
+  Schema,
+  setupBase,
+  setupParagraph,
+} from '@bangle.io/prosemirror-plugins';
+import { describe, expect, it } from 'vitest';
+import { resolveRememberedCursor } from '../pm-editor-service';
+
+function parseParagraph(source: string) {
+  const extensions = [setupBase(), setupParagraph()];
+  const resolved = resolve(extensions);
+  const schema = new Schema({ nodes: resolved.nodes, marks: resolved.marks });
+  const doc = markdownLoader(extensions, schema).parser.parse(source);
+  if (!doc) {
+    throw new Error('Expected Markdown parser to return a document');
+  }
+  return doc;
+}
+
+describe('resolveRememberedCursor', () => {
+  it('restores an unchanged text position', () => {
+    const doc = parseParagraph('alpha beta');
+
+    const selection = resolveRememberedCursor(doc, 7);
+
+    expect(selection?.head).toBe(7);
+    expect(selection?.$head.parent.textContent).toBe('alpha beta');
+  });
+
+  it('falls back to the nearest text cursor when the document became shorter', () => {
+    const doc = parseParagraph('short');
+
+    const selection = resolveRememberedCursor(doc, 500);
+
+    expect(selection?.head).toBe(6);
+    expect(selection?.$head.parent.textContent).toBe('short');
+  });
+});

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -51,24 +51,15 @@ import { setupExtensions } from './extensions';
 import { findHeadingIndexBySlug } from './heading-slug';
 import { createLocalImageNodeView } from './local-image-node-view';
 import { createEditor } from './pm-setup';
+import {
+  getRememberedCursorPosition,
+  resolveRememberedCursor,
+} from './remembered-cursor';
 import { isMarkdownRoundTripPreserved } from './round-trip-check';
 
 const editorSaveQueueStore = createEditorSaveQueueStore();
 const ASSET_TOAST_FILE_NAME_MAX_LENGTH = 44;
 const EMPTY_WS_PATH_SET: ReadonlySet<string> = new Set();
-
-/** @internal Resolves a remembered document position to a safe text cursor. */
-export function resolveRememberedCursor(
-  doc: EditorView['state']['doc'],
-  position: number,
-): TextSelection | undefined {
-  const clampedPosition = Math.max(
-    0,
-    Math.min(Math.trunc(position), doc.content.size),
-  );
-  const selection = TextSelection.near(doc.resolve(clampedPosition));
-  return selection instanceof TextSelection ? selection : undefined;
-}
 
 function formatFileSize(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB'];
@@ -339,9 +330,10 @@ export class PmEditorService
         const { fragment } = pendingHeading;
         this.pendingHeading = undefined;
         this.navigateToHeading(editorView, fragment);
-      } else if (pendingHeading) {
-        this.pendingHeading = undefined;
       } else {
+        if (pendingHeading) {
+          this.pendingHeading = undefined;
+        }
         this.restoreCursor(editorView, wsPath);
       }
     } catch (cause) {
@@ -368,11 +360,13 @@ export class PmEditorService
   private unmountEditor(domNode: HTMLElement) {
     const editor = this.editors.get(domNode);
     if (editor && 'editorView' in editor) {
-      const { selection } = editor.editorView.state;
-      if (selection instanceof TextSelection && selection.empty) {
-        this.rememberedCursors.set(editor.wsPath, selection.head);
-      } else {
+      const position = getRememberedCursorPosition(
+        editor.editorView.state.selection,
+      );
+      if (position === undefined) {
         this.rememberedCursors.delete(editor.wsPath);
+      } else {
+        this.rememberedCursors.set(editor.wsPath, position);
       }
       editor.editorView.destroy();
     }

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -57,6 +57,19 @@ const editorSaveQueueStore = createEditorSaveQueueStore();
 const ASSET_TOAST_FILE_NAME_MAX_LENGTH = 44;
 const EMPTY_WS_PATH_SET: ReadonlySet<string> = new Set();
 
+/** @internal Resolves a remembered document position to a safe text cursor. */
+export function resolveRememberedCursor(
+  doc: EditorView['state']['doc'],
+  position: number,
+): TextSelection | undefined {
+  const clampedPosition = Math.max(
+    0,
+    Math.min(Math.trunc(position), doc.content.size),
+  );
+  const selection = TextSelection.near(doc.resolve(clampedPosition));
+  return selection instanceof TextSelection ? selection : undefined;
+}
+
 function formatFileSize(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB'];
   let value = bytes;
@@ -135,6 +148,7 @@ export class PmEditorService
 
   private saveQueue: EditorSaveQueue;
   private pendingHeading: { fragment: string; wsPath: string } | undefined;
+  private rememberedCursors = new Map<string, number>();
 
   private editors = new Map<HTMLElement, EditorEntry>();
 
@@ -213,6 +227,7 @@ export class PmEditorService
         }
       }
       this.editors.clear();
+      this.rememberedCursors.clear();
     });
     this.addCleanup(
       this.store.sub(this.dependencies.navigation.$routeInfo, () => {
@@ -326,6 +341,8 @@ export class PmEditorService
         this.navigateToHeading(editorView, fragment);
       } else if (pendingHeading) {
         this.pendingHeading = undefined;
+      } else {
+        this.restoreCursor(editorView, wsPath);
       }
     } catch (cause) {
       const editorEntry = this.editors.get(domNode);
@@ -351,12 +368,41 @@ export class PmEditorService
   private unmountEditor(domNode: HTMLElement) {
     const editor = this.editors.get(domNode);
     if (editor && 'editorView' in editor) {
+      const { selection } = editor.editorView.state;
+      if (selection instanceof TextSelection && selection.empty) {
+        this.rememberedCursors.set(editor.wsPath, selection.head);
+      } else {
+        this.rememberedCursors.delete(editor.wsPath);
+      }
       editor.editorView.destroy();
     }
     this.editors.delete(domNode);
     if (editor) {
       this.setRoundTripWarning(editor.wsPath, false);
     }
+  }
+
+  private restoreCursor(editorView: EditorView, wsPath: string): void {
+    const position = this.rememberedCursors.get(wsPath);
+    if (position === undefined) {
+      return;
+    }
+    const selection = resolveRememberedCursor(editorView.state.doc, position);
+    if (!selection) {
+      return;
+    }
+    editorView.dispatch(
+      editorView.state.tr.setSelection(selection).scrollIntoView(),
+    );
+    // Restoring a cursor inside a Markdown link is navigation state, not a
+    // user interaction with that link. Keep the cursor without reopening the
+    // floating link editor, which can otherwise cover content after returning
+    // to a note.
+    this.extensions.linkMenu.command.dismissLinkMenu()(
+      editorView.state,
+      editorView.dispatch,
+      editorView,
+    );
   }
 
   /**

--- a/packages/core/editor/src/remembered-cursor.ts
+++ b/packages/core/editor/src/remembered-cursor.ts
@@ -1,0 +1,25 @@
+import {
+  type PMNode,
+  type Selection,
+  TextSelection,
+} from '@bangle.io/prosemirror-plugins';
+
+/** Returns the text cursor position to remember for a note. */
+export function getRememberedCursorPosition(
+  selection: Selection,
+): number | undefined {
+  return selection instanceof TextSelection ? selection.head : undefined;
+}
+
+/** Resolves a remembered document position to a safe text cursor. */
+export function resolveRememberedCursor(
+  doc: PMNode,
+  position: number,
+): TextSelection | undefined {
+  const clampedPosition = Math.max(
+    0,
+    Math.min(Math.trunc(position), doc.content.size),
+  );
+  const selection = TextSelection.near(doc.resolve(clampedPosition));
+  return selection instanceof TextSelection ? selection : undefined;
+}

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -141,6 +141,8 @@ export const t = {
       general: {
         title: 'General',
         appSection: 'App',
+        versionTitle: 'Version',
+        versionDescription: 'The version and build identity of this app.',
         installPwaTitle: 'Install Bangle.io',
         installPwaDescription:
           'Add Bangle.io to this device and open it in its own app window.',

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -198,14 +198,6 @@ test('pastes workspace-backed image and PDF assets, reloads, and opens asset pag
   const toaster = page.locator('[data-sonner-toaster]');
   await expect(toaster).toHaveAttribute('data-x-position', 'right');
   await expect(toaster).toHaveAttribute('data-y-position', 'top');
-
-  const toastBox = await savedToast.boundingBox();
-  const viewport = page.viewportSize();
-  if (!toastBox || !viewport) {
-    throw new Error('Expected the toast and viewport to have visible bounds');
-  }
-  expect(toastBox.x + toastBox.width).toBeGreaterThan(viewport.width - 48);
-  expect(toastBox.y).toBeLessThan(48);
   const markdown = await readStoredMarkdown(page, workspaceName, noteName);
   expect(markdown).not.toContain('data:');
   expect(markdown).toContain('[Spec Sheet.PDF](assets/spec-sheet-');

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -191,11 +191,21 @@ test('pastes workspace-backed image and PDF assets, reloads, and opens asset pag
     .toContain(
       '![Extremely Long Image Drop Filename For Toast UX.PNG](assets/extremely-long-image-drop-filename-for-toast-ux-',
     );
-  await expect(
-    page.getByText(
-      'Saved Extremely Long Image Drop...For Toast UX.PNG + 1 more',
-    ),
-  ).toBeVisible();
+  const savedToast = page.getByRole('listitem').filter({
+    hasText: 'Saved Extremely Long Image Drop...For Toast UX.PNG + 1 more',
+  });
+  await expect(savedToast).toBeVisible();
+  const toaster = page.locator('[data-sonner-toaster]');
+  await expect(toaster).toHaveAttribute('data-x-position', 'right');
+  await expect(toaster).toHaveAttribute('data-y-position', 'top');
+
+  const toastBox = await savedToast.boundingBox();
+  const viewport = page.viewportSize();
+  if (!toastBox || !viewport) {
+    throw new Error('Expected the toast and viewport to have visible bounds');
+  }
+  expect(toastBox.x + toastBox.width).toBeGreaterThan(viewport.width - 48);
+  expect(toastBox.y).toBeLessThan(48);
   const markdown = await readStoredMarkdown(page, workspaceName, noteName);
   expect(markdown).not.toContain('data:');
   expect(markdown).toContain('[Spec Sheet.PDF](assets/spec-sheet-');

--- a/packages/tooling/e2e-tests/src/editor-cursor-position.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-cursor-position.e2e.ts
@@ -1,0 +1,61 @@
+import { expect, type Page, test } from '@playwright/test';
+import {
+  collapseEditorSelection,
+  createBrowserWorkspaceAndNote,
+  getEditorLocator,
+  readStoredMarkdown,
+  waitForEditorFocus,
+} from './common';
+
+const workspaceName = 'remember-cursor';
+
+async function createNote(page: Page, noteName: string) {
+  await page.getByRole('button', { name: 'Bangle.io' }).click();
+  await page.getByRole('menuitem', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill(noteName);
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(getEditorLocator(page, {})).toBeVisible();
+  await waitForEditorFocus(page, {});
+}
+
+async function openNote(page: Page, fileName: string) {
+  await page
+    .getByTestId('bangle-file-explorer')
+    .getByRole('treeitem', { name: fileName })
+    .click();
+  await expect(
+    page.getByLabel('breadcrumb').getByRole('button', { name: fileName }),
+  ).toBeVisible();
+  await waitForEditorFocus(page, {});
+}
+
+test('restores a note cursor after switching away and back', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'note-a',
+  });
+  const editor = getEditorLocator(page, {});
+  await waitForEditorFocus(page, {});
+  await editor.fill('alpha before middle after');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'note-a'))
+    .toBe('alpha before middle after');
+
+  await createNote(page, 'note-b');
+  await openNote(page, 'note-a.md');
+  await expect(editor).toHaveText('alpha before middle after');
+  await collapseEditorSelection(page, 'alpha before'.length);
+
+  await openNote(page, 'note-b.md');
+  await openNote(page, 'note-a.md');
+  await expect(editor).toHaveText('alpha before middle after');
+  await editor.focus();
+  await page.keyboard.insertText(' RESTORED');
+
+  await expect(editor).toHaveText('alpha before RESTORED middle after');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'note-a'))
+    .toBe('alpha before RESTORED middle after');
+});

--- a/packages/tooling/e2e-tests/src/settings-general.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-general.e2e.ts
@@ -14,6 +14,15 @@ test('general settings update and persist user preferences', async ({
 
   await expect(page.getByRole('link', { name: 'Back to app' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { exact: true, name: 'App' }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/^\d+\.\d+\.\d+\+local$/, { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Install app' })).toHaveCount(
+    0,
+  );
 
   await page.getByRole('combobox', { name: 'Theme preference' }).click();
   await page.getByRole('option', { name: 'Dark' }).click();

--- a/packages/tooling/e2e-tests/src/settings-general.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-general.e2e.ts
@@ -17,9 +17,9 @@ test('general settings update and persist user preferences', async ({
   await expect(
     page.getByRole('heading', { exact: true, name: 'App' }),
   ).toBeVisible();
-  await expect(
-    page.getByText(/^\d+\.\d+\.\d+\+local$/, { exact: true }),
-  ).toBeVisible();
+  await expect(page.getByTestId('app-version')).toHaveText(
+    /^\d+\.\d+\.\d+(?:[-+].*)?$/,
+  );
   await expect(page.getByRole('button', { name: 'Install app' })).toHaveCount(
     0,
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@bangle.io/base-utils':
         specifier: workspace:*
         version: link:../../shared/base-utils
+      '@bangle.io/config':
+        specifier: workspace:*
+        version: link:../../shared/config
       '@bangle.io/constants':
         specifier: workspace:*
         version: link:../../shared/constants


### PR DESCRIPTION
## What changed

- move global toasts from the top center to the top right and verify their rendered placement
- always show the App section in General Settings with the friendly release/build identity
- remember a collapsed text cursor per note while switching notes in the current session
- clamp stale cursor positions safely, preserve heading-link navigation precedence, and avoid reopening the floating link editor on restoration

## Why

These are small, unambiguous UX improvements from the current issue list: notifications should not cover the primary editing area, build identity should be discoverable for support/debugging, and note switching should preserve writing context.

The cursor was previously recreated at the document start because each note switch destroys and mounts a new ProseMirror view. The editor service now retains only the cursor position for each workspace path during its lifetime and restores it defensively.

## User impact

- less interruptive notifications
- visible app version/build information in Settings
- returning to a note resumes at the prior cursor location without disrupting Markdown link interactions or `#heading` navigation

## Validation

- `pnpm build`
- `pnpm local-ci-check`
  - 1,929 unit tests passed, 1 skipped
  - lint, TypeScript, workspace validation, and dependency checks passed
  - 128 Playwright E2E tests passed
  - 7 Playwright component tests passed
  - 28 desktop tests, browser/desktop builds, and Electron persistence smoke passed
