### PR TITLE
feat: polish editor and workspace UX

### DIFF
--- a/packages/core/app/src/__tests__/app-error-handler.spec.ts
+++ b/packages/core/app/src/__tests__/app-error-handler.spec.ts
@@ -41,6 +41,13 @@ describe('shouldReportAppError', () => {
     },
     {
       appError: {
+        name: 'error::workspace:native-fs-reconnect-failed',
+        payload: { wsName: 'notes' },
+      } satisfies AppError,
+      expected: false,
+    },
+    {
+      appError: {
         name: 'error::file:already-existing',
         payload: { wsPath: 'notes:existing.md' },
       } satisfies AppError,

--- a/packages/core/app/src/app-error-handler.tsx
+++ b/packages/core/app/src/app-error-handler.tsx
@@ -1,4 +1,5 @@
 import { getGithubUrl, handleAppError } from '@bangle.io/base-utils';
+import { SERVICE_NAME } from '@bangle.io/constants';
 import { useCoreServices, useLogger } from '@bangle.io/context';
 import type { AppError, RootEmitter } from '@bangle.io/types';
 import { toast } from '@bangle.io/ui-components';
@@ -10,6 +11,7 @@ export function shouldReportAppError(appError: AppError): boolean {
     case 'error::file:size-too-large':
     case 'error::file-storage:file-does-not-exist':
     case 'error::workspace:native-fs-auth-needed':
+    case 'error::workspace:native-fs-reconnect-failed':
     case 'error::workspace:no-note-opened':
     case 'error::workspace:no-notes-found':
     case 'error::workspace:not-opened':
@@ -98,6 +100,31 @@ export function AppErrorHandler({ rootEmitter }: { rootEmitter: RootEmitter }) {
               { wsName: appError.payload.wsName },
               'AppErrorHandler',
             );
+            return;
+          }
+
+          case 'error::workspace:native-fs-reconnect-failed': {
+            toast.error(error.message, {
+              duration: 5000,
+              cancel: {
+                label: t.app.common.dismiss,
+                onClick: () => {},
+              },
+            });
+            return;
+          }
+
+          case 'error::file-storage:file-does-not-exist': {
+            if (
+              appError.payload.storage ===
+                SERVICE_NAME.fileStorageNativeFsService &&
+              appError.payload.wsPath.endsWith(':')
+            ) {
+              // WorkspaceState exposes a missing Native FS root as a full-page
+              // recovery view. A second transient toast would compete with it.
+              return;
+            }
+            showAppLikeError(error);
             return;
           }
 

--- a/packages/core/app/src/index.tsx
+++ b/packages/core/app/src/index.tsx
@@ -25,6 +25,7 @@ import {
   PageFatalError,
   PageNativeFsAuthFailed,
   PageNativeFsAuthReq,
+  PageNativeFsRecovery,
   PageNotFound,
   PageSettings,
   PageWelcome,
@@ -88,6 +89,16 @@ function BrowserAppDocumentSetup() {
 function AppRoutes() {
   const coreServices = useCoreServices();
   const { route } = useAtomValue(coreServices.navigation.$routeInfo);
+  const fileTreeListState = useAtomValue(
+    coreServices.workspaceState.$fileTreeListState,
+  );
+
+  if (
+    fileTreeListState.status === 'native-fs-directory-not-found' &&
+    (route === 'editor' || route === 'asset' || route === 'ws-home')
+  ) {
+    return <PageNativeFsRecovery wsName={fileTreeListState.wsName} />;
+  }
 
   switch (route) {
     case 'editor':

--- a/packages/core/app/src/index.tsx
+++ b/packages/core/app/src/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@bangle.io/context';
 import type { Logger } from '@bangle.io/logger';
 import { OmniSearch } from '@bangle.io/omni-search';
-import type { RootEmitter, Store } from '@bangle.io/types';
+import type { AppRouteInfo, RootEmitter, Store } from '@bangle.io/types';
 import { Toaster } from '@bangle.io/ui-components';
 import { Provider, useAtomValue } from 'jotai/react';
 import React from 'react';
@@ -86,6 +86,29 @@ function BrowserAppDocumentSetup() {
   return null;
 }
 
+function routeUsesWorkspaceFileTree(route: AppRouteInfo['route']): boolean {
+  switch (route) {
+    case 'editor':
+    case 'asset':
+    case 'ws-home':
+      return true;
+    case 'welcome':
+    case 'native-fs-auth-req':
+    case 'native-fs-auth-failed':
+    case 'workspace-not-found':
+    case 'ws-path-not-found':
+    case 'fatal-error':
+    case 'not-found':
+    case 'settings-general':
+    case 'settings-workspaces':
+      return false;
+    default: {
+      const _exhaustiveCheck: never = route;
+      throw new Error(`Unknown route: ${_exhaustiveCheck}`);
+    }
+  }
+}
+
 function AppRoutes() {
   const coreServices = useCoreServices();
   const { route } = useAtomValue(coreServices.navigation.$routeInfo);
@@ -95,7 +118,7 @@ function AppRoutes() {
 
   if (
     fileTreeListState.status === 'native-fs-directory-not-found' &&
-    (route === 'editor' || route === 'asset' || route === 'ws-home')
+    routeUsesWorkspaceFileTree(route)
   ) {
     return <PageNativeFsRecovery wsName={fileTreeListState.wsName} />;
   }

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -11,8 +11,13 @@ interface SidebarProps {
 }
 
 export const AppSidebar = ({ children }: SidebarProps) => {
-  const { commandDispatcher, workspaceState, workbenchState, navigation } =
-    useCoreServices();
+  const {
+    commandDispatcher,
+    workspaceState,
+    workbenchState,
+    navigation,
+    userActivityService,
+  } = useCoreServices();
   const setOpenOmniSearch = useSetAtom(workbenchState.$openOmniSearch);
   const workspaces = useAtomValue(workspaceState.$workspaces);
   const [sidebarOpen, setSidebarOpen] = useAtom(workbenchState.$sidebarOpen);
@@ -24,7 +29,28 @@ export const AppSidebar = ({ children }: SidebarProps) => {
   const activeWsPaths = useAtomValue(workspaceState.$activeWsPaths);
   const wsPaths = useAtomValue(workspaceState.$wsPaths);
   const noteWsPaths = useAtomValue(workspaceState.$noteWsPaths);
+  const starredWsPaths = useAtomValue(userActivityService.$starredWsPaths);
   const fileTreeListState = useAtomValue(workspaceState.$fileTreeListState);
+
+  const starredItems = React.useMemo(() => {
+    const notesByWsPath = new Map(
+      noteWsPaths.map((wsPath) => [wsPath.wsPath, wsPath]),
+    );
+    const activePathSet = new Set(activeWsPaths.map((wsPath) => wsPath.wsPath));
+
+    return starredWsPaths.flatMap((starredWsPath) => {
+      const wsPath = notesByWsPath.get(starredWsPath);
+      return wsPath
+        ? [
+            {
+              title: wsPath.fileName || wsPath.path,
+              wsPath: wsPath.wsPath,
+              isActive: activePathSet.has(wsPath.wsPath),
+            },
+          ]
+        : [];
+    });
+  }, [activeWsPaths, noteWsPaths, starredWsPaths]);
 
   const getActionsForEntry = useSidebarFileActions({
     activeWsName,
@@ -51,6 +77,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
           title: wsPath.fileName || '',
           wsPath: wsPath.wsPath,
         }))}
+        starredItems={starredItems}
         wsPathToHref={(wsPath) => navigation.toWsFileUri(wsPath)}
         wsNameToHref={(wsName) =>
           navigation.toUri({

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -32,6 +32,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
   const starredWsPaths = useAtomValue(userActivityService.$starredWsPaths);
   const fileTreeListState = useAtomValue(workspaceState.$fileTreeListState);
 
+  // Keep this domain-to-view join local until another consumer needs it.
   const starredItems = React.useMemo(() => {
     const notesByWsPath = new Map(
       noteWsPaths.map((wsPath) => [wsPath.wsPath, wsPath]),

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -16,6 +16,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
   const setOpenOmniSearch = useSetAtom(workbenchState.$openOmniSearch);
   const workspaces = useAtomValue(workspaceState.$workspaces);
   const [sidebarOpen, setSidebarOpen] = useAtom(workbenchState.$sidebarOpen);
+  const [sidebarWidth, setSidebarWidth] = useAtom(workbenchState.$sidebarWidth);
   const [showNoteFilesOnly, setShowNoteFilesOnly] = useAtom(
     workbenchState.$showNoteFilesOnlyInSidebar,
   );
@@ -34,6 +35,8 @@ export const AppSidebar = ({ children }: SidebarProps) => {
     <Sidebar.SidebarProvider
       open={sidebarOpen}
       onOpenChange={(open) => setSidebarOpen(open)}
+      width={sidebarWidth}
+      onWidthChange={setSidebarWidth}
     >
       <UIAppSidebar
         workspaces={workspaces.map((ws, _i) => ({

--- a/packages/core/app/src/pages/index.ts
+++ b/packages/core/app/src/pages/index.ts
@@ -3,6 +3,7 @@ export { PageEditor } from './page-editor';
 export { PageFatalError } from './page-fatal-error';
 export { PageNativeFsAuthFailed } from './page-native-fs-auth-failed';
 export { PageNativeFsAuthReq } from './page-native-fs-auth-req';
+export { PageNativeFsRecovery } from './page-native-fs-recovery';
 export { PageNotFound } from './page-not-found';
 export { PageSettings } from './page-settings';
 export { PageWelcome } from './page-welcome';

--- a/packages/core/app/src/pages/page-native-fs-recovery.tsx
+++ b/packages/core/app/src/pages/page-native-fs-recovery.tsx
@@ -1,0 +1,54 @@
+import { useCoreServices } from '@bangle.io/context';
+import { FolderSearch } from 'lucide-react';
+import React from 'react';
+import { ContentSection } from '../components/common/content-section';
+import { NoticeView } from '../components/feedback/notice-view';
+import { AppHeader } from '../layout/app-header';
+import { PageContentContainer } from '../layout/main-content-container';
+
+export function PageNativeFsRecovery({ wsName }: { wsName: string }) {
+  const coreServices = useCoreServices();
+
+  return (
+    <>
+      <AppHeader />
+      <PageContentContainer testId="page-native-fs-recovery">
+        <ContentSection hasPadding>
+          <NoticeView
+            title={t.app.pageNativeFsRecovery.title}
+            description={t.app.pageNativeFsRecovery.description({ wsName })}
+            illustration={
+              <div className="flex items-center justify-center">
+                <FolderSearch
+                  className="h-24 w-24 stroke-[1.5] text-muted-foreground"
+                  aria-hidden="true"
+                />
+              </div>
+            }
+            actions={[
+              {
+                label: t.app.pageNativeFsRecovery.locateFolderButton,
+                onClick: () =>
+                  coreServices.commandDispatcher.dispatch(
+                    'command::ui:reconnect-native-fs-workspace',
+                    { wsName },
+                    'ui',
+                  ),
+              },
+              {
+                label: t.app.pageNativeFsRecovery.switchWorkspaceButton,
+                variant: 'outline',
+                onClick: () =>
+                  coreServices.commandDispatcher.dispatch(
+                    'command::ui:switch-workspace',
+                    null,
+                    'ui',
+                  ),
+              },
+            ]}
+          />
+        </ContentSection>
+      </PageContentContainer>
+    </>
+  );
+}

--- a/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { setupTest } from './test-utils';
+
+describe('command::ui:reconnect-native-fs-workspace', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('replaces the stored handle and reloads services after a valid selection', async () => {
+    const { dispatch, services, getCommandResults } = await setupTest({
+      targetId: 'command::ui:reconnect-native-fs-workspace',
+      autoNavigate: false,
+    });
+    const originalHandle = { name: 'test-ws' };
+    const replacementHandle = {
+      name: 'test-ws',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    };
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'test-ws',
+      type: WORKSPACE_STORAGE_TYPE.NativeFS,
+      metadata: { rootDirHandle: originalHandle },
+    });
+    vi.stubGlobal(
+      'showDirectoryPicker',
+      vi.fn().mockResolvedValue(replacementHandle),
+    );
+    const reloadSpy = vi.spyOn(services.workbenchState, 'reloadUi');
+
+    dispatch('command::ui:reconnect-native-fs-workspace', {
+      wsName: 'test-ws',
+    });
+
+    await vi.waitFor(async () => {
+      expect(
+        await services.workspaceOps.getWorkspaceMetadata('test-ws'),
+      ).toEqual({ rootDirHandle: replacementHandle });
+      expect(reloadSpy).toHaveBeenCalledOnce();
+      expect(getCommandResults().at(-1)?.type).toBe('success');
+    });
+  });
+
+  it('keeps the stored handle when the selected folder name does not match', async () => {
+    const { dispatch, services, getCommandResults } = await setupTest({
+      targetId: 'command::ui:reconnect-native-fs-workspace',
+      autoNavigate: false,
+    });
+    const originalHandle = { name: 'test-ws' };
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'test-ws',
+      type: WORKSPACE_STORAGE_TYPE.NativeFS,
+      metadata: { rootDirHandle: originalHandle },
+    });
+    vi.stubGlobal(
+      'showDirectoryPicker',
+      vi.fn().mockResolvedValue({
+        name: 'different-folder',
+        requestPermission: vi.fn().mockResolvedValue('granted'),
+      }),
+    );
+    const reloadSpy = vi.spyOn(services.workbenchState, 'reloadUi');
+
+    dispatch('command::ui:reconnect-native-fs-workspace', {
+      wsName: 'test-ws',
+    });
+
+    await vi.waitFor(() => {
+      expect(getCommandResults().at(-1)?.type).toBe('failure');
+    });
+    expect(await services.workspaceOps.getWorkspaceMetadata('test-ws')).toEqual(
+      { rootDirHandle: originalHandle },
+    );
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/command-handlers/src/ui-command-handlers.ts
+++ b/packages/core/command-handlers/src/ui-command-handlers.ts
@@ -1,5 +1,6 @@
 import {
   basicOperationsHandlers,
+  nativeFsRecoveryHandlers,
   noteManagementHandlers,
   testHandlers,
   workspaceManagementHandlers,
@@ -8,6 +9,7 @@ import {
 export const uiCommandHandlers = [
   ...testHandlers,
   ...basicOperationsHandlers,
+  ...nativeFsRecoveryHandlers,
   ...noteManagementHandlers,
   ...workspaceManagementHandlers,
 ];

--- a/packages/core/command-handlers/src/ui-handlers/index.ts
+++ b/packages/core/command-handlers/src/ui-handlers/index.ts
@@ -1,4 +1,5 @@
 export { basicOperationsHandlers } from './basic-operations';
+export { nativeFsRecoveryHandlers } from './native-fs-recovery';
 export { noteManagementHandlers } from './note-management';
 export { testHandlers } from './test-handler';
 export { workspaceManagementHandlers } from './workspace-management';

--- a/packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts
+++ b/packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts
@@ -1,0 +1,66 @@
+import {
+  BaseFileSystemError,
+  NATIVE_BROWSER_USER_ABORTED_ERROR,
+  pickADirectory,
+} from '@bangle.io/baby-fs';
+import { throwAppError } from '@bangle.io/base-utils';
+import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import { c } from '../helper';
+
+export const nativeFsRecoveryHandlers = [
+  c(
+    'command::ui:reconnect-native-fs-workspace',
+    async ({ workspaceOps, workbenchState }, { wsName }) => {
+      const workspace = await workspaceOps.getWorkspaceInfo(wsName, {
+        type: WORKSPACE_STORAGE_TYPE.NativeFS,
+      });
+      if (!workspace) {
+        throwAppError(
+          'error::workspace:not-found',
+          t.app.errors.workspace.reconnectNotFound({ wsName }),
+          { wsName },
+        );
+      }
+
+      let rootDirHandle: FileSystemDirectoryHandle;
+      try {
+        rootDirHandle = await pickADirectory();
+      } catch (error) {
+        if (
+          error instanceof BaseFileSystemError &&
+          error.code === NATIVE_BROWSER_USER_ABORTED_ERROR
+        ) {
+          return;
+        }
+        throwAppError(
+          'error::workspace:native-fs-reconnect-failed',
+          t.app.errors.workspace.reconnectFailed,
+          { wsName },
+        );
+      }
+
+      // Native FS paths are rooted by the directory name today. Accepting a
+      // different folder would make a successful reconnect look like an empty
+      // workspace, so preserve the old handle until the selection is valid.
+      if (rootDirHandle.name !== wsName) {
+        throwAppError(
+          'error::workspace:native-fs-reconnect-failed',
+          t.app.errors.workspace.reconnectNameMismatch({
+            expectedName: wsName,
+            selectedName: rootDirHandle.name,
+          }),
+          { wsName },
+        );
+      }
+
+      await workspaceOps.updateWorkspaceMetadata(wsName, (metadata) => ({
+        ...metadata,
+        rootDirHandle,
+      }));
+
+      // Recreate the service graph so every Native FS handle cache observes
+      // the newly stored directory before any reads or writes resume.
+      workbenchState.reloadUi();
+    },
+  ),
+];

--- a/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/code-block-markdown.spec.ts
@@ -127,28 +127,30 @@ describe('code block Markdown', () => {
 
   it('parses fenced code blocks inside blockquotes', () => {
     const { document, serialized } = expectEquivalentAfterSerialize(
-      '> ```js\n> quoted();\n> ```',
+      '> ```js\n> quoted();\n> return quoted;\n> ```',
     );
     const [blockquote] = findNodes(document, 'blockquote');
     const [codeBlock] = findNodes(document, 'code_block');
 
     expect(blockquote).toBeDefined();
     expect(codeBlock?.attrs.language).toBe('js');
-    expect(codeBlock?.textContent).toBe('quoted();');
-    expect(serialized).toBe('> ```js\n> quoted();\n> ```');
+    expect(codeBlock?.textContent).toBe('quoted();\nreturn quoted;');
+    expect(serialized).toBe('> ```js\n> quoted();\n> return quoted;\n> ```');
   });
 
   it('parses fenced code blocks inside list items', () => {
     const { document, serialized } = expectEquivalentAfterSerialize(
-      '- item\n\n  ```js\n  listed();\n  ```',
+      '- item\n\n  ```js\n  listed();\n  return listed;\n  ```',
     );
     const [list] = findNodes(document, 'list');
     const [codeBlock] = findNodes(document, 'code_block');
 
     expect(list).toBeDefined();
     expect(codeBlock?.attrs.language).toBe('js');
-    expect(codeBlock?.textContent).toBe('listed();');
-    expect(serialized).toBe('- item\n\n  ```js\n  listed();\n  ```');
+    expect(codeBlock?.textContent).toBe('listed();\nreturn listed;');
+    expect(serialized).toBe(
+      '- item\n\n  ```js\n  listed();\n  return listed;\n  ```',
+    );
   });
 
   it('serializes fenced code blocks inside ordered list items with marker-width indentation', () => {

--- a/packages/core/service-core/src/__tests__/user-activity-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/user-activity-service.spec.ts
@@ -332,6 +332,27 @@ describe('UserActivityService', () => {
       });
     });
 
+    it('preserves persisted order while filtering stale paths', async () => {
+      const { userActivityService, workspaceOps, goWsPath } =
+        await setupUserActivityService({ controller });
+
+      await goWsPath(TEST_WS_PATH_IN_WS2);
+      await workspaceOps.updateWorkspaceMetadata(TEST_WS_NAME, (metadata) => ({
+        ...metadata,
+        'starred-items': [
+          TEST_WS_PATH2,
+          `${TEST_WS_NAME}:deleted-note.md`,
+          TEST_WS_PATH,
+        ],
+      }));
+      await goWsPath(TEST_WS_PATH);
+
+      await vi.waitFor(async () => {
+        const { starredWsPaths } = userActivityService.resolveAtoms();
+        expect(starredWsPaths).toEqual([TEST_WS_PATH2, TEST_WS_PATH]);
+      });
+    });
+
     it('should toggle star status correctly on multiple calls', async () => {
       const { userActivityService, goWsPath } = await setupUserActivityService({
         controller,

--- a/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
@@ -1,3 +1,4 @@
+import { throwAppError } from '@bangle.io/base-utils';
 import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -599,6 +600,40 @@ describe('WorkspaceStateService file tree updates', () => {
 
     // Never present workspace A's files as workspace B's tree.
     expect(services.workspaceState.resolveAtoms().wsPaths).toEqual([]);
+  });
+
+  it('exposes a typed recovery state when a native workspace directory is missing', async () => {
+    const { services, store } = await setupWorkspaceStateService({
+      controller,
+    });
+
+    vi.spyOn(services.fileSystem, 'listWorkspaceFiles').mockImplementation(
+      async (wsName) => {
+        throwAppError(
+          'error::file-storage:file-does-not-exist',
+          'Native workspace path was not found',
+          {
+            storage: 'file-storage-nativefs',
+            wsPath: `${wsName}:`,
+          },
+        );
+      },
+    );
+
+    services.fileSystem.refreshFileTree();
+
+    await vi.waitFor(() => {
+      expect(store.get(services.workspaceState.$fileTreeListState)).toEqual({
+        status: 'native-fs-directory-not-found',
+        error: expect.any(Error),
+        wsName: WS_NAME,
+      });
+    });
+
+    // A missing folder is a recovery state, never an empty-workspace success.
+    expect(
+      services.workspaceState.resolveAtoms().wsPaths.map((path) => path.wsPath),
+    ).not.toEqual([]);
   });
 
   it('does not expose ignored Markdown files returned by storage scans', async () => {

--- a/packages/core/service-core/src/workbench-state-service.ts
+++ b/packages/core/service-core/src/workbench-state-service.ts
@@ -8,7 +8,11 @@ import type {
   ThemeConfig,
   ThemeManager,
 } from '@bangle.io/color-scheme-manager';
-import { isAssetLocationPreference, SERVICE_NAME } from '@bangle.io/constants';
+import {
+  isAssetLocationPreference,
+  SERVICE_NAME,
+  SIDEBAR_DEFAULT_WIDTH,
+} from '@bangle.io/constants';
 import { T } from '@bangle.io/mini-js-utils';
 import type {
   AssetLocationPreference,
@@ -68,6 +72,7 @@ export class WorkbenchStateService extends BaseService {
 
   private $_wideEditor: PrimitiveAtom<boolean> | undefined;
   private $_sidebarOpen: PrimitiveAtom<boolean> | undefined;
+  private $_sidebarWidth: PrimitiveAtom<number> | undefined;
   private $_linkedMentionsCollapsed: PrimitiveAtom<boolean> | undefined;
   private $_showNoteFilesOnlyInSidebar: PrimitiveAtom<boolean> | undefined;
   private $_assetLocationPreference:
@@ -210,6 +215,24 @@ export class WorkbenchStateService extends BaseService {
       });
     }
     return this.$_sidebarOpen;
+  }
+
+  get $sidebarWidth() {
+    if (!this.$_sidebarWidth) {
+      this.$_sidebarWidth = atomStorage({
+        serviceName: this.name,
+        key: 'sidebar-width',
+        initValue: SIDEBAR_DEFAULT_WIDTH,
+        syncDb: this.dep.syncDatabase,
+        validator: {
+          validate: (value): value is number =>
+            typeof value === 'number' && Number.isFinite(value),
+          typeName: 'finite-number',
+        },
+        logger: this.logger,
+      });
+    }
+    return this.$_sidebarWidth;
   }
 
   get $linkedMentionsCollapsed() {

--- a/packages/core/service-core/src/workspace-state-service.ts
+++ b/packages/core/service-core/src/workspace-state-service.ts
@@ -4,6 +4,7 @@ import {
   BaseService,
   type BaseServiceContext,
   createAsyncAtom,
+  getAppErrorCause,
   isAbortError,
   isAppError,
 } from '@bangle.io/base-utils';
@@ -36,6 +37,11 @@ const FILE_TREE_LIST_OK: FileTreeListState = { status: 'ok' };
 
 export type FileTreeListState =
   | { status: 'ok'; error?: undefined }
+  | {
+      status: 'native-fs-directory-not-found';
+      error: unknown;
+      wsName: string;
+    }
   | { status: 'error'; error: unknown };
 
 export type BacklinkIndexState =
@@ -287,7 +293,24 @@ export class WorkspaceStateService extends BaseService {
                 if (this.lastListedWsName !== wsName) {
                   set(this.$rawWsPaths, EMPTY_STRING_ARRAY);
                 }
-                set(this.$fileTreeListState, { status: 'error', error });
+                const appError = isAppError(error)
+                  ? getAppErrorCause(error)
+                  : undefined;
+                if (
+                  appError?.name ===
+                    'error::file-storage:file-does-not-exist' &&
+                  appError.payload.storage ===
+                    SERVICE_NAME.fileStorageNativeFsService &&
+                  appError.payload.wsPath === `${wsName}:`
+                ) {
+                  set(this.$fileTreeListState, {
+                    status: 'native-fs-directory-not-found',
+                    error,
+                    wsName,
+                  });
+                } else {
+                  set(this.$fileTreeListState, { status: 'error', error });
+                }
                 if (error instanceof Error && isAppError(error)) {
                   this.emitAppError(error);
                 } else {

--- a/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/code-block.spec.ts
@@ -5,6 +5,7 @@ import { setupBase } from '../base';
 import { setupBlockquote } from '../blockquote';
 import { setupCodeBlock } from '../code-block';
 import { collection } from '../common';
+import { setupHardBreak } from '../hard-break';
 import { setupHeading } from '../heading';
 import { setupList } from '../list';
 import { setupParagraph } from '../paragraph';
@@ -57,6 +58,7 @@ const nestedEditorTest = createBangerEditorTestSetup({
     setupBlockquote(),
     setupList(),
     setupCodeBlock(),
+    setupHardBreak(),
     collection({
       id: 'restricted-test-container',
       nodes: {
@@ -136,6 +138,44 @@ describe('code block keymap', () => {
 
     editor.expectDoc(doc(codeBlock('const done = true;\n')));
     expect(editor.selectionParentType()).toBe('code_block');
+  });
+
+  it('keeps Shift-Enter inside top-level and nested code blocks', () => {
+    const topLevelEditor = nestedEditorTest.createEditor(
+      nestedEditorTest.builders.doc(
+        nestedEditorTest.builders.codeBlock('top<cursor>'),
+      ),
+    );
+
+    expect(topLevelEditor.pressKey('Enter', { shiftKey: true })).toBe(true);
+    topLevelEditor.expectDoc(
+      nestedEditorTest.builders.doc(
+        nestedEditorTest.builders.codeBlock('top\n'),
+      ),
+    );
+    expect(topLevelEditor.selectionParentType()).toBe('code_block');
+
+    const blockquote = nestedEditorTest.nodeBuilder('bq');
+    const list = nestedEditorTest.nodeBuilder('list');
+    const nestedDoc = nestedEditorTest.nodeBuilder('doc');
+    const nestedCodeBlock = nestedEditorTest.nodeBuilder('codeBlock');
+    const blockquoteEditor = nestedEditorTest.createEditor(
+      nestedDoc(blockquote(nestedCodeBlock('quoted<cursor>'))),
+    );
+
+    expect(blockquoteEditor.pressKey('Enter', { shiftKey: true })).toBe(true);
+    blockquoteEditor.expectDoc(
+      nestedDoc(blockquote(nestedCodeBlock('quoted\n'))),
+    );
+    expect(blockquoteEditor.selectionParentType()).toBe('code_block');
+
+    const listEditor = nestedEditorTest.createEditor(
+      nestedDoc(list(nestedCodeBlock('listed<cursor>'))),
+    );
+
+    expect(listEditor.pressKey('Enter', { shiftKey: true })).toBe(true);
+    listEditor.expectDoc(nestedDoc(list(nestedCodeBlock('listed\n'))));
+    expect(listEditor.selectionParentType()).toBe('code_block');
   });
 
   it('exits an empty code block on Enter so it does not trap the cursor', () => {

--- a/packages/js-lib/banger-editor/src/code-block.ts
+++ b/packages/js-lib/banger-editor/src/code-block.ts
@@ -30,6 +30,7 @@ export type CodeBlockConfig = {
   // keys
   keyToCodeBlock?: string | false;
   keyExit?: string | false;
+  keyInsertNewline?: string | false;
   keyBackspace?: string | false;
   keyDeleteWordBackward?: string | false;
   keyJumpToLineStart?: string | false;
@@ -52,6 +53,7 @@ const DEFAULT_CONFIG: RequiredConfig = {
   getParagraphNodeType: defaultGetParagraphNodeType,
   keyToCodeBlock: false,
   keyExit: 'Enter',
+  keyInsertNewline: 'Shift-Enter',
   keyBackspace: 'Backspace',
   keyDeleteWordBackward: isMac ? 'Alt-Backspace' : false,
   keyJumpToLineStart: isMac ? 'Ctrl-a' : false,
@@ -133,6 +135,7 @@ function pluginKeybindings(config: RequiredConfig) {
         : convertCommand,
     ],
     [config.keyBackspace, backspaceEmptyCodeBlock(config)],
+    [config.keyInsertNewline, insertCodeBlockNewline(config)],
     [config.keyDeleteWordBackward, deletePreviousCodeWord(config)],
     [config.keyJumpToLineStart, jumpToCodeLineBoundary(config, 'start')],
     [config.keyJumpToLineEnd, jumpToCodeLineBoundary(config, 'end')],
@@ -157,6 +160,23 @@ function pluginKeybindings(config: RequiredConfig) {
 }
 
 // COMMANDS
+function insertCodeBlockNewline(config: RequiredConfig): Command {
+  return (state, dispatch) => {
+    const codeBlockType = getNodeType(state.schema, config.name);
+    const { $from, $to } = state.selection;
+    const node = findParentNodeOfType(codeBlockType)(state.selection);
+
+    if (!node || $from.parent !== $to.parent) {
+      return false;
+    }
+
+    if (dispatch) {
+      dispatch(state.tr.insertText('\n').scrollIntoView());
+    }
+    return true;
+  };
+}
+
 function moveCodeBlock(
   config: RequiredConfig,
   direction: 'UP' | 'DOWN',
@@ -645,7 +665,7 @@ function markdown(config: RequiredConfig): CollectionType['markdown'] {
           const info = getCodeBlockInfo(node.attrs.language);
           const fence = createCodeFence(node.textContent, info);
           state.write(`${fence}${info}\n`);
-          state.write(node.textContent);
+          state.text(node.textContent, false);
           if (node.textContent) {
             state.write('\n');
           }

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -314,6 +314,17 @@ export const uiCommands = narrow([
     omniSearch: false,
   },
   {
+    id: 'command::ui:reconnect-native-fs-workspace',
+    dependencies: {
+      services: ['workspaceOps', 'workbenchState'],
+    },
+    autoFocusEditor: false,
+    args: {
+      wsName: T.String,
+    },
+    omniSearch: false,
+  },
+  {
     id: 'command::ui:toggle-all-files',
     title: 'View All Files',
     keywords: ['files', 'list', 'browse', 'all'],

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -5,6 +5,9 @@ export const COLOR_SCHEME = {
   DARK: DARK_SCHEME,
 } as const;
 export const WIDESCREEN_WIDTH = 759;
+export const SIDEBAR_DEFAULT_WIDTH = 272;
+export const SIDEBAR_MIN_WIDTH = 224;
+export const SIDEBAR_MAX_WIDTH = 400;
 export const KEYBOARD_SHORTCUTS = {
   toggleOmniSearch: { id: 'toggleOmniSearch', keys: ['ctrl', 'k'] },
 } as const;

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -109,7 +109,8 @@ export const t = {
       discord: 'Discord',
       footerTitle: 'Bangle.io',
       toggleSidebarSr: 'Seitenleiste umschalten',
-      toggleSidebarRailTitle: 'Seitenleiste umschalten',
+      toggleSidebarRailTitle:
+        'Seitenleiste skalieren. Doppelklicken zum Zurücksetzen.',
     },
     settings: {
       title: 'Einstellungen',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -368,6 +368,18 @@ export const t = {
         noNoteOpenToClone: 'No note open to clone',
         noWorkspaceForDailyNote: 'No workspace is open to create a daily note.',
         noNoteOpened: 'No note is currently open.',
+        reconnectNotFound: ({ wsName }: { wsName: string }) =>
+          `The workspace "${wsName}" is no longer available.`,
+        reconnectFailed:
+          'Bangle could not reconnect that folder. Your workspace was not changed.',
+        reconnectNameMismatch: ({
+          expectedName,
+          selectedName,
+        }: {
+          expectedName: string;
+          selectedName: string;
+        }) =>
+          `Choose the folder named "${expectedName}", not "${selectedName}". Your workspace was not changed.`,
       },
       file: {
         invalidNotePath: 'Invalid note path provided',
@@ -542,6 +554,13 @@ export const t = {
       recentNotesHeading: 'Recent notes',
       noNotesMessage: 'No notes found in this workspace.',
       newNoteButton: 'New Note',
+      switchWorkspaceButton: 'Switch Workspace',
+    },
+    pageNativeFsRecovery: {
+      title: 'Reconnect your workspace folder',
+      description: ({ wsName }: { wsName: string }) =>
+        `Bangle can’t find the folder linked to “${wsName}”. It may have moved, been deleted, or be on a disconnected drive. Bangle has not changed your workspace entry or files. Locate the same folder to reconnect it.`,
+      locateFolderButton: 'Locate Folder',
       switchWorkspaceButton: 'Switch Workspace',
     },
     pageWsPathNotFound: {

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -133,7 +133,7 @@ export const t = {
       discord: 'Discord',
       footerTitle: 'Bangle.io',
       toggleSidebarSr: 'Toggle Sidebar',
-      toggleSidebarRailTitle: 'Toggle Sidebar',
+      toggleSidebarRailTitle: 'Resize sidebar. Double-click to reset.',
     },
     settings: {
       title: 'Settings',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -592,6 +592,7 @@ export const t = {
     components: {
       appSidebar: {
         openedLabel: 'Opened',
+        starredLabel: 'Starred',
         filesLabel: 'Files',
         fileTreeLabel: 'Workspace files',
         noteCount: ({ count }: { count: number }) =>

--- a/packages/shared/types/app-errors.ts
+++ b/packages/shared/types/app-errors.ts
@@ -71,6 +71,12 @@ export type AppError =
       };
     }
   | {
+      name: `error::workspace:native-fs-reconnect-failed`;
+      payload: {
+        wsName: string;
+      };
+    }
+  | {
       name: 'error::workspace:no-notes-found';
       payload: {
         wsName?: string;

--- a/packages/tooling/e2e-tests/src/app-shell-layout.e2e.ts
+++ b/packages/tooling/e2e-tests/src/app-shell-layout.e2e.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 import {
   createBrowserWorkspace,
   createBrowserWorkspaceAndNote,
+  expectNoPageHorizontalOverflow,
 } from './common';
 
 // Guards the app-shell macro layout: a full-height, edge-to-edge sidebar (the
@@ -55,6 +56,84 @@ test('app shell: full-height flush sidebar, thin titlebar, collapse/expand', asy
   await expect
     .poll(async () => (await sidebarPanel.boundingBox())?.x ?? -1)
     .toBeGreaterThanOrEqual(0);
+});
+
+test('app shell: resize the sidebar with pointer or keyboard and persist its width', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await createBrowserWorkspace(page, { workspaceName: 'resizable-sidebar-ws' });
+
+  const sidebar = page.locator('[data-sidebar="sidebar"]').first();
+  const rail = page.getByRole('separator', {
+    name: 'Resize sidebar. Double-click to reset.',
+  });
+  await expect(rail).toBeVisible();
+  await expect(rail).toHaveAttribute('aria-valuemin', '224');
+  await expect(rail).toHaveAttribute('aria-valuemax', '400');
+  await expect(rail).toHaveCSS('cursor', 'col-resize');
+
+  const initialSidebarBox = await sidebar.boundingBox();
+  const initialWidth = Number(await rail.getAttribute('aria-valuenow'));
+  await rail.hover({ position: { x: 8, y: 120 } });
+  const railBox = await rail.boundingBox();
+  expect(initialSidebarBox).not.toBeNull();
+  expect(railBox).not.toBeNull();
+  expect(railBox?.width ?? 0).toBeGreaterThanOrEqual(12);
+
+  const startX = (railBox?.x ?? 0) + 8;
+  const startY = (railBox?.y ?? 0) + 120;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 80, startY, { steps: 5 });
+  await page.mouse.up();
+
+  const resizedWidth = (initialSidebarBox?.width ?? 0) + 80;
+  await expect
+    .poll(async () => (await sidebar.boundingBox())?.width ?? 0)
+    .toBeCloseTo(resizedWidth, 0);
+  await expect(rail).toHaveAttribute('aria-valuenow', `${initialWidth + 80}`);
+
+  await page.reload();
+  await expect
+    .poll(async () => (await sidebar.boundingBox())?.width ?? 0)
+    .toBeCloseTo(resizedWidth, 0);
+
+  await rail.focus();
+  await page.keyboard.press('ArrowLeft');
+  await expect
+    .poll(async () => (await sidebar.boundingBox())?.width ?? 0)
+    .toBeCloseTo(resizedWidth - 8, 0);
+
+  await page.keyboard.press('Home');
+  await expect(rail).toHaveAttribute('aria-valuenow', '224');
+  await page.keyboard.press('End');
+  await expect(rail).toHaveAttribute('aria-valuenow', '400');
+  await expectNoPageHorizontalOverflow(page);
+
+  const companionPage = await page.context().newPage();
+  await companionPage.goto('/');
+  const companionRail = companionPage.getByRole('separator', {
+    name: 'Resize sidebar. Double-click to reset.',
+  });
+  await expect(companionRail).toHaveAttribute('aria-valuenow', '400');
+  await rail.focus();
+  await page.keyboard.press('ArrowLeft');
+  await expect(companionRail).toHaveAttribute('aria-valuenow', '392');
+  await page.keyboard.press('ArrowRight');
+  await expect(companionRail).toHaveAttribute('aria-valuenow', '400');
+  await companionPage.close();
+
+  const toggle = page.getByRole('button', { name: 'Toggle Sidebar' }).first();
+  await toggle.click();
+  await expect(
+    page.locator('[data-variant][data-side="left"]').first(),
+  ).toHaveAttribute('data-state', 'collapsed');
+  await toggle.click();
+  await expect(rail).toHaveAttribute('aria-valuenow', '400');
+
+  await rail.dblclick();
+  await expect(rail).toHaveAttribute('aria-valuenow', '272');
 });
 
 test('app shell: PWA window controls overlay keeps titlebar actions outside reserved chrome geometry', async ({

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -79,6 +79,82 @@ test('converts a typed fenced-code marker inside a blockquote', async ({
     .toBe('> ```ts\n> const quoted = true;\n> ```');
 });
 
+test('Shift-Enter adds persisted lines inside nested code blocks', async ({
+  page,
+}) => {
+  const workspaceName = 'nested-code-block-newlines';
+  const noteName = 'nested-newlines';
+  const initialMarkdown = [
+    '- ```js',
+    '  const listed = true;',
+    '  ```',
+    '',
+    '> ```ts',
+    '> const quoted = true;',
+    '> ```',
+  ].join('\n');
+  const expectedMarkdown = [
+    '- ```js',
+    '  const listed = true;',
+    '  return listed;',
+    '  ```',
+    '',
+    '> ```ts',
+    '> const quoted = true;',
+    '> return quoted;',
+    '> ```',
+  ].join('\n');
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(page, workspaceName, noteName, initialMarkdown);
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  // Flat-list renders list items without a native <li>; the first fenced block
+  // is the list-owned block and persisted Markdown below proves its ownership.
+  const listedCode = editor.locator('pre code').first();
+  const listedBox = await listedCode.boundingBox();
+  expect(listedBox).not.toBeNull();
+  if (!listedBox) {
+    return;
+  }
+  await page.mouse.click(listedBox.x + 24, listedBox.y + listedBox.height - 8);
+  await page.keyboard.press(isDarwin ? 'Control+e' : 'End');
+  await page.keyboard.press('Shift+Enter');
+  await page.keyboard.insertText('return listed;');
+
+  const quotedCode = editor.locator('blockquote pre code');
+  const quotedBox = await quotedCode.boundingBox();
+  expect(quotedBox).not.toBeNull();
+  if (!quotedBox) {
+    return;
+  }
+  await page.mouse.click(quotedBox.x + 24, quotedBox.y + quotedBox.height - 8);
+  await page.keyboard.press(isDarwin ? 'Control+e' : 'End');
+  await page.keyboard.press('Shift+Enter');
+  await page.keyboard.insertText('return quoted;');
+
+  await expect(listedCode).toContainText(
+    'const listed = true;\nreturn listed;',
+  );
+  await expect(quotedCode).toContainText(
+    'const quoted = true;\nreturn quoted;',
+  );
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(expectedMarkdown);
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(editor.locator('pre code').first()).toContainText(
+    'const listed = true;\nreturn listed;',
+  );
+  await expect(editor.locator('blockquote pre code')).toContainText(
+    'const quoted = true;\nreturn quoted;',
+  );
+  await expect(readStoredMarkdown(page, workspaceName, noteName)).resolves.toBe(
+    expectedMarkdown,
+  );
+});
+
 test('copies code-block text from the visible code action', async ({
   context,
   page,

--- a/packages/tooling/e2e-tests/src/native-fs-recovery.e2e.ts
+++ b/packages/tooling/e2e-tests/src/native-fs-recovery.e2e.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '@playwright/test';
+import { expectNoPageHorizontalOverflow } from './common';
+
+const WORKSPACE_NAME = 'recovery-workspace';
+const MISSING_PARENT = 'native-recovery-missing-parent';
+const REPLACEMENT_PARENT = 'native-recovery-replacement-parent';
+
+test('recovers a missing Native FS workspace without presenting it as empty', async ({
+  page,
+}) => {
+  await page.addInitScript(
+    ({ replacementParent, workspaceName }) => {
+      window.showDirectoryPicker = async () => {
+        const root = await navigator.storage.getDirectory();
+        const parent = await root.getDirectoryHandle(replacementParent);
+        return parent.getDirectoryHandle(workspaceName);
+      };
+    },
+    {
+      replacementParent: REPLACEMENT_PARENT,
+      workspaceName: WORKSPACE_NAME,
+    },
+  );
+
+  await page.goto('/');
+  await page.evaluate(
+    async ({ missingParentName, replacementParentName, workspaceName }) => {
+      const root = await navigator.storage.getDirectory();
+      for (const parentName of [missingParentName, replacementParentName]) {
+        await root.removeEntry(parentName, { recursive: true }).catch(() => {});
+      }
+
+      const missingParent = await root.getDirectoryHandle(missingParentName, {
+        create: true,
+      });
+      const missingHandle = await missingParent.getDirectoryHandle(
+        workspaceName,
+        { create: true },
+      );
+
+      const replacementParent = await root.getDirectoryHandle(
+        replacementParentName,
+        { create: true },
+      );
+      const replacementHandle = await replacementParent.getDirectoryHandle(
+        workspaceName,
+        { create: true },
+      );
+      const welcomeHandle = await replacementHandle.getFileHandle(
+        'welcome.md',
+        { create: true },
+      );
+      const writable = await welcomeHandle.createWritable();
+      await writable.write('# Reconnected workspace\n');
+      await writable.close();
+
+      const request = indexedDB.open('bangle-io-db');
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      await new Promise<void>((resolve, reject) => {
+        const transaction = database.transaction('WorkspaceInfo', 'readwrite');
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error);
+        transaction.objectStore('WorkspaceInfo').put({
+          key: workspaceName,
+          lastModified: Date.now(),
+          value: {
+            name: workspaceName,
+            type: 'nativefs',
+            deleted: false,
+            lastModified: Date.now(),
+            metadata: { rootDirHandle: missingHandle },
+          },
+        });
+      });
+      database.close();
+
+      // The stored handle remains cloneable but reading it now raises the same
+      // NotFoundError as a moved/deleted local directory.
+      await root.removeEntry(missingParentName, { recursive: true });
+    },
+    {
+      missingParentName: MISSING_PARENT,
+      replacementParentName: REPLACEMENT_PARENT,
+      workspaceName: WORKSPACE_NAME,
+    },
+  );
+
+  await page.goto(
+    `/ws#route=ws-home&wsName=${encodeURIComponent(WORKSPACE_NAME)}`,
+  );
+
+  const recovery = page.getByTestId('page-native-fs-recovery');
+  await expect(recovery).toBeVisible();
+  await expect(
+    recovery.getByRole('heading', {
+      name: 'Reconnect your workspace folder',
+    }),
+  ).toBeVisible();
+  await expect(recovery).toContainText(
+    'Bangle has not changed your workspace entry or files.',
+  );
+  await expect(recovery.getByText('No notes found')).toHaveCount(0);
+  await expect(
+    recovery.getByRole('button', { name: 'Locate Folder' }),
+  ).toBeVisible();
+  await expect(
+    recovery.getByRole('button', { name: 'Switch Workspace' }),
+  ).toBeVisible();
+  await expectNoPageHorizontalOverflow(page);
+
+  await recovery.getByRole('button', { name: 'Locate Folder' }).click();
+
+  await expect(recovery).toHaveCount(0);
+  await expect(page.getByRole('link', { name: 'welcome.md' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: WORKSPACE_NAME }),
+  ).toBeVisible();
+});

--- a/packages/tooling/e2e-tests/src/starred-notes.e2e.ts
+++ b/packages/tooling/e2e-tests/src/starred-notes.e2e.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import { createBrowserWorkspaceAndNote } from './common';
+
+test('starred notes stay visible, ordered, navigable, and persisted in the sidebar', async ({
+  page,
+}) => {
+  const workspaceName = 'starred-sidebar-ws';
+  const firstNoteName =
+    'a-deliberately-long-starred-note-name-that-must-not-widen-the-sidebar';
+  const secondNoteName = 'second-starred-note';
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: firstNoteName,
+  });
+
+  await expect(page.getByText('Starred', { exact: true })).toHaveCount(0);
+  await page.getByRole('button', { name: 'Star this item' }).click();
+
+  const starredSection = page
+    .getByText('Starred', { exact: true })
+    .locator('..');
+  const starredLinks = starredSection.getByRole('link');
+  const firstStarredLink = starredSection.getByRole('link', {
+    name: `${firstNoteName}.md`,
+  });
+  await expect(page.getByText('Starred', { exact: true })).toBeVisible();
+  await expect(firstStarredLink).toBeVisible();
+
+  const sidebar = page.locator('[data-sidebar="sidebar"]').first();
+  const sidebarWidthBefore = (await sidebar.boundingBox())?.width;
+  expect(sidebarWidthBefore).toBeDefined();
+  await expect
+    .poll(async () => (await sidebar.boundingBox())?.width)
+    .toBe(sidebarWidthBefore);
+
+  await page.getByRole('link', { name: 'Home' }).click();
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill(secondNoteName);
+  await page.getByRole('button', { name: 'Create' }).click();
+  await page.getByRole('button', { name: 'Star this item' }).click();
+
+  await expect(starredLinks).toHaveCount(2);
+  await expect(starredLinks.nth(0)).toHaveAccessibleName(`${firstNoteName}.md`);
+  await expect(starredLinks.nth(1)).toHaveAccessibleName(
+    `${secondNoteName}.md`,
+  );
+  await expect(starredLinks.nth(1)).toHaveAttribute('aria-current', 'page');
+
+  await firstStarredLink.click();
+  await expect(firstStarredLink).toHaveAttribute('aria-current', 'page');
+  await expect(
+    page.getByRole('button', { name: `${firstNoteName}.md` }),
+  ).toBeVisible();
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(page.getByText('Starred', { exact: true })).toBeVisible();
+  await expect(starredLinks).toHaveCount(2);
+  await expect(starredLinks.nth(0)).toHaveAccessibleName(`${firstNoteName}.md`);
+  await expect(starredLinks.nth(1)).toHaveAccessibleName(
+    `${secondNoteName}.md`,
+  );
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole('button', { name: 'Toggle Sidebar' }).click();
+  const mobileSidebar = page.getByRole('dialog', { name: 'Sidebar' });
+  await expect(mobileSidebar).toBeVisible();
+  await mobileSidebar
+    .getByText('Starred', { exact: true })
+    .locator('..')
+    .getByRole('link', { name: `${secondNoteName}.md` })
+    .click();
+  await expect(mobileSidebar).toBeHidden();
+  await expect(
+    page.getByRole('button', { name: `${secondNoteName}.md` }),
+  ).toBeVisible();
+
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await firstStarredLink.click();
+
+  await page.getByRole('button', { name: 'Unstar this item' }).click();
+  await expect(firstStarredLink).toHaveCount(0);
+  await expect(page.getByText('Starred', { exact: true })).toBeVisible();
+
+  await starredLinks.first().click();
+  await page.getByRole('button', { name: 'Unstar this item' }).click();
+  await expect(page.getByText('Starred', { exact: true })).toHaveCount(0);
+});

--- a/packages/ui/ui-components/src/__tests__/sidebar.spec.ts
+++ b/packages/ui/ui-components/src/__tests__/sidebar.spec.ts
@@ -1,0 +1,19 @@
+import { SIDEBAR_MAX_WIDTH, SIDEBAR_MIN_WIDTH } from '@bangle.io/constants';
+import { describe, expect, it } from 'vitest';
+import { clampSidebarWidth } from '../sidebar';
+
+describe('clampSidebarWidth', () => {
+  it('preserves widths inside the supported range', () => {
+    expect(clampSidebarWidth(312)).toBe(312);
+  });
+
+  it('keeps the sidebar within its usable minimum and maximum', () => {
+    expect(clampSidebarWidth(100)).toBe(SIDEBAR_MIN_WIDTH);
+    expect(clampSidebarWidth(900)).toBe(SIDEBAR_MAX_WIDTH);
+  });
+
+  it('supports custom bounds for reusable sidebar layouts', () => {
+    expect(clampSidebarWidth(250, 260, 320)).toBe(260);
+    expect(clampSidebarWidth(330, 260, 320)).toBe(320);
+  });
+});

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Plus,
   Search,
   Settings,
+  Star,
 } from 'lucide-react';
 import React, { useId } from 'react';
 import bangleIcon from './bangle-transparent_x512.png';
@@ -64,6 +65,7 @@ export type AppSidebarProps = {
   workspaces: Workspace[];
   filePaths: string[];
   navItems: NavItem[];
+  starredItems?: NavItem[];
   onSearchClick?: () => void;
   activeFilePaths?: string[];
   getActionsForEntry: (
@@ -200,6 +202,7 @@ export function AppSidebar({
   workspaces,
   filePaths,
   navItems,
+  starredItems = [],
   onSearchClick = () => {},
   activeFilePaths = [],
   getActionsForEntry,
@@ -236,60 +239,18 @@ export function AppSidebar({
         />
       </SidebarHeader>
       <SidebarContent className="gap-1 overflow-hidden">
-        {navItems.length > 0 && (
-          <SidebarGroup>
-            <SidebarGroupLabel>
-              {t.app.components.appSidebar.openedLabel}
-            </SidebarGroupLabel>
-            <SidebarMenu className="gap-2">
-              {navItems.map((item) => (
-                <SidebarMenuItem key={item.title} className="min-w-0">
-                  <SidebarMenuButton
-                    render={
-                      <a
-                        href={
-                          wsPathToHref ? wsPathToHref(item.wsPath) : '#dead'
-                        }
-                        title={item.title}
-                        className="min-w-0 font-medium"
-                      />
-                    }
-                  >
-                    <span className="block min-w-0 truncate">{item.title}</span>
-                  </SidebarMenuButton>
-                  {item.items?.length ? (
-                    <SidebarMenuSub className="ml-0 border-l-0 px-1.5">
-                      {item.items.map((item) => (
-                        <SidebarMenuSubItem
-                          key={item.title}
-                          className="min-w-0"
-                        >
-                          <SidebarMenuSubButton
-                            render={
-                              <a
-                                href={
-                                  wsPathToHref
-                                    ? wsPathToHref(item.wsPath)
-                                    : '#dead'
-                                }
-                                title={item.title}
-                                className="min-w-0"
-                              />
-                            }
-                          >
-                            <span className="block min-w-0 truncate">
-                              {item.title}
-                            </span>
-                          </SidebarMenuSubButton>
-                        </SidebarMenuSubItem>
-                      ))}
-                    </SidebarMenuSub>
-                  ) : null}
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroup>
-        )}
+        <SidebarNavGroup
+          items={navItems}
+          label={t.app.components.appSidebar.openedLabel}
+          wsPathToHref={wsPathToHref}
+        />
+        <SidebarNavGroup
+          items={starredItems}
+          label={t.app.components.appSidebar.starredLabel}
+          wsPathToHref={wsPathToHref}
+          icon={Star}
+          scrollable
+        />
         <SidebarGroup className="min-h-0 flex-1 overflow-hidden p-0 pt-0">
           <SidebarGroupLabel className="sr-only">
             {t.app.components.appSidebar.filesLabel}
@@ -336,6 +297,100 @@ export function AppSidebar({
       )}
       <SidebarRail />
     </Sidebar>
+  );
+}
+
+function SidebarNavGroup({
+  items,
+  label,
+  wsPathToHref,
+  icon: Icon,
+  scrollable = false,
+}: {
+  items: NavItem[];
+  label: string;
+  wsPathToHref?: (wsPath: string) => string;
+  icon?: React.ElementType;
+  scrollable?: boolean;
+}) {
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <SidebarGroup className="py-1">
+      <SidebarGroupLabel>{label}</SidebarGroupLabel>
+      <SidebarMenu
+        className={cn(
+          'gap-1',
+          scrollable && 'max-h-[min(10rem,25vh)] overflow-y-auto pr-1',
+        )}
+      >
+        {items.map((item) => (
+          <SidebarMenuItem key={item.wsPath} className="min-w-0">
+            <SidebarMenuButton
+              isActive={item.isActive}
+              render={
+                <a
+                  href={wsPathToHref ? wsPathToHref(item.wsPath) : '#dead'}
+                  title={item.title}
+                  aria-current={item.isActive ? 'page' : undefined}
+                  className="min-w-0 font-medium"
+                  onClick={() => {
+                    if (isMobile) {
+                      setOpenMobile(false);
+                    }
+                  }}
+                />
+              }
+            >
+              {Icon && (
+                <Icon
+                  aria-hidden="true"
+                  className="size-3.5 shrink-0 fill-current text-amber-500"
+                />
+              )}
+              <span className="block min-w-0 truncate">{item.title}</span>
+            </SidebarMenuButton>
+            {item.items?.length ? (
+              <SidebarMenuSub className="ml-0 border-l-0 px-1.5">
+                {item.items.map((childItem) => (
+                  <SidebarMenuSubItem
+                    key={childItem.wsPath}
+                    className="min-w-0"
+                  >
+                    <SidebarMenuSubButton
+                      render={
+                        <a
+                          href={
+                            wsPathToHref
+                              ? wsPathToHref(childItem.wsPath)
+                              : '#dead'
+                          }
+                          title={childItem.title}
+                          className="min-w-0"
+                          onClick={() => {
+                            if (isMobile) {
+                              setOpenMobile(false);
+                            }
+                          }}
+                        />
+                      }
+                    >
+                      <span className="block min-w-0 truncate">
+                        {childItem.title}
+                      </span>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                ))}
+              </SidebarMenuSub>
+            ) : null}
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
   );
 }
 

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -40,6 +40,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  SidebarRail,
   useSidebar,
 } from './sidebar';
 
@@ -333,6 +334,7 @@ export function AppSidebar({
           {footerChildren}
         </AppSidebarFooter>
       )}
+      <SidebarRail />
     </Sidebar>
   );
 }

--- a/packages/ui/ui-components/src/sidebar.tsx
+++ b/packages/ui/ui-components/src/sidebar.tsx
@@ -392,7 +392,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'hr'>) {
       aria-valuemax={maxWidth}
       aria-valuenow={Math.round(width)}
       aria-label={t.app.sidebar.toggleSidebarRailTitle}
-      tabIndex={isMobile || state === 'collapsed' ? -1 : 0}
+      tabIndex={state === 'collapsed' ? -1 : 0}
       onDoubleClick={() => commitWidth(SIDEBAR_DEFAULT_WIDTH)}
       onKeyDown={(event) => {
         const direction = resizeDirection(event.currentTarget);
@@ -414,12 +414,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'hr'>) {
         }
       }}
       onPointerDown={(event) => {
-        if (
-          event.button !== 0 ||
-          !event.isPrimary ||
-          isMobile ||
-          state === 'collapsed'
-        ) {
+        if (event.button !== 0 || !event.isPrimary || state === 'collapsed') {
           return;
         }
 

--- a/packages/ui/ui-components/src/sidebar.tsx
+++ b/packages/ui/ui-components/src/sidebar.tsx
@@ -16,14 +16,26 @@ import {
   TooltipTrigger,
   useRender,
 } from '@bangle.io/base-ui';
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+} from '@bangle.io/constants';
 import { useIsMobile } from '@bangle.io/ui-misc';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { PanelLeftIcon } from 'lucide-react';
 import * as React from 'react';
 
-const SIDEBAR_WIDTH = '17rem';
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
+
+export function clampSidebarWidth(
+  width: number,
+  minWidth = SIDEBAR_MIN_WIDTH,
+  maxWidth = SIDEBAR_MAX_WIDTH,
+) {
+  return Math.min(Math.max(width, minWidth), maxWidth);
+}
 
 type SidebarContextProps = {
   state: 'expanded' | 'collapsed';
@@ -33,6 +45,12 @@ type SidebarContextProps = {
   setOpenMobile: (open: boolean) => void;
   isMobile: boolean;
   toggleSidebar: () => void;
+  width: number;
+  minWidth: number;
+  maxWidth: number;
+  isResizing: boolean;
+  previewWidth: (width: number) => void;
+  commitWidth: (width: number) => void;
 };
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
@@ -54,6 +72,11 @@ function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
+  defaultWidth = SIDEBAR_DEFAULT_WIDTH,
+  width: widthProp,
+  onWidthChange: setWidthProp,
+  minWidth = SIDEBAR_MIN_WIDTH,
+  maxWidth = SIDEBAR_MAX_WIDTH,
   className,
   style,
   children,
@@ -62,12 +85,26 @@ function SidebarProvider({
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  defaultWidth?: number;
+  width?: number;
+  onWidthChange?: (width: number) => void;
+  minWidth?: number;
+  maxWidth?: number;
 }) {
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
 
   const [_open, _setOpen] = React.useState(defaultOpen);
+  const [_width, _setWidth] = React.useState(() =>
+    clampSidebarWidth(defaultWidth, minWidth, maxWidth),
+  );
+  const [previewedWidth, setPreviewedWidth] = React.useState<number>();
   const open = openProp ?? _open;
+  const width = clampSidebarWidth(
+    previewedWidth ?? widthProp ?? _width,
+    minWidth,
+    maxWidth,
+  );
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
       const openState = typeof value === 'function' ? value(open) : value;
@@ -86,6 +123,26 @@ function SidebarProvider({
       : setOpen((current) => !current);
   }, [isMobile, setOpen]);
 
+  const previewWidth = React.useCallback(
+    (nextWidth: number) => {
+      setPreviewedWidth(clampSidebarWidth(nextWidth, minWidth, maxWidth));
+    },
+    [maxWidth, minWidth],
+  );
+
+  const commitWidth = React.useCallback(
+    (nextWidth: number) => {
+      const clampedWidth = clampSidebarWidth(nextWidth, minWidth, maxWidth);
+      if (setWidthProp) {
+        setWidthProp(clampedWidth);
+      } else {
+        _setWidth(clampedWidth);
+      }
+      setPreviewedWidth(undefined);
+    },
+    [maxWidth, minWidth, setWidthProp],
+  );
+
   const state = open ? 'expanded' : 'collapsed';
 
   const contextValue = React.useMemo<SidebarContextProps>(
@@ -97,8 +154,27 @@ function SidebarProvider({
       openMobile,
       setOpenMobile,
       toggleSidebar,
+      width,
+      minWidth,
+      maxWidth,
+      isResizing: previewedWidth !== undefined,
+      previewWidth,
+      commitWidth,
     }),
-    [state, open, setOpen, isMobile, openMobile, toggleSidebar],
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      toggleSidebar,
+      width,
+      minWidth,
+      maxWidth,
+      previewedWidth,
+      previewWidth,
+      commitWidth,
+    ],
   );
 
   return (
@@ -108,7 +184,7 @@ function SidebarProvider({
           data-slot="sidebar-wrapper"
           style={
             {
-              '--sidebar-width': SIDEBAR_WIDTH,
+              '--sidebar-width': `${width}px`,
               '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
               ...style,
             } as React.CSSProperties
@@ -117,6 +193,9 @@ function SidebarProvider({
             'group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar',
             className,
           )}
+          data-sidebar-resizing={
+            previewedWidth !== undefined ? 'true' : 'false'
+          }
           {...props}
         >
           {children}
@@ -197,7 +276,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
+          'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear group-data-[sidebar-resizing=true]/sidebar-wrapper:transition-none',
           'group-data-[collapsible=offcanvas]:w-0',
           'group-data-[side=right]:rotate-180',
           variant === 'floating' || variant === 'inset'
@@ -209,7 +288,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=right]:right-0 data-[side=left]:left-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] md:flex',
+          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=right]:right-0 data-[side=left]:left-0 group-data-[sidebar-resizing=true]/sidebar-wrapper:transition-none data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] md:flex',
           // When slid off-canvas, clip the panel so decorative shadows do not
           // bleed back across the viewport edge.
           'group-data-[collapsible=offcanvas]:overflow-hidden',
@@ -258,27 +337,126 @@ function SidebarTrigger({
   );
 }
 
-function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
-  const { toggleSidebar } = useSidebar();
+function SidebarRail({ className, ...props }: React.ComponentProps<'hr'>) {
+  const {
+    state,
+    isMobile,
+    width,
+    minWidth,
+    maxWidth,
+    isResizing,
+    previewWidth,
+    commitWidth,
+  } = useSidebar();
+  const dragRef = React.useRef<
+    | {
+        pointerId: number;
+        startX: number;
+        startWidth: number;
+        direction: 1 | -1;
+      }
+    | undefined
+  >(undefined);
+
+  const resizeDirection = (element: HTMLElement): 1 | -1 => {
+    return element.closest('[data-side="right"]') ? -1 : 1;
+  };
+
+  const finishPointerResize = (event: React.PointerEvent<HTMLHRElement>) => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const nextWidth =
+      drag.startWidth + (event.clientX - drag.startX) * drag.direction;
+    dragRef.current = undefined;
+    commitWidth(nextWidth);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  if (isMobile) {
+    return null;
+  }
 
   return (
-    <button
+    <hr
+      {...props}
       data-sidebar="rail"
       data-slot="sidebar-rail"
+      data-resizing={isResizing ? 'true' : 'false'}
+      aria-orientation="vertical"
+      aria-valuemin={minWidth}
+      aria-valuemax={maxWidth}
+      aria-valuenow={Math.round(width)}
       aria-label={t.app.sidebar.toggleSidebarRailTitle}
-      tabIndex={-1}
-      onClick={toggleSidebar}
+      tabIndex={isMobile || state === 'collapsed' ? -1 : 0}
+      onDoubleClick={() => commitWidth(SIDEBAR_DEFAULT_WIDTH)}
+      onKeyDown={(event) => {
+        const direction = resizeDirection(event.currentTarget);
+        const step = event.shiftKey ? 24 : 8;
+        let nextWidth: number | undefined;
+        if (event.key === 'Home') {
+          nextWidth = minWidth;
+        } else if (event.key === 'End') {
+          nextWidth = maxWidth;
+        } else if (event.key === 'ArrowLeft') {
+          nextWidth = width - step * direction;
+        } else if (event.key === 'ArrowRight') {
+          nextWidth = width + step * direction;
+        }
+
+        if (nextWidth !== undefined) {
+          event.preventDefault();
+          commitWidth(nextWidth);
+        }
+      }}
+      onPointerDown={(event) => {
+        if (
+          event.button !== 0 ||
+          !event.isPrimary ||
+          isMobile ||
+          state === 'collapsed'
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        dragRef.current = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startWidth: width,
+          direction: resizeDirection(event.currentTarget),
+        };
+        previewWidth(width);
+      }}
+      onPointerMove={(event) => {
+        const drag = dragRef.current;
+        if (!drag || drag.pointerId !== event.pointerId) {
+          return;
+        }
+        previewWidth(
+          drag.startWidth + (event.clientX - drag.startX) * drag.direction,
+        );
+      }}
+      onPointerUp={finishPointerResize}
+      onPointerCancel={(event) => {
+        const drag = dragRef.current;
+        if (drag?.pointerId === event.pointerId) {
+          dragRef.current = undefined;
+          commitWidth(drag.startWidth);
+        }
+      }}
       title={t.app.sidebar.toggleSidebarRailTitle}
       className={cn(
-        'absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2',
-        'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
-        '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
-        'group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full',
-        '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
-        '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+        'absolute inset-y-0 z-20 m-0 hidden h-auto w-4 touch-none select-none border-0 outline-none after:absolute after:inset-y-0 after:start-1/2 after:w-px after:bg-sidebar-border/60 after:transition-[width,background-color] hover:after:w-0.5 hover:after:bg-primary/70 focus-visible:after:w-0.5 focus-visible:after:bg-ring data-[resizing=true]:after:w-0.5 data-[resizing=true]:after:bg-primary group-data-[side=left]:-right-2 group-data-[side=right]:-left-2 sm:flex',
+        'cursor-col-resize',
+        'group-data-[collapsible=offcanvas]:pointer-events-none group-data-[collapsible=offcanvas]:opacity-0',
         className,
       )}
-      {...props}
     />
   );
 }


### PR DESCRIPTION
## Summary

- keep Shift+Enter inside code blocks, including blocks nested in lists and blockquotes, while preserving multiline Markdown delimiters
- add an accessible desktop sidebar resizer with bounded pointer/keyboard controls, reload persistence, cross-tab sync, and mobile-safe behavior
- turn missing Native FS roots into a dedicated, data-safe recovery flow that can reconnect the same folder or switch workspaces
- surface persisted starred notes in a stable, scroll-bounded sidebar section with active state, stale-path filtering, and mobile navigation

## User impact

These changes address four high-frequency or high-trust problems: surprising code-block exits, a fixed-width sidebar, an opaque missing-folder error, and stars that were difficult to discover or use.

Native FS failures never become an empty-workspace success state, and reconnecting replaces only the stored directory handle after validating the selected folder. Cmd/Ctrl+1–9 shortcuts are intentionally not registered or advertised because browsers reserve them and page-level handling is not reliable.

## Validation

- `pnpm local-ci-check`
  - 1,939 unit tests passed, 1 skipped
  - lint, TypeScript, workspace validation, and Knip gates passed
  - 132 browser E2Es and 7 component tests passed
  - production browser/desktop builds, desktop tests, and Electron persistence smoke passed
- a second full browser run passed all 132 E2Es with no retries
- playwright-cli UX audits covered desktop min/default/max sidebar widths, compact desktop, mobile sheets, long filenames, short-height scrolling, Native FS recovery/reconnect, and nested code-block edit/reload behavior

The first full Playwright run marked three unrelated existing tests flaky after passing on retry: two move-note command-menu tests and the cursor-switch test. The immediate second full run passed all 132 without retries.

## Follow-ups

- after the in-flight Native FS library replacement lands, the isolated reconnect handler will need a mechanical picker/error import migration
- renaming or moving a starred note currently filters the stale old path rather than migrating the star; preserving it needs a separate post-rename metadata failure policy