### PR TITLE
feat(nativefs): external-change auto-refresh — watching, revalidation, editor sync (#521)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -9,6 +9,15 @@
       "env": {
         "BANGLE_DEV_PORT": "5225"
       }
+    },
+    {
+      "name": "bangle-preview-production",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["preview-production"],
+      "port": 4963,
+      "env": {
+        "BANGLE_PREVIEW_PORT": "4963"
+      }
     }
   ]
 }

--- a/packages/core/app/src/pages/page-editor.tsx
+++ b/packages/core/app/src/pages/page-editor.tsx
@@ -25,24 +25,33 @@ export function PageEditor() {
   const $forceReloadCounter = useAtomValue(
     coreServices.editorService.$forceReloadCounter,
   );
+  const routeWsPath = useAtomValue(coreServices.navigation.$wsFilePath);
   const routeWsName = useAtomValue(coreServices.navigation.$wsName);
+  const routeWsPathValue = routeWsPath?.wsPath;
+  const hasPendingSave =
+    routeWsPathValue !== undefined &&
+    coreServices.editorEngine.hasPendingOrFailedSave(routeWsPathValue);
+  // A watcher-driven rename/delete removes the route path from the file tree.
+  // Keep a dirty editor mounted so its only unsaved copy remains recoverable.
+  const editorWsPath =
+    currentWsPath ?? (hasPendingSave ? routeWsPath : undefined);
 
   const editorKey = useMemo(() => {
-    return currentWsPath
-      ? `editor::${MAIN_EDITOR_NAME}:${currentWsPath.wsPath}:${$forceReloadCounter}`
+    return editorWsPath
+      ? `editor::${MAIN_EDITOR_NAME}:${editorWsPath.wsPath}:${$forceReloadCounter}`
       : `${MAIN_EDITOR_NAME}:${$forceReloadCounter}`;
-  }, [currentWsPath, $forceReloadCounter]);
+  }, [editorWsPath, $forceReloadCounter]);
 
   return (
     <>
       <AppHeader />
       <PageContentContainer applyPadding={false}>
-        {currentWsPath && currentWsName ? (
+        {editorWsPath && currentWsName ? (
           <>
             <EditorSurface
               key={editorKey}
               name={editorKey}
-              wsPath={currentWsPath.wsPath}
+              wsPath={editorWsPath.wsPath}
               className={EDITOR_CONTENT_PADDING}
             />
             {/* Clicking the empty space under a short note puts the caret back
@@ -60,7 +69,9 @@ export function PageEditor() {
               tabIndex={-1}
               type="button"
             />
-            <LinkedMentions currentWsPath={currentWsPath} />
+            {/* The editor can outlive the tree entry when a dirty note is
+                externally renamed or deleted, so this has no path to render. */}
+            {currentWsPath && <LinkedMentions currentWsPath={currentWsPath} />}
           </>
         ) : !currentWsName ? (
           <WorkspaceNotFoundView wsName={routeWsName} />

--- a/packages/core/app/src/pages/page-editor.tsx
+++ b/packages/core/app/src/pages/page-editor.tsx
@@ -1,7 +1,7 @@
 import { EDITOR_GUTTER_PADDING_LEFT } from '@bangle.io/constants';
-import { useCoreServices } from '@bangle.io/context';
+import { type EditorEngineContract, useCoreServices } from '@bangle.io/context';
 import { useAtomValue } from 'jotai';
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useSyncExternalStore } from 'react';
 import { LinkedMentions } from '../components/backlinks/linked-mentions';
 import { EditorSurface } from '../components/editor-surface';
 import { NoteNotFoundView } from '../components/feedback/note-not-found-view';
@@ -13,6 +13,35 @@ const MAIN_EDITOR_NAME = 'main-editor';
 
 // APP_MAIN_CONTENT_PADDING with the left side widened for the block handle.
 const EDITOR_CONTENT_PADDING = `py-4 pt-0 pr-4 md:pr-6 ${EDITOR_GUTTER_PADDING_LEFT}`;
+
+type SaveStatusSource = Pick<
+  EditorEngineContract,
+  'hasPendingOrFailedSave' | 'subscribeToSaveStatus'
+>;
+
+/**
+ * Save status lives outside Jotai, so it has to be subscribed to rather than
+ * read during render: otherwise a save that settles after the file tree
+ * dropped the path would never re-render this page.
+ */
+function useHasPendingSave(
+  saveStatus: SaveStatusSource,
+  wsPath: string | undefined,
+): boolean {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      wsPath === undefined
+        ? () => {}
+        : saveStatus.subscribeToSaveStatus(onStoreChange, wsPath),
+    [saveStatus, wsPath],
+  );
+  const getSnapshot = useCallback(
+    () => wsPath !== undefined && saveStatus.hasPendingOrFailedSave(wsPath),
+    [saveStatus, wsPath],
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
 
 export function PageEditor() {
   const coreServices = useCoreServices();
@@ -27,10 +56,10 @@ export function PageEditor() {
   );
   const routeWsPath = useAtomValue(coreServices.navigation.$wsFilePath);
   const routeWsName = useAtomValue(coreServices.navigation.$wsName);
-  const routeWsPathValue = routeWsPath?.wsPath;
-  const hasPendingSave =
-    routeWsPathValue !== undefined &&
-    coreServices.editorEngine.hasPendingOrFailedSave(routeWsPathValue);
+  const hasPendingSave = useHasPendingSave(
+    coreServices.editorEngine,
+    routeWsPath?.wsPath,
+  );
   // A watcher-driven rename/delete removes the route path from the file tree.
   // Keep a dirty editor mounted so its only unsaved copy remains recoverable.
   const editorWsPath =

--- a/packages/core/editor/src/__tests__/editor-save-queue.spec.ts
+++ b/packages/core/editor/src/__tests__/editor-save-queue.spec.ts
@@ -390,6 +390,8 @@ describe('EditorSaveQueue', () => {
     );
 
     firstQueue.enqueue('workspace:note.md', 'old service content');
+    expect(coordinator.hasPendingOrFailedSave('workspace:note.md')).toBe(true);
+    expect(coordinator.hasPendingOrFailedSave()).toBe(true);
 
     const secondQueue = new EditorSaveQueue(
       vi.fn((_: string, doc: string) => {
@@ -414,6 +416,8 @@ describe('EditorSaveQueue', () => {
     expect(secondQueue.getStatus('workspace:note.md')).toEqual({
       status: 'clean',
     });
+    expect(coordinator.hasPendingOrFailedSave('workspace:note.md')).toBe(false);
+    expect(coordinator.hasPendingOrFailedSave()).toBe(false);
   });
 
   it('retries a retained failure through the current service graph', async () => {

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -7,6 +7,7 @@ import {
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { toast } from '@bangle.io/ui-components';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RECONCILE_SETTLE_MS } from '../external-content-sync';
 import { PmEditorService } from '../pm-editor-service';
 
 function asPmEditor(editorEngine: unknown): PmEditorService {
@@ -14,6 +15,15 @@ function asPmEditor(editorEngine: unknown): PmEditorService {
     throw new Error('expected the ProseMirror editor engine');
   }
   return editorEngine;
+}
+
+/**
+ * Waits long enough that "the editor did not change" proves the sync refused
+ * rather than simply not having run yet. Derived from the sync's own timings,
+ * so tuning them cannot turn these negative assertions vacuous.
+ */
+function settleReconcile(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, RECONCILE_SETTLE_MS));
 }
 
 const WS_NAME = 'test-ws';
@@ -260,7 +270,7 @@ describe('editor refresh on external file changes', () => {
 
     // Give the sync path ample opportunity to (incorrectly) run — well past
     // its quiet-period and stability-read delays.
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await settleReconcile();
 
     expect(editorText(domNode)).toContain('USER-UNSAVED-EDIT');
     expect(editorText(domNode)).not.toContain(
@@ -460,7 +470,7 @@ describe('editor refresh on external file changes', () => {
       sender: EXTERNAL_SENDER,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await settleReconcile();
     expect(warningSpy).not.toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
@@ -513,7 +523,7 @@ describe('editor refresh on external file changes', () => {
     });
     allowPreservation.resolve();
 
-    await new Promise((resolve) => setTimeout(resolve, 350));
+    await settleReconcile();
     expect(editorText(domNode)).toContain('the original note body');
     expect(editorText(domNode)).not.toContain(
       'updated while composition begins',
@@ -565,7 +575,7 @@ describe('editor refresh on external file changes', () => {
     });
     allowPreservation.resolve();
 
-    await new Promise((resolve) => setTimeout(resolve, 350));
+    await settleReconcile();
     expect(editorText(domNode)).toContain('the original note body');
     expect(editorText(domNode)).not.toContain(
       'external content from the old path',
@@ -586,7 +596,7 @@ describe('editor refresh on external file changes', () => {
     // is never auto-applied.
     await simulateExternalEdit(testEnv, services, '');
 
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await settleReconcile();
     expect(editorText(domNode)).toContain('the original note body');
   });
 
@@ -653,7 +663,7 @@ describe('editor refresh on external file changes', () => {
     const docBefore = domNode.innerHTML;
 
     await simulateExternalEdit(testEnv, services, 'the original note body\n');
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await settleReconcile();
 
     expect(domNode.innerHTML).toBe(docBefore);
     expect(editorText(domNode)).toContain('the original note body');
@@ -778,6 +788,34 @@ describe('editor refresh on external file changes', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Could not read note.md'),
     );
+    expect(editorText(domNode)).toContain('the original note body');
+  });
+
+  it('reports when loading a requested disk version throws', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const errorSpy = vi.spyOn(toast, 'error');
+
+    await simulateRefusedExternalEdit(testEnv, services);
+
+    // Read and parse/serialize failures both surface here. A parse failure is
+    // deterministic — retrying can never succeed — so the user must be told
+    // the action did nothing rather than left guessing.
+    vi.spyOn(services.fileSystem, 'readFileAsText').mockRejectedValue(
+      new Error('storage read exploded'),
+    );
+    dismissSpy.mockClear();
+    await asPmEditor(services.editorEngine).loadDiskVersionIntoEditors(
+      NOTE_WS_PATH,
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('The disk version of note.md was not loaded'),
+    );
+    // The notice stays: it is still the only way back to the disk copy.
+    expect(dismissSpy).not.toHaveBeenCalledWith(STALE_TOAST_ID);
     expect(editorText(domNode)).toContain('the original note body');
   });
 

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -138,6 +138,34 @@ describe('editor refresh on external file changes', () => {
     ).resolves.toMatchObject({ content: 'the original note body' });
   });
 
+  it('snapshots the exact loaded Markdown when external content replaces a lossy clean document', async () => {
+    const originalSource =
+      'the original note body\n\n[unused]: https://example.com/original\n';
+    const { testEnv, services, domNode } =
+      await setupEditorWithNote(originalSource);
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'updated by a sync tool elsewhere',
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain(
+          'updated by a sync tool elsewhere',
+        );
+      },
+      { timeout: 3_000 },
+    );
+
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    expect(snapshots).toHaveLength(1);
+    await expect(
+      services.noteSnapshot.getSnapshot(snapshots[0]?.id ?? ''),
+    ).resolves.toMatchObject({ content: originalSource });
+  });
+
   it('also refreshes on an external coarse refresh (force-update) event', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',
@@ -204,6 +232,63 @@ describe('editor refresh on external file changes', () => {
 
     // Unwedge the save so the shared queue store returns to clean.
     releaseSave();
+    await vi.waitFor(() => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+    });
+  });
+
+  it('keeps pending editor content on its original path across a foreign-tab rename', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const renamedWsPath = `${WS_NAME}:renamed.md`;
+    const pendingWrites: Array<() => void> = [];
+    const writeSpy = vi
+      .spyOn(services.fileSystem, 'writeFile')
+      .mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            pendingWrites.push(resolve);
+          }),
+      );
+
+    expect(
+      services.editorEngine.insertMarkdownAtSelection('FIRST-LOCAL-EDIT'),
+    ).toBe(true);
+    await vi.waitFor(() => {
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    await services.fileStorageMemory.renameFile(NOTE_WS_PATH, {
+      newWsPath: renamedWsPath,
+    });
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-rename',
+      oldWsPath: NOTE_WS_PATH,
+      wsPath: renamedWsPath,
+      sender: { id: 'another-tab', tag: 'file-system' },
+    });
+
+    expect(
+      asPmEditor(services.editorEngine).getEditorLoadStatus('main-test-editor'),
+    ).toMatchObject({ status: 'ready', wsPath: NOTE_WS_PATH });
+    const editorView = asPmEditor(services.editorEngine).getEditor(
+      'main-test-editor',
+    );
+    expect(editorView).toBeDefined();
+    editorView?.dispatch(editorView.state.tr.insertText('SECOND-LOCAL-EDIT'));
+    expect(editorText(domNode)).toContain('FIRST-LOCAL-EDIT');
+    expect(editorText(domNode)).toContain('SECOND-LOCAL-EDIT');
+
+    pendingWrites.shift()?.();
+    await vi.waitFor(() => {
+      expect(writeSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(writeSpy.mock.calls.map(([wsPath]) => wsPath)).toEqual([
+      NOTE_WS_PATH,
+      NOTE_WS_PATH,
+    ]);
+    pendingWrites.shift()?.();
     await vi.waitFor(() => {
       expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
     });

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -28,7 +28,18 @@ function settleReconcile(): Promise<void> {
 
 const WS_NAME = 'test-ws';
 const NOTE_WS_PATH = `${WS_NAME}:note.md`;
-const REFUSED_SOURCE = 'see [the spec][1]\n\n[1]: https://example.com/spec\n';
+/**
+ * A link reference definition nothing resolves against. The parser consumes it
+ * and emits nothing, so applying this would silently drop content the user can
+ * still see on disk — the one class the auto-apply gate refuses.
+ */
+const REFUSED_SOURCE = 'see the spec\n\n[unused]: https://example.com/spec\n';
+/**
+ * Soft-wrapped prose: reformats on save, but parsing keeps everything. This
+ * must auto-apply rather than leave the editor stale.
+ */
+const REFLOWED_SOURCE =
+  '- Standup notes:\n  https://example.com/standup\n- second item\n';
 const STALE_TOAST_ID = `external-stale-content:${NOTE_WS_PATH}`;
 const EXTERNAL_SENDER = {
   id: 'other-source',
@@ -419,32 +430,64 @@ describe('editor refresh on external file changes', () => {
     expect(editorText(domNode)).toContain('the original note body');
   });
 
-  it('refuses external content that does not round-trip (fidelity gate)', async () => {
+  it('refuses external content whose parse drops what the user can see', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',
     );
 
-    // Reference-style links resolve to inline links in the schema, so
-    // serializing rewrites the source — exactly the lossy shape the load
-    // path refuses. The external sync must refuse it too: applying it would
-    // let the user's next keystroke save the rewritten note.
+    // The parser consumes an unresolved link reference definition and emits
+    // nothing, so applying this would arm the user's next keystroke to delete
+    // a line that is still on disk.
     await simulateRefusedExternalEdit(testEnv, services);
     expect(editorText(domNode)).toContain('the original note body');
-    expect(editorText(domNode)).not.toContain('the spec');
+    expect(editorText(domNode)).not.toContain('see the spec');
   });
 
-  it('refuses lossy source even when it serializes like the open document', async () => {
+  it('auto-applies external content that only reformats on save', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const writeSpy = vi.spyOn(services.fileSystem, 'writeFile');
+
+    // Soft-wrapped list items serialize to one line, so this never round-trips
+    // byte-for-byte — but parsing keeps every word. Refusing it would leave the
+    // editor stale on a large share of ordinary hand-written Markdown.
+    await simulateExternalEdit(testEnv, services, REFLOWED_SOURCE);
+
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain('Standup notes');
+      },
+      { timeout: 3_000 },
+    );
+    expect(editorText(domNode)).toContain('second item');
+    // Applying must not write back, and must not raise the stale-content
+    // notice — the fidelity notice covers the reformat-on-save warning.
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(warningSpy).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ id: STALE_TOAST_ID }),
+    );
+    // The reformat risk is surfaced through the fidelity notice instead.
+    expect(
+      testEnv.store.get(asPmEditor(services.editorEngine).$roundTripWarnings),
+    ).toContain(NOTE_WS_PATH);
+  });
+
+  it('refuses dropped content even when it serializes like the open document', async () => {
     const { testEnv, services } = await setupEditorWithNote(
       'the original note body with [the spec](https://example.com/spec)',
     );
     const warningSpy = vi.spyOn(toast, 'warning');
 
-    // This parses to the same editor document as the inline link above, but
-    // its reference definition would be normalized away by the next save.
+    // Serializes identically to the open document — the unused definition is
+    // the only difference, and it vanishes. The refusal must outrank the
+    // serializer-equality no-op.
     await simulateExternalEdit(
       testEnv,
       services,
-      'the original note body with [the spec][1]\n\n[1]: https://example.com/spec\n',
+      'the original note body with [the spec](https://example.com/spec)\n\n[unused]: https://example.com/other\n',
     );
 
     await vi.waitFor(

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -5,6 +5,7 @@ import {
   WORKSPACE_STORAGE_TYPE,
 } from '@bangle.io/constants';
 import { createTestEnvironment } from '@bangle.io/test-utils';
+import { toast } from '@bangle.io/ui-components';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const WS_NAME = 'test-ws';
@@ -18,6 +19,7 @@ let cleanupControllers: AbortController[] = [];
 let cleanupDomNodes: HTMLElement[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const controller of cleanupControllers) {
     controller.abort();
   }
@@ -364,5 +366,50 @@ describe('editor refresh on external file changes', () => {
 
     expect(domNode.innerHTML).toBe(docBefore);
     expect(editorText(domNode)).toContain('the original note body');
+  });
+
+  it('surfaces a refusal as a per-note warning toast and withdraws it once reconciled', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
+
+    // Content the fidelity gate refuses: without a user-visible surface the
+    // editor would silently show older content than disk forever.
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+    const [message, options] = warningSpy.mock.calls[0] ?? [];
+    expect(String(message)).toContain('note.md');
+    expect(options?.id).toBe(expectedToastId);
+    // The refusal itself still holds — the editor keeps the current note.
+    expect(editorText(domNode)).toContain('the original note body');
+
+    // The sync tool then writes content the editor can apply: the stale
+    // notice is withdrawn instead of lingering over reconciled state.
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'clean content after the conflict',
+    );
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain(
+          'clean content after the conflict',
+        );
+      },
+      { timeout: 3_000 },
+    );
+    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
   });
 });

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -7,7 +7,7 @@ import {
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { toast } from '@bangle.io/ui-components';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { RECONCILE_SETTLE_MS } from '../external-content-sync';
+import { ExternalContentSync } from '../external-content-sync';
 import { PmEditorService } from '../pm-editor-service';
 
 function asPmEditor(editorEngine: unknown): PmEditorService {
@@ -23,7 +23,9 @@ function asPmEditor(editorEngine: unknown): PmEditorService {
  * so tuning them cannot turn these negative assertions vacuous.
  */
 function settleReconcile(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, RECONCILE_SETTLE_MS));
+  return new Promise((resolve) =>
+    setTimeout(resolve, ExternalContentSync.RECONCILE_SETTLE_MS),
+  );
 }
 
 const WS_NAME = 'test-ws';
@@ -501,6 +503,45 @@ describe('editor refresh on external file changes', () => {
     expect(
       testEnv.store.get(asPmEditor(services.editorEngine).$roundTripWarnings),
     ).toContain(NOTE_WS_PATH);
+  });
+
+  it('applies a serializer-equal external change so the fidelity baseline follows disk', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      '- the original note body\n',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const writeSpy = vi.spyOn(services.fileSystem, 'writeFile');
+
+    // `* item` parses to the same document as `- item`, so the serializer
+    // comparison alone calls this an echo. But disk now holds different bytes:
+    // without refreshing the retained baseline and fidelity notice, the next
+    // local save would silently revert the external author's formatting.
+    await simulateExternalEdit(testEnv, services, '* the original note body\n');
+
+    await vi.waitFor(
+      () => {
+        expect(
+          testEnv.store.get(
+            asPmEditor(services.editorEngine).$roundTripWarnings,
+          ),
+        ).toContain(NOTE_WS_PATH);
+      },
+      { timeout: 3_000 },
+    );
+    expect(editorText(domNode)).toContain('the original note body');
+    // Applying is not a save — nothing may bounce back to storage — and a
+    // visually identical document is no reason for a conflict notice.
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(warningSpy).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ id: STALE_TOAST_ID }),
+    );
+    // The pre-change bytes stay recoverable.
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    expect(snapshots).toHaveLength(1);
+    await expect(
+      services.noteSnapshot.getSnapshot(snapshots[0]?.id ?? ''),
+    ).resolves.toMatchObject({ content: '- the original note body\n' });
   });
 
   it('refuses dropped content even when it serializes like the open document', async () => {

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -186,7 +186,7 @@ describe('editor refresh on external file changes', () => {
     );
     const preserveSpy = vi
       .spyOn(services.noteSnapshot, 'preserveExternalOverwrite')
-      .mockResolvedValueOnce(false);
+      .mockResolvedValueOnce('retry');
 
     await simulateExternalEdit(testEnv, services, 'externally updated');
 
@@ -692,6 +692,34 @@ describe('editor refresh on external file changes', () => {
     expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
   });
 
+  it('refuses to replace content it could not preserve', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    // Snapshotting is impossible for this note (e.g. it is over the snapshot
+    // size limit). Applying disk content anyway would destroy the editor's
+    // copy with nothing to recover it from.
+    vi.spyOn(
+      services.noteSnapshot,
+      'preserveExternalOverwrite',
+    ).mockResolvedValue('unpreservable');
+
+    await simulateExternalEdit(testEnv, services, 'externally updated');
+
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalledWith(
+          expect.stringContaining('note.md'),
+          expect.objectContaining({ id: STALE_TOAST_ID }),
+        );
+      },
+      { timeout: 3_000 },
+    );
+    expect(editorText(domNode)).toContain('the original note body');
+    expect(editorText(domNode)).not.toContain('externally updated');
+  });
+
   it('withdraws a stale-content warning when the file is externally deleted', async () => {
     const { testEnv, services } = await setupEditorWithNote(
       'the original note body',
@@ -858,6 +886,8 @@ describe('editor refresh on external file changes', () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',
     );
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const errorSpy = vi.spyOn(toast, 'error');
 
     await simulateRefusedExternalEdit(testEnv, services);
 
@@ -878,12 +908,19 @@ describe('editor refresh on external file changes', () => {
     });
 
     // Their unsaved edit exists nowhere else: the disk version must lose.
+    dismissSpy.mockClear();
     await asPmEditor(services.editorEngine).loadDiskVersionIntoEditors(
       NOTE_WS_PATH,
     );
 
     expect(editorText(domNode)).toContain('USER-EDIT-AFTER-TOAST');
     expect(editorText(domNode)).not.toContain('the spec');
+    // Nothing was loaded, so the notice must stay put with an explanation
+    // rather than vanish as if the request had succeeded.
+    expect(dismissSpy).not.toHaveBeenCalledWith(STALE_TOAST_ID);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('The disk version of note.md was not loaded'),
+    );
 
     releaseSave();
     await vi.waitFor(() => {

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import {
+  EXTERNAL_FILE_CHANGE_SENDER_TAG,
+  WORKSPACE_STORAGE_TYPE,
+} from '@bangle.io/constants';
+import { createTestEnvironment } from '@bangle.io/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const WS_NAME = 'test-ws';
+const NOTE_WS_PATH = `${WS_NAME}:note.md`;
+const EXTERNAL_SENDER = {
+  id: 'other-source',
+  tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
+};
+
+let cleanupControllers: AbortController[] = [];
+let cleanupDomNodes: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const controller of cleanupControllers) {
+    controller.abort();
+  }
+  cleanupControllers = [];
+  for (const domNode of cleanupDomNodes) {
+    domNode.remove();
+  }
+  cleanupDomNodes = [];
+});
+
+async function setupEditorWithNote(initialContent: string) {
+  const controller = new AbortController();
+  cleanupControllers.push(controller);
+  const testEnv = createTestEnvironment({ controller });
+  const services = testEnv.instantiateAll();
+  await testEnv.mountAll();
+
+  await services.workspaceOps.createWorkspaceInfo({
+    name: WS_NAME,
+    type: WORKSPACE_STORAGE_TYPE.Memory,
+    metadata: {},
+  });
+  await services.fileSystem.createTextFile(NOTE_WS_PATH, initialContent);
+
+  const domNode = document.createElement('div');
+  document.body.append(domNode);
+  cleanupDomNodes.push(domNode);
+
+  services.editorEngine.mountEditor({
+    domNode,
+    wsPath: NOTE_WS_PATH,
+    name: 'main-test-editor',
+    focus: false,
+  });
+  await vi.waitFor(() => {
+    expect(editorText(domNode)).toContain('the original note body');
+  });
+
+  return { testEnv, services, domNode };
+}
+
+// `mountEditor` turns the passed node itself into the contenteditable
+// ProseMirror root, so the editor content is the node's own content.
+function editorText(domNode: HTMLElement): string {
+  return domNode.textContent ?? '';
+}
+
+/**
+ * Simulates a sync tool changing the file on disk: the storage adapter is
+ * written to directly (no FileSystemService events fire), then the tagged
+ * external event that a storage watcher would produce is emitted.
+ */
+async function simulateExternalEdit(
+  testEnv: Awaited<ReturnType<typeof setupEditorWithNote>>['testEnv'],
+  services: Awaited<ReturnType<typeof setupEditorWithNote>>['services'],
+  content: string,
+) {
+  await services.fileStorageMemory.writeFile(
+    NOTE_WS_PATH,
+    new File([content], 'note.md', { type: 'text/plain' }),
+  );
+  testEnv.rootEmitter.emit('event::file:update', {
+    type: 'file-content-update',
+    wsPath: NOTE_WS_PATH,
+    sender: EXTERNAL_SENDER,
+  });
+}
+
+describe('editor refresh on external file changes', () => {
+  it('replaces a clean editor with the external content without re-saving it', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const writeSpy = vi.spyOn(services.fileSystem, 'writeFile');
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'updated by a sync tool elsewhere',
+    );
+
+    await vi.waitFor(() => {
+      expect(editorText(domNode)).toContain('updated by a sync tool elsewhere');
+      expect(editorText(domNode)).not.toContain('the original note body');
+    });
+
+    // Applying external content must not bounce a save back to storage —
+    // that write would churn the file's mtime and make sync tools loop.
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('also refreshes on an external coarse refresh (force-update) event', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    await services.fileStorageMemory.writeFile(
+      NOTE_WS_PATH,
+      new File(['content after coarse refresh'], 'note.md', {
+        type: 'text/plain',
+      }),
+    );
+    testEnv.rootEmitter.emit('event::file:force-update', {
+      sender: EXTERNAL_SENDER,
+    });
+
+    await vi.waitFor(() => {
+      expect(editorText(domNode)).toContain('content after coarse refresh');
+    });
+  });
+
+  it('never clobbers unsaved editor content: pending edits win over the external copy', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    // Wedge the save pipeline so the user's edit stays pending/unsaved.
+    vi.spyOn(services.fileSystem, 'writeFile').mockImplementation(
+      () => new Promise<void>(() => {}),
+    );
+
+    // Simulate the user typing (inserts at the current selection and
+    // enqueues a save, which now hangs).
+    expect(
+      services.editorEngine.insertMarkdownAtSelection('USER-UNSAVED-EDIT'),
+    ).toBe(true);
+    await vi.waitFor(() => {
+      expect(editorText(domNode)).toContain('USER-UNSAVED-EDIT');
+    });
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'external content that must not win',
+    );
+
+    // Give the sync path ample opportunity to (incorrectly) run.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(editorText(domNode)).toContain('USER-UNSAVED-EDIT');
+    expect(editorText(domNode)).not.toContain(
+      'external content that must not win',
+    );
+  });
+
+  it('leaves the editor untouched when the external content is identical (echo)', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    const docBefore = domNode.innerHTML;
+
+    await simulateExternalEdit(testEnv, services, 'the original note body\n');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(domNode.innerHTML).toBe(docBefore);
+    expect(editorText(domNode)).toContain('the original note body');
+  });
+});

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -99,10 +99,15 @@ describe('editor refresh on external file changes', () => {
       'updated by a sync tool elsewhere',
     );
 
-    await vi.waitFor(() => {
-      expect(editorText(domNode)).toContain('updated by a sync tool elsewhere');
-      expect(editorText(domNode)).not.toContain('the original note body');
-    });
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain(
+          'updated by a sync tool elsewhere',
+        );
+        expect(editorText(domNode)).not.toContain('the original note body');
+      },
+      { timeout: 3_000 },
+    );
 
     // Applying external content must not bounce a save back to storage —
     // that write would churn the file's mtime and make sync tools loop.
@@ -124,9 +129,12 @@ describe('editor refresh on external file changes', () => {
       sender: EXTERNAL_SENDER,
     });
 
-    await vi.waitFor(() => {
-      expect(editorText(domNode)).toContain('content after coarse refresh');
-    });
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain('content after coarse refresh');
+      },
+      { timeout: 3_000 },
+    );
   });
 
   it('never clobbers unsaved editor content: pending edits win over the external copy', async () => {
@@ -135,8 +143,15 @@ describe('editor refresh on external file changes', () => {
     );
 
     // Wedge the save pipeline so the user's edit stays pending/unsaved.
+    // Resolvable at the end: the save queue store is a module-level
+    // singleton (production wiring), so a forever-pending entry would leak
+    // a dirty state for this wsPath into later tests.
+    let releaseSave = () => {};
     vi.spyOn(services.fileSystem, 'writeFile').mockImplementation(
-      () => new Promise<void>(() => {}),
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        }),
     );
 
     // Simulate the user typing (inserts at the current selection and
@@ -154,13 +169,98 @@ describe('editor refresh on external file changes', () => {
       'external content that must not win',
     );
 
-    // Give the sync path ample opportunity to (incorrectly) run.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Give the sync path ample opportunity to (incorrectly) run — well past
+    // its quiet-period and stability-read delays.
+    await new Promise((resolve) => setTimeout(resolve, 700));
 
     expect(editorText(domNode)).toContain('USER-UNSAVED-EDIT');
     expect(editorText(domNode)).not.toContain(
       'external content that must not win',
     );
+
+    // Unwedge the save so the shared queue store returns to clean.
+    releaseSave();
+    await vi.waitFor(() => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+    });
+  });
+
+  it('does not apply a transient mid-write read; it settles on the final content', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    // Simulate a truncate-then-write external editor: the first read after
+    // the watcher event sees an empty file, later reads see the final
+    // content. The empty snapshot must never reach the editor.
+    const realRead = services.fileSystem.readFileAsText.bind(
+      services.fileSystem,
+    );
+    const readSpy = vi
+      .spyOn(services.fileSystem, 'readFileAsText')
+      .mockImplementation(realRead);
+    readSpy.mockImplementationOnce(async () => '');
+
+    await simulateExternalEdit(testEnv, services, 'final synced content');
+
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain('final synced content');
+      },
+      { timeout: 3_000 },
+    );
+    // The transient empty read never replaced the doc: had it been applied,
+    // the placeholder-empty doc would have been visible and, worse, the
+    // final content would only arrive via a second watcher event that this
+    // simulation never sends.
+  });
+
+  it('applies external content to a note loaded after another note primed the markdown loader', async () => {
+    // Regression: markdown loaders are schema-bound and every editor builds
+    // its own schema. Loading one note first (its load-time fidelity check
+    // primes the loader) must not make a later note's external sync parse
+    // with a foreign schema — that silently produced an empty document.
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    const otherWsPath = `${WS_NAME}:other.md`;
+    await services.fileSystem.createTextFile(otherWsPath, 'other note');
+    const otherDomNode = document.createElement('div');
+    document.body.append(otherDomNode);
+    cleanupDomNodes.push(otherDomNode);
+    services.editorEngine.mountEditor({
+      domNode: otherDomNode,
+      wsPath: otherWsPath,
+      name: 'second-test-editor',
+      focus: false,
+    });
+    await vi.waitFor(() => {
+      expect(otherDomNode.textContent).toContain('other note');
+    });
+
+    await services.fileStorageMemory.writeFile(
+      otherWsPath,
+      new File(['other note updated externally'], 'other.md', {
+        type: 'text/plain',
+      }),
+    );
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: otherWsPath,
+      sender: EXTERNAL_SENDER,
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(otherDomNode.textContent).toContain(
+          'other note updated externally',
+        );
+      },
+      { timeout: 3_000 },
+    );
+    // The first editor is untouched.
+    expect(editorText(domNode)).toContain('the original note body');
   });
 
   it('leaves the editor untouched when the external content is identical (echo)', async () => {
@@ -171,7 +271,7 @@ describe('editor refresh on external file changes', () => {
     const docBefore = domNode.innerHTML;
 
     await simulateExternalEdit(testEnv, services, 'the original note body\n');
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await new Promise((resolve) => setTimeout(resolve, 700));
 
     expect(domNode.innerHTML).toBe(docBefore);
     expect(editorText(domNode)).toContain('the original note body');

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -263,6 +263,40 @@ describe('editor refresh on external file changes', () => {
     expect(editorText(domNode)).toContain('the original note body');
   });
 
+  it('refuses external content that does not round-trip (fidelity gate)', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    // Reference-style links resolve to inline links in the schema, so
+    // serializing rewrites the source — exactly the lossy shape the load
+    // path refuses. The external sync must refuse it too: applying it would
+    // let the user's next keystroke save the rewritten note.
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(editorText(domNode)).toContain('the original note body');
+    expect(editorText(domNode)).not.toContain('the spec');
+  });
+
+  it('never blanks a non-empty note from an external truncation', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    // A truncate-then-write writer can stay empty across both stability
+    // reads. Emptying the note is the destructive shape of that race, so it
+    // is never auto-applied.
+    await simulateExternalEdit(testEnv, services, '');
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(editorText(domNode)).toContain('the original note body');
+  });
+
   it('a workspace-scoped refresh does not touch editors in other workspaces', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -130,6 +130,12 @@ describe('editor refresh on external file changes', () => {
     // Applying external content must not bounce a save back to storage —
     // that write would churn the file's mtime and make sync tools loop.
     expect(writeSpy).not.toHaveBeenCalled();
+
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    expect(snapshots).toHaveLength(1);
+    await expect(
+      services.noteSnapshot.getSnapshot(snapshots[0]?.id ?? ''),
+    ).resolves.toMatchObject({ content: 'the original note body' });
   });
 
   it('also refreshes on an external coarse refresh (force-update) event', async () => {

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -392,6 +392,159 @@ describe('editor refresh on external file changes', () => {
     expect(editorText(domNode)).not.toContain('the spec');
   });
 
+  it('refuses lossy source even when it serializes like the open document', async () => {
+    const { testEnv, services } = await setupEditorWithNote(
+      'the original note body with [the spec](https://example.com/spec)',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+
+    // This parses to the same editor document as the inline link above, but
+    // its reference definition would be normalized away by the next save.
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'the original note body with [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            id: `external-stale-content:${NOTE_WS_PATH}`,
+          }),
+        );
+      },
+      { timeout: 3_000 },
+    );
+  });
+
+  it('does not report unchanged lossy source as a coarse-refresh conflict', async () => {
+    const { testEnv } = await setupEditorWithNote(
+      'the original note body with [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+
+    testEnv.rootEmitter.emit('event::file:force-update', {
+      sender: EXTERNAL_SENDER,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(warningSpy).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        id: `external-stale-content:${NOTE_WS_PATH}`,
+      }),
+    );
+  });
+
+  it('does not replace an editor when IME composition starts during preservation', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const editorView = asPmEditor(services.editorEngine).getEditor(
+      'main-test-editor',
+    );
+    expect(editorView).toBeDefined();
+    if (!editorView) {
+      throw new Error('expected mounted editor');
+    }
+
+    const preservationStarted = createDeferred<void>();
+    const allowPreservation = createDeferred<void>();
+    const originalPreserve =
+      services.noteSnapshot.preserveExternalOverwrite.bind(
+        services.noteSnapshot,
+      );
+    let firstCall = true;
+    vi.spyOn(
+      services.noteSnapshot,
+      'preserveExternalOverwrite',
+    ).mockImplementation(async (...args) => {
+      if (firstCall) {
+        firstCall = false;
+        preservationStarted.resolve();
+        await allowPreservation.promise;
+      }
+      await originalPreserve(...args);
+    });
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'updated while composition begins',
+    );
+    await preservationStarted.promise;
+    let composing = true;
+    Object.defineProperty(editorView, 'composing', {
+      configurable: true,
+      get: () => composing,
+    });
+    allowPreservation.resolve();
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(editorText(domNode)).toContain('the original note body');
+    expect(editorText(domNode)).not.toContain(
+      'updated while composition begins',
+    );
+
+    composing = false;
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain(
+          'updated while composition begins',
+        );
+      },
+      { timeout: 4_000 },
+    );
+    Reflect.deleteProperty(editorView, 'composing');
+  });
+
+  it('does not replace or save a view renamed during preservation', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const preservationStarted = createDeferred<void>();
+    const allowPreservation = createDeferred<void>();
+    const originalPreserve =
+      services.noteSnapshot.preserveExternalOverwrite.bind(
+        services.noteSnapshot,
+      );
+    vi.spyOn(
+      services.noteSnapshot,
+      'preserveExternalOverwrite',
+    ).mockImplementation(async (...args) => {
+      preservationStarted.resolve();
+      await allowPreservation.promise;
+      await originalPreserve(...args);
+    });
+    const writeSpy = vi.spyOn(services.fileSystem, 'writeFile');
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'external content from the old path',
+    );
+    await preservationStarted.promise;
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-rename',
+      oldWsPath: NOTE_WS_PATH,
+      wsPath: `${WS_NAME}:renamed.md`,
+      sender: EXTERNAL_SENDER,
+    });
+    allowPreservation.resolve();
+
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    expect(editorText(domNode)).toContain('the original note body');
+    expect(editorText(domNode)).not.toContain(
+      'external content from the old path',
+    );
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(
+      asPmEditor(services.editorEngine).getEditorLoadStatus('main-test-editor'),
+    ).toMatchObject({ wsPath: `${WS_NAME}:renamed.md` });
+  });
+
   it('never blanks a non-empty note from an external truncation', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',
@@ -526,11 +679,9 @@ describe('editor refresh on external file changes', () => {
     const dismissSpy = vi.spyOn(toast, 'dismiss');
 
     // Fidelity-refused external content: the editor keeps the current note.
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
+    const refusedSource =
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n';
+    await simulateExternalEdit(testEnv, services, refusedSource);
     await new Promise((resolve) => setTimeout(resolve, 700));
     expect(editorText(domNode)).toContain('the original note body');
 
@@ -548,6 +699,39 @@ describe('editor refresh on external file changes', () => {
     expect(dismissSpy).toHaveBeenCalledWith(
       `external-stale-content:${NOTE_WS_PATH}`,
     );
+
+    const snapshotsAfterManualLoad =
+      await services.noteSnapshot.listSnapshots();
+    const originalSnapshot = await services.noteSnapshot.getSnapshot(
+      snapshotsAfterManualLoad[0]?.id ?? '',
+    );
+    expect(originalSnapshot?.content).toBe('the original note body');
+
+    // The accepted disk source becomes the new exact baseline. A later
+    // external replacement must preserve the reference-style Markdown, not
+    // the editor's normalized inline-link serialization.
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'clean content after manual recovery',
+    );
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain(
+          'clean content after manual recovery',
+        );
+      },
+      { timeout: 3_000 },
+    );
+    const snapshotsAfterExternalReplace =
+      await services.noteSnapshot.listSnapshots();
+    const snapshotContents = await Promise.all(
+      snapshotsAfterExternalReplace.map(
+        async ({ id }) =>
+          (await services.noteSnapshot.getSnapshot(id))?.content,
+      ),
+    );
+    expect(snapshotContents).toContain(refusedSource);
   });
 
   it('loading the disk version refuses to clobber edits made since the refusal', async () => {

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -18,6 +18,8 @@ function asPmEditor(editorEngine: unknown): PmEditorService {
 
 const WS_NAME = 'test-ws';
 const NOTE_WS_PATH = `${WS_NAME}:note.md`;
+const REFUSED_SOURCE = 'see [the spec][1]\n\n[1]: https://example.com/spec\n';
+const STALE_TOAST_ID = `external-stale-content:${NOTE_WS_PATH}`;
 const EXTERNAL_SENDER = {
   id: 'other-source',
   tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
@@ -102,6 +104,18 @@ async function simulateExternalEdit(
     wsPath: NOTE_WS_PATH,
     sender: EXTERNAL_SENDER,
   });
+}
+
+async function simulateRefusedExternalEdit(
+  testEnv: Awaited<ReturnType<typeof setupEditorWithNote>>['testEnv'],
+  services: Awaited<ReturnType<typeof setupEditorWithNote>>['services'],
+) {
+  const warningSpy = vi.spyOn(toast, 'warning');
+  await simulateExternalEdit(testEnv, services, REFUSED_SOURCE);
+  await vi.waitFor(() => expect(warningSpy).toHaveBeenCalled(), {
+    timeout: 3_000,
+  });
+  return warningSpy;
 }
 
 describe('editor refresh on external file changes', () => {
@@ -381,13 +395,7 @@ describe('editor refresh on external file changes', () => {
     // serializing rewrites the source — exactly the lossy shape the load
     // path refuses. The external sync must refuse it too: applying it would
     // let the user's next keystroke save the rewritten note.
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await simulateRefusedExternalEdit(testEnv, services);
     expect(editorText(domNode)).toContain('the original note body');
     expect(editorText(domNode)).not.toContain('the spec');
   });
@@ -466,7 +474,7 @@ describe('editor refresh on external file changes', () => {
         preservationStarted.resolve();
         await allowPreservation.promise;
       }
-      await originalPreserve(...args);
+      return originalPreserve(...args);
     });
 
     await simulateExternalEdit(
@@ -516,7 +524,7 @@ describe('editor refresh on external file changes', () => {
     ).mockImplementation(async (...args) => {
       preservationStarted.resolve();
       await allowPreservation.promise;
-      await originalPreserve(...args);
+      return originalPreserve(...args);
     });
     const writeSpy = vi.spyOn(services.fileSystem, 'writeFile');
 
@@ -632,26 +640,14 @@ describe('editor refresh on external file changes', () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',
     );
-    const warningSpy = vi.spyOn(toast, 'warning');
     const dismissSpy = vi.spyOn(toast, 'dismiss');
-    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
 
     // Content the fidelity gate refuses: without a user-visible surface the
     // editor would silently show older content than disk forever.
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await vi.waitFor(
-      () => {
-        expect(warningSpy).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
+    const warningSpy = await simulateRefusedExternalEdit(testEnv, services);
     const [message, options] = warningSpy.mock.calls[0] ?? [];
     expect(String(message)).toContain('note.md');
-    expect(options?.id).toBe(expectedToastId);
+    expect(options?.id).toBe(STALE_TOAST_ID);
     // The refusal itself still holds — the editor keeps the current note.
     expect(editorText(domNode)).toContain('the original note body');
 
@@ -670,28 +666,16 @@ describe('editor refresh on external file changes', () => {
       },
       { timeout: 3_000 },
     );
-    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
   });
 
   it('withdraws a stale-content warning when the file is externally deleted', async () => {
     const { testEnv, services } = await setupEditorWithNote(
       'the original note body',
     );
-    const warningSpy = vi.spyOn(toast, 'warning');
     const dismissSpy = vi.spyOn(toast, 'dismiss');
-    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
 
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await vi.waitFor(
-      () => {
-        expect(warningSpy).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
+    await simulateRefusedExternalEdit(testEnv, services);
 
     dismissSpy.mockClear();
     testEnv.rootEmitter.emit('event::file:update', {
@@ -700,28 +684,16 @@ describe('editor refresh on external file changes', () => {
       sender: EXTERNAL_SENDER,
     });
 
-    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
   });
 
   it('withdraws a stale-content warning when the file is externally renamed', async () => {
     const { testEnv, services } = await setupEditorWithNote(
       'the original note body',
     );
-    const warningSpy = vi.spyOn(toast, 'warning');
     const dismissSpy = vi.spyOn(toast, 'dismiss');
-    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
 
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await vi.waitFor(
-      () => {
-        expect(warningSpy).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
+    await simulateRefusedExternalEdit(testEnv, services);
 
     dismissSpy.mockClear();
     testEnv.rootEmitter.emit('event::file:update', {
@@ -731,29 +703,17 @@ describe('editor refresh on external file changes', () => {
       sender: EXTERNAL_SENDER,
     });
 
-    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
   });
 
   it('reports when a requested disk version is no longer readable', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',
     );
-    const warningSpy = vi.spyOn(toast, 'warning');
     const dismissSpy = vi.spyOn(toast, 'dismiss');
     const errorSpy = vi.spyOn(toast, 'error');
-    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
 
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await vi.waitFor(
-      () => {
-        expect(warningSpy).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
+    await simulateRefusedExternalEdit(testEnv, services);
 
     vi.spyOn(services.fileSystem, 'readFileAsText').mockResolvedValue(
       undefined,
@@ -763,7 +723,7 @@ describe('editor refresh on external file changes', () => {
       NOTE_WS_PATH,
     );
 
-    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Could not read note.md'),
     );
@@ -774,21 +734,9 @@ describe('editor refresh on external file changes', () => {
     const { testEnv, services } = await setupEditorWithNote(
       'the original note body',
     );
-    const warningSpy = vi.spyOn(toast, 'warning');
     const dismissSpy = vi.spyOn(toast, 'dismiss');
-    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
 
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await vi.waitFor(
-      () => {
-        expect(warningSpy).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
+    await simulateRefusedExternalEdit(testEnv, services);
 
     dismissSpy.mockClear();
     expect(
@@ -796,7 +744,7 @@ describe('editor refresh on external file changes', () => {
     ).toBe(true);
     await vi.waitFor(() => {
       expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
-      expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+      expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
     });
   });
 
@@ -804,50 +752,26 @@ describe('editor refresh on external file changes', () => {
     const { testEnv, services, unmountEditor } = await setupEditorWithNote(
       'the original note body',
     );
-    const warningSpy = vi.spyOn(toast, 'warning');
     const dismissSpy = vi.spyOn(toast, 'dismiss');
-    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
 
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await vi.waitFor(
-      () => {
-        expect(warningSpy).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
+    await simulateRefusedExternalEdit(testEnv, services);
 
     dismissSpy.mockClear();
     unmountEditor();
-    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
   });
 
   it('withdraws tracked stale-content warnings during service cleanup', async () => {
     const { controller, testEnv, services } = await setupEditorWithNote(
       'the original note body',
     );
-    const warningSpy = vi.spyOn(toast, 'warning');
     const dismissSpy = vi.spyOn(toast, 'dismiss');
-    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
 
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await vi.waitFor(
-      () => {
-        expect(warningSpy).toHaveBeenCalled();
-      },
-      { timeout: 3_000 },
-    );
+    await simulateRefusedExternalEdit(testEnv, services);
 
     dismissSpy.mockClear();
     controller.abort();
-    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
   });
 
   it('loading the disk version applies refused content in place without writing back', async () => {
@@ -857,10 +781,7 @@ describe('editor refresh on external file changes', () => {
     const dismissSpy = vi.spyOn(toast, 'dismiss');
 
     // Fidelity-refused external content: the editor keeps the current note.
-    const refusedSource =
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n';
-    await simulateExternalEdit(testEnv, services, refusedSource);
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await simulateRefusedExternalEdit(testEnv, services);
     expect(editorText(domNode)).toContain('the original note body');
 
     // The user consents via the toast action: the disk version replaces
@@ -874,9 +795,7 @@ describe('editor refresh on external file changes', () => {
     expect(editorText(domNode)).not.toContain('the original note body');
     // Consented content equals disk: writing it back would churn mtime.
     expect(writeSpy).not.toHaveBeenCalled();
-    expect(dismissSpy).toHaveBeenCalledWith(
-      `external-stale-content:${NOTE_WS_PATH}`,
-    );
+    expect(dismissSpy).toHaveBeenCalledWith(STALE_TOAST_ID);
 
     const snapshotsAfterManualLoad =
       await services.noteSnapshot.listSnapshots();
@@ -909,7 +828,7 @@ describe('editor refresh on external file changes', () => {
           (await services.noteSnapshot.getSnapshot(id))?.content,
       ),
     );
-    expect(snapshotContents).toContain(refusedSource);
+    expect(snapshotContents).toContain(REFUSED_SOURCE);
   });
 
   it('loading the disk version refuses to clobber edits made since the refusal', async () => {
@@ -917,12 +836,7 @@ describe('editor refresh on external file changes', () => {
       'the original note body',
     );
 
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await new Promise((resolve) => setTimeout(resolve, 700));
+    await simulateRefusedExternalEdit(testEnv, services);
 
     // The user typed after the refusal toast appeared; wedge the save so
     // the edit stays pending (same module-level queue caveat as above).
@@ -946,63 +860,6 @@ describe('editor refresh on external file changes', () => {
     );
 
     expect(editorText(domNode)).toContain('USER-EDIT-AFTER-TOAST');
-    expect(editorText(domNode)).not.toContain('the spec');
-
-    releaseSave();
-    await vi.waitFor(() => {
-      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
-    });
-  });
-
-  it('loading the disk version refuses edits made while the disk read is pending', async () => {
-    const { testEnv, services, domNode } = await setupEditorWithNote(
-      'the original note body',
-    );
-
-    await simulateExternalEdit(
-      testEnv,
-      services,
-      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
-    );
-    await new Promise((resolve) => setTimeout(resolve, 700));
-
-    const readStarted = createDeferred<void>();
-    const allowRead = createDeferred<void>();
-    const originalRead = services.fileSystem.readFileAsText.bind(
-      services.fileSystem,
-    );
-    vi.spyOn(services.fileSystem, 'readFileAsText').mockImplementation(
-      async (...args) => {
-        readStarted.resolve();
-        await allowRead.promise;
-        return originalRead(...args);
-      },
-    );
-
-    let releaseSave = () => {};
-    vi.spyOn(services.fileSystem, 'writeFile').mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseSave = resolve;
-        }),
-    );
-
-    const loadPromise = asPmEditor(
-      services.editorEngine,
-    ).loadDiskVersionIntoEditors(NOTE_WS_PATH);
-    await readStarted.promise;
-
-    expect(
-      services.editorEngine.insertMarkdownAtSelection('EDIT-DURING-DISK-READ'),
-    ).toBe(true);
-    await vi.waitFor(() => {
-      expect(editorText(domNode)).toContain('EDIT-DURING-DISK-READ');
-    });
-
-    allowRead.resolve();
-    await loadPromise;
-
-    expect(editorText(domNode)).toContain('EDIT-DURING-DISK-READ');
     expect(editorText(domNode)).not.toContain('the spec');
 
     releaseSave();

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -7,6 +7,14 @@ import {
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { toast } from '@bangle.io/ui-components';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PmEditorService } from '../pm-editor-service';
+
+function asPmEditor(editorEngine: unknown): PmEditorService {
+  if (!(editorEngine instanceof PmEditorService)) {
+    throw new Error('expected the ProseMirror editor engine');
+  }
+  return editorEngine;
+}
 
 const WS_NAME = 'test-ws';
 const NOTE_WS_PATH = `${WS_NAME}:note.md`;
@@ -17,6 +25,14 @@ const EXTERNAL_SENDER = {
 
 let cleanupControllers: AbortController[] = [];
 let cleanupDomNodes: HTMLElement[] = [];
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -411,5 +427,134 @@ describe('editor refresh on external file changes', () => {
       { timeout: 3_000 },
     );
     expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+  });
+  it('loading the disk version applies refused content in place without writing back', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+
+    // Fidelity-refused external content: the editor keeps the current note.
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    expect(editorText(domNode)).toContain('the original note body');
+
+    // The user consents via the toast action: the disk version replaces
+    // only this note's editors — no UI reload, no other editor touched.
+    const writeSpy = vi.spyOn(services.fileSystem, 'writeFile');
+    await asPmEditor(services.editorEngine).loadDiskVersionIntoEditors(
+      NOTE_WS_PATH,
+    );
+
+    expect(editorText(domNode)).toContain('the spec');
+    expect(editorText(domNode)).not.toContain('the original note body');
+    // Consented content equals disk: writing it back would churn mtime.
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(dismissSpy).toHaveBeenCalledWith(
+      `external-stale-content:${NOTE_WS_PATH}`,
+    );
+  });
+
+  it('loading the disk version refuses to clobber edits made since the refusal', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    // The user typed after the refusal toast appeared; wedge the save so
+    // the edit stays pending (same module-level queue caveat as above).
+    let releaseSave = () => {};
+    vi.spyOn(services.fileSystem, 'writeFile').mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        }),
+    );
+    expect(
+      services.editorEngine.insertMarkdownAtSelection('USER-EDIT-AFTER-TOAST'),
+    ).toBe(true);
+    await vi.waitFor(() => {
+      expect(editorText(domNode)).toContain('USER-EDIT-AFTER-TOAST');
+    });
+
+    // Their unsaved edit exists nowhere else: the disk version must lose.
+    await asPmEditor(services.editorEngine).loadDiskVersionIntoEditors(
+      NOTE_WS_PATH,
+    );
+
+    expect(editorText(domNode)).toContain('USER-EDIT-AFTER-TOAST');
+    expect(editorText(domNode)).not.toContain('the spec');
+
+    releaseSave();
+    await vi.waitFor(() => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+    });
+  });
+
+  it('loading the disk version refuses edits made while the disk read is pending', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await new Promise((resolve) => setTimeout(resolve, 700));
+
+    const readStarted = createDeferred<void>();
+    const allowRead = createDeferred<void>();
+    const originalRead = services.fileSystem.readFileAsText.bind(
+      services.fileSystem,
+    );
+    vi.spyOn(services.fileSystem, 'readFileAsText').mockImplementation(
+      async (...args) => {
+        readStarted.resolve();
+        await allowRead.promise;
+        return originalRead(...args);
+      },
+    );
+
+    let releaseSave = () => {};
+    vi.spyOn(services.fileSystem, 'writeFile').mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        }),
+    );
+
+    const loadPromise = asPmEditor(
+      services.editorEngine,
+    ).loadDiskVersionIntoEditors(NOTE_WS_PATH);
+    await readStarted.promise;
+
+    expect(
+      services.editorEngine.insertMarkdownAtSelection('EDIT-DURING-DISK-READ'),
+    ).toBe(true);
+    await vi.waitFor(() => {
+      expect(editorText(domNode)).toContain('EDIT-DURING-DISK-READ');
+    });
+
+    allowRead.resolve();
+    await loadPromise;
+
+    expect(editorText(domNode)).toContain('EDIT-DURING-DISK-READ');
+    expect(editorText(domNode)).not.toContain('the spec');
+
+    releaseSave();
+    await vi.waitFor(() => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+    });
   });
 });

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -263,6 +263,61 @@ describe('editor refresh on external file changes', () => {
     expect(editorText(domNode)).toContain('the original note body');
   });
 
+  it('a workspace-scoped refresh does not touch editors in other workspaces', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+
+    // Mount a second editor in a different workspace.
+    const OTHER_WS = 'other-ws';
+    await services.workspaceOps.createWorkspaceInfo({
+      name: OTHER_WS,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    const otherWsPath = `${OTHER_WS}:note.md`;
+    await services.fileSystem.createTextFile(otherWsPath, 'other ws note');
+    const otherDomNode = document.createElement('div');
+    document.body.append(otherDomNode);
+    cleanupDomNodes.push(otherDomNode);
+    services.editorEngine.mountEditor({
+      domNode: otherDomNode,
+      wsPath: otherWsPath,
+      name: 'other-ws-editor',
+      focus: false,
+    });
+    await vi.waitFor(() => {
+      expect(otherDomNode.textContent).toContain('other ws note');
+    });
+
+    // Change BOTH notes on storage, then send a refresh scoped to OTHER_WS.
+    await services.fileStorageMemory.writeFile(
+      NOTE_WS_PATH,
+      new File(['changed but out of scope'], 'note.md', {
+        type: 'text/plain',
+      }),
+    );
+    await services.fileStorageMemory.writeFile(
+      otherWsPath,
+      new File(['other ws refreshed'], 'note.md', { type: 'text/plain' }),
+    );
+    testEnv.rootEmitter.emit('event::file:force-update', {
+      wsName: OTHER_WS,
+      sender: EXTERNAL_SENDER,
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(otherDomNode.textContent).toContain('other ws refreshed');
+      },
+      { timeout: 3_000 },
+    );
+    // The first workspace's editor was outside the refresh scope: untouched
+    // even though its file changed on storage.
+    expect(editorText(domNode)).toContain('the original note body');
+    expect(editorText(domNode)).not.toContain('changed but out of scope');
+  });
+
   it('leaves the editor untouched when the external content is identical (echo)', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -180,6 +180,29 @@ describe('editor refresh on external file changes', () => {
     ).resolves.toMatchObject({ content: originalSource });
   });
 
+  it('retries the replacement when snapshot preservation fails', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const preserveSpy = vi
+      .spyOn(services.noteSnapshot, 'preserveExternalOverwrite')
+      .mockResolvedValueOnce(false);
+
+    await simulateExternalEdit(testEnv, services, 'externally updated');
+
+    await vi.waitFor(
+      () => {
+        expect(preserveSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect(editorText(domNode)).toContain('externally updated');
+      },
+      { timeout: 4_000 },
+    );
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    await expect(
+      services.noteSnapshot.getSnapshot(snapshots[0]?.id ?? ''),
+    ).resolves.toMatchObject({ content: 'the original note body' });
+  });
+
   it('also refreshes on an external coarse refresh (force-update) event', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -443,6 +443,34 @@ describe('editor refresh on external file changes', () => {
     expect(editorText(domNode)).not.toContain('see the spec');
   });
 
+  it('auto-applies a resolved reference link', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+
+    // A definition that a link resolves against survives the parse as that
+    // link's target, so nothing is lost. This is the largest class of real
+    // Markdown the byte comparison alone used to leave permanently stale.
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][ref]\n\n[ref]: https://example.com/spec\n',
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(editorText(domNode)).toContain('the spec');
+      },
+      { timeout: 3_000 },
+    );
+    expect(editorText(domNode)).not.toContain('the original note body');
+    expect(warningSpy).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ id: STALE_TOAST_ID }),
+    );
+  });
+
   it('auto-applies external content that only reformats on save', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -64,7 +64,7 @@ async function setupEditorWithNote(initialContent: string) {
   document.body.append(domNode);
   cleanupDomNodes.push(domNode);
 
-  services.editorEngine.mountEditor({
+  const unmountEditor = services.editorEngine.mountEditor({
     domNode,
     wsPath: NOTE_WS_PATH,
     name: 'main-test-editor',
@@ -74,7 +74,7 @@ async function setupEditorWithNote(initialContent: string) {
     expect(editorText(domNode)).toContain('the original note body');
   });
 
-  return { testEnv, services, domNode };
+  return { controller, testEnv, services, domNode, unmountEditor };
 }
 
 // `mountEditor` turns the passed node itself into the contenteditable
@@ -672,6 +672,184 @@ describe('editor refresh on external file changes', () => {
     );
     expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
   });
+
+  it('withdraws a stale-content warning when the file is externally deleted', async () => {
+    const { testEnv, services } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+
+    dismissSpy.mockClear();
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-delete',
+      wsPath: NOTE_WS_PATH,
+      sender: EXTERNAL_SENDER,
+    });
+
+    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+  });
+
+  it('withdraws a stale-content warning when the file is externally renamed', async () => {
+    const { testEnv, services } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+
+    dismissSpy.mockClear();
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-rename',
+      oldWsPath: NOTE_WS_PATH,
+      wsPath: `${WS_NAME}:renamed.md`,
+      sender: EXTERNAL_SENDER,
+    });
+
+    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+  });
+
+  it('reports when a requested disk version is no longer readable', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const errorSpy = vi.spyOn(toast, 'error');
+    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+
+    vi.spyOn(services.fileSystem, 'readFileAsText').mockResolvedValue(
+      undefined,
+    );
+    dismissSpy.mockClear();
+    await asPmEditor(services.editorEngine).loadDiskVersionIntoEditors(
+      NOTE_WS_PATH,
+    );
+
+    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Could not read note.md'),
+    );
+    expect(editorText(domNode)).toContain('the original note body');
+  });
+
+  it('withdraws a stale-content warning after a successful local save', async () => {
+    const { testEnv, services } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+
+    dismissSpy.mockClear();
+    expect(
+      services.editorEngine.insertMarkdownAtSelection('LOCAL-VERSION-WINS'),
+    ).toBe(true);
+    await vi.waitFor(() => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+      expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+    });
+  });
+
+  it('withdraws a stale-content warning when its last editor unmounts', async () => {
+    const { testEnv, services, unmountEditor } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+
+    dismissSpy.mockClear();
+    unmountEditor();
+    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+  });
+
+  it('withdraws tracked stale-content warnings during service cleanup', async () => {
+    const { controller, testEnv, services } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const warningSpy = vi.spyOn(toast, 'warning');
+    const dismissSpy = vi.spyOn(toast, 'dismiss');
+    const expectedToastId = `external-stale-content:${NOTE_WS_PATH}`;
+
+    await simulateExternalEdit(
+      testEnv,
+      services,
+      'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    );
+    await vi.waitFor(
+      () => {
+        expect(warningSpy).toHaveBeenCalled();
+      },
+      { timeout: 3_000 },
+    );
+
+    dismissSpy.mockClear();
+    controller.abort();
+    expect(dismissSpy).toHaveBeenCalledWith(expectedToastId);
+  });
+
   it('loading the disk version applies refused content in place without writing back', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -35,8 +35,8 @@ function makeHost(overrides: Partial<ExternalContentSyncHost> = {}) {
     getMarkdown: vi.fn(() => {
       throw new Error('not needed in these tests');
     }),
-    preserveCurrentContent: vi.fn(async () => {}),
-    withSaveSuppressed: vi.fn((_wsPath, dispatch) => dispatch()),
+    getRetainedSource: vi.fn(() => undefined),
+    replaceContent: vi.fn(async (): Promise<'applied'> => 'applied'),
     onStaleContentRefused: vi.fn(),
     onContentReconciled: vi.fn(),
     logger: { warn: vi.fn(), error: vi.fn() },
@@ -169,7 +169,7 @@ describe('coalescing and stability', () => {
       expect.stringContaining('kept changing'),
     );
     // Nothing was ever applied.
-    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+    expect(host.replaceContent).not.toHaveBeenCalled();
   }, 20_000);
 
   it('content that settles after the pass bound is still applied by the trailing pass', async () => {
@@ -225,7 +225,7 @@ describe('coalescing and stability', () => {
     // Stable reads but a composing view: the pass keeps retrying (bounded)
     // instead of dispatching into the live composition.
     await waitUntil(() => reads >= 4, 10_000);
-    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+    expect(host.replaceContent).not.toHaveBeenCalled();
     expect(host.getMarkdown).not.toHaveBeenCalled();
   });
 });
@@ -262,8 +262,7 @@ describe('refusal and reconciliation reporting', () => {
     );
     expect(host.onStaleContentRefused).toHaveBeenCalledWith('ws:a.md');
     expect(host.onContentReconciled).not.toHaveBeenCalled();
-    expect(host.preserveCurrentContent).not.toHaveBeenCalled();
-    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+    expect(host.replaceContent).not.toHaveBeenCalled();
   });
 
   it('an echo (serializer-equal content) reports reconciliation, clearing stale notices', async () => {
@@ -274,6 +273,7 @@ describe('refusal and reconciliation reporting', () => {
     } as never;
     const host = makeHost({
       getViews: vi.fn(() => [view]),
+      readFileAsText: vi.fn(async () => 'same output'),
       getMarkdown: vi.fn(
         () =>
           ({
@@ -294,8 +294,7 @@ describe('refusal and reconciliation reporting', () => {
     );
     expect(host.onContentReconciled).toHaveBeenCalledWith('ws:a.md');
     expect(host.onStaleContentRefused).not.toHaveBeenCalled();
-    expect(host.preserveCurrentContent).not.toHaveBeenCalled();
-    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+    expect(host.replaceContent).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -134,7 +134,7 @@ describe('coalescing and stability', () => {
     expect(passes).toBe(2);
   });
 
-  it('never-stable content is bounded: one burst, one trailing pass, then gives up', async () => {
+  it('bounds never-stable content to an initial and trailing retry burst', async () => {
     let reads = 0;
     const host = makeHost({
       getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
@@ -152,8 +152,7 @@ describe('coalescing and stability', () => {
 
     // MAX_PASSES = 5 → 10 reads in the burst...
     await waitUntil(() => reads === 10, 10_000);
-    // ...then the single delayed trailing pass runs its own bounded burst
-    // and gives up for good (a trailing pass never re-arms another).
+    // ...then one delayed retry burst runs and gives up for good.
     await waitUntil(() => reads === 20, 10_000);
     await new Promise((resolve) => setTimeout(resolve, 2_000));
     expect(reads).toBe(20);
@@ -164,7 +163,7 @@ describe('coalescing and stability', () => {
     expect(host.replaceContent).not.toHaveBeenCalled();
   }, 20_000);
 
-  it('content that settles after the pass bound is still applied by the trailing pass', async () => {
+  it('content that settles after the pass bound is applied by the trailing retry', async () => {
     let reads = 0;
     const host = makeHost({
       // A destroyed view keeps the pass from reaching content application
@@ -286,6 +285,23 @@ describe('refusal and reconciliation reporting', () => {
     );
     expect(host.onContentReconciled).toHaveBeenCalledWith('ws:a.md');
     expect(host.onStaleContentRefused).not.toHaveBeenCalled();
+    expect(host.replaceContent).not.toHaveBeenCalled();
+  });
+});
+
+describe('user-approved disk version', () => {
+  it('keeps edits that become pending while disk is being read', async () => {
+    const view = { state: { doc: {} } } as never;
+    const host = makeHost({
+      getViews: vi.fn(() => [view]),
+      hasPendingSaves: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
+    });
+    const sync = new ExternalContentSync(host);
+
+    await sync.acceptDiskVersion('ws:a.md');
+
+    expect(host.readFileAsText).toHaveBeenCalledTimes(1);
+    expect(host.getMarkdown).not.toHaveBeenCalled();
     expect(host.replaceContent).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -176,7 +176,7 @@ describe('coalescing and stability', () => {
         vi
           .mocked(host.logger.warn)
           .mock.calls.some(([message]) =>
-            String(message).includes('kept changing'),
+            String(message).includes('could not be reconciled'),
           ),
       15_000,
     );
@@ -184,6 +184,9 @@ describe('coalescing and stability', () => {
     await new Promise((resolve) => setTimeout(resolve, 500));
     expect(reads).toBe(readsAtGiveUp);
     expect(host.replaceContent).not.toHaveBeenCalled();
+    // Giving up leaves the editor knowingly behind disk — the user must get
+    // the stale-content surface, not only a console warning.
+    expect(host.onStaleContentRefused).toHaveBeenCalledWith('ws:a.md');
   }, 20_000);
 
   it('reconciles content that only settles after the fast passes', async () => {
@@ -209,8 +212,9 @@ describe('coalescing and stability', () => {
     await waitUntil(() => reads > 10, 10_000);
     await new Promise((resolve) => setTimeout(resolve, 400));
     expect(host.logger.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining('kept changing'),
+      expect.stringContaining('could not be reconciled'),
     );
+    expect(host.onStaleContentRefused).not.toHaveBeenCalled();
   }, 15_000);
 
   it('a view busy with IME composition is never replaced; the pass retries', async () => {

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -1,0 +1,154 @@
+import type { ExternalFileChangeEvent } from '@bangle.io/service-core';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ExternalContentSync,
+  type ExternalContentSyncHost,
+} from '../external-content-sync';
+
+/**
+ * Lifecycle-focused tests against a fake host: sequencing, coalescing, read
+ * stability, and target selection. Content application against real
+ * ProseMirror views is covered by external-change-sync.spec.ts through the
+ * full service wiring.
+ */
+
+function makeEvent(
+  partial: Partial<ExternalFileChangeEvent> &
+    Pick<ExternalFileChangeEvent, 'type'>,
+): ExternalFileChangeEvent {
+  return { sequence: 1, ...partial };
+}
+
+function makeHost(overrides: Partial<ExternalContentSyncHost> = {}) {
+  const host: ExternalContentSyncHost = {
+    // A non-empty views list keeps passes running to the read stage; content
+    // application is exercised in the integration spec.
+    getViews: vi.fn(() => []),
+    getMountedWsPaths: vi.fn(() => []),
+    hasPendingSaves: vi.fn(() => false),
+    readFileAsText: vi.fn(async () => 'stable content'),
+    getMarkdown: vi.fn(() => {
+      throw new Error('not needed in these tests');
+    }),
+    withSaveSuppressed: vi.fn((_wsPath, dispatch) => dispatch()),
+    logger: { warn: vi.fn(), error: vi.fn() },
+    ...overrides,
+  };
+  return host;
+}
+
+async function waitUntil(check: () => boolean, timeoutMs = 5_000) {
+  await vi.waitFor(
+    () => {
+      expect(check()).toBe(true);
+    },
+    { timeout: timeoutMs },
+  );
+}
+
+describe('target selection', () => {
+  it('content updates target only mounted editors for that exact path', () => {
+    const getViews = vi.fn((wsPath: string) =>
+      wsPath === 'ws:open.md' ? [{} as never] : [],
+    );
+    const host = makeHost({
+      getViews,
+      // Force syncPath to bail immediately after selection.
+      hasPendingSaves: vi.fn(() => true),
+    });
+    const sync = new ExternalContentSync(host);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:closed.md' }),
+    );
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:open.md' }),
+    );
+    // Deletes and renames never reconcile content.
+    sync.handleEvent(makeEvent({ type: 'file-delete', wsPath: 'ws:open.md' }));
+    sync.handleEvent(makeEvent({ type: 'file-rename', wsPath: 'ws:open.md' }));
+
+    expect(getViews).toHaveBeenCalledWith('ws:closed.md');
+    expect(getViews).toHaveBeenCalledWith('ws:open.md');
+    // Only the open path progressed into a sync pass (checked via the
+    // dirty-guard probe that runs first in a pass).
+    expect(host.hasPendingSaves).toHaveBeenCalledTimes(1);
+    expect(host.hasPendingSaves).toHaveBeenCalledWith('ws:open.md');
+  });
+
+  it('scoped refreshes ask only for that workspace; app-wide for all', () => {
+    const getMountedWsPaths = vi.fn(() => []);
+    const sync = new ExternalContentSync(makeHost({ getMountedWsPaths }));
+
+    sync.handleEvent(makeEvent({ type: 'refresh', wsName: 'ws-a' }));
+    expect(getMountedWsPaths).toHaveBeenLastCalledWith('ws-a');
+
+    sync.handleEvent(makeEvent({ type: 'refresh' }));
+    expect(getMountedWsPaths).toHaveBeenLastCalledWith(undefined);
+  });
+});
+
+describe('coalescing and stability', () => {
+  it('events during an in-flight pass coalesce into exactly one more pass', async () => {
+    let passes = 0;
+    const host = makeHost({
+      // Non-empty so the pass reaches the reads (and thus takes time).
+      getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
+      readFileAsText: vi.fn(async () => {
+        passes += 1;
+        return 'same';
+      }),
+      // Bail right after the stable reads, before content application.
+      hasPendingSaves: vi
+        .fn()
+        .mockReturnValueOnce(false) // pass 1 entry
+        .mockReturnValue(true), // post-read checks and later passes
+    });
+    const sync = new ExternalContentSync(host);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+    // Three more events arrive while the first pass sleeps through its quiet
+    // period — they must coalesce into a single rerun, not three.
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+
+    // Pass 1 reads twice; the coalesced rerun bails at its dirty check
+    // without reading again.
+    await waitUntil(() => passes === 2);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(passes).toBe(2);
+  });
+
+  it('disagreeing reads rerun the pass until stable, bounded per burst', async () => {
+    let reads = 0;
+    const host = makeHost({
+      getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
+      // Every read returns something different: never stable.
+      readFileAsText: vi.fn(async () => {
+        reads += 1;
+        return `content-${reads}`;
+      }),
+    });
+    const sync = new ExternalContentSync(host);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+
+    // MAX_PASSES = 5 → exactly 10 reads, then the burst gives up.
+    await waitUntil(() => reads === 10, 10_000);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(reads).toBe(10);
+    // Nothing was ever applied.
+    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -13,10 +13,15 @@ import {
  */
 
 function makeEvent(
-  partial: Partial<ExternalFileChangeEvent> &
-    Pick<ExternalFileChangeEvent, 'type'>,
+  payload:
+    | {
+        type: 'file-create' | 'file-content-update' | 'file-delete';
+        wsPath: string;
+      }
+    | { type: 'file-rename'; wsPath: string; oldWsPath: string }
+    | { type: 'refresh'; wsName?: string },
 ): ExternalFileChangeEvent {
-  return { sequence: 1, ...partial };
+  return { sequence: 1, ...payload };
 }
 
 function makeHost(overrides: Partial<ExternalContentSyncHost> = {}) {
@@ -31,6 +36,8 @@ function makeHost(overrides: Partial<ExternalContentSyncHost> = {}) {
       throw new Error('not needed in these tests');
     }),
     withSaveSuppressed: vi.fn((_wsPath, dispatch) => dispatch()),
+    onStaleContentRefused: vi.fn(),
+    onContentReconciled: vi.fn(),
     logger: { warn: vi.fn(), error: vi.fn() },
     ...overrides,
   };
@@ -66,7 +73,13 @@ describe('target selection', () => {
     );
     // Deletes and renames never reconcile content.
     sync.handleEvent(makeEvent({ type: 'file-delete', wsPath: 'ws:open.md' }));
-    sync.handleEvent(makeEvent({ type: 'file-rename', wsPath: 'ws:open.md' }));
+    sync.handleEvent(
+      makeEvent({
+        type: 'file-rename',
+        wsPath: 'ws:open.md',
+        oldWsPath: 'ws:old.md',
+      }),
+    );
 
     expect(getViews).toHaveBeenCalledWith('ws:closed.md');
     expect(getViews).toHaveBeenCalledWith('ws:open.md');
@@ -128,7 +141,7 @@ describe('coalescing and stability', () => {
     expect(passes).toBe(2);
   });
 
-  it('disagreeing reads rerun the pass until stable, bounded per burst', async () => {
+  it('never-stable content is bounded: one burst, one trailing pass, then gives up', async () => {
     let reads = 0;
     const host = makeHost({
       getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
@@ -144,11 +157,165 @@ describe('coalescing and stability', () => {
       makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
     );
 
-    // MAX_PASSES = 5 → exactly 10 reads, then the burst gives up.
+    // MAX_PASSES = 5 → 10 reads in the burst...
     await waitUntil(() => reads === 10, 10_000);
-    await new Promise((resolve) => setTimeout(resolve, 400));
-    expect(reads).toBe(10);
+    // ...then the single delayed trailing pass runs its own bounded burst
+    // and gives up for good (a trailing pass never re-arms another).
+    await waitUntil(() => reads === 20, 10_000);
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
+    expect(reads).toBe(20);
+    expect(host.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('kept changing'),
+    );
     // Nothing was ever applied.
     expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+  }, 20_000);
+
+  it('content that settles after the pass bound is still applied by the trailing pass', async () => {
+    let reads = 0;
+    const host = makeHost({
+      // A destroyed view keeps the pass from reaching content application
+      // while still exercising the full read protocol.
+      getViews: vi.fn(() => [
+        { isDestroyed: true, state: { doc: {} } } as never,
+      ]),
+      readFileAsText: vi.fn(async () => {
+        reads += 1;
+        // Unstable through the whole first burst (10 reads), stable after.
+        return reads <= 10 ? `content-${reads}` : 'settled';
+      }),
+    });
+    const sync = new ExternalContentSync(host);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+
+    // Burst exhausts unstable; the trailing pass gets two agreeing reads and
+    // settles instead of silently dropping the pending work.
+    await waitUntil(() => reads === 12, 10_000);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(reads).toBe(12);
+    expect(host.logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('kept changing'),
+    );
+  }, 15_000);
+
+  it('a view busy with IME composition is never replaced; the pass retries', async () => {
+    let reads = 0;
+    const view = {
+      isDestroyed: false,
+      composing: true,
+      state: { doc: {}, schema: {} },
+    } as never;
+    const host = makeHost({
+      getViews: vi.fn(() => [view]),
+      readFileAsText: vi.fn(async () => {
+        reads += 1;
+        return 'stable external content';
+      }),
+    });
+    const sync = new ExternalContentSync(host);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+
+    // Stable reads but a composing view: the pass keeps retrying (bounded)
+    // instead of dispatching into the live composition.
+    await waitUntil(() => reads >= 4, 10_000);
+    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+    expect(host.getMarkdown).not.toHaveBeenCalled();
+  });
+});
+
+describe('refusal and reconciliation reporting', () => {
+  it('an unparseable external change is refused and reported to the host', async () => {
+    const view = {
+      isDestroyed: false,
+      composing: false,
+      state: { doc: {}, schema: {} },
+    } as never;
+    const host = makeHost({
+      getViews: vi.fn(() => [view]),
+      getMarkdown: vi.fn(
+        () =>
+          ({
+            parser: {
+              parse: () => {
+                throw new Error('cannot parse');
+              },
+            },
+            serializer: { serialize: () => 'unused' },
+          }) as never,
+      ),
+    });
+    const sync = new ExternalContentSync(host);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+
+    await waitUntil(
+      () => vi.mocked(host.onStaleContentRefused).mock.calls.length > 0,
+    );
+    expect(host.onStaleContentRefused).toHaveBeenCalledWith('ws:a.md');
+    expect(host.onContentReconciled).not.toHaveBeenCalled();
+    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+  });
+
+  it('an echo (serializer-equal content) reports reconciliation, clearing stale notices', async () => {
+    const view = {
+      isDestroyed: false,
+      composing: false,
+      state: { doc: {}, schema: {} },
+    } as never;
+    const host = makeHost({
+      getViews: vi.fn(() => [view]),
+      getMarkdown: vi.fn(
+        () =>
+          ({
+            parser: { parse: () => ({}) },
+            // Editor doc and disk content serialize identically → echo.
+            serializer: { serialize: () => 'same output' },
+          }) as never,
+      ),
+    });
+    const sync = new ExternalContentSync(host);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+
+    await waitUntil(
+      () => vi.mocked(host.onContentReconciled).mock.calls.length > 0,
+    );
+    expect(host.onContentReconciled).toHaveBeenCalledWith('ws:a.md');
+    expect(host.onStaleContentRefused).not.toHaveBeenCalled();
+    expect(host.withSaveSuppressed).not.toHaveBeenCalled();
+  });
+});
+
+describe('abort', () => {
+  it('an aborted signal stops in-flight passes without further reads', async () => {
+    let reads = 0;
+    const controller = new AbortController();
+    const host = makeHost({
+      getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
+      readFileAsText: vi.fn(async () => {
+        reads += 1;
+        return `content-${reads}`;
+      }),
+    });
+    const sync = new ExternalContentSync(host, controller.signal);
+
+    sync.handleEvent(
+      makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
+    );
+    // Abort while the first pass sleeps through its quiet period.
+    controller.abort();
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    expect(reads).toBe(0);
   });
 });

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -18,7 +18,6 @@ function makeEvent(
         type: 'file-create' | 'file-content-update' | 'file-delete';
         wsPath: string;
       }
-    | { type: 'file-rename'; wsPath: string; oldWsPath: string }
     | { type: 'refresh'; wsName?: string },
 ): ExternalFileChangeEvent {
   return { sequence: 1, ...payload };
@@ -72,15 +71,8 @@ describe('target selection', () => {
     sync.handleEvent(
       makeEvent({ type: 'file-content-update', wsPath: 'ws:open.md' }),
     );
-    // Deletes and renames never reconcile content.
+    // Deletes never reconcile content.
     sync.handleEvent(makeEvent({ type: 'file-delete', wsPath: 'ws:open.md' }));
-    sync.handleEvent(
-      makeEvent({
-        type: 'file-rename',
-        wsPath: 'ws:open.md',
-        oldWsPath: 'ws:old.md',
-      }),
-    );
 
     expect(getViews).toHaveBeenCalledWith('ws:closed.md');
     expect(getViews).toHaveBeenCalledWith('ws:open.md');

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -35,6 +35,7 @@ function makeHost(overrides: Partial<ExternalContentSyncHost> = {}) {
     getMarkdown: vi.fn(() => {
       throw new Error('not needed in these tests');
     }),
+    preserveCurrentContent: vi.fn(async () => {}),
     withSaveSuppressed: vi.fn((_wsPath, dispatch) => dispatch()),
     onStaleContentRefused: vi.fn(),
     onContentReconciled: vi.fn(),
@@ -261,6 +262,7 @@ describe('refusal and reconciliation reporting', () => {
     );
     expect(host.onStaleContentRefused).toHaveBeenCalledWith('ws:a.md');
     expect(host.onContentReconciled).not.toHaveBeenCalled();
+    expect(host.preserveCurrentContent).not.toHaveBeenCalled();
     expect(host.withSaveSuppressed).not.toHaveBeenCalled();
   });
 
@@ -292,6 +294,7 @@ describe('refusal and reconciliation reporting', () => {
     );
     expect(host.onContentReconciled).toHaveBeenCalledWith('ws:a.md');
     expect(host.onStaleContentRefused).not.toHaveBeenCalled();
+    expect(host.preserveCurrentContent).not.toHaveBeenCalled();
     expect(host.withSaveSuppressed).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -1,3 +1,4 @@
+import type { EditorView } from '@bangle.io/prosemirror-plugins';
 import type { ExternalFileChangeEvent } from '@bangle.io/service-core';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -21,6 +22,24 @@ function makeEvent(
     | { type: 'refresh'; wsName?: string },
 ): ExternalFileChangeEvent {
   return { sequence: 1, ...payload };
+}
+
+/**
+ * Minimal stand-in for a mounted view. The sync only ever touches these
+ * fields, so the single cast lives here instead of at every call site.
+ */
+function fakeView({
+  composing = false,
+  isDestroyed = false,
+}: {
+  composing?: boolean;
+  isDestroyed?: boolean;
+} = {}): EditorView {
+  return {
+    composing,
+    isDestroyed,
+    state: { doc: {}, schema: {} },
+  } as unknown as EditorView;
 }
 
 function makeHost(overrides: Partial<ExternalContentSyncHost> = {}) {
@@ -56,7 +75,7 @@ async function waitUntil(check: () => boolean, timeoutMs = 5_000) {
 describe('target selection', () => {
   it('content updates target only mounted editors for that exact path', () => {
     const getViews = vi.fn((wsPath: string) =>
-      wsPath === 'ws:open.md' ? [{} as never] : [],
+      wsPath === 'ws:open.md' ? [fakeView()] : [],
     );
     const host = makeHost({
       getViews,
@@ -99,7 +118,7 @@ describe('coalescing and stability', () => {
     let passes = 0;
     const host = makeHost({
       // Non-empty so the pass reaches the reads (and thus takes time).
-      getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
+      getViews: vi.fn(() => [fakeView()]),
       readFileAsText: vi.fn(async () => {
         passes += 1;
         return 'same';
@@ -134,10 +153,10 @@ describe('coalescing and stability', () => {
     expect(passes).toBe(2);
   });
 
-  it('bounds never-stable content to an initial and trailing retry burst', async () => {
+  it('gives up on never-stable content instead of spinning forever', async () => {
     let reads = 0;
     const host = makeHost({
-      getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
+      getViews: vi.fn(() => [fakeView()]),
       // Every read returns something different: never stable.
       readFileAsText: vi.fn(async () => {
         reads += 1;
@@ -150,30 +169,33 @@ describe('coalescing and stability', () => {
       makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
     );
 
-    // MAX_PASSES = 5 → 10 reads in the burst...
-    await waitUntil(() => reads === 10, 10_000);
-    // ...then one delayed retry burst runs and gives up for good.
-    await waitUntil(() => reads === 20, 10_000);
-    await new Promise((resolve) => setTimeout(resolve, 2_000));
-    expect(reads).toBe(20);
-    expect(host.logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('kept changing'),
+    // How many passes it takes is tuning; the contract is that the loop ends,
+    // says so, and never applies content it could not confirm.
+    await waitUntil(
+      () =>
+        vi
+          .mocked(host.logger.warn)
+          .mock.calls.some(([message]) =>
+            String(message).includes('kept changing'),
+          ),
+      15_000,
     );
-    // Nothing was ever applied.
+    const readsAtGiveUp = reads;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    expect(reads).toBe(readsAtGiveUp);
     expect(host.replaceContent).not.toHaveBeenCalled();
   }, 20_000);
 
-  it('content that settles after the pass bound is applied by the trailing retry', async () => {
+  it('reconciles content that only settles after the fast passes', async () => {
     let reads = 0;
     const host = makeHost({
       // A destroyed view keeps the pass from reaching content application
       // while still exercising the full read protocol.
-      getViews: vi.fn(() => [
-        { isDestroyed: true, state: { doc: {} } } as never,
-      ]),
+      getViews: vi.fn(() => [fakeView({ isDestroyed: true })]),
       readFileAsText: vi.fn(async () => {
         reads += 1;
-        // Unstable through the whole first burst (10 reads), stable after.
+        // Unstable for longer than the back-to-back passes, so only the
+        // post-backoff passes can see two agreeing reads.
         return reads <= 10 ? `content-${reads}` : 'settled';
       }),
     });
@@ -183,11 +205,9 @@ describe('coalescing and stability', () => {
       makeEvent({ type: 'file-content-update', wsPath: 'ws:a.md' }),
     );
 
-    // Burst exhausts unstable; the trailing pass gets two agreeing reads and
-    // settles instead of silently dropping the pending work.
-    await waitUntil(() => reads === 12, 10_000);
+    // The trailing passes settle it rather than silently dropping the work.
+    await waitUntil(() => reads > 10, 10_000);
     await new Promise((resolve) => setTimeout(resolve, 400));
-    expect(reads).toBe(12);
     expect(host.logger.warn).not.toHaveBeenCalledWith(
       expect.stringContaining('kept changing'),
     );
@@ -195,11 +215,7 @@ describe('coalescing and stability', () => {
 
   it('a view busy with IME composition is never replaced; the pass retries', async () => {
     let reads = 0;
-    const view = {
-      isDestroyed: false,
-      composing: true,
-      state: { doc: {}, schema: {} },
-    } as never;
+    const view = fakeView({ composing: true });
     const host = makeHost({
       getViews: vi.fn(() => [view]),
       readFileAsText: vi.fn(async () => {
@@ -223,11 +239,7 @@ describe('coalescing and stability', () => {
 
 describe('refusal and reconciliation reporting', () => {
   it('an unparseable external change is refused and reported to the host', async () => {
-    const view = {
-      isDestroyed: false,
-      composing: false,
-      state: { doc: {}, schema: {} },
-    } as never;
+    const view = fakeView();
     const host = makeHost({
       getViews: vi.fn(() => [view]),
       getMarkdown: vi.fn(
@@ -257,11 +269,7 @@ describe('refusal and reconciliation reporting', () => {
   });
 
   it('an echo (serializer-equal content) reports reconciliation, clearing stale notices', async () => {
-    const view = {
-      isDestroyed: false,
-      composing: false,
-      state: { doc: {}, schema: {} },
-    } as never;
+    const view = fakeView();
     const host = makeHost({
       getViews: vi.fn(() => [view]),
       readFileAsText: vi.fn(async () => 'same output'),
@@ -291,7 +299,7 @@ describe('refusal and reconciliation reporting', () => {
 
 describe('user-approved disk version', () => {
   it('keeps edits that become pending while disk is being read', async () => {
-    const view = { state: { doc: {} } } as never;
+    const view = fakeView();
     const host = makeHost({
       getViews: vi.fn(() => [view]),
       hasPendingSaves: vi.fn().mockReturnValueOnce(false).mockReturnValue(true),
@@ -311,7 +319,7 @@ describe('abort', () => {
     let reads = 0;
     const controller = new AbortController();
     const host = makeHost({
-      getViews: vi.fn(() => [{ state: { doc: {} } } as never]),
+      getViews: vi.fn(() => [fakeView()]),
       readFileAsText: vi.fn(async () => {
         reads += 1;
         return `content-${reads}`;

--- a/packages/core/editor/src/__tests__/markdown-paste-gate.spec.ts
+++ b/packages/core/editor/src/__tests__/markdown-paste-gate.spec.ts
@@ -115,4 +115,31 @@ describe('Markdown paste content gate', () => {
       false,
     );
   });
+
+  // CommonMark consumes definitions nested inside blockquotes and list items
+  // too; a gate that only scans line starts would let these vanish silently.
+  const nestedDropped = [
+    ['blockquote', '> quoted text\n>\n> [gone]: https://example.com/spec'],
+    ['list item', '- item text\n\n- [gone]: https://example.com/spec'],
+    [
+      'ordered list item',
+      '1. item text\n\n2. [gone]: https://example.com/spec',
+    ],
+    [
+      'blockquote inside a list item',
+      '- > quoted\n  >\n  > [gone]: https://example.com/spec',
+    ],
+  ] as const;
+
+  for (const [name, source] of nestedDropped) {
+    it(`refuses a dropped definition inside a ${name}`, () => {
+      expect(setup()(source)).toBe(false);
+    });
+  }
+
+  it('accepts a resolved definition inside a blockquote', () => {
+    expect(
+      setup()('> see [the spec][ref]\n>\n> [ref]: https://example.com/spec'),
+    ).toBe(true);
+  });
 });

--- a/packages/core/editor/src/editor-save-queue.ts
+++ b/packages/core/editor/src/editor-save-queue.ts
@@ -43,13 +43,27 @@ type SaveStatusSubscription = {
 export type EditorSaveCoordinator = {
   currentSession?: EditorSaveSession;
   entries: Map<string, SaveEntry>;
+  hasPendingOrFailedSave(wsPath?: string): boolean;
   lastHasPendingOrFailed: boolean;
   subscriptions: Set<SaveStatusSubscription>;
 };
 
 export function createEditorSaveCoordinator(): EditorSaveCoordinator {
+  const entries = new Map<string, SaveEntry>();
   return {
-    entries: new Map(),
+    entries,
+    hasPendingOrFailedSave: (wsPath) => {
+      if (wsPath !== undefined) {
+        const entry = entries.get(wsPath);
+        return entry !== undefined && entry.status.status !== 'clean';
+      }
+      for (const entry of entries.values()) {
+        if (entry.status.status !== 'clean') {
+          return true;
+        }
+      }
+      return false;
+    },
     lastHasPendingOrFailed: false,
     subscriptions: new Set(),
   };
@@ -81,17 +95,7 @@ export class EditorSaveQueue {
   }
 
   hasPendingOrFailed(wsPath?: string): boolean {
-    if (wsPath !== undefined) {
-      return this.getStatus(wsPath).status !== 'clean';
-    }
-
-    for (const entry of this.coordinator.entries.values()) {
-      if (entry.status.status !== 'clean') {
-        return true;
-      }
-    }
-
-    return false;
+    return this.coordinator.hasPendingOrFailedSave(wsPath);
   }
 
   subscribe(listener: SaveStatusListener, wsPath?: string): () => void {

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -23,10 +23,31 @@ const STABILITY_MS = 100;
  * fresh sync.
  */
 const MAX_PASSES = 5;
+/**
+ * Backoff before the single trailing pass that runs when MAX_PASSES was
+ * exhausted with work still pending. Writers commit their final state with
+ * no follow-up record (the premise of the two-read protocol), so giving up
+ * silently at the bound would leave the editor stale forever; one delayed,
+ * non-re-arming retry covers the settle-after-the-bound case while keeping
+ * total work per burst finite.
+ */
+const TRAILING_PASS_DELAY_MS = 1_000;
 
-function sleep(ms: number): Promise<void> {
+function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
   return new Promise((resolve) => {
-    setTimeout(resolve, ms);
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
   });
 }
 
@@ -48,11 +69,24 @@ export interface ExternalContentSyncHost {
   readFileAsText(wsPath: string): Promise<string | undefined>;
   getMarkdown(schema: Schema): ReturnType<typeof markdownLoader>;
   /**
-   * Runs `dispatch` with the editor's save pipeline suppressed for `wsPath`,
-   * so applying external content is not re-saved (a no-op write would churn
-   * the file's mtime and make sync tools loop on their own change).
+   * Runs `dispatch` with the editor's save pipeline suppressed for `wsPath`
+   * (see `suppressSaveForExternalSync` in the editor service for why the
+   * write-back must not happen).
    */
   withSaveSuppressed(wsPath: string, dispatch: () => void): void;
+  /**
+   * The disk copy of `wsPath` was confirmed stable and different, but was
+   * refused (fidelity, emptied-file, schema, or parse refusal) — the open
+   * editor now knowingly shows older content than disk. Hosts surface this
+   * to the user with a recovery path; the refusal itself is deliberate.
+   */
+  onStaleContentRefused(wsPath: string): void;
+  /**
+   * A later pass reconciled `wsPath` — external content was applied, or
+   * disk and editor turned out equal — so any stale-content notice for the
+   * path can be withdrawn.
+   */
+  onContentReconciled(wsPath: string): void;
   logger: {
     warn(...args: unknown[]): void;
     error(...args: unknown[]): void;
@@ -69,16 +103,28 @@ export interface ExternalContentSyncHost {
  * - echoes and normalization no-ops are coalesced by serializer-level
  *   comparison and never touch the editor;
  * - a replacement that lost the parsed content (schema mismatch) is refused;
- * - applied content stays out of the undo stack and is not re-saved.
+ * - applied content stays out of the undo stack and is not re-saved;
+ * - refusals are reported to the host so the user learns the editor is
+ *   deliberately showing older content than disk.
  */
 export class ExternalContentSync {
   /**
    * wsPaths with a sync pass in flight; the boolean marks whether another
-   * external event arrived meanwhile and the pass must run again.
+   * external event arrived meanwhile and the pass must run again. Only
+   * `handleEvent`/`syncPath` write it — passes report their own rerun needs
+   * through `applyIfClean`'s return value.
    */
   private runs = new Map<string, boolean>();
 
-  constructor(private host: ExternalContentSyncHost) {}
+  constructor(
+    private host: ExternalContentSyncHost,
+    /** Service lifetime; in-flight passes stop when it aborts. */
+    private signal?: AbortSignal,
+  ) {}
+
+  private get aborted(): boolean {
+    return this.signal?.aborted === true;
+  }
 
   handleEvent(event: ExternalFileChangeEvent): void {
     let targets: string[];
@@ -86,10 +132,7 @@ export class ExternalContentSync {
       case 'file-content-update':
       case 'file-create': {
         targets =
-          event.wsPath !== undefined &&
-          this.host.getViews(event.wsPath).length > 0
-            ? [event.wsPath]
-            : [];
+          this.host.getViews(event.wsPath).length > 0 ? [event.wsPath] : [];
         break;
       }
       case 'refresh': {
@@ -100,11 +143,18 @@ export class ExternalContentSync {
       }
       default: {
         // Deletes/renames change the tree, not the open document's content.
+        // An open editor on the removed path keeps the user's content; its
+        // next save fails visibly through the save-error surface rather
+        // than silently recreating the file here.
         targets = [];
       }
     }
     for (const wsPath of targets) {
       void this.syncPath(wsPath).catch((error) => {
+        if (this.aborted) {
+          // Teardown mid-pass; reads racing the abort are expected to fail.
+          return;
+        }
         this.host.logger.warn(
           `Failed to refresh editor from external change: ${wsPath}`,
           error,
@@ -113,9 +163,11 @@ export class ExternalContentSync {
     }
   }
 
-  private async syncPath(wsPath: string): Promise<void> {
-    const running = this.runs.get(wsPath);
-    if (running !== undefined) {
+  private async syncPath(
+    wsPath: string,
+    isTrailingPass = false,
+  ): Promise<void> {
+    if (this.runs.has(wsPath)) {
       // A pass is already in flight — ask it to run once more so the final
       // external state is not dropped.
       this.runs.set(wsPath, true);
@@ -123,26 +175,53 @@ export class ExternalContentSync {
     }
     this.runs.set(wsPath, false);
     let passes = 0;
+    let pendingWork = false;
     try {
       do {
         this.runs.set(wsPath, false);
         passes += 1;
-        await this.applyIfClean(wsPath);
-      } while (this.runs.get(wsPath) && passes < MAX_PASSES);
+        const wantsRerun = await this.applyIfClean(wsPath);
+        pendingWork = wantsRerun || this.runs.get(wsPath) === true;
+      } while (pendingWork && passes < MAX_PASSES && !this.aborted);
     } finally {
       this.runs.delete(wsPath);
     }
+
+    if (!pendingWork || this.aborted) {
+      return;
+    }
+    // MAX_PASSES exhausted with work still pending. The writer's final
+    // commit may produce no further watcher record, so give the file one
+    // delayed, fresh chance to settle — but never re-arm from within that
+    // trailing pass, keeping per-burst work finite for a file under truly
+    // continuous external writes.
+    if (isTrailingPass) {
+      this.host.logger.warn(
+        `External content for ${wsPath} kept changing; giving up until the next external event`,
+      );
+      return;
+    }
+    await sleep(TRAILING_PASS_DELAY_MS, this.signal);
+    if (this.aborted) {
+      return;
+    }
+    await this.syncPath(wsPath, true);
   }
 
-  private async applyIfClean(wsPath: string): Promise<void> {
+  /**
+   * Runs one reconciliation pass. Returns true when the pass could not
+   * settle (mid-write reads disagreed, or a view was busy composing) and
+   * the caller should run another pass.
+   */
+  private async applyIfClean(wsPath: string): Promise<boolean> {
     // Unsaved or failed-to-save local edits always win: replacing the doc
     // would destroy content that exists nowhere else.
     if (this.host.hasPendingSaves(wsPath)) {
-      return;
+      return false;
     }
     const views = this.host.getViews(wsPath);
     if (views.length === 0) {
-      return;
+      return false;
     }
     const docsBefore = views.map((view) => view.state.doc);
 
@@ -152,50 +231,71 @@ export class ExternalContentSync {
     // short quiet period, then require two consecutive reads to agree before
     // treating the content as settled — otherwise an open note would flash
     // (or stick) empty on a truncate-then-write.
-    await sleep(QUIET_MS);
-    const firstRead = await this.host.readFileAsText(wsPath);
-    if (firstRead === undefined) {
-      return;
+    await sleep(QUIET_MS, this.signal);
+    if (this.aborted) {
+      return false;
     }
-    await sleep(STABILITY_MS);
+    const firstRead = await this.host.readFileAsText(wsPath);
+    if (firstRead === undefined || this.aborted) {
+      return false;
+    }
+    await sleep(STABILITY_MS, this.signal);
+    if (this.aborted) {
+      return false;
+    }
     const diskText = await this.host.readFileAsText(wsPath);
-    if (diskText === undefined) {
-      return;
+    if (diskText === undefined || this.aborted) {
+      return false;
     }
     if (diskText !== firstRead) {
-      // Still being written — run another pass after the loop's rerun check.
-      this.runs.set(wsPath, true);
-      return;
+      // Still being written — ask for another pass.
+      return true;
     }
     // The user may have typed while the reads were in flight — re-check, and
     // bail if any doc moved on. A newer watcher event re-triggers this pass.
     if (this.host.hasPendingSaves(wsPath)) {
-      return;
+      return false;
     }
 
+    let needsRerun = false;
+    let refused = false;
+    let reconciled = false;
     for (const [index, view] of views.entries()) {
       if (view.isDestroyed || view.state.doc !== docsBefore[index]) {
         continue;
       }
-      const markdown = this.host.getMarkdown(view.state.schema);
-      let parsed: ReturnType<typeof markdown.parser.parse>;
-      try {
-        parsed = markdown.parser.parse(diskText);
-      } catch (error) {
-        // A parse failure must never touch the editor (or disk) — the user
-        // keeps their current view of the note.
-        this.host.logger.warn(
-          `Could not parse externally changed content for ${wsPath}`,
-          error,
-        );
+      if (view.composing) {
+        // Replacing the doc mid-IME-composition aborts the composition and
+        // silently drops the user's uncommitted keystrokes. Retry after the
+        // burst; once composition commits, the resulting save re-triggers
+        // reconciliation anyway.
+        needsRerun = true;
         continue;
       }
-      // Compare through the serializer so normalization differences (e.g.
-      // list markers) don't register as changes; equal content means this is
-      // our own echo or a no-op and the editor is left untouched.
-      const currentSerialized = markdown.serializer.serialize(view.state.doc);
-      const diskSerialized = markdown.serializer.serialize(parsed);
+      const markdown = this.host.getMarkdown(view.state.schema);
+      let parsed: ReturnType<typeof markdown.parser.parse>;
+      let currentSerialized: string;
+      let diskSerialized: string;
+      try {
+        parsed = markdown.parser.parse(diskText);
+        // Compare through the serializer so normalization differences (e.g.
+        // list markers) don't register as changes; equal content means this
+        // is our own echo or a no-op and the editor is left untouched.
+        currentSerialized = markdown.serializer.serialize(view.state.doc);
+        diskSerialized = markdown.serializer.serialize(parsed);
+      } catch (error) {
+        // A parse or serialize failure must never touch the editor (or
+        // disk) — the user keeps their current view of the note, and the
+        // remaining views still get their chance.
+        this.host.logger.warn(
+          `Could not parse or compare externally changed content for ${wsPath}`,
+          error,
+        );
+        refused = true;
+        continue;
+      }
       if (currentSerialized === diskSerialized) {
+        reconciled = true;
         continue;
       }
       // Same fidelity gate as initial note loading: if the external Markdown
@@ -208,6 +308,7 @@ export class ExternalContentSync {
         this.host.logger.warn(
           `External change to ${wsPath} does not round-trip through the editor; not auto-applying`,
         );
+        refused = true;
         continue;
       }
       // Two agreeing reads can still both land inside a truncate-then-write
@@ -219,6 +320,7 @@ export class ExternalContentSync {
         this.host.logger.warn(
           `External change emptied ${wsPath}; keeping the editor content`,
         );
+        refused = true;
         continue;
       }
 
@@ -232,6 +334,7 @@ export class ExternalContentSync {
         this.host.logger.error(
           `External sync for ${wsPath} produced an empty document from non-empty content; skipping`,
         );
+        refused = true;
         continue;
       }
       tr = tr.setSelection(
@@ -246,6 +349,16 @@ export class ExternalContentSync {
       this.host.withSaveSuppressed(wsPath, () => {
         view.dispatch(tr);
       });
+      reconciled = true;
     }
+
+    // One outcome per pass: a refusal outranks a reconciliation (the user
+    // should learn about the diverged view even if another view applied).
+    if (refused) {
+      this.host.onStaleContentRefused(wsPath);
+    } else if (reconciled) {
+      this.host.onContentReconciled(wsPath);
+    }
+    return needsRerun;
   }
 }

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -92,6 +92,8 @@ export interface ExternalContentSyncHost {
   hasPendingSaves(wsPath: string): boolean;
   readFileAsText(wsPath: string): Promise<string | undefined>;
   getMarkdown(schema: Schema): ReturnType<typeof markdownLoader>;
+  /** Saves the clean editor content before an external version replaces it. */
+  preserveCurrentContent(wsPath: string, content: string): Promise<void>;
   /**
    * Runs `dispatch` with the editor's save pipeline suppressed for `wsPath`
    * (see `suppressSaveForExternalSync` in the editor service for why the
@@ -284,6 +286,7 @@ export class ExternalContentSync {
     let needsRerun = false;
     let refused = false;
     let reconciled = false;
+    let preservedCurrentContent = false;
     for (const [index, view] of views.entries()) {
       if (view.isDestroyed || view.state.doc !== docsBefore[index]) {
         continue;
@@ -358,6 +361,23 @@ export class ExternalContentSync {
         );
         refused = true;
         continue;
+      }
+
+      if (!preservedCurrentContent) {
+        await this.host.preserveCurrentContent(wsPath, currentSerialized);
+        if (this.aborted) {
+          return false;
+        }
+        // Snapshot storage is asynchronous. A keystroke made while it was in
+        // flight still wins over the external copy.
+        if (
+          this.host.hasPendingSaves(wsPath) ||
+          view.isDestroyed ||
+          view.state.doc !== docsBefore[index]
+        ) {
+          continue;
+        }
+        preservedCurrentContent = true;
       }
 
       this.host.withSaveSuppressed(wsPath, () => {

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -16,19 +16,12 @@ import {
  * Quiet period between an external change notification and the first disk
  * read, letting in-progress writes (truncate-then-write) finish first.
  */
-export const QUIET_MS = 150;
+const QUIET_MS = 150;
 /**
  * Gap between the two confirming reads that must agree before externally
  * changed content is applied to an open editor.
  */
-export const STABILITY_MS = 100;
-/**
- * How long a test must wait before "the editor did not change" proves a
- * refusal rather than the pass simply not having run yet. Exported so those
- * negative assertions cannot quietly go vacuous when the timings above are
- * tuned.
- */
-export const RECONCILE_SETTLE_MS = (QUIET_MS + STABILITY_MS) * 2 + 150;
+const STABILITY_MS = 100;
 /** Back-to-back passes before backing off, for a writer that settles quickly. */
 const PASSES_BEFORE_BACKOFF = 5;
 /**
@@ -162,6 +155,14 @@ type ReconcileMode = 'automatic' | 'user-approved';
  */
 export class ExternalContentSync {
   /**
+   * How long a test must wait before "the editor did not change" proves a
+   * refusal rather than the pass simply not having run yet. Lives here so
+   * those negative assertions cannot quietly go vacuous when the timings
+   * above are tuned.
+   */
+  static readonly RECONCILE_SETTLE_MS = (QUIET_MS + STABILITY_MS) * 2 + 150;
+
+  /**
    * wsPaths with a sync pass in flight; the boolean marks whether another
    * external event arrived meanwhile and the pass must run again. Only
    * `handleEvent`/`syncPath` write it — passes report their own rerun needs
@@ -260,8 +261,12 @@ export class ExternalContentSync {
         pendingWork = result.retry || this.runs.get(wsPath) === true;
       } while (pendingWork && passes < MAX_PASSES && !this.aborted);
       if (pendingWork && !this.aborted) {
+        // Every retry was spent (never-stable reads, a long IME composition,
+        // or repeated snapshot-preservation failures). The editor may now be
+        // behind disk, so tell the user instead of leaving a console trail.
+        this.host.onStaleContentRefused(wsPath);
         this.host.logger.warn(
-          `External content for ${wsPath} kept changing; giving up until the next external event`,
+          `External content for ${wsPath} could not be reconciled after ${passes} passes; giving up until the next external event`,
         );
       }
     } finally {
@@ -401,7 +406,16 @@ export class ExternalContentSync {
           refused = true;
           continue;
         }
-        if (currentSerialized === diskSerialized) {
+        if (
+          currentSerialized === diskSerialized &&
+          retainedSource === undefined
+        ) {
+          // The doc changed since load, so a save writes exactly these bytes —
+          // nothing on disk can be silently reverted. Typically our own save's
+          // echo. With a retained baseline this falls through instead: disk
+          // holds different bytes than the baseline, and applying refreshes
+          // the baseline and the fidelity notice so a later save cannot
+          // silently revert the external author's formatting.
           reconciled = true;
           continue;
         }

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -6,7 +6,11 @@ import type {
 } from '@bangle.io/prosemirror-plugins';
 import { TextSelection } from '@bangle.io/prosemirror-plugins';
 import type { ExternalFileChangeEvent } from '@bangle.io/service-core';
-import { isMarkdownRoundTripPreserved } from './round-trip-check';
+import {
+  collectLinkTargets,
+  isMarkdownContentPreserved,
+  isMarkdownRoundTripPreserved,
+} from './round-trip-check';
 
 /**
  * Quiet period between an external change notification and the first disk
@@ -381,9 +385,19 @@ export class ExternalContentSync {
           reconciled = true;
           continue;
         }
-        if (!isMarkdownRoundTripPreserved(diskText, diskSerialized)) {
+        // Applying writes nothing, so the question is not "would saving
+        // rewrite this file?" (pure normalization would, and the fidelity
+        // notice already says so) but "did parsing lose anything the user can
+        // see?". Only the latter justifies showing older content than disk.
+        // The two tests are not nested: a fenced code block that merely
+        // contains a definition-shaped line is byte-identical yet fails the
+        // content test, so either one passing is enough.
+        if (
+          !isMarkdownRoundTripPreserved(diskText, diskSerialized) &&
+          !isMarkdownContentPreserved(diskText, collectLinkTargets(parsed))
+        ) {
           this.host.logger.warn(
-            `External change to ${wsPath} does not round-trip through the editor; not auto-applying`,
+            `Parsing the external change to ${wsPath} dropped content; not auto-applying`,
           );
           refused = true;
           continue;

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -2,6 +2,7 @@ import type {
   EditorView,
   markdownLoader,
   Schema,
+  Transaction,
 } from '@bangle.io/prosemirror-plugins';
 import { TextSelection } from '@bangle.io/prosemirror-plugins';
 import type { ExternalFileChangeEvent } from '@bangle.io/service-core';
@@ -49,6 +50,29 @@ function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
     };
     signal?.addEventListener('abort', onAbort, { once: true });
   });
+}
+
+/**
+ * Builds a save-suppressed, non-undoable replacement for externally sourced
+ * content while preserving the selection near its previous position. Returns
+ * undefined when applying a non-empty document would unexpectedly blank it.
+ */
+export function buildExternalDocReplace(
+  view: EditorView,
+  parsedDoc: EditorView['state']['doc'],
+): Transaction | undefined {
+  const { state } = view;
+  const selectionHead = state.selection.head;
+  let tr = state.tr.replaceWith(0, state.doc.content.size, parsedDoc.content);
+  if (parsedDoc.content.size > 0 && tr.doc.content.size === 0) {
+    return undefined;
+  }
+  tr = tr.setSelection(
+    TextSelection.near(
+      tr.doc.resolve(Math.min(selectionHead, tr.doc.content.size)),
+    ),
+  );
+  return tr.setMeta('addToHistory', false);
 }
 
 /**
@@ -324,27 +348,17 @@ export class ExternalContentSync {
         continue;
       }
 
-      const { state } = view;
-      const selectionHead = state.selection.head;
-      let tr = state.tr.replaceWith(0, state.doc.content.size, parsed.content);
-      // Defense in depth: if the replacement lost the parsed content (e.g.
-      // a schema mismatch makes the replace fitting drop foreign nodes),
-      // never apply it — a wrong-but-present note beats a blanked one.
-      if (parsed.content.size > 0 && tr.doc.content.size === 0) {
+      const tr = buildExternalDocReplace(view, parsed);
+      // Defense in depth: if the replacement lost the parsed content (e.g. a
+      // schema mismatch), never apply it — a wrong-but-present note beats a
+      // blanked one.
+      if (!tr) {
         this.host.logger.error(
           `External sync for ${wsPath} produced an empty document from non-empty content; skipping`,
         );
         refused = true;
         continue;
       }
-      tr = tr.setSelection(
-        TextSelection.near(
-          tr.doc.resolve(Math.min(selectionHead, tr.doc.content.size)),
-        ),
-      );
-      // External content is not a user edit: keep it out of the undo stack
-      // (undoing it locally would fight the sync tool).
-      tr = tr.setMeta('addToHistory', false);
 
       this.host.withSaveSuppressed(wsPath, () => {
         view.dispatch(tr);

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -18,15 +18,17 @@ const QUIET_MS = 150;
  * changed content is applied to an open editor.
  */
 const STABILITY_MS = 100;
+/** Back-to-back passes before backing off, for a writer that settles quickly. */
+const PASSES_BEFORE_BACKOFF = 5;
 /**
- * Upper bound on re-runs per event burst so a file under continuous external
+ * Upper bound on passes per event burst so a file under continuous external
  * writes cannot spin the sync loop forever; the next watcher event starts a
  * fresh sync.
  */
-const MAX_PASSES = 5;
+const MAX_PASSES = 10;
 /**
- * Backoff before one final bounded retry burst. A writer may settle without
- * producing another watcher event, so the first bound cannot simply give up.
+ * Backoff before the remaining passes. A writer may settle without producing
+ * another watcher event, so the fast passes cannot simply give up.
  */
 const TRAILING_RETRY_DELAY_MS = 1_000;
 
@@ -93,7 +95,8 @@ export interface ExternalContentSyncHost {
   /**
    * Preserves the current source, re-checks that the editor is still safe to
    * replace, applies the transaction without re-saving it, and records the
-   * newly loaded source baseline.
+   * newly loaded source baseline. `refused` means the editor's own content
+   * could not be preserved, so replacing it would lose it for good.
    */
   replaceContent(args: {
     currentSerialized: string;
@@ -102,7 +105,7 @@ export interface ExternalContentSyncHost {
     transaction: Transaction;
     view: EditorView;
     wsPath: string;
-  }): Promise<'applied' | 'retry' | 'skipped'>;
+  }): Promise<'applied' | 'refused' | 'retry' | 'skipped'>;
   /**
    * The disk copy of `wsPath` was confirmed stable and different, but was
    * refused (fidelity, emptied-file, schema, or parse refusal) — the open
@@ -223,7 +226,7 @@ export class ExternalContentSync {
     let pendingWork = false;
     try {
       do {
-        if (passes === MAX_PASSES) {
+        if (passes === PASSES_BEFORE_BACKOFF) {
           await sleep(TRAILING_RETRY_DELAY_MS, this.signal);
           if (this.aborted) {
             return;
@@ -233,7 +236,7 @@ export class ExternalContentSync {
         passes += 1;
         const result = await this.reconcileOnce(wsPath, 'automatic');
         pendingWork = result.retry || this.runs.get(wsPath) === true;
-      } while (pendingWork && passes < MAX_PASSES * 2 && !this.aborted);
+      } while (pendingWork && passes < MAX_PASSES && !this.aborted);
       if (pendingWork && !this.aborted) {
         this.host.logger.warn(
           `External content for ${wsPath} kept changing; giving up until the next external event`,
@@ -318,13 +321,9 @@ export class ExternalContentSync {
       const markdown = this.host.getMarkdown(view.state.schema);
       let parsed: ReturnType<typeof markdown.parser.parse>;
       let currentSerialized: string;
-      let diskSerialized: string | undefined;
       try {
         parsed = markdown.parser.parse(diskText);
         currentSerialized = markdown.serializer.serialize(view.state.doc);
-        if (mode === 'automatic') {
-          diskSerialized = markdown.serializer.serialize(parsed);
-        }
       } catch (error) {
         if (mode === 'user-approved') {
           throw error;
@@ -338,11 +337,19 @@ export class ExternalContentSync {
       }
 
       if (mode === 'automatic') {
-        // Serializer comparison coalesces echoes and normalization-only
-        // differences. Retained source recognizes unchanged lossy Markdown.
-        if (diskSerialized === undefined) {
+        let diskSerialized: string;
+        try {
+          diskSerialized = markdown.serializer.serialize(parsed);
+        } catch (error) {
+          this.host.logger.warn(
+            `Could not serialize externally changed content for ${wsPath}`,
+            error,
+          );
+          refused = true;
           continue;
         }
+        // Serializer comparison coalesces echoes and normalization-only
+        // differences. Retained source recognizes unchanged lossy Markdown.
         const retainedSource = this.host.getRetainedSource(view);
         if (
           currentSerialized === diskSerialized &&
@@ -396,6 +403,8 @@ export class ExternalContentSync {
       }
       if (replaceResult === 'retry') {
         outcome.retry = true;
+      } else if (replaceResult === 'refused') {
+        refused = true;
       } else if (replaceResult === 'applied') {
         outcome.appliedViews.push(view);
         reconciled = true;

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -140,7 +140,6 @@ export interface ExternalContentSyncHost {
 export type DiskVersionApplyResult = {
   /** How many mounted views were replaced. */
   appliedCount: number;
-  content?: string;
   retry: boolean;
   unavailable: boolean;
 };
@@ -322,7 +321,6 @@ export class ExternalContentSync {
         return outcome;
       }
     }
-    outcome.content = diskText;
 
     // The user may have typed while disk was being read.
     if (this.host.hasPendingSaves(wsPath)) {

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -138,7 +138,8 @@ export interface ExternalContentSyncHost {
 }
 
 export type DiskVersionApplyResult = {
-  appliedViews: EditorView[];
+  /** How many mounted views were replaced. */
+  appliedCount: number;
   content?: string;
   retry: boolean;
   unavailable: boolean;
@@ -274,7 +275,7 @@ export class ExternalContentSync {
     mode: ReconcileMode,
   ): Promise<DiskVersionApplyResult> {
     const outcome: DiskVersionApplyResult = {
-      appliedViews: [],
+      appliedCount: 0,
       retry: false,
       unavailable: false,
     };
@@ -442,7 +443,7 @@ export class ExternalContentSync {
       } else if (replaceResult === 'refused') {
         refused = true;
       } else if (replaceResult === 'applied') {
-        outcome.appliedViews.push(view);
+        outcome.appliedCount += 1;
         reconciled = true;
       }
     }

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -93,7 +93,11 @@ export interface ExternalContentSyncHost {
   readFileAsText(wsPath: string): Promise<string | undefined>;
   getMarkdown(schema: Schema): ReturnType<typeof markdownLoader>;
   /** Saves the clean editor content before an external version replaces it. */
-  preserveCurrentContent(wsPath: string, content: string): Promise<void>;
+  preserveCurrentContent(
+    wsPath: string,
+    content: string,
+    view: EditorView,
+  ): Promise<void>;
   /**
    * Runs `dispatch` with the editor's save pipeline suppressed for `wsPath`
    * (see `suppressSaveForExternalSync` in the editor service for why the
@@ -364,7 +368,7 @@ export class ExternalContentSync {
       }
 
       if (!preservedCurrentContent) {
-        await this.host.preserveCurrentContent(wsPath, currentSerialized);
+        await this.host.preserveCurrentContent(wsPath, currentSerialized, view);
         if (this.aborted) {
           return false;
         }

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -93,14 +93,15 @@ export interface ExternalContentSyncHost {
   /** Exact disk source retained while this view's document is unchanged. */
   getRetainedSource(view: EditorView): string | undefined;
   /**
-   * Preserves the current source, re-checks that the editor is still safe to
+   * Preserves `preservableSource`, re-checks that the editor is still safe to
    * replace, applies the transaction without re-saving it, and records the
    * newly loaded source baseline. `refused` means the editor's own content
    * could not be preserved, so replacing it would lose it for good.
    */
   replaceContent(args: {
-    currentSerialized: string;
     expectedDoc: EditorView['state']['doc'];
+    /** What to keep recoverable before the editor is overwritten. */
+    preservableSource: string;
     sourceMarkdown: string;
     transaction: Transaction;
     view: EditorView;
@@ -336,6 +337,11 @@ export class ExternalContentSync {
         continue;
       }
 
+      // While the document is unchanged since load, the exact bytes it was
+      // parsed from are what must be preserved — a re-serialization would
+      // normalize away Markdown the editor cannot round-trip.
+      const retainedSource = this.host.getRetainedSource(view);
+
       if (mode === 'automatic') {
         let diskSerialized: string;
         try {
@@ -350,7 +356,6 @@ export class ExternalContentSync {
         }
         // Serializer comparison coalesces echoes and normalization-only
         // differences. Retained source recognizes unchanged lossy Markdown.
-        const retainedSource = this.host.getRetainedSource(view);
         if (
           currentSerialized === diskSerialized &&
           retainedSource !== undefined &&
@@ -391,8 +396,8 @@ export class ExternalContentSync {
       }
 
       const replaceResult = await this.host.replaceContent({
-        currentSerialized,
         expectedDoc: docsBefore[index],
+        preservableSource: retainedSource ?? currentSerialized,
         sourceMarkdown: diskText,
         transaction,
         view,

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -1,0 +1,227 @@
+import type {
+  EditorView,
+  markdownLoader,
+  Schema,
+} from '@bangle.io/prosemirror-plugins';
+import { TextSelection } from '@bangle.io/prosemirror-plugins';
+import type { ExternalFileChangeEvent } from '@bangle.io/service-core';
+
+/**
+ * Quiet period between an external change notification and the first disk
+ * read, letting in-progress writes (truncate-then-write) finish first.
+ */
+const QUIET_MS = 150;
+/**
+ * Gap between the two confirming reads that must agree before externally
+ * changed content is applied to an open editor.
+ */
+const STABILITY_MS = 100;
+/**
+ * Upper bound on re-runs per event burst so a file under continuous external
+ * writes cannot spin the sync loop forever; the next watcher event starts a
+ * fresh sync.
+ */
+const MAX_PASSES = 5;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * The slice of the editor service that external-disk reconciliation needs.
+ * Kept narrow so the sync logic can be tested with a fake host and cannot
+ * reach into unrelated editor state.
+ */
+export interface ExternalContentSyncHost {
+  /** Ready, non-destroyed views currently showing `wsPath`. */
+  getViews(wsPath: string): EditorView[];
+  /**
+   * wsPaths of all mounted, ready editors — scoped to one workspace when
+   * `wsName` is given.
+   */
+  getMountedWsPaths(wsName?: string): string[];
+  /** Whether unsaved or failed-to-save local edits exist for the path. */
+  hasPendingSaves(wsPath: string): boolean;
+  readFileAsText(wsPath: string): Promise<string | undefined>;
+  getMarkdown(schema: Schema): ReturnType<typeof markdownLoader>;
+  /**
+   * Runs `dispatch` with the editor's save pipeline suppressed for `wsPath`,
+   * so applying external content is not re-saved (a no-op write would churn
+   * the file's mtime and make sync tools loop on their own change).
+   */
+  withSaveSuppressed(wsPath: string, dispatch: () => void): void;
+  logger: {
+    warn(...args: unknown[]): void;
+    error(...args: unknown[]): void;
+  };
+}
+
+/**
+ * Reconciles open editors with files changed outside this app instance
+ * (sync tools, other editors), without ever losing user work:
+ *
+ * - unsaved or failed-to-save local edits always win over the external copy;
+ * - watcher events are treated as hints — content is only applied once two
+ *   consecutive reads agree, tolerating truncate-then-write writers;
+ * - echoes and normalization no-ops are coalesced by serializer-level
+ *   comparison and never touch the editor;
+ * - a replacement that lost the parsed content (schema mismatch) is refused;
+ * - applied content stays out of the undo stack and is not re-saved.
+ */
+export class ExternalContentSync {
+  /**
+   * wsPaths with a sync pass in flight; the boolean marks whether another
+   * external event arrived meanwhile and the pass must run again.
+   */
+  private runs = new Map<string, boolean>();
+
+  constructor(private host: ExternalContentSyncHost) {}
+
+  handleEvent(event: ExternalFileChangeEvent): void {
+    let targets: string[];
+    switch (event.type) {
+      case 'file-content-update':
+      case 'file-create': {
+        targets =
+          event.wsPath !== undefined &&
+          this.host.getViews(event.wsPath).length > 0
+            ? [event.wsPath]
+            : [];
+        break;
+      }
+      case 'refresh': {
+        // A refresh scoped to a workspace only reconciles that workspace's
+        // editors; an app-wide refresh (no wsName) reconciles everything.
+        targets = this.host.getMountedWsPaths(event.wsName);
+        break;
+      }
+      default: {
+        // Deletes/renames change the tree, not the open document's content.
+        targets = [];
+      }
+    }
+    for (const wsPath of targets) {
+      void this.syncPath(wsPath).catch((error) => {
+        this.host.logger.warn(
+          `Failed to refresh editor from external change: ${wsPath}`,
+          error,
+        );
+      });
+    }
+  }
+
+  private async syncPath(wsPath: string): Promise<void> {
+    const running = this.runs.get(wsPath);
+    if (running !== undefined) {
+      // A pass is already in flight — ask it to run once more so the final
+      // external state is not dropped.
+      this.runs.set(wsPath, true);
+      return;
+    }
+    this.runs.set(wsPath, false);
+    let passes = 0;
+    try {
+      do {
+        this.runs.set(wsPath, false);
+        passes += 1;
+        await this.applyIfClean(wsPath);
+      } while (this.runs.get(wsPath) && passes < MAX_PASSES);
+    } finally {
+      this.runs.delete(wsPath);
+    }
+  }
+
+  private async applyIfClean(wsPath: string): Promise<void> {
+    // Unsaved or failed-to-save local edits always win: replacing the doc
+    // would destroy content that exists nowhere else.
+    if (this.host.hasPendingSaves(wsPath)) {
+      return;
+    }
+    const views = this.host.getViews(wsPath);
+    if (views.length === 0) {
+      return;
+    }
+    const docsBefore = views.map((view) => view.state.doc);
+
+    // Watcher records are hints that can fire mid-write: a sync tool (or the
+    // browser's own writable stream) may truncate the file before the new
+    // bytes land, with no follow-up record for the final commit. Wait out a
+    // short quiet period, then require two consecutive reads to agree before
+    // treating the content as settled — otherwise an open note would flash
+    // (or stick) empty on a truncate-then-write.
+    await sleep(QUIET_MS);
+    const firstRead = await this.host.readFileAsText(wsPath);
+    if (firstRead === undefined) {
+      return;
+    }
+    await sleep(STABILITY_MS);
+    const diskText = await this.host.readFileAsText(wsPath);
+    if (diskText === undefined) {
+      return;
+    }
+    if (diskText !== firstRead) {
+      // Still being written — run another pass after the loop's rerun check.
+      this.runs.set(wsPath, true);
+      return;
+    }
+    // The user may have typed while the reads were in flight — re-check, and
+    // bail if any doc moved on. A newer watcher event re-triggers this pass.
+    if (this.host.hasPendingSaves(wsPath)) {
+      return;
+    }
+
+    for (const [index, view] of views.entries()) {
+      if (view.isDestroyed || view.state.doc !== docsBefore[index]) {
+        continue;
+      }
+      const markdown = this.host.getMarkdown(view.state.schema);
+      let parsed: ReturnType<typeof markdown.parser.parse>;
+      try {
+        parsed = markdown.parser.parse(diskText);
+      } catch (error) {
+        // A parse failure must never touch the editor (or disk) — the user
+        // keeps their current view of the note.
+        this.host.logger.warn(
+          `Could not parse externally changed content for ${wsPath}`,
+          error,
+        );
+        continue;
+      }
+      // Compare through the serializer so normalization differences (e.g.
+      // list markers) don't register as changes; equal content means this is
+      // our own echo or a no-op and the editor is left untouched.
+      const currentSerialized = markdown.serializer.serialize(view.state.doc);
+      const diskSerialized = markdown.serializer.serialize(parsed);
+      if (currentSerialized === diskSerialized) {
+        continue;
+      }
+
+      const { state } = view;
+      const selectionHead = state.selection.head;
+      let tr = state.tr.replaceWith(0, state.doc.content.size, parsed.content);
+      // Defense in depth: if the replacement lost the parsed content (e.g.
+      // a schema mismatch makes the replace fitting drop foreign nodes),
+      // never apply it — a wrong-but-present note beats a blanked one.
+      if (parsed.content.size > 0 && tr.doc.content.size === 0) {
+        this.host.logger.error(
+          `External sync for ${wsPath} produced an empty document from non-empty content; skipping`,
+        );
+        continue;
+      }
+      tr = tr.setSelection(
+        TextSelection.near(
+          tr.doc.resolve(Math.min(selectionHead, tr.doc.content.size)),
+        ),
+      );
+      // External content is not a user edit: keep it out of the undo stack
+      // (undoing it locally would fight the sync tool).
+      tr = tr.setMeta('addToHistory', false);
+
+      this.host.withSaveSuppressed(wsPath, () => {
+        view.dispatch(tr);
+      });
+    }
+  }
+}

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -25,14 +25,10 @@ const STABILITY_MS = 100;
  */
 const MAX_PASSES = 5;
 /**
- * Backoff before the single trailing pass that runs when MAX_PASSES was
- * exhausted with work still pending. Writers commit their final state with
- * no follow-up record (the premise of the two-read protocol), so giving up
- * silently at the bound would leave the editor stale forever; one delayed,
- * non-re-arming retry covers the settle-after-the-bound case while keeping
- * total work per burst finite.
+ * Backoff before one final bounded retry burst. A writer may settle without
+ * producing another watcher event, so the first bound cannot simply give up.
  */
-const TRAILING_PASS_DELAY_MS = 1_000;
+const TRAILING_RETRY_DELAY_MS = 1_000;
 
 function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
   return new Promise((resolve) => {
@@ -57,7 +53,7 @@ function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
  * content while preserving the selection near its previous position. Returns
  * undefined when applying a non-empty document would unexpectedly blank it.
  */
-export function buildExternalDocReplace(
+function buildExternalDocReplace(
   view: EditorView,
   parsedDoc: EditorView['state']['doc'],
 ): Transaction | undefined {
@@ -126,6 +122,15 @@ export interface ExternalContentSyncHost {
   };
 }
 
+export type DiskVersionApplyResult = {
+  appliedViews: EditorView[];
+  content?: string;
+  retry: boolean;
+  unavailable: boolean;
+};
+
+type ReconcileMode = 'automatic' | 'user-approved';
+
 /**
  * Reconciles open editors with files changed outside this app instance
  * (sync tools, other editors), without ever losing user work:
@@ -145,7 +150,7 @@ export class ExternalContentSync {
    * wsPaths with a sync pass in flight; the boolean marks whether another
    * external event arrived meanwhile and the pass must run again. Only
    * `handleEvent`/`syncPath` write it — passes report their own rerun needs
-   * through `applyIfClean`'s return value.
+   * through `reconcileOnce`'s return value.
    */
   private runs = new Map<string, boolean>();
 
@@ -196,10 +201,17 @@ export class ExternalContentSync {
     }
   }
 
-  private async syncPath(
-    wsPath: string,
-    isTrailingPass = false,
-  ): Promise<void> {
+  /**
+   * Applies the current disk version after explicit user consent. This shares
+   * the dirty-edit, composition, parsing, and replacement lifecycle with
+   * automatic reconciliation, while bypassing its fidelity and empty-file
+   * refusals.
+   */
+  acceptDiskVersion(wsPath: string): Promise<DiskVersionApplyResult> {
+    return this.reconcileOnce(wsPath, 'user-approved');
+  }
+
+  private async syncPath(wsPath: string): Promise<void> {
     if (this.runs.has(wsPath)) {
       // A pass is already in flight — ask it to run once more so the final
       // external state is not dropped.
@@ -211,86 +223,86 @@ export class ExternalContentSync {
     let pendingWork = false;
     try {
       do {
+        if (passes === MAX_PASSES) {
+          await sleep(TRAILING_RETRY_DELAY_MS, this.signal);
+          if (this.aborted) {
+            return;
+          }
+        }
         this.runs.set(wsPath, false);
         passes += 1;
-        const wantsRerun = await this.applyIfClean(wsPath);
-        pendingWork = wantsRerun || this.runs.get(wsPath) === true;
-      } while (pendingWork && passes < MAX_PASSES && !this.aborted);
+        const result = await this.reconcileOnce(wsPath, 'automatic');
+        pendingWork = result.retry || this.runs.get(wsPath) === true;
+      } while (pendingWork && passes < MAX_PASSES * 2 && !this.aborted);
+      if (pendingWork && !this.aborted) {
+        this.host.logger.warn(
+          `External content for ${wsPath} kept changing; giving up until the next external event`,
+        );
+      }
     } finally {
       this.runs.delete(wsPath);
     }
-
-    if (!pendingWork || this.aborted) {
-      return;
-    }
-    // MAX_PASSES exhausted with work still pending. The writer's final
-    // commit may produce no further watcher record, so give the file one
-    // delayed, fresh chance to settle — but never re-arm from within that
-    // trailing pass, keeping per-burst work finite for a file under truly
-    // continuous external writes.
-    if (isTrailingPass) {
-      this.host.logger.warn(
-        `External content for ${wsPath} kept changing; giving up until the next external event`,
-      );
-      return;
-    }
-    await sleep(TRAILING_PASS_DELAY_MS, this.signal);
-    if (this.aborted) {
-      return;
-    }
-    await this.syncPath(wsPath, true);
   }
 
-  /**
-   * Runs one reconciliation pass. Returns true when the pass could not
-   * settle (mid-write reads disagreed, or a view was busy composing) and
-   * the caller should run another pass.
-   */
-  private async applyIfClean(wsPath: string): Promise<boolean> {
+  private async reconcileOnce(
+    wsPath: string,
+    mode: ReconcileMode,
+  ): Promise<DiskVersionApplyResult> {
+    const outcome: DiskVersionApplyResult = {
+      appliedViews: [],
+      retry: false,
+      unavailable: false,
+    };
+
     // Unsaved or failed-to-save local edits always win: replacing the doc
     // would destroy content that exists nowhere else.
     if (this.host.hasPendingSaves(wsPath)) {
-      return false;
+      return outcome;
     }
     const views = this.host.getViews(wsPath);
     if (views.length === 0) {
-      return false;
+      return outcome;
     }
     const docsBefore = views.map((view) => view.state.doc);
 
-    // Watcher records are hints that can fire mid-write: a sync tool (or the
-    // browser's own writable stream) may truncate the file before the new
-    // bytes land, with no follow-up record for the final commit. Wait out a
-    // short quiet period, then require two consecutive reads to agree before
-    // treating the content as settled — otherwise an open note would flash
-    // (or stick) empty on a truncate-then-write.
-    await sleep(QUIET_MS, this.signal);
-    if (this.aborted) {
-      return false;
+    let diskText: string | undefined;
+    if (mode === 'automatic') {
+      // Watcher records can fire mid-write. Wait briefly, then require two
+      // consecutive reads to agree before treating the content as settled.
+      await sleep(QUIET_MS, this.signal);
+      if (this.aborted) {
+        return outcome;
+      }
+      const firstRead = await this.host.readFileAsText(wsPath);
+      if (firstRead === undefined || this.aborted) {
+        return outcome;
+      }
+      await sleep(STABILITY_MS, this.signal);
+      if (this.aborted) {
+        return outcome;
+      }
+      diskText = await this.host.readFileAsText(wsPath);
+      if (diskText === undefined || this.aborted) {
+        return outcome;
+      }
+      if (diskText !== firstRead) {
+        outcome.retry = true;
+        return outcome;
+      }
+    } else {
+      diskText = await this.host.readFileAsText(wsPath);
+      if (diskText === undefined || this.aborted) {
+        outcome.unavailable = true;
+        return outcome;
+      }
     }
-    const firstRead = await this.host.readFileAsText(wsPath);
-    if (firstRead === undefined || this.aborted) {
-      return false;
-    }
-    await sleep(STABILITY_MS, this.signal);
-    if (this.aborted) {
-      return false;
-    }
-    const diskText = await this.host.readFileAsText(wsPath);
-    if (diskText === undefined || this.aborted) {
-      return false;
-    }
-    if (diskText !== firstRead) {
-      // Still being written — ask for another pass.
-      return true;
-    }
-    // The user may have typed while the reads were in flight — re-check, and
-    // bail if any doc moved on. A newer watcher event re-triggers this pass.
+    outcome.content = diskText;
+
+    // The user may have typed while disk was being read.
     if (this.host.hasPendingSaves(wsPath)) {
-      return false;
+      return outcome;
     }
 
-    let needsRerun = false;
     let refused = false;
     let reconciled = false;
     for (const [index, view] of views.entries()) {
@@ -298,28 +310,25 @@ export class ExternalContentSync {
         continue;
       }
       if (view.composing) {
-        // Replacing the doc mid-IME-composition aborts the composition and
-        // silently drops the user's uncommitted keystrokes. Retry after the
-        // burst; once composition commits, the resulting save re-triggers
-        // reconciliation anyway.
-        needsRerun = true;
+        // Replacing the doc mid-composition silently drops uncommitted input.
+        outcome.retry = true;
         continue;
       }
+
       const markdown = this.host.getMarkdown(view.state.schema);
       let parsed: ReturnType<typeof markdown.parser.parse>;
       let currentSerialized: string;
-      let diskSerialized: string;
+      let diskSerialized: string | undefined;
       try {
         parsed = markdown.parser.parse(diskText);
-        // Compare through the serializer so normalization differences (e.g.
-        // list markers) don't register as changes; equal content means this
-        // is our own echo or a no-op and the editor is left untouched.
         currentSerialized = markdown.serializer.serialize(view.state.doc);
-        diskSerialized = markdown.serializer.serialize(parsed);
+        if (mode === 'automatic') {
+          diskSerialized = markdown.serializer.serialize(parsed);
+        }
       } catch (error) {
-        // A parse or serialize failure must never touch the editor (or
-        // disk) — the user keeps their current view of the note, and the
-        // remaining views still get their chance.
+        if (mode === 'user-approved') {
+          throw error;
+        }
         this.host.logger.warn(
           `Could not parse or compare externally changed content for ${wsPath}`,
           error,
@@ -327,53 +336,46 @@ export class ExternalContentSync {
         refused = true;
         continue;
       }
-      // A coarse refresh also visits unchanged notes. Lossy Markdown cannot
-      // equal its serializer output, so recognize the exact retained source
-      // before treating serializer-equal content as a changed lossy source.
-      const retainedSource = this.host.getRetainedSource(view);
-      if (
-        currentSerialized === diskSerialized &&
-        retainedSource !== undefined &&
-        isMarkdownRoundTripPreserved(diskText, retainedSource)
-      ) {
-        reconciled = true;
-        continue;
-      }
-      // Same fidelity gate as initial note loading: if the external Markdown
-      // does not round-trip exactly (footnotes, reference links, other
-      // constructs the schema rewrites), applying it would put a lossy doc in
-      // the editor and the user's next keystroke would save that loss to
-      // disk. Leave the editor as-is; opening the note goes through the load
-      // path, which surfaces the fidelity warning.
-      if (!isMarkdownRoundTripPreserved(diskText, diskSerialized)) {
-        this.host.logger.warn(
-          `External change to ${wsPath} does not round-trip through the editor; not auto-applying`,
-        );
-        refused = true;
-        continue;
-      }
-      if (currentSerialized === diskSerialized) {
-        reconciled = true;
-        continue;
-      }
-      // Two agreeing reads can still both land inside a truncate-then-write
-      // writer's truncated state. Blanking a non-empty note is the one
-      // destructive shape of that race, so never auto-apply it — a genuine
-      // external clear still shows after the writer's next event with real
-      // content, or on reload.
-      if (diskText.trim() === '' && currentSerialized.trim() !== '') {
-        this.host.logger.warn(
-          `External change emptied ${wsPath}; keeping the editor content`,
-        );
-        refused = true;
-        continue;
+
+      if (mode === 'automatic') {
+        // Serializer comparison coalesces echoes and normalization-only
+        // differences. Retained source recognizes unchanged lossy Markdown.
+        if (diskSerialized === undefined) {
+          continue;
+        }
+        const retainedSource = this.host.getRetainedSource(view);
+        if (
+          currentSerialized === diskSerialized &&
+          retainedSource !== undefined &&
+          isMarkdownRoundTripPreserved(diskText, retainedSource)
+        ) {
+          reconciled = true;
+          continue;
+        }
+        if (!isMarkdownRoundTripPreserved(diskText, diskSerialized)) {
+          this.host.logger.warn(
+            `External change to ${wsPath} does not round-trip through the editor; not auto-applying`,
+          );
+          refused = true;
+          continue;
+        }
+        if (currentSerialized === diskSerialized) {
+          reconciled = true;
+          continue;
+        }
+        // Agreeing reads can both land inside a writer's truncated state.
+        // Never automatically blank a non-empty editor.
+        if (diskText.trim() === '' && currentSerialized.trim() !== '') {
+          this.host.logger.warn(
+            `External change emptied ${wsPath}; keeping the editor content`,
+          );
+          refused = true;
+          continue;
+        }
       }
 
-      const tr = buildExternalDocReplace(view, parsed);
-      // Defense in depth: if the replacement lost the parsed content (e.g. a
-      // schema mismatch), never apply it — a wrong-but-present note beats a
-      // blanked one.
-      if (!tr) {
+      const transaction = buildExternalDocReplace(view, parsed);
+      if (!transaction) {
         this.host.logger.error(
           `External sync for ${wsPath} produced an empty document from non-empty content; skipping`,
         );
@@ -381,31 +383,33 @@ export class ExternalContentSync {
         continue;
       }
 
-      const result = await this.host.replaceContent({
+      const replaceResult = await this.host.replaceContent({
         currentSerialized,
         expectedDoc: docsBefore[index],
         sourceMarkdown: diskText,
-        transaction: tr,
+        transaction,
         view,
         wsPath,
       });
       if (this.aborted) {
-        return false;
+        return outcome;
       }
-      if (result === 'retry') {
-        needsRerun = true;
-      } else if (result === 'applied') {
+      if (replaceResult === 'retry') {
+        outcome.retry = true;
+      } else if (replaceResult === 'applied') {
+        outcome.appliedViews.push(view);
         reconciled = true;
       }
     }
 
-    // One outcome per pass: a refusal outranks a reconciliation (the user
-    // should learn about the diverged view even if another view applied).
-    if (refused) {
-      this.host.onStaleContentRefused(wsPath);
-    } else if (reconciled) {
-      this.host.onContentReconciled(wsPath);
+    if (mode === 'automatic') {
+      // A refusal outranks a reconciliation: one diverged view is actionable.
+      if (refused) {
+        this.host.onStaleContentRefused(wsPath);
+      } else if (reconciled) {
+        this.host.onContentReconciled(wsPath);
+      }
     }
-    return needsRerun;
+    return outcome;
   }
 }

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -92,18 +92,21 @@ export interface ExternalContentSyncHost {
   hasPendingSaves(wsPath: string): boolean;
   readFileAsText(wsPath: string): Promise<string | undefined>;
   getMarkdown(schema: Schema): ReturnType<typeof markdownLoader>;
-  /** Saves the clean editor content before an external version replaces it. */
-  preserveCurrentContent(
-    wsPath: string,
-    content: string,
-    view: EditorView,
-  ): Promise<void>;
+  /** Exact disk source retained while this view's document is unchanged. */
+  getRetainedSource(view: EditorView): string | undefined;
   /**
-   * Runs `dispatch` with the editor's save pipeline suppressed for `wsPath`
-   * (see `suppressSaveForExternalSync` in the editor service for why the
-   * write-back must not happen).
+   * Preserves the current source, re-checks that the editor is still safe to
+   * replace, applies the transaction without re-saving it, and records the
+   * newly loaded source baseline.
    */
-  withSaveSuppressed(wsPath: string, dispatch: () => void): void;
+  replaceContent(args: {
+    currentSerialized: string;
+    expectedDoc: EditorView['state']['doc'];
+    sourceMarkdown: string;
+    transaction: Transaction;
+    view: EditorView;
+    wsPath: string;
+  }): Promise<'applied' | 'retry' | 'skipped'>;
   /**
    * The disk copy of `wsPath` was confirmed stable and different, but was
    * refused (fidelity, emptied-file, schema, or parse refusal) — the open
@@ -290,7 +293,6 @@ export class ExternalContentSync {
     let needsRerun = false;
     let refused = false;
     let reconciled = false;
-    let preservedCurrentContent = false;
     for (const [index, view] of views.entries()) {
       if (view.isDestroyed || view.state.doc !== docsBefore[index]) {
         continue;
@@ -325,7 +327,15 @@ export class ExternalContentSync {
         refused = true;
         continue;
       }
-      if (currentSerialized === diskSerialized) {
+      // A coarse refresh also visits unchanged notes. Lossy Markdown cannot
+      // equal its serializer output, so recognize the exact retained source
+      // before treating serializer-equal content as a changed lossy source.
+      const retainedSource = this.host.getRetainedSource(view);
+      if (
+        currentSerialized === diskSerialized &&
+        retainedSource !== undefined &&
+        isMarkdownRoundTripPreserved(diskText, retainedSource)
+      ) {
         reconciled = true;
         continue;
       }
@@ -340,6 +350,10 @@ export class ExternalContentSync {
           `External change to ${wsPath} does not round-trip through the editor; not auto-applying`,
         );
         refused = true;
+        continue;
+      }
+      if (currentSerialized === diskSerialized) {
+        reconciled = true;
         continue;
       }
       // Two agreeing reads can still both land inside a truncate-then-write
@@ -367,27 +381,22 @@ export class ExternalContentSync {
         continue;
       }
 
-      if (!preservedCurrentContent) {
-        await this.host.preserveCurrentContent(wsPath, currentSerialized, view);
-        if (this.aborted) {
-          return false;
-        }
-        // Snapshot storage is asynchronous. A keystroke made while it was in
-        // flight still wins over the external copy.
-        if (
-          this.host.hasPendingSaves(wsPath) ||
-          view.isDestroyed ||
-          view.state.doc !== docsBefore[index]
-        ) {
-          continue;
-        }
-        preservedCurrentContent = true;
-      }
-
-      this.host.withSaveSuppressed(wsPath, () => {
-        view.dispatch(tr);
+      const result = await this.host.replaceContent({
+        currentSerialized,
+        expectedDoc: docsBefore[index],
+        sourceMarkdown: diskText,
+        transaction: tr,
+        view,
+        wsPath,
       });
-      reconciled = true;
+      if (this.aborted) {
+        return false;
+      }
+      if (result === 'retry') {
+        needsRerun = true;
+      } else if (result === 'applied') {
+        reconciled = true;
+      }
     }
 
     // One outcome per pass: a refusal outranks a reconciliation (the user

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -12,12 +12,19 @@ import { isMarkdownRoundTripPreserved } from './round-trip-check';
  * Quiet period between an external change notification and the first disk
  * read, letting in-progress writes (truncate-then-write) finish first.
  */
-const QUIET_MS = 150;
+export const QUIET_MS = 150;
 /**
  * Gap between the two confirming reads that must agree before externally
  * changed content is applied to an open editor.
  */
-const STABILITY_MS = 100;
+export const STABILITY_MS = 100;
+/**
+ * How long a test must wait before "the editor did not change" proves a
+ * refusal rather than the pass simply not having run yet. Exported so those
+ * negative assertions cannot quietly go vacuous when the timings above are
+ * tuned.
+ */
+export const RECONCILE_SETTLE_MS = (QUIET_MS + STABILITY_MS) * 2 + 150;
 /** Back-to-back passes before backing off, for a writer that settles quickly. */
 const PASSES_BEFORE_BACKOFF = 5;
 /**
@@ -210,6 +217,16 @@ export class ExternalContentSync {
    * the dirty-edit, composition, parsing, and replacement lifecycle with
    * automatic reconciliation, while bypassing its fidelity and empty-file
    * refusals.
+   *
+   * Two deliberate differences from the automatic path:
+   * - it reads once instead of requiring two agreeing reads, so consenting
+   *   while a writer is mid-write can load a truncated file. The editor's own
+   *   copy is snapshotted first, so that stays recoverable, and making the
+   *   user wait out a stability protocol for an explicit action is worse than
+   *   the rare bad read;
+   * - it runs outside `runs`, so it can interleave with an automatic pass.
+   *   Whichever applies first changes the doc, and the loser's `expectedDoc`
+   *   check turns it into a no-op.
    */
   acceptDiskVersion(wsPath: string): Promise<DiskVersionApplyResult> {
     return this.reconcileOnce(wsPath, 'user-approved');

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -5,6 +5,7 @@ import type {
 } from '@bangle.io/prosemirror-plugins';
 import { TextSelection } from '@bangle.io/prosemirror-plugins';
 import type { ExternalFileChangeEvent } from '@bangle.io/service-core';
+import { isMarkdownRoundTripPreserved } from './round-trip-check';
 
 /**
  * Quiet period between an external change notification and the first disk
@@ -195,6 +196,29 @@ export class ExternalContentSync {
       const currentSerialized = markdown.serializer.serialize(view.state.doc);
       const diskSerialized = markdown.serializer.serialize(parsed);
       if (currentSerialized === diskSerialized) {
+        continue;
+      }
+      // Same fidelity gate as initial note loading: if the external Markdown
+      // does not round-trip exactly (footnotes, reference links, other
+      // constructs the schema rewrites), applying it would put a lossy doc in
+      // the editor and the user's next keystroke would save that loss to
+      // disk. Leave the editor as-is; opening the note goes through the load
+      // path, which surfaces the fidelity warning.
+      if (!isMarkdownRoundTripPreserved(diskText, diskSerialized)) {
+        this.host.logger.warn(
+          `External change to ${wsPath} does not round-trip through the editor; not auto-applying`,
+        );
+        continue;
+      }
+      // Two agreeing reads can still both land inside a truncate-then-write
+      // writer's truncated state. Blanking a non-empty note is the one
+      // destructive shape of that race, so never auto-apply it — a genuine
+      // external clear still shows after the writer's next event with real
+      // content, or on reload.
+      if (diskText.trim() === '' && currentSerialized.trim() !== '') {
+        this.host.logger.warn(
+          `External change emptied ${wsPath}; keeping the editor content`,
+        );
         continue;
       }
 

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -175,10 +175,10 @@ export class ExternalContentSync {
         break;
       }
       default: {
-        // Deletes/renames change the tree, not the open document's content.
-        // An open editor on the removed path keeps the user's content; its
-        // next save fails visibly through the save-error surface rather
-        // than silently recreating the file here.
+        // Deletes change the tree, not the open document's content. An open
+        // editor on the removed path keeps the user's content; its next save
+        // fails visibly through the save-error surface rather than silently
+        // recreating the file here.
         targets = [];
       }
     }

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -49,7 +49,10 @@ import {
   EditorSaveQueue,
 } from './editor-save-queue';
 import { setupExtensions } from './extensions';
-import { ExternalContentSync } from './external-content-sync';
+import {
+  buildExternalDocReplace,
+  ExternalContentSync,
+} from './external-content-sync';
 import { findHeadingIndexBySlug } from './heading-slug';
 import { createLocalImageNodeView } from './local-image-node-view';
 import { createEditor } from './pm-setup';
@@ -591,9 +594,10 @@ export class PmEditorService
    * The external sync confirmed the disk copy of `wsPath` differs but
    * refused to auto-apply it (fidelity, emptied-file, schema, or parse
    * refusal). Without this the user would keep looking at silently stale
-   * content with only a console warning. Reloading the UI sends the note
-   * through the load path, which shows the disk content and surfaces the
-   * fidelity warning when applicable.
+   * content with only a console warning. The offered action loads the disk
+   * version into this note's editors in place — deliberately not a UI reload,
+   * which would tear down every editor and could strand another note's pending
+   * or failed save.
    */
   private showStaleExternalContentToast(wsPath: string): void {
     const fileName = WsPath.safeParseFile(wsPath).data?.fileName ?? wsPath;
@@ -605,12 +609,85 @@ export class PmEditorService
         onClick: () => {},
       },
       action: {
-        label: t.app.toasts.reloadToApplyExternalChange,
+        label: t.app.toasts.loadDiskVersion,
         onClick: () => {
-          this.dependencies.workbenchState.reloadUi();
+          void this.loadDiskVersionIntoEditors(wsPath);
         },
       },
     });
+  }
+
+  /**
+   * User-consented recovery for external changes the automatic sync
+   * refused: replaces only this note's open editors with the current disk
+   * content, then runs the same fidelity check as note loading. Unsaved
+   * local edits still win — a note that became dirty since the refusal is
+   * left alone (its save resolves the divergence).
+   */
+  async loadDiskVersionIntoEditors(wsPath: string): Promise<void> {
+    try {
+      if (this.saveQueue.hasPendingOrFailed(wsPath)) {
+        this.logger.debug(
+          `${wsPath}: not loading the disk version — the user edited since the refusal and their save resolves the divergence`,
+        );
+        toast.dismiss(staleExternalContentToastId(wsPath));
+        return;
+      }
+      const viewsBeforeRead = [...this.readyEditors()]
+        .filter((editor) => editor.wsPath === wsPath)
+        .map((editor) => ({
+          doc: editor.editorView.state.doc,
+          view: editor.editorView,
+        }));
+      const content = await this.dependencies.fileSystem.readFileAsText(
+        wsPath,
+        { signal: this.abortSignal },
+      );
+      if (content === undefined) {
+        this.logger.warn(
+          `Disk version of ${wsPath} could not be read; keeping the editor content`,
+        );
+        return;
+      }
+      // The action does not block input. Re-check after the async read so a
+      // keystroke made while it was in flight cannot be replaced by stale disk
+      // content.
+      if (this.saveQueue.hasPendingOrFailed(wsPath)) {
+        this.logger.debug(
+          `${wsPath}: not loading the disk version — the user edited while it was being read`,
+        );
+        toast.dismiss(staleExternalContentToastId(wsPath));
+        return;
+      }
+      for (const { doc, view } of viewsBeforeRead) {
+        if (view.isDestroyed || view.state.doc !== doc) {
+          continue;
+        }
+        const markdown = this.getMarkdown(view.state.schema);
+        const parsed = markdown.parser.parse(content);
+        const tr = buildExternalDocReplace(view, parsed);
+        if (!tr) {
+          this.logger.error(
+            `Disk version of ${wsPath} produced an empty document from non-empty content; skipping`,
+          );
+          continue;
+        }
+        this.suppressSaveForExternalSync.add(wsPath);
+        try {
+          view.dispatch(tr);
+        } finally {
+          this.suppressSaveForExternalSync.delete(wsPath);
+        }
+        this.logger.info(
+          `${wsPath}: loaded the disk version into the open editor at the user's request (${content.length} chars)`,
+        );
+        this.checkRoundTripFidelity({ content, editorView: view, wsPath });
+      }
+      toast.dismiss(staleExternalContentToastId(wsPath));
+    } catch (error) {
+      // Editor and toast stay as they are; the user can retry.
+      this.logger.warn(`Could not load the disk version of ${wsPath}`, error);
+    }
   }
 
   private setRoundTripWarning(wsPath: string, hasWarning: boolean): void {

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -64,6 +64,23 @@ import {
 } from './round-trip-check';
 
 const ASSET_TOAST_FILE_NAME_MAX_LENGTH = 44;
+
+/**
+ * Quiet period between an external change notification and the first disk
+ * read, letting in-progress writes (truncate-then-write) finish first.
+ */
+const EXTERNAL_SYNC_QUIET_MS = 150;
+/**
+ * Gap between the two confirming reads that must agree before externally
+ * changed content is applied to an open editor.
+ */
+const EXTERNAL_SYNC_STABILITY_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 const EMPTY_WS_PATH_SET: ReadonlySet<string> = new Set();
 
 export type PmEditorServiceConfig = {
@@ -154,6 +171,14 @@ export class PmEditorService
 
   private editors = new Map<HTMLElement, EditorEntry>();
 
+  /**
+   * Markdown parse/serialize loaders keyed by editor schema. Every mounted
+   * editor builds its own `Schema` instance, and parsing creates nodes bound
+   * to the loader's schema — feeding nodes from one editor's schema into
+   * another editor's document makes ProseMirror's replace fitting silently
+   * drop the content. Keying by schema keeps each loader usable only with
+   * the views it belongs to.
+   */
   private markdownBySchema = new WeakMap<
     Schema,
     ReturnType<typeof markdownLoader>
@@ -357,11 +382,15 @@ export class PmEditorService
       return;
     }
     this.externalSyncRuns.set(wsPath, false);
+    // Bounded so a file under continuous external writes cannot spin this
+    // loop forever; the next watcher event starts a fresh sync.
+    let attempts = 0;
     try {
       do {
         this.externalSyncRuns.set(wsPath, false);
+        attempts += 1;
         await this.applyExternalContentIfClean(wsPath);
-      } while (this.externalSyncRuns.get(wsPath));
+      } while (this.externalSyncRuns.get(wsPath) && attempts < 5);
     } finally {
       this.externalSyncRuns.delete(wsPath);
     }
@@ -388,11 +417,28 @@ export class PmEditorService
     }
     const docsBefore = views.map((view) => view.state.doc);
 
+    // Watcher records are hints that can fire mid-write: a sync tool (or the
+    // browser's own writable stream) may truncate the file before the new
+    // bytes land, with no follow-up record for the final commit. Wait out a
+    // short quiet period, then require two consecutive reads to agree before
+    // treating the content as settled — otherwise an open note would flash
+    // (or stick) empty on a truncate-then-write.
+    await sleep(EXTERNAL_SYNC_QUIET_MS);
+    const firstRead = await this.dependencies.fileSystem.readFileAsText(wsPath);
+    if (firstRead === undefined) {
+      return;
+    }
+    await sleep(EXTERNAL_SYNC_STABILITY_MS);
     const diskText = await this.dependencies.fileSystem.readFileAsText(wsPath);
     if (diskText === undefined) {
       return;
     }
-    // The user may have typed while the read was in flight — re-check, and
+    if (diskText !== firstRead) {
+      // Still being written — run another pass after the loop's rerun check.
+      this.externalSyncRuns.set(wsPath, true);
+      return;
+    }
+    // The user may have typed while the reads were in flight — re-check, and
     // bail if any doc moved on. A newer watcher event re-triggers this pass.
     if (this.saveQueue.hasPendingOrFailed(wsPath)) {
       return;
@@ -427,6 +473,15 @@ export class PmEditorService
       const { state } = view;
       const selectionHead = state.selection.head;
       let tr = state.tr.replaceWith(0, state.doc.content.size, parsed.content);
+      // Defense in depth: if the replacement lost the parsed content (e.g.
+      // a schema mismatch makes the replace fitting drop foreign nodes),
+      // never apply it — a wrong-but-present note beats a blanked one.
+      if (parsed.content.size > 0 && tr.doc.content.size === 0) {
+        this.logger.error(
+          `External sync for ${wsPath} produced an empty document from non-empty content; skipping`,
+        );
+        return;
+      }
       tr = tr.setSelection(
         TextSelection.near(
           tr.doc.resolve(Math.min(selectionHead, tr.doc.content.size)),

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -762,10 +762,14 @@ export class PmEditorService
       return 'retry';
     }
 
-    await this.dependencies.noteSnapshot.preserveExternalOverwrite(
-      wsPath,
-      this.getExactPreservableContent(view, currentSerialized),
-    );
+    const preserved =
+      await this.dependencies.noteSnapshot.preserveExternalOverwrite(
+        wsPath,
+        this.getExactPreservableContent(view, currentSerialized),
+      );
+    if (!preserved) {
+      return 'retry';
+    }
 
     if (
       this.abortSignal.aborted ||

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -124,6 +124,9 @@ type EditorEntry =
   | {
       name: string;
       editorView: ReturnType<typeof createEditor>;
+      /** Exact source retained while the loaded document remains unchanged. */
+      loadedDoc: EditorView['state']['doc'];
+      loadedMarkdown: string;
       removeFocusListener: () => void;
       wsPath: string;
     }
@@ -225,10 +228,10 @@ export class PmEditorService
           signal: this.abortSignal,
         }),
       getMarkdown: (schema) => this.getMarkdown(schema),
-      preserveCurrentContent: (wsPath, content) =>
+      preserveCurrentContent: (wsPath, content, view) =>
         this.dependencies.noteSnapshot.preserveExternalOverwrite(
           wsPath,
-          content,
+          this.getExactPreservableContent(view, content),
         ),
       withSaveSuppressed: (wsPath, dispatch) => {
         this.suppressSaveForExternalSync.add(wsPath);
@@ -360,7 +363,7 @@ export class PmEditorService
           this.dependencies.fileSystem.$fileRenameEvent,
         );
         if (event) {
-          this.handleFileRename(event.oldWsPath, event.wsPath);
+          this.handleFileRename(event.oldWsPath, event.wsPath, event.external);
         }
       }),
     );
@@ -381,7 +384,18 @@ export class PmEditorService
     );
   }
 
-  private handleFileRename(oldWsPath: string, newWsPath: string): void {
+  private handleFileRename(
+    oldWsPath: string,
+    newWsPath: string,
+    external: boolean,
+  ): void {
+    // A local rename drains this queue before moving the file. A rename from
+    // another tab has no such guarantee: keep a pending/failed editor on its
+    // old path so its only unsaved body stays mounted and fails visibly rather
+    // than being retargeted over the renamed file.
+    if (external && this.saveQueue.hasPendingOrFailed(oldWsPath)) {
+      return;
+    }
     this.saveQueue.relocate(oldWsPath, newWsPath);
 
     for (const [domNode, editor] of this.editors) {
@@ -467,6 +481,8 @@ export class PmEditorService
       this.editors.set(domNode, {
         name,
         editorView,
+        loadedDoc: editorView.state.doc,
+        loadedMarkdown: content ?? '',
         removeFocusListener: () => {
           editorView.dom.removeEventListener('focusin', handleFocusIn);
         },
@@ -710,6 +726,23 @@ export class PmEditorService
       next.delete(wsPath);
     }
     this.store.set(this.$roundTripWarnings, next);
+  }
+
+  /**
+   * A freshly loaded note may contain Markdown the editor cannot serialize
+   * byte-for-byte. Until its document changes, preserve that exact source
+   * rather than a normalized serialization when external content replaces it.
+   */
+  private getExactPreservableContent(
+    view: EditorView,
+    serialized: string,
+  ): string {
+    for (const editor of this.readyEditors()) {
+      if (editor.editorView === view && editor.loadedDoc === view.state.doc) {
+        return editor.loadedMarkdown;
+      }
+    }
+    return serialized;
   }
 
   getEditorLoadStatus(

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -16,7 +16,6 @@ import {
 } from '@bangle.io/prosemirror-plugins';
 import {
   displayNameForAsset,
-  type ExternalFileChangeEvent,
   type FileSystemService,
   type NavigationService,
   type StoredMarkdownAsset,
@@ -50,6 +49,7 @@ import {
   EditorSaveQueue,
 } from './editor-save-queue';
 import { setupExtensions } from './extensions';
+import { ExternalContentSync } from './external-content-sync';
 import { findHeadingIndexBySlug } from './heading-slug';
 import { createLocalImageNodeView } from './local-image-node-view';
 import { createEditor } from './pm-setup';
@@ -65,22 +65,6 @@ import {
 
 const ASSET_TOAST_FILE_NAME_MAX_LENGTH = 44;
 
-/**
- * Quiet period between an external change notification and the first disk
- * read, letting in-progress writes (truncate-then-write) finish first.
- */
-const EXTERNAL_SYNC_QUIET_MS = 150;
-/**
- * Gap between the two confirming reads that must agree before externally
- * changed content is applied to an open editor.
- */
-const EXTERNAL_SYNC_STABILITY_MS = 100;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 const EMPTY_WS_PATH_SET: ReadonlySet<string> = new Set();
 
 export type PmEditorServiceConfig = {
@@ -186,17 +170,48 @@ export class PmEditorService
 
   private handledExternalChangeSequence = 0;
   /**
-   * wsPaths with an external-sync pass in flight; the boolean marks whether
-   * another external event arrived meanwhile and the pass must run again.
-   */
-  private externalSyncRuns = new Map<string, boolean>();
-  /**
    * One-shot markers telling `onDocChange` that the next doc change for this
    * wsPath was produced by an external sync (not the user) and must not be
    * re-saved — writing it back would bump the file's mtime and make sync
    * tools churn on their own change.
    */
   private suppressSaveForExternalSync = new Set<string>();
+
+  /**
+   * Reconciles open editors with externally changed files. Owns sequencing,
+   * coalescing, and content-stability policy; this service only supplies the
+   * narrow host surface below.
+   */
+  private externalContentSync = new ExternalContentSync({
+    getViews: (wsPath) =>
+      [...this.readyEditors()]
+        .filter((editor) => editor.wsPath === wsPath)
+        .map((editor) => editor.editorView),
+    getMountedWsPaths: (wsName) => [
+      ...new Set(
+        [...this.readyEditors()]
+          .filter(
+            (editor) =>
+              wsName === undefined ||
+              WsPath.safeParse(editor.wsPath).data?.wsName === wsName,
+          )
+          .map((editor) => editor.wsPath),
+      ),
+    ],
+    hasPendingSaves: (wsPath) => this.saveQueue.hasPendingOrFailed(wsPath),
+    readFileAsText: (wsPath) =>
+      this.dependencies.fileSystem.readFileAsText(wsPath),
+    getMarkdown: (schema) => this.getMarkdown(schema),
+    withSaveSuppressed: (wsPath, dispatch) => {
+      this.suppressSaveForExternalSync.add(wsPath);
+      try {
+        dispatch();
+      } finally {
+        this.suppressSaveForExternalSync.delete(wsPath);
+      }
+    },
+    logger: this.logger,
+  });
 
   constructor(
     context: BaseServiceContext,
@@ -323,7 +338,7 @@ export class PmEditorService
             return;
           }
           this.handledExternalChangeSequence = event.sequence;
-          this.onExternalFileChange(event);
+          this.externalContentSync.handleEvent(event);
         },
       ),
     );
@@ -338,166 +353,6 @@ export class PmEditorService
       }
       this.editors.set(domNode, { ...editor, wsPath: newWsPath });
     }
-  }
-
-  /**
-   * Reacts to file changes made outside this app instance (sync tools, other
-   * editors) by refreshing mounted editors from disk — but only when doing so
-   * cannot lose user work; unsaved local edits always win over the external
-   * copy.
-   */
-  private onExternalFileChange(event: ExternalFileChangeEvent): void {
-    if (
-      event.type !== 'file-content-update' &&
-      event.type !== 'file-create' &&
-      event.type !== 'refresh'
-    ) {
-      return;
-    }
-    const targets = new Set<string>();
-    for (const editor of this.editors.values()) {
-      if (!('editorView' in editor)) {
-        continue;
-      }
-      if (event.type === 'refresh' || editor.wsPath === event.wsPath) {
-        targets.add(editor.wsPath);
-      }
-    }
-    for (const wsPath of targets) {
-      void this.syncEditorWithDisk(wsPath).catch((error) => {
-        this.logger.warn(
-          `Failed to refresh editor from external change: ${wsPath}`,
-          error,
-        );
-      });
-    }
-  }
-
-  private async syncEditorWithDisk(wsPath: string): Promise<void> {
-    const running = this.externalSyncRuns.get(wsPath);
-    if (running !== undefined) {
-      // A pass is already in flight — ask it to run once more so the final
-      // external state is not dropped.
-      this.externalSyncRuns.set(wsPath, true);
-      return;
-    }
-    this.externalSyncRuns.set(wsPath, false);
-    // Bounded so a file under continuous external writes cannot spin this
-    // loop forever; the next watcher event starts a fresh sync.
-    let attempts = 0;
-    try {
-      do {
-        this.externalSyncRuns.set(wsPath, false);
-        attempts += 1;
-        await this.applyExternalContentIfClean(wsPath);
-      } while (this.externalSyncRuns.get(wsPath) && attempts < 5);
-    } finally {
-      this.externalSyncRuns.delete(wsPath);
-    }
-  }
-
-  private async applyExternalContentIfClean(wsPath: string): Promise<void> {
-    // Unsaved or failed-to-save local edits always win: replacing the doc
-    // would destroy content that exists nowhere else.
-    if (this.saveQueue.hasPendingOrFailed(wsPath)) {
-      return;
-    }
-    const views: EditorView[] = [];
-    for (const editor of this.editors.values()) {
-      if (
-        'editorView' in editor &&
-        editor.wsPath === wsPath &&
-        !editor.editorView.isDestroyed
-      ) {
-        views.push(editor.editorView);
-      }
-    }
-    if (views.length === 0) {
-      return;
-    }
-    const docsBefore = views.map((view) => view.state.doc);
-
-    // Watcher records are hints that can fire mid-write: a sync tool (or the
-    // browser's own writable stream) may truncate the file before the new
-    // bytes land, with no follow-up record for the final commit. Wait out a
-    // short quiet period, then require two consecutive reads to agree before
-    // treating the content as settled — otherwise an open note would flash
-    // (or stick) empty on a truncate-then-write.
-    await sleep(EXTERNAL_SYNC_QUIET_MS);
-    const firstRead = await this.dependencies.fileSystem.readFileAsText(wsPath);
-    if (firstRead === undefined) {
-      return;
-    }
-    await sleep(EXTERNAL_SYNC_STABILITY_MS);
-    const diskText = await this.dependencies.fileSystem.readFileAsText(wsPath);
-    if (diskText === undefined) {
-      return;
-    }
-    if (diskText !== firstRead) {
-      // Still being written — run another pass after the loop's rerun check.
-      this.externalSyncRuns.set(wsPath, true);
-      return;
-    }
-    // The user may have typed while the reads were in flight — re-check, and
-    // bail if any doc moved on. A newer watcher event re-triggers this pass.
-    if (this.saveQueue.hasPendingOrFailed(wsPath)) {
-      return;
-    }
-
-    views.forEach((view, index) => {
-      if (view.isDestroyed || view.state.doc !== docsBefore[index]) {
-        return;
-      }
-      const markdown = this.getMarkdown(view.state.schema);
-      let parsed: ReturnType<typeof markdown.parser.parse>;
-      try {
-        parsed = markdown.parser.parse(diskText);
-      } catch (error) {
-        // A parse failure must never touch the editor (or disk) — the user
-        // keeps their current view of the note.
-        this.logger.warn(
-          `Could not parse externally changed content for ${wsPath}`,
-          error,
-        );
-        return;
-      }
-      // Compare through the serializer so normalization differences (e.g.
-      // list markers) don't register as changes; equal content means this is
-      // our own echo or a no-op and the editor is left untouched.
-      const currentSerialized = markdown.serializer.serialize(view.state.doc);
-      const diskSerialized = markdown.serializer.serialize(parsed);
-      if (currentSerialized === diskSerialized) {
-        return;
-      }
-
-      const { state } = view;
-      const selectionHead = state.selection.head;
-      let tr = state.tr.replaceWith(0, state.doc.content.size, parsed.content);
-      // Defense in depth: if the replacement lost the parsed content (e.g.
-      // a schema mismatch makes the replace fitting drop foreign nodes),
-      // never apply it — a wrong-but-present note beats a blanked one.
-      if (parsed.content.size > 0 && tr.doc.content.size === 0) {
-        this.logger.error(
-          `External sync for ${wsPath} produced an empty document from non-empty content; skipping`,
-        );
-        return;
-      }
-      tr = tr.setSelection(
-        TextSelection.near(
-          tr.doc.resolve(Math.min(selectionHead, tr.doc.content.size)),
-        ),
-      );
-      // External content is not a user edit: keep it out of the undo stack
-      // (undoing it locally would fight the sync tool).
-      tr = tr.setMeta('addToHistory', false);
-
-      this.suppressSaveForExternalSync.add(wsPath);
-      try {
-        view.dispatch(tr);
-      } finally {
-        this.suppressSaveForExternalSync.delete(wsPath);
-      }
-    });
   }
 
   mountEditor({
@@ -1351,6 +1206,15 @@ export class PmEditorService
     );
     this.markdownBySchema.set(schema, markdown);
     return markdown;
+  }
+
+  /** Mounted editors whose view is created and not destroyed. */
+  private *readyEditors(): Generator<ReadyEditorEntry> {
+    for (const editor of this.editors.values()) {
+      if ('editorView' in editor && !editor.editorView.isDestroyed) {
+        yield editor;
+      }
+    }
   }
 
   private getActiveEditorView() {

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -700,8 +700,11 @@ export class PmEditorService
         this.dismissStaleExternalContentToast(wsPath);
       }
     } catch (error) {
-      // Editor and toast stay as they are; the user can retry.
+      // Parsing or serializing the disk copy threw. The notice stays so the
+      // user keeps a way back, but they must be told the action did nothing —
+      // a deterministic parse failure will never succeed on retry.
       this.logger.warn(`Could not load the disk version of ${wsPath}`, error);
+      toast.error(t.app.toasts.externalDiskVersionNotApplied({ fileName }));
     }
   }
 

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -185,18 +185,17 @@ export class PmEditorService
 
   private handledExternalChangeSequence = 0;
   /**
-   * One-shot markers telling `onDocChange` that the next doc change for this
-   * wsPath was produced by an external sync (not the user) and must not be
-   * re-saved — writing it back would bump the file's mtime and make sync
-   * tools churn on their own change.
+   * Tells `onDocChange` that the doc change it is seeing was produced by an
+   * external sync (not the user) and must not be re-saved — writing it back
+   * would bump the file's mtime and make sync tools churn on their own change.
    *
-   * Contract: this only works because the saveDoc plugin's `view.update`
-   * (and therefore `onDocChange`) runs synchronously inside
+   * Contract: a plain boolean is enough only because the saveDoc plugin's
+   * `view.update` (and therefore `onDocChange`) runs synchronously inside
    * `view.dispatch`, which `replaceEditorContent` wraps. If the save pipeline
    * ever defers off the dispatch (debounce, microtask), this flag must move
    * onto the transaction itself (a meta read from plugin state).
    */
-  private suppressSaveForExternalSync = new Set<string>();
+  private applyingExternalSync = false;
   private staleExternalContentWsPaths = new Set<string>();
 
   /**
@@ -452,13 +451,15 @@ export class PmEditorService
         store: this.store as Store,
         domNode,
         onDocChange: (doc) => {
-          const currentWsPath = this.editors.get(domNode)?.wsPath ?? wsPath;
-          if (this.suppressSaveForExternalSync.has(currentWsPath)) {
+          if (this.applyingExternalSync) {
             // External sync applying disk content — must not be re-saved;
-            // see suppressSaveForExternalSync.
+            // see applyingExternalSync.
             return;
           }
-          this.saveQueue.enqueue(currentWsPath, doc);
+          this.saveQueue.enqueue(
+            this.editors.get(domNode)?.wsPath ?? wsPath,
+            doc,
+          );
         },
         extensions: this.extensions,
         nodeViews: {
@@ -720,16 +721,10 @@ export class PmEditorService
 
   /**
    * A freshly loaded note may contain Markdown the editor cannot serialize
-   * byte-for-byte. Until its document changes, preserve that exact source
-   * rather than a normalized serialization when external content replaces it.
+   * byte-for-byte. While its document is unchanged, that exact source is what
+   * must be preserved when external content replaces it — not a normalized
+   * re-serialization.
    */
-  private getExactPreservableContent(
-    view: EditorView,
-    serialized: string,
-  ): string {
-    return this.getRetainedSource(view) ?? serialized;
-  }
-
   private getRetainedSource(view: EditorView): string | undefined {
     for (const editor of this.readyEditors()) {
       if (editor.editorView === view && editor.loadedDoc === view.state.doc) {
@@ -740,27 +735,17 @@ export class PmEditorService
   }
 
   /**
-   * The single lifecycle for replacing a mounted editor from disk. Snapshot
-   * storage is asynchronous, so every safety condition is checked both before
-   * and after it; in particular an IME composition that begins while the
-   * snapshot is being stored must never be destroyed by the replacement.
+   * Whether this view may still be replaced from disk. Re-checked after every
+   * await in `replaceEditorContent`, so it lives in one place: two hand-copied
+   * condition chains had already drifted apart.
    */
-  private async replaceEditorContent({
-    currentSerialized,
-    expectedDoc,
-    sourceMarkdown,
-    transaction,
-    view,
-    wsPath,
-  }: {
-    currentSerialized: string;
-    expectedDoc: EditorView['state']['doc'];
-    sourceMarkdown: string;
-    transaction: Transaction;
-    view: EditorView;
-    wsPath: string;
-  }): Promise<'applied' | 'refused' | 'retry' | 'skipped'> {
+  private checkReplaceable(
+    view: EditorView,
+    expectedDoc: EditorView['state']['doc'],
+    wsPath: string,
+  ): 'ok' | 'retry' | 'skipped' {
     if (
+      this.abortSignal.aborted ||
       this.saveQueue.hasPendingOrFailed(wsPath) ||
       view.isDestroyed ||
       view.state.doc !== expectedDoc ||
@@ -768,14 +753,40 @@ export class PmEditorService
     ) {
       return 'skipped';
     }
-    if (view.composing) {
-      return 'retry';
+    // Replacing the doc mid-composition silently drops uncommitted input.
+    return view.composing ? 'retry' : 'ok';
+  }
+
+  /**
+   * The single lifecycle for replacing a mounted editor from disk. Snapshot
+   * storage is asynchronous, so every safety condition is checked both before
+   * and after it; in particular an IME composition that begins while the
+   * snapshot is being stored must never be destroyed by the replacement.
+   */
+  private async replaceEditorContent({
+    expectedDoc,
+    preservableSource,
+    sourceMarkdown,
+    transaction,
+    view,
+    wsPath,
+  }: {
+    expectedDoc: EditorView['state']['doc'];
+    preservableSource: string;
+    sourceMarkdown: string;
+    transaction: Transaction;
+    view: EditorView;
+    wsPath: string;
+  }): Promise<'applied' | 'refused' | 'retry' | 'skipped'> {
+    const before = this.checkReplaceable(view, expectedDoc, wsPath);
+    if (before !== 'ok') {
+      return before;
     }
 
     const preserved =
       await this.dependencies.noteSnapshot.preserveExternalOverwrite(
         wsPath,
-        this.getExactPreservableContent(view, currentSerialized),
+        preservableSource,
       );
     if (preserved === 'retry') {
       return 'retry';
@@ -786,24 +797,16 @@ export class PmEditorService
       return 'refused';
     }
 
-    if (
-      this.abortSignal.aborted ||
-      this.saveQueue.hasPendingOrFailed(wsPath) ||
-      view.isDestroyed ||
-      view.state.doc !== expectedDoc ||
-      this.getEditorEntryByView(view)?.wsPath !== wsPath
-    ) {
-      return 'skipped';
-    }
-    if (view.composing) {
-      return 'retry';
+    const after = this.checkReplaceable(view, expectedDoc, wsPath);
+    if (after !== 'ok') {
+      return after;
     }
 
-    this.suppressSaveForExternalSync.add(wsPath);
+    this.applyingExternalSync = true;
     try {
       view.dispatch(transaction);
     } finally {
-      this.suppressSaveForExternalSync.delete(wsPath);
+      this.applyingExternalSync = false;
     }
 
     const editor = this.getEditorEntryByView(view);

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -16,6 +16,7 @@ import {
 } from '@bangle.io/prosemirror-plugins';
 import {
   displayNameForAsset,
+  type ExternalFileChangeEvent,
   type FileSystemService,
   type NavigationService,
   type StoredMarkdownAsset,
@@ -158,6 +159,20 @@ export class PmEditorService
     ReturnType<typeof markdownLoader>
   >();
 
+  private handledExternalChangeSequence = 0;
+  /**
+   * wsPaths with an external-sync pass in flight; the boolean marks whether
+   * another external event arrived meanwhile and the pass must run again.
+   */
+  private externalSyncRuns = new Map<string, boolean>();
+  /**
+   * One-shot markers telling `onDocChange` that the next doc change for this
+   * wsPath was produced by an external sync (not the user) and must not be
+   * re-saved — writing it back would bump the file's mtime and make sync
+   * tools churn on their own change.
+   */
+  private suppressSaveForExternalSync = new Set<string>();
+
   constructor(
     context: BaseServiceContext,
     private dependencies: {
@@ -272,6 +287,21 @@ export class PmEditorService
         }
       }),
     );
+    this.addCleanup(
+      this.store.sub(
+        this.dependencies.fileSystem.$externalFileChangeEvent,
+        () => {
+          const event = this.store.get(
+            this.dependencies.fileSystem.$externalFileChangeEvent,
+          );
+          if (!event || event.sequence <= this.handledExternalChangeSequence) {
+            return;
+          }
+          this.handledExternalChangeSequence = event.sequence;
+          this.onExternalFileChange(event);
+        },
+      ),
+    );
   }
 
   private handleFileRename(oldWsPath: string, newWsPath: string): void {
@@ -283,6 +313,136 @@ export class PmEditorService
       }
       this.editors.set(domNode, { ...editor, wsPath: newWsPath });
     }
+  }
+
+  /**
+   * Reacts to file changes made outside this app instance (sync tools, other
+   * editors) by refreshing mounted editors from disk — but only when doing so
+   * cannot lose user work; unsaved local edits always win over the external
+   * copy.
+   */
+  private onExternalFileChange(event: ExternalFileChangeEvent): void {
+    if (
+      event.type !== 'file-content-update' &&
+      event.type !== 'file-create' &&
+      event.type !== 'refresh'
+    ) {
+      return;
+    }
+    const targets = new Set<string>();
+    for (const editor of this.editors.values()) {
+      if (!('editorView' in editor)) {
+        continue;
+      }
+      if (event.type === 'refresh' || editor.wsPath === event.wsPath) {
+        targets.add(editor.wsPath);
+      }
+    }
+    for (const wsPath of targets) {
+      void this.syncEditorWithDisk(wsPath).catch((error) => {
+        this.logger.warn(
+          `Failed to refresh editor from external change: ${wsPath}`,
+          error,
+        );
+      });
+    }
+  }
+
+  private async syncEditorWithDisk(wsPath: string): Promise<void> {
+    const running = this.externalSyncRuns.get(wsPath);
+    if (running !== undefined) {
+      // A pass is already in flight — ask it to run once more so the final
+      // external state is not dropped.
+      this.externalSyncRuns.set(wsPath, true);
+      return;
+    }
+    this.externalSyncRuns.set(wsPath, false);
+    try {
+      do {
+        this.externalSyncRuns.set(wsPath, false);
+        await this.applyExternalContentIfClean(wsPath);
+      } while (this.externalSyncRuns.get(wsPath));
+    } finally {
+      this.externalSyncRuns.delete(wsPath);
+    }
+  }
+
+  private async applyExternalContentIfClean(wsPath: string): Promise<void> {
+    // Unsaved or failed-to-save local edits always win: replacing the doc
+    // would destroy content that exists nowhere else.
+    if (this.saveQueue.hasPendingOrFailed(wsPath)) {
+      return;
+    }
+    const views: EditorView[] = [];
+    for (const editor of this.editors.values()) {
+      if (
+        'editorView' in editor &&
+        editor.wsPath === wsPath &&
+        !editor.editorView.isDestroyed
+      ) {
+        views.push(editor.editorView);
+      }
+    }
+    if (views.length === 0) {
+      return;
+    }
+    const docsBefore = views.map((view) => view.state.doc);
+
+    const diskText = await this.dependencies.fileSystem.readFileAsText(wsPath);
+    if (diskText === undefined) {
+      return;
+    }
+    // The user may have typed while the read was in flight — re-check, and
+    // bail if any doc moved on. A newer watcher event re-triggers this pass.
+    if (this.saveQueue.hasPendingOrFailed(wsPath)) {
+      return;
+    }
+
+    views.forEach((view, index) => {
+      if (view.isDestroyed || view.state.doc !== docsBefore[index]) {
+        return;
+      }
+      const markdown = this.getMarkdown(view.state.schema);
+      let parsed: ReturnType<typeof markdown.parser.parse>;
+      try {
+        parsed = markdown.parser.parse(diskText);
+      } catch (error) {
+        // A parse failure must never touch the editor (or disk) — the user
+        // keeps their current view of the note.
+        this.logger.warn(
+          `Could not parse externally changed content for ${wsPath}`,
+          error,
+        );
+        return;
+      }
+      // Compare through the serializer so normalization differences (e.g.
+      // list markers) don't register as changes; equal content means this is
+      // our own echo or a no-op and the editor is left untouched.
+      const currentSerialized = markdown.serializer.serialize(view.state.doc);
+      const diskSerialized = markdown.serializer.serialize(parsed);
+      if (currentSerialized === diskSerialized) {
+        return;
+      }
+
+      const { state } = view;
+      const selectionHead = state.selection.head;
+      let tr = state.tr.replaceWith(0, state.doc.content.size, parsed.content);
+      tr = tr.setSelection(
+        TextSelection.near(
+          tr.doc.resolve(Math.min(selectionHead, tr.doc.content.size)),
+        ),
+      );
+      // External content is not a user edit: keep it out of the undo stack
+      // (undoing it locally would fight the sync tool).
+      tr = tr.setMeta('addToHistory', false);
+
+      this.suppressSaveForExternalSync.add(wsPath);
+      try {
+        view.dispatch(tr);
+      } finally {
+        this.suppressSaveForExternalSync.delete(wsPath);
+      }
+    });
   }
 
   mountEditor({
@@ -336,6 +496,12 @@ export class PmEditorService
         domNode,
         onDocChange: (doc) => {
           const currentWsPath = this.editors.get(domNode)?.wsPath ?? wsPath;
+          if (this.suppressSaveForExternalSync.has(currentWsPath)) {
+            // This doc change was produced by an external sync applying disk
+            // content to the editor — writing it back would be a no-op write
+            // that churns the file's mtime.
+            return;
+          }
           this.saveQueue.enqueue(currentWsPath, doc);
         },
         extensions: this.extensions,

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -661,6 +661,7 @@ export class PmEditorService
    * left alone (its save resolves the divergence).
    */
   async loadDiskVersionIntoEditors(wsPath: string): Promise<void> {
+    const fileName = WsPath.safeParseFile(wsPath).data?.fileName ?? wsPath;
     try {
       const result = await this.externalContentSync.acceptDiskVersion(wsPath);
       if (result.unavailable) {
@@ -668,8 +669,17 @@ export class PmEditorService
           `Disk version of ${wsPath} could not be read; keeping the editor content`,
         );
         this.dismissStaleExternalContentToast(wsPath);
-        const fileName = WsPath.safeParseFile(wsPath).data?.fileName ?? wsPath;
         toast.error(t.app.toasts.externalDiskVersionUnavailable({ fileName }));
+        return;
+      }
+      if (result.appliedViews.length === 0) {
+        // Nothing was replaced — local edits reclaimed the note, or it was
+        // closed. Keep the notice so the user still has a way back to disk
+        // instead of silently leaving them on the older content.
+        this.logger.warn(
+          `Disk version of ${wsPath} was not applied; keeping the editor content`,
+        );
+        toast.error(t.app.toasts.externalDiskVersionNotApplied({ fileName }));
         return;
       }
 
@@ -749,7 +759,7 @@ export class PmEditorService
     transaction: Transaction;
     view: EditorView;
     wsPath: string;
-  }): Promise<'applied' | 'retry' | 'skipped'> {
+  }): Promise<'applied' | 'refused' | 'retry' | 'skipped'> {
     if (
       this.saveQueue.hasPendingOrFailed(wsPath) ||
       view.isDestroyed ||
@@ -767,8 +777,13 @@ export class PmEditorService
         wsPath,
         this.getExactPreservableContent(view, currentSerialized),
       );
-    if (!preserved) {
+    if (preserved === 'retry') {
       return 'retry';
+    }
+    if (preserved === 'unpreservable') {
+      // Applying disk content would destroy the editor's copy with no
+      // recovery path, so keep it and tell the user instead.
+      return 'refused';
     }
 
     if (

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -673,7 +673,7 @@ export class PmEditorService
         toast.error(t.app.toasts.externalDiskVersionUnavailable({ fileName }));
         return;
       }
-      if (result.appliedViews.length === 0) {
+      if (result.appliedCount === 0) {
         // Nothing was replaced — local edits reclaimed the note, or it was
         // closed. Keep the notice so the user still has a way back to disk
         // instead of silently leaving them on the older content.
@@ -685,7 +685,7 @@ export class PmEditorService
       }
 
       this.logger.info(
-        `${wsPath}: loaded the disk version into ${result.appliedViews.length} open editor(s) at the user's request (${result.content?.length ?? 0} chars)`,
+        `${wsPath}: loaded the disk version into ${result.appliedCount} open editor(s) at the user's request (${result.content?.length ?? 0} chars)`,
       );
       // The fidelity notice is refreshed by replaceEditorContent, which every
       // applied view goes through.

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -51,10 +51,7 @@ import {
   EditorSaveQueue,
 } from './editor-save-queue';
 import { setupExtensions } from './extensions';
-import {
-  buildExternalDocReplace,
-  ExternalContentSync,
-} from './external-content-sync';
+import { ExternalContentSync } from './external-content-sync';
 import { findHeadingIndexBySlug } from './heading-slug';
 import { createLocalImageNodeView } from './local-image-node-view';
 import { createEditor } from './pm-setup';
@@ -665,24 +662,8 @@ export class PmEditorService
    */
   async loadDiskVersionIntoEditors(wsPath: string): Promise<void> {
     try {
-      if (this.saveQueue.hasPendingOrFailed(wsPath)) {
-        this.logger.debug(
-          `${wsPath}: not loading the disk version — the user edited since the refusal and their save resolves the divergence`,
-        );
-        this.dismissStaleExternalContentToast(wsPath);
-        return;
-      }
-      const viewsBeforeRead = [...this.readyEditors()]
-        .filter((editor) => editor.wsPath === wsPath)
-        .map((editor) => ({
-          doc: editor.editorView.state.doc,
-          view: editor.editorView,
-        }));
-      const content = await this.dependencies.fileSystem.readFileAsText(
-        wsPath,
-        { signal: this.abortSignal },
-      );
-      if (content === undefined) {
+      const result = await this.externalContentSync.acceptDiskVersion(wsPath);
+      if (result.unavailable) {
         this.logger.warn(
           `Disk version of ${wsPath} could not be read; keeping the editor content`,
         );
@@ -691,52 +672,20 @@ export class PmEditorService
         toast.error(t.app.toasts.externalDiskVersionUnavailable({ fileName }));
         return;
       }
-      // The action does not block input. Re-check after the async read so a
-      // keystroke made while it was in flight cannot be replaced by stale disk
-      // content.
-      if (this.saveQueue.hasPendingOrFailed(wsPath)) {
-        this.logger.debug(
-          `${wsPath}: not loading the disk version — the user edited while it was being read`,
-        );
-        this.dismissStaleExternalContentToast(wsPath);
-        return;
-      }
-      let compositionBlocked = false;
-      for (const { doc, view } of viewsBeforeRead) {
-        if (view.isDestroyed || view.state.doc !== doc) {
-          continue;
-        }
-        const markdown = this.getMarkdown(view.state.schema);
-        const parsed = markdown.parser.parse(content);
-        const currentSerialized = markdown.serializer.serialize(view.state.doc);
-        const tr = buildExternalDocReplace(view, parsed);
-        if (!tr) {
-          this.logger.error(
-            `Disk version of ${wsPath} produced an empty document from non-empty content; skipping`,
-          );
-          continue;
-        }
-        const result = await this.replaceEditorContent({
-          currentSerialized,
-          expectedDoc: doc,
-          sourceMarkdown: content,
-          transaction: tr,
-          view,
-          wsPath,
-        });
-        if (result === 'retry') {
-          compositionBlocked = true;
-          continue;
-        }
-        if (result !== 'applied') {
-          continue;
-        }
+
+      for (const view of result.appliedViews) {
         this.logger.info(
-          `${wsPath}: loaded the disk version into the open editor at the user's request (${content.length} chars)`,
+          `${wsPath}: loaded the disk version into the open editor at the user's request (${result.content?.length ?? 0} chars)`,
         );
-        this.checkRoundTripFidelity({ content, editorView: view, wsPath });
+        if (result.content !== undefined) {
+          this.checkRoundTripFidelity({
+            content: result.content,
+            editorView: view,
+            wsPath,
+          });
+        }
       }
-      if (!compositionBlocked) {
+      if (!result.retry) {
         this.dismissStaleExternalContentToast(wsPath);
       }
     } catch (error) {

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -685,7 +685,7 @@ export class PmEditorService
       }
 
       this.logger.info(
-        `${wsPath}: loaded the disk version into ${result.appliedCount} open editor(s) at the user's request (${result.content?.length ?? 0} chars)`,
+        `${wsPath}: loaded the disk version into ${result.appliedCount} open editor(s) at the user's request`,
       );
       // The fidelity notice is refreshed by replaceEditorContent, which every
       // applied view goes through.

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -18,6 +18,7 @@ import {
   displayNameForAsset,
   type FileSystemService,
   type NavigationService,
+  type NoteSnapshotService,
   type StoredMarkdownAsset,
   storeWorkspaceAssetFiles,
   type WorkbenchStateService,
@@ -143,6 +144,7 @@ export class PmEditorService
   static deps = [
     'fileSystem',
     'navigation',
+    'noteSnapshot',
     'workbenchState',
     'workspaceState',
   ] as const;
@@ -223,6 +225,11 @@ export class PmEditorService
           signal: this.abortSignal,
         }),
       getMarkdown: (schema) => this.getMarkdown(schema),
+      preserveCurrentContent: (wsPath, content) =>
+        this.dependencies.noteSnapshot.preserveExternalOverwrite(
+          wsPath,
+          content,
+        ),
       withSaveSuppressed: (wsPath, dispatch) => {
         this.suppressSaveForExternalSync.add(wsPath);
         try {
@@ -247,6 +254,7 @@ export class PmEditorService
     private dependencies: {
       fileSystem: FileSystemService;
       navigation: NavigationService;
+      noteSnapshot: NoteSnapshotService;
       workbenchState: WorkbenchStateService;
       workspaceState: WorkspaceStateService;
     },

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -71,6 +71,15 @@ export type PmEditorServiceConfig = {
   saveCoordinator: EditorSaveCoordinator;
 };
 
+/**
+ * Stable per-path toast id so repeated refusals for the same note update one
+ * toast instead of stacking, and a later successful reconciliation can
+ * withdraw it.
+ */
+function staleExternalContentToastId(wsPath: string): string {
+  return `external-stale-content:${wsPath}`;
+}
+
 function formatFileSize(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB'];
   let value = bytes;
@@ -174,6 +183,12 @@ export class PmEditorService
    * wsPath was produced by an external sync (not the user) and must not be
    * re-saved — writing it back would bump the file's mtime and make sync
    * tools churn on their own change.
+   *
+   * Contract: this only works because the saveDoc plugin's `view.update`
+   * (and therefore `onDocChange`) runs synchronously inside
+   * `view.dispatch`, which `withSaveSuppressed` wraps. If the save pipeline
+   * ever defers off the dispatch (debounce, microtask), this flag must move
+   * onto the transaction itself (a meta read from plugin state).
    */
   private suppressSaveForExternalSync = new Set<string>();
 
@@ -182,36 +197,47 @@ export class PmEditorService
    * coalescing, and content-stability policy; this service only supplies the
    * narrow host surface below.
    */
-  private externalContentSync = new ExternalContentSync({
-    getViews: (wsPath) =>
-      [...this.readyEditors()]
-        .filter((editor) => editor.wsPath === wsPath)
-        .map((editor) => editor.editorView),
-    getMountedWsPaths: (wsName) => [
-      ...new Set(
+  private externalContentSync = new ExternalContentSync(
+    {
+      getViews: (wsPath) =>
         [...this.readyEditors()]
-          .filter(
-            (editor) =>
-              wsName === undefined ||
-              WsPath.safeParse(editor.wsPath).data?.wsName === wsName,
-          )
-          .map((editor) => editor.wsPath),
-      ),
-    ],
-    hasPendingSaves: (wsPath) => this.saveQueue.hasPendingOrFailed(wsPath),
-    readFileAsText: (wsPath) =>
-      this.dependencies.fileSystem.readFileAsText(wsPath),
-    getMarkdown: (schema) => this.getMarkdown(schema),
-    withSaveSuppressed: (wsPath, dispatch) => {
-      this.suppressSaveForExternalSync.add(wsPath);
-      try {
-        dispatch();
-      } finally {
-        this.suppressSaveForExternalSync.delete(wsPath);
-      }
+          .filter((editor) => editor.wsPath === wsPath)
+          .map((editor) => editor.editorView),
+      getMountedWsPaths: (wsName) => [
+        ...new Set(
+          [...this.readyEditors()]
+            .filter(
+              (editor) =>
+                wsName === undefined ||
+                WsPath.safeParse(editor.wsPath).data?.wsName === wsName,
+            )
+            .map((editor) => editor.wsPath),
+        ),
+      ],
+      hasPendingSaves: (wsPath) => this.saveQueue.hasPendingOrFailed(wsPath),
+      readFileAsText: (wsPath) =>
+        this.dependencies.fileSystem.readFileAsText(wsPath, {
+          signal: this.abortSignal,
+        }),
+      getMarkdown: (schema) => this.getMarkdown(schema),
+      withSaveSuppressed: (wsPath, dispatch) => {
+        this.suppressSaveForExternalSync.add(wsPath);
+        try {
+          dispatch();
+        } finally {
+          this.suppressSaveForExternalSync.delete(wsPath);
+        }
+      },
+      onStaleContentRefused: (wsPath) => {
+        this.showStaleExternalContentToast(wsPath);
+      },
+      onContentReconciled: (wsPath) => {
+        toast.dismiss(staleExternalContentToastId(wsPath));
+      },
+      logger: this.logger,
     },
-    logger: this.logger,
-  });
+    this.abortSignal,
+  );
 
   constructor(
     context: BaseServiceContext,
@@ -407,9 +433,8 @@ export class PmEditorService
         onDocChange: (doc) => {
           const currentWsPath = this.editors.get(domNode)?.wsPath ?? wsPath;
           if (this.suppressSaveForExternalSync.has(currentWsPath)) {
-            // This doc change was produced by an external sync applying disk
-            // content to the editor — writing it back would be a no-op write
-            // that churns the file's mtime.
+            // External sync applying disk content — must not be re-saved;
+            // see suppressSaveForExternalSync.
             return;
           }
           this.saveQueue.enqueue(currentWsPath, doc);
@@ -560,6 +585,32 @@ export class PmEditorService
       );
       this.setRoundTripWarning(wsPath, true);
     }
+  }
+
+  /**
+   * The external sync confirmed the disk copy of `wsPath` differs but
+   * refused to auto-apply it (fidelity, emptied-file, schema, or parse
+   * refusal). Without this the user would keep looking at silently stale
+   * content with only a console warning. Reloading the UI sends the note
+   * through the load path, which shows the disk content and surfaces the
+   * fidelity warning when applicable.
+   */
+  private showStaleExternalContentToast(wsPath: string): void {
+    const fileName = WsPath.safeParseFile(wsPath).data?.fileName ?? wsPath;
+    toast.warning(t.app.toasts.externalChangeNotApplied({ fileName }), {
+      id: staleExternalContentToastId(wsPath),
+      duration: Number.POSITIVE_INFINITY,
+      cancel: {
+        label: t.app.common.dismiss,
+        onClick: () => {},
+      },
+      action: {
+        label: t.app.toasts.reloadToApplyExternalChange,
+        onClick: () => {
+          this.dependencies.workbenchState.reloadUi();
+        },
+      },
+    });
   }
 
   private setRoundTripWarning(wsPath: string, hasWarning: boolean): void {

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -13,6 +13,7 @@ import {
   type PMNode,
   type Schema,
   TextSelection,
+  type Transaction,
 } from '@bangle.io/prosemirror-plugins';
 import {
   displayNameForAsset,
@@ -194,7 +195,7 @@ export class PmEditorService
    *
    * Contract: this only works because the saveDoc plugin's `view.update`
    * (and therefore `onDocChange`) runs synchronously inside
-   * `view.dispatch`, which `withSaveSuppressed` wraps. If the save pipeline
+   * `view.dispatch`, which `replaceEditorContent` wraps. If the save pipeline
    * ever defers off the dispatch (debounce, microtask), this flag must move
    * onto the transaction itself (a meta read from plugin state).
    */
@@ -228,19 +229,8 @@ export class PmEditorService
           signal: this.abortSignal,
         }),
       getMarkdown: (schema) => this.getMarkdown(schema),
-      preserveCurrentContent: (wsPath, content, view) =>
-        this.dependencies.noteSnapshot.preserveExternalOverwrite(
-          wsPath,
-          this.getExactPreservableContent(view, content),
-        ),
-      withSaveSuppressed: (wsPath, dispatch) => {
-        this.suppressSaveForExternalSync.add(wsPath);
-        try {
-          dispatch();
-        } finally {
-          this.suppressSaveForExternalSync.delete(wsPath);
-        }
-      },
+      getRetainedSource: (view) => this.getRetainedSource(view),
+      replaceContent: (args) => this.replaceEditorContent(args),
       onStaleContentRefused: (wsPath) => {
         this.showStaleExternalContentToast(wsPath);
       },
@@ -683,12 +673,14 @@ export class PmEditorService
         toast.dismiss(staleExternalContentToastId(wsPath));
         return;
       }
+      let compositionBlocked = false;
       for (const { doc, view } of viewsBeforeRead) {
         if (view.isDestroyed || view.state.doc !== doc) {
           continue;
         }
         const markdown = this.getMarkdown(view.state.schema);
         const parsed = markdown.parser.parse(content);
+        const currentSerialized = markdown.serializer.serialize(view.state.doc);
         const tr = buildExternalDocReplace(view, parsed);
         if (!tr) {
           this.logger.error(
@@ -696,18 +688,29 @@ export class PmEditorService
           );
           continue;
         }
-        this.suppressSaveForExternalSync.add(wsPath);
-        try {
-          view.dispatch(tr);
-        } finally {
-          this.suppressSaveForExternalSync.delete(wsPath);
+        const result = await this.replaceEditorContent({
+          currentSerialized,
+          expectedDoc: doc,
+          sourceMarkdown: content,
+          transaction: tr,
+          view,
+          wsPath,
+        });
+        if (result === 'retry') {
+          compositionBlocked = true;
+          continue;
+        }
+        if (result !== 'applied') {
+          continue;
         }
         this.logger.info(
           `${wsPath}: loaded the disk version into the open editor at the user's request (${content.length} chars)`,
         );
         this.checkRoundTripFidelity({ content, editorView: view, wsPath });
       }
-      toast.dismiss(staleExternalContentToastId(wsPath));
+      if (!compositionBlocked) {
+        toast.dismiss(staleExternalContentToastId(wsPath));
+      }
     } catch (error) {
       // Editor and toast stay as they are; the user can retry.
       this.logger.warn(`Could not load the disk version of ${wsPath}`, error);
@@ -737,12 +740,82 @@ export class PmEditorService
     view: EditorView,
     serialized: string,
   ): string {
+    return this.getRetainedSource(view) ?? serialized;
+  }
+
+  private getRetainedSource(view: EditorView): string | undefined {
     for (const editor of this.readyEditors()) {
       if (editor.editorView === view && editor.loadedDoc === view.state.doc) {
         return editor.loadedMarkdown;
       }
     }
-    return serialized;
+    return undefined;
+  }
+
+  /**
+   * The single lifecycle for replacing a mounted editor from disk. Snapshot
+   * storage is asynchronous, so every safety condition is checked both before
+   * and after it; in particular an IME composition that begins while the
+   * snapshot is being stored must never be destroyed by the replacement.
+   */
+  private async replaceEditorContent({
+    currentSerialized,
+    expectedDoc,
+    sourceMarkdown,
+    transaction,
+    view,
+    wsPath,
+  }: {
+    currentSerialized: string;
+    expectedDoc: EditorView['state']['doc'];
+    sourceMarkdown: string;
+    transaction: Transaction;
+    view: EditorView;
+    wsPath: string;
+  }): Promise<'applied' | 'retry' | 'skipped'> {
+    if (
+      this.saveQueue.hasPendingOrFailed(wsPath) ||
+      view.isDestroyed ||
+      view.state.doc !== expectedDoc ||
+      this.getEditorEntryByView(view)?.wsPath !== wsPath
+    ) {
+      return 'skipped';
+    }
+    if (view.composing) {
+      return 'retry';
+    }
+
+    await this.dependencies.noteSnapshot.preserveExternalOverwrite(
+      wsPath,
+      this.getExactPreservableContent(view, currentSerialized),
+    );
+
+    if (
+      this.abortSignal.aborted ||
+      this.saveQueue.hasPendingOrFailed(wsPath) ||
+      view.isDestroyed ||
+      view.state.doc !== expectedDoc ||
+      this.getEditorEntryByView(view)?.wsPath !== wsPath
+    ) {
+      return 'skipped';
+    }
+    if (view.composing) {
+      return 'retry';
+    }
+
+    this.suppressSaveForExternalSync.add(wsPath);
+    try {
+      view.dispatch(transaction);
+    } finally {
+      this.suppressSaveForExternalSync.delete(wsPath);
+    }
+
+    const editor = this.getEditorEntryByView(view);
+    if (editor?.wsPath === wsPath) {
+      editor.loadedDoc = view.state.doc;
+      editor.loadedMarkdown = sourceMarkdown;
+    }
+    return 'applied';
   }
 
   getEditorLoadStatus(

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -684,18 +684,11 @@ export class PmEditorService
         return;
       }
 
-      for (const view of result.appliedViews) {
-        this.logger.info(
-          `${wsPath}: loaded the disk version into the open editor at the user's request (${result.content?.length ?? 0} chars)`,
-        );
-        if (result.content !== undefined) {
-          this.checkRoundTripFidelity({
-            content: result.content,
-            editorView: view,
-            wsPath,
-          });
-        }
-      }
+      this.logger.info(
+        `${wsPath}: loaded the disk version into ${result.appliedViews.length} open editor(s) at the user's request (${result.content?.length ?? 0} chars)`,
+      );
+      // The fidelity notice is refreshed by replaceEditorContent, which every
+      // applied view goes through.
       if (!result.retry) {
         this.dismissStaleExternalContentToast(wsPath);
       }
@@ -817,6 +810,14 @@ export class PmEditorService
       editor.loadedDoc = view.state.doc;
       editor.loadedMarkdown = sourceMarkdown;
     }
+    // The newly loaded source has its own fidelity: external content may
+    // normalize on save where the previous content did not, or vice versa.
+    // Auto-applied content needs this as much as a user-requested load.
+    this.checkRoundTripFidelity({
+      content: sourceMarkdown,
+      editorView: view,
+      wsPath,
+    });
     return 'applied';
   }
 

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -200,6 +200,7 @@ export class PmEditorService
    * onto the transaction itself (a meta read from plugin state).
    */
   private suppressSaveForExternalSync = new Set<string>();
+  private staleExternalContentWsPaths = new Set<string>();
 
   /**
    * Reconciles open editors with externally changed files. Owns sequencing,
@@ -235,7 +236,7 @@ export class PmEditorService
         this.showStaleExternalContentToast(wsPath);
       },
       onContentReconciled: (wsPath) => {
-        toast.dismiss(staleExternalContentToastId(wsPath));
+        this.dismissStaleExternalContentToast(wsPath);
       },
       logger: this.logger,
     },
@@ -299,6 +300,7 @@ export class PmEditorService
             type: 'text/plain',
           }),
         );
+        this.dismissStaleExternalContentToast(wsPath);
       },
       this.emitAppError,
       config.saveCoordinator,
@@ -317,6 +319,9 @@ export class PmEditorService
       this.editors.clear();
       this.lastActiveEditorView = undefined;
       this.rememberedCursors.clear();
+      for (const wsPath of [...this.staleExternalContentWsPaths]) {
+        this.dismissStaleExternalContentToast(wsPath);
+      }
     });
     this.addCleanup(
       this.store.sub(this.dependencies.navigation.$routeInfo, () => {
@@ -368,6 +373,9 @@ export class PmEditorService
             return;
           }
           this.handledExternalChangeSequence = event.sequence;
+          if (event.type === 'file-delete') {
+            this.dismissStaleExternalContentToast(event.wsPath);
+          }
           this.externalContentSync.handleEvent(event);
         },
       ),
@@ -379,6 +387,7 @@ export class PmEditorService
     newWsPath: string,
     external: boolean,
   ): void {
+    this.dismissStaleExternalContentToast(oldWsPath);
     // A local rename drains this queue before moving the file. A rename from
     // another tab has no such guarantee: keep a pending/failed editor on its
     // old path so its only unsaved body stays mounted and fails visibly rather
@@ -541,6 +550,14 @@ export class PmEditorService
     this.editors.delete(domNode);
     if (editor) {
       this.setRoundTripWarning(editor.wsPath, false);
+      if (
+        'editorView' in editor &&
+        ![...this.readyEditors()].some(
+          (mountedEditor) => mountedEditor.wsPath === editor.wsPath,
+        )
+      ) {
+        this.dismissStaleExternalContentToast(editor.wsPath);
+      }
     }
   }
 
@@ -615,6 +632,7 @@ export class PmEditorService
    */
   private showStaleExternalContentToast(wsPath: string): void {
     const fileName = WsPath.safeParseFile(wsPath).data?.fileName ?? wsPath;
+    this.staleExternalContentWsPaths.add(wsPath);
     toast.warning(t.app.toasts.externalChangeNotApplied({ fileName }), {
       id: staleExternalContentToastId(wsPath),
       duration: Number.POSITIVE_INFINITY,
@@ -631,6 +649,13 @@ export class PmEditorService
     });
   }
 
+  private dismissStaleExternalContentToast(wsPath: string): void {
+    if (!this.staleExternalContentWsPaths.delete(wsPath)) {
+      return;
+    }
+    toast.dismiss(staleExternalContentToastId(wsPath));
+  }
+
   /**
    * User-consented recovery for external changes the automatic sync
    * refused: replaces only this note's open editors with the current disk
@@ -644,7 +669,7 @@ export class PmEditorService
         this.logger.debug(
           `${wsPath}: not loading the disk version — the user edited since the refusal and their save resolves the divergence`,
         );
-        toast.dismiss(staleExternalContentToastId(wsPath));
+        this.dismissStaleExternalContentToast(wsPath);
         return;
       }
       const viewsBeforeRead = [...this.readyEditors()]
@@ -661,6 +686,9 @@ export class PmEditorService
         this.logger.warn(
           `Disk version of ${wsPath} could not be read; keeping the editor content`,
         );
+        this.dismissStaleExternalContentToast(wsPath);
+        const fileName = WsPath.safeParseFile(wsPath).data?.fileName ?? wsPath;
+        toast.error(t.app.toasts.externalDiskVersionUnavailable({ fileName }));
         return;
       }
       // The action does not block input. Re-check after the async read so a
@@ -670,7 +698,7 @@ export class PmEditorService
         this.logger.debug(
           `${wsPath}: not loading the disk version — the user edited while it was being read`,
         );
-        toast.dismiss(staleExternalContentToastId(wsPath));
+        this.dismissStaleExternalContentToast(wsPath);
         return;
       }
       let compositionBlocked = false;
@@ -709,7 +737,7 @@ export class PmEditorService
         this.checkRoundTripFidelity({ content, editorView: view, wsPath });
       }
       if (!compositionBlocked) {
-        toast.dismiss(staleExternalContentToastId(wsPath));
+        this.dismissStaleExternalContentToast(wsPath);
       }
     } catch (error) {
       // Editor and toast stay as they are; the user can retry.

--- a/packages/core/editor/src/round-trip-check.ts
+++ b/packages/core/editor/src/round-trip-check.ts
@@ -25,8 +25,14 @@ function normalizeForComparison(markdown: string): string {
 
 /**
  * A link reference definition line: `[label]: https://example.com "title"`.
+ * CommonMark also consumes definitions nested inside blockquotes and list
+ * items (`> [label]: …`, `- [label]: …`), so those prefixes are allowed, in
+ * any combination. Over-matching (a definition-shaped line inside indented
+ * code) errs toward refusal, never toward silent loss — and the byte
+ * comparison in the caller accepts such content first when it round-trips.
  */
-const LINK_DEFINITION = /^[ \t]{0,3}\[[^\]]+\]:[ \t]*<?([^\s>]+)>?/gm;
+const LINK_DEFINITION =
+  /^(?:[ \t>]|(?:[-*+]|\d{1,9}[.)])[ \t])*\[[^\]]+\]:[ \t]*<?([^\s>]+)>?/gm;
 
 /** Attributes that hold a link or image target. */
 const LINK_TARGET_ATTRS = ['href', 'src'] as const;

--- a/packages/core/initialize-services/src/__tests__/service-setup.spec.ts
+++ b/packages/core/initialize-services/src/__tests__/service-setup.spec.ts
@@ -12,7 +12,11 @@ import {
 } from '@bangle.io/service-platform/testing';
 import { makeTestCommonOpts } from '@bangle.io/test-utils';
 import { describe, expect, test, vi } from 'vitest';
-import { coreServiceClasses, createServiceSetup } from '../service-setup';
+import {
+  type CoreConfigOverrides,
+  coreServiceClasses,
+  createServiceSetup,
+} from '../service-setup';
 
 const coreServiceSlotIds = [...Object.keys(coreServiceClasses), 'editorEngine'];
 
@@ -25,8 +29,10 @@ const themeManager = {
 
 function makeSetup({
   fileStorageConfig = () => ({ onChange: () => {} }),
+  coreConfigOverrides,
 }: {
   fileStorageConfig?: () => { onChange: () => void };
+  coreConfigOverrides?: CoreConfigOverrides;
 } = {}) {
   const controller = new AbortController();
   const { commonOpts, rootEmitter } = makeTestCommonOpts({ controller });
@@ -51,6 +57,7 @@ function makeSetup({
     fileStorageSlots: ['fileStorageMemory'],
     editorEngineId: 'prosemirror',
     editorSaveCoordinator: createEditorSaveCoordinator(),
+    coreConfigOverrides,
   });
 
   return { setup, controller };
@@ -62,6 +69,23 @@ describe('createServiceSetup', () => {
 
     expect(() => setup.getServices()).toThrow(/instantiate\(\)/);
     expect(() => setup.coreServices()).toThrow(/instantiate\(\)/);
+
+    controller.abort();
+  });
+
+  test('workspace save status does not resolve the editor engine', () => {
+    const inspectBaseConfig = vi.fn<
+      NonNullable<CoreConfigOverrides['workspaceState']>
+    >((base) => {
+      expect(base.hasPendingOrFailedSave('workspace:note.md')).toBe(false);
+      return base;
+    });
+    const { setup, controller } = makeSetup({
+      coreConfigOverrides: { workspaceState: inspectBaseConfig },
+    });
+
+    expect(() => setup.instantiate()).not.toThrow();
+    expect(inspectBaseConfig).toHaveBeenCalledOnce();
 
     controller.abort();
   });

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_EDITOR_ENGINE,
   EDITOR_ENGINE_QUERY_PARAM,
   type EditorEngineId,
+  EXTERNAL_FILE_CHANGE_SENDER_TAG,
   isEditorEngineId,
 } from '@bangle.io/constants';
 import type { EditorSaveCoordinator } from '@bangle.io/editor';
@@ -79,6 +80,58 @@ export function initializeServices(
     fileStorageNativeFs: slot(FileStorageNativeFs, () => ({
       onChange: (change) => {
         commonOpts.logger.info('File storage change:', change);
+      },
+      // External edits (sync tools, other editors) feed the same typed event
+      // pipeline as the app's own file mutations, so the file tree, indexes,
+      // and editors react to them identically — the sender tag is what lets
+      // consumers tell the two apart.
+      onExternalChange: (change) => {
+        commonOpts.logger.info('External file storage change:', change);
+        const sender = getEventSenderMetadata({
+          tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
+        });
+        switch (change.type) {
+          case 'create': {
+            rootEmitter.emit('event::file:update', {
+              type: 'file-create',
+              wsPath: change.wsPath,
+              sender,
+            });
+            break;
+          }
+          case 'update': {
+            rootEmitter.emit('event::file:update', {
+              type: 'file-content-update',
+              wsPath: change.wsPath,
+              sender,
+            });
+            break;
+          }
+          case 'delete': {
+            rootEmitter.emit('event::file:update', {
+              type: 'file-delete',
+              wsPath: change.wsPath,
+              sender,
+            });
+            break;
+          }
+          case 'rename': {
+            rootEmitter.emit('event::file:update', {
+              type: 'file-rename',
+              wsPath: change.newWsPath,
+              oldWsPath: change.oldWsPath,
+              sender,
+            });
+            break;
+          }
+          case 'refresh': {
+            rootEmitter.emit('event::file:force-update', { sender });
+            break;
+          }
+          default: {
+            const _exhaustiveCheck: never = change;
+          }
+        }
       },
       getRootDirHandle: async (wsName: string) => {
         assertIsDefined(getWorkspaceOps, 'getWorkspaceOps');

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -29,6 +29,7 @@ import {
 import type {
   BaseServiceCommonOptions,
   CommandHandler,
+  FileStorageExternalChangeEvent,
   RootEmitter,
 } from '@bangle.io/types';
 import { createServiceSetup } from './service-setup';
@@ -41,6 +42,20 @@ export function readEditorEngineFromUrl(
   );
   return isEditorEngineId(engineId) ? engineId : DEFAULT_EDITOR_ENGINE;
 }
+
+/**
+ * Per-path watcher changes carry the same meaning as the app's own file
+ * mutations; only the event names differ. The `Record` key type keeps this
+ * exhaustive over the non-`refresh` cases.
+ */
+const EXTERNAL_CHANGE_TO_FILE_EVENT = {
+  create: 'file-create',
+  update: 'file-content-update',
+  delete: 'file-delete',
+} as const satisfies Record<
+  Exclude<FileStorageExternalChangeEvent['type'], 'refresh'>,
+  string
+>;
 
 export function initializeServices(
   commonOpts: BaseServiceCommonOptions,
@@ -94,42 +109,18 @@ export function initializeServices(
         const sender = getEventSenderMetadata({
           tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
         });
-        switch (change.type) {
-          case 'create': {
-            rootEmitter.emit('event::file:update', {
-              type: 'file-create',
-              wsPath: change.wsPath,
-              sender,
-            });
-            break;
-          }
-          case 'update': {
-            rootEmitter.emit('event::file:update', {
-              type: 'file-content-update',
-              wsPath: change.wsPath,
-              sender,
-            });
-            break;
-          }
-          case 'delete': {
-            rootEmitter.emit('event::file:update', {
-              type: 'file-delete',
-              wsPath: change.wsPath,
-              sender,
-            });
-            break;
-          }
-          case 'refresh': {
-            rootEmitter.emit('event::file:force-update', {
-              wsName: change.wsName,
-              sender,
-            });
-            break;
-          }
-          default: {
-            const _exhaustiveCheck: never = change;
-          }
+        if (change.type === 'refresh') {
+          rootEmitter.emit('event::file:force-update', {
+            wsName: change.wsName,
+            sender,
+          });
+          return;
         }
+        rootEmitter.emit('event::file:update', {
+          type: EXTERNAL_CHANGE_TO_FILE_EVENT[change.type],
+          wsPath: change.wsPath,
+          sender,
+        });
       },
       subscribePageReturn: (listener, signal) => {
         assertIsDefined(getRouter, 'getRouter');

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -119,15 +119,6 @@ export function initializeServices(
             });
             break;
           }
-          case 'rename': {
-            rootEmitter.emit('event::file:update', {
-              type: 'file-rename',
-              wsPath: change.newWsPath,
-              oldWsPath: change.oldWsPath,
-              sender,
-            });
-            break;
-          }
           case 'refresh': {
             rootEmitter.emit('event::file:force-update', {
               wsName: change.wsName,

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -24,6 +24,7 @@ import {
   FileStorageNativeFs,
   HashStrategy,
   IdbDatabaseService,
+  onPageReturn,
 } from '@bangle.io/service-platform';
 import type {
   BaseServiceCommonOptions,
@@ -54,6 +55,9 @@ export function initializeServices(
   // a core service. The lookup is late-bound: it is wired right after the
   // setup is created and only runs after services are instantiated.
   let getWorkspaceOps: (() => WorkspaceOpsService) | undefined;
+  // Same late-binding for the router, whose page-lifecycle stream drives
+  // native FS page-return revalidation.
+  let getRouter: (() => BrowserRouterService) | undefined;
 
   const browserPlatformServices = {
     errorService: slot(BrowserErrorHandlerService, () => ({
@@ -133,6 +137,10 @@ export function initializeServices(
           }
         }
       },
+      subscribePageReturn: (listener, signal) => {
+        assertIsDefined(getRouter, 'getRouter');
+        onPageReturn(getRouter().emitter, listener, signal);
+      },
       getRootDirHandle: async (wsName: string) => {
         assertIsDefined(getWorkspaceOps, 'getWorkspaceOps');
         const { rootDirHandle } =
@@ -177,6 +185,7 @@ export function initializeServices(
   });
 
   getWorkspaceOps = () => setup.getServices().workspaceOps;
+  getRouter = () => setup.getServices().router;
 
   setup.instantiate();
 

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -129,7 +129,10 @@ export function initializeServices(
             break;
           }
           case 'refresh': {
-            rootEmitter.emit('event::file:force-update', { sender });
+            rootEmitter.emit('event::file:force-update', {
+              wsName: change.wsName,
+              sender,
+            });
             break;
           }
           default: {

--- a/packages/core/initialize-services/src/service-setup.ts
+++ b/packages/core/initialize-services/src/service-setup.ts
@@ -354,6 +354,7 @@ export function createServiceSetup<
           );
           return fileStorageServices;
         },
+        selfSenderId: BROWSING_CONTEXT_ID,
       })),
     ),
     navigation: slot(NavigationService),
@@ -425,7 +426,13 @@ export function createServiceSetup<
       })),
     ),
     workspaceOps: slot(WorkspaceOpsService),
-    workspaceState: slot(WorkspaceStateService),
+    workspaceState: slot(
+      WorkspaceStateService,
+      withOverride('workspaceState', () => ({
+        hasPendingOrFailedSave: (wsPath) =>
+          getCoreInstances().editorEngine.hasPendingOrFailedSave(wsPath),
+      })),
+    ),
     userActivityService: slot(
       UserActivityService,
       withOverride('userActivityService', () => ({

--- a/packages/core/initialize-services/src/service-setup.ts
+++ b/packages/core/initialize-services/src/service-setup.ts
@@ -429,8 +429,7 @@ export function createServiceSetup<
     workspaceState: slot(
       WorkspaceStateService,
       withOverride('workspaceState', () => ({
-        hasPendingOrFailedSave: (wsPath) =>
-          getCoreInstances().editorEngine.hasPendingOrFailedSave(wsPath),
+        hasPendingOrFailedSave: editorSaveCoordinator.hasPendingOrFailedSave,
       })),
     ),
     userActivityService: slot(

--- a/packages/core/service-core/src/__tests__/file-system-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/file-system-service.spec.ts
@@ -1,4 +1,5 @@
 import {
+  EXTERNAL_FILE_CHANGE_SENDER_TAG,
   FILE_STORAGE_MAX_FILE_SIZE_BYTES,
   WORKSPACE_STORAGE_TYPE,
 } from '@bangle.io/constants';
@@ -409,5 +410,59 @@ describe('FileSystemService', () => {
     expect(deleteCountDuringWrites).toEqual([before, before, before]);
     // ...and all three land together afterwards.
     expect(store.get(fileSystem.$fileDeleteCount)).toBe(before + paths.length);
+  });
+});
+
+describe('external file change events', () => {
+  const EXTERNAL_SENDER = {
+    id: 'other-source',
+    tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
+  };
+
+  it('exposes externally tagged file events through $externalFileChangeEvent', async () => {
+    const controller = new AbortController();
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+    const { store } = testEnv;
+    const fileSystem = services.fileSystem;
+
+    expect(store.get(fileSystem.$externalFileChangeEvent)).toBeUndefined();
+
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: 'some-ws:one.md',
+      sender: EXTERNAL_SENDER,
+    });
+    expect(store.get(fileSystem.$externalFileChangeEvent)).toEqual({
+      sequence: 1,
+      type: 'file-content-update',
+      wsPath: 'some-ws:one.md',
+    });
+    // External events also feed the regular counters so the file tree and
+    // indexes react to them like any other change.
+    expect(store.get(fileSystem.$fileContentUpdateCount)).toBe(1);
+
+    // Events from the app's own writes never mark the external atom.
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: 'some-ws:two.md',
+      sender: { id: 'bangle-app', tag: 'file-system' },
+    });
+    expect(store.get(fileSystem.$externalFileChangeEvent)).toMatchObject({
+      sequence: 1,
+      wsPath: 'some-ws:one.md',
+    });
+
+    // An externally tagged force-update maps to a coarse refresh.
+    testEnv.rootEmitter.emit('event::file:force-update', {
+      sender: EXTERNAL_SENDER,
+    });
+    expect(store.get(fileSystem.$externalFileChangeEvent)).toEqual({
+      sequence: 2,
+      type: 'refresh',
+    });
+
+    controller.abort();
   });
 });

--- a/packages/core/service-core/src/__tests__/file-system-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/file-system-service.spec.ts
@@ -454,13 +454,16 @@ describe('external file change events', () => {
       wsPath: 'some-ws:one.md',
     });
 
-    // An externally tagged force-update maps to a coarse refresh.
+    // An externally tagged force-update maps to a coarse refresh, keeping
+    // its workspace scope when the emitter provided one.
     testEnv.rootEmitter.emit('event::file:force-update', {
+      wsName: 'some-ws',
       sender: EXTERNAL_SENDER,
     });
     expect(store.get(fileSystem.$externalFileChangeEvent)).toEqual({
       sequence: 2,
       type: 'refresh',
+      wsName: 'some-ws',
     });
 
     controller.abort();

--- a/packages/core/service-core/src/__tests__/file-system-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/file-system-service.spec.ts
@@ -475,11 +475,12 @@ describe('external file change events', () => {
       wsPath: 'some-ws:new.md',
       sender: { id: 'other-tab', tag: 'file-system' },
     });
+    // Renames have their own typed atom; content reconciliation only needs a
+    // coarse refresh after the editor has been retargeted.
     expect(store.get(fileSystem.$externalFileChangeEvent)).toEqual({
       sequence: 3,
-      type: 'file-rename',
-      oldWsPath: 'some-ws:old.md',
-      wsPath: 'some-ws:new.md',
+      type: 'refresh',
+      wsName: 'some-ws',
     });
     // The tree re-lists, but this tab's editors are not sent through the
     // rename event without being told the source is external.

--- a/packages/core/service-core/src/__tests__/file-system-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/file-system-service.spec.ts
@@ -1,3 +1,4 @@
+import { getEventSenderMetadata } from '@bangle.io/base-utils';
 import {
   EXTERNAL_FILE_CHANGE_SENDER_TAG,
   FILE_STORAGE_MAX_FILE_SIZE_BYTES,
@@ -443,15 +444,51 @@ describe('external file change events', () => {
     // indexes react to them like any other change.
     expect(store.get(fileSystem.$fileContentUpdateCount)).toBe(1);
 
-    // Events from the app's own writes never mark the external atom.
+    // Events from this browsing context's own writes never mark the external
+    // atom.
     testEnv.rootEmitter.emit('event::file:update', {
       type: 'file-content-update',
       wsPath: 'some-ws:two.md',
-      sender: { id: 'bangle-app', tag: 'file-system' },
+      sender: getEventSenderMetadata({ tag: 'file-system' }),
     });
     expect(store.get(fileSystem.$externalFileChangeEvent)).toMatchObject({
       sequence: 1,
       wsPath: 'some-ws:one.md',
+    });
+
+    // A normal app write broadcast from another browsing context is just as
+    // external to this editor as a storage-watcher event.
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: 'some-ws:from-other-tab.md',
+      sender: { id: 'other-tab', tag: 'file-system' },
+    });
+    expect(store.get(fileSystem.$externalFileChangeEvent)).toEqual({
+      sequence: 2,
+      type: 'file-content-update',
+      wsPath: 'some-ws:from-other-tab.md',
+    });
+
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-rename',
+      oldWsPath: 'some-ws:old.md',
+      wsPath: 'some-ws:new.md',
+      sender: { id: 'other-tab', tag: 'file-system' },
+    });
+    expect(store.get(fileSystem.$externalFileChangeEvent)).toEqual({
+      sequence: 3,
+      type: 'file-rename',
+      oldWsPath: 'some-ws:old.md',
+      wsPath: 'some-ws:new.md',
+    });
+    // The tree re-lists, but this tab's editors are not sent through the
+    // rename event without being told the source is external.
+    expect(store.get(fileSystem.$fileRenameCount)).toBe(1);
+    expect(store.get(fileSystem.$fileRenameEvent)).toEqual({
+      external: true,
+      oldWsPath: 'some-ws:old.md',
+      sequence: 1,
+      wsPath: 'some-ws:new.md',
     });
 
     // An externally tagged force-update maps to a coarse refresh, keeping
@@ -461,7 +498,7 @@ describe('external file change events', () => {
       sender: EXTERNAL_SENDER,
     });
     expect(store.get(fileSystem.$externalFileChangeEvent)).toEqual({
-      sequence: 2,
+      sequence: 4,
       type: 'refresh',
       wsName: 'some-ws',
     });

--- a/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
@@ -411,6 +411,16 @@ describe('NoteSnapshotService', () => {
     controller.abort();
   });
 
+  it('applies the snapshot size limit to externally displaced editor content', async () => {
+    const { controller, services } = await setup();
+    const huge = `# big\n${'word '.repeat(1_000_000)}`;
+
+    await services.noteSnapshot.preserveExternalOverwrite(NOTE_WS_PATH, huge);
+
+    expect(await services.noteSnapshot.listSnapshots()).toEqual([]);
+    controller.abort();
+  });
+
   it('evicts old snapshots beyond the workspace cap, preferring recent ones', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date('2026-07-21T00:00:00Z'));

--- a/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
@@ -299,6 +299,42 @@ describe('NoteSnapshotService', () => {
     controller.abort();
   });
 
+  it('keeps capturing local versions once the throttle window has passed', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-21T00:00:00Z'));
+    const { controller, services, testEnv } = await setup({
+      minCaptureIntervalMs: 60_000,
+    });
+    await services.fileSystem.createTextFile(NOTE_WS_PATH, 'v1');
+    await writeNote(services, NOTE_WS_PATH, 'v2 from this tab');
+
+    // A watched workspace echoes every one of this tab's own writes back. That
+    // must not switch off ordinary snapshot history: after the throttle window
+    // the next save still has to preserve the version it overwrites.
+    // Spaced past the retention thinning bucket so each version survives.
+    for (const content of ['v3 from this tab', 'v4 from this tab']) {
+      testEnv.rootEmitter.emit('event::file:update', {
+        type: 'file-content-update',
+        wsPath: NOTE_WS_PATH,
+        sender: SELF_WATCHER_SENDER,
+      });
+      vi.advanceTimersByTime(11 * 60_000);
+      await writeNote(services, NOTE_WS_PATH, content);
+    }
+
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    const contents = await Promise.all(
+      snapshots.map(
+        async ({ id }) =>
+          (await services.noteSnapshot.getSnapshot(id))?.content,
+      ),
+    );
+    expect(contents).toEqual(
+      expect.arrayContaining(['v1', 'v2 from this tab', 'v3 from this tab']),
+    );
+    controller.abort();
+  });
+
   it('does not snapshot a same-tab watcher echo as external content', async () => {
     const { controller, services, testEnv } = await setup({
       minCaptureIntervalMs: 60_000,
@@ -502,12 +538,15 @@ describe('NoteSnapshotService', () => {
     controller.abort();
   });
 
-  it('applies the snapshot size limit to externally displaced editor content', async () => {
+  it('reports externally displaced editor content over the size limit as unpreservable', async () => {
     const { controller, services } = await setup();
     const huge = `# big\n${'word '.repeat(1_000_000)}`;
 
-    await services.noteSnapshot.preserveExternalOverwrite(NOTE_WS_PATH, huge);
-
+    // Reporting this as preserved would let the caller destroy the only
+    // remaining copy of the note.
+    await expect(
+      services.noteSnapshot.preserveExternalOverwrite(NOTE_WS_PATH, huge),
+    ).resolves.toBe('unpreservable');
     expect(await services.noteSnapshot.listSnapshots()).toEqual([]);
     controller.abort();
   });

--- a/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
@@ -1,5 +1,6 @@
 import {
   DATABASE_TABLE_NAME,
+  EXTERNAL_FILE_CHANGE_SENDER_TAG,
   WORKSPACE_STORAGE_TYPE,
 } from '@bangle.io/constants';
 import { createTestEnvironment } from '@bangle.io/test-utils';
@@ -226,6 +227,45 @@ describe('NoteSnapshotService', () => {
         snapshots[0]?.id ?? '',
       );
       expect(newest?.content).toBe('v2 from this tab');
+    });
+    controller.abort();
+  });
+
+  it('retains outgoing content across a watcher create echo', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-21T00:00:00Z'));
+    const { controller, services, testEnv } = await setup({
+      minCaptureIntervalMs: 60_000,
+    });
+    await services.fileSystem.createTextFile(NOTE_WS_PATH, 'v1');
+    await writeNote(services, NOTE_WS_PATH, 'v2 from this tab');
+    vi.advanceTimersByTime(11 * 60_000);
+
+    // NativeFS atomic replacement can surface as temp-file -> visible-file,
+    // which the watcher reports as a create even though this was our write.
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-create',
+      wsPath: NOTE_WS_PATH,
+      sender: {
+        id: 'storage-watcher',
+        tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
+      },
+    });
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: NOTE_WS_PATH,
+      sender: { id: 'some-other-tab', tag: 'file-system-service' },
+    });
+
+    await vi.waitFor(async () => {
+      const snapshots = await services.noteSnapshot.listSnapshots();
+      const contents = await Promise.all(
+        snapshots.map(
+          async ({ id }) =>
+            (await services.noteSnapshot.getSnapshot(id))?.content,
+        ),
+      );
+      expect(contents).toContain('v2 from this tab');
     });
     controller.abort();
   });

--- a/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
@@ -1,3 +1,4 @@
+import { getEventSenderMetadata } from '@bangle.io/base-utils';
 import {
   DATABASE_TABLE_NAME,
   EXTERNAL_FILE_CHANGE_SENDER_TAG,
@@ -9,6 +10,9 @@ import { countWords } from '../note-snapshot-service';
 
 const TEST_WS_NAME = 'test-ws';
 const NOTE_WS_PATH = `${TEST_WS_NAME}:note.md`;
+const SELF_WATCHER_SENDER = getEventSenderMetadata({
+  tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
+});
 
 async function setup({
   minCaptureIntervalMs = 0,
@@ -246,10 +250,7 @@ describe('NoteSnapshotService', () => {
     testEnv.rootEmitter.emit('event::file:update', {
       type: 'file-create',
       wsPath: NOTE_WS_PATH,
-      sender: {
-        id: 'storage-watcher',
-        tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
-      },
+      sender: SELF_WATCHER_SENDER,
     });
     testEnv.rootEmitter.emit('event::file:update', {
       type: 'file-content-update',
@@ -267,6 +268,56 @@ describe('NoteSnapshotService', () => {
       );
       expect(contents).toContain('v2 from this tab');
     });
+    controller.abort();
+  });
+
+  it('re-captures same-tab watcher content despite the throttle', async () => {
+    const { controller, services, testEnv } = await setup({
+      minCaptureIntervalMs: 60_000,
+    });
+    await services.fileSystem.createTextFile(NOTE_WS_PATH, 'v1');
+    await writeNote(services, NOTE_WS_PATH, 'v2 from this tab');
+
+    // Production watcher events carry this browsing context's id plus the
+    // external-change tag. Write storage directly to model the external edit.
+    await services.fileStorageMemory.writeFile(
+      NOTE_WS_PATH,
+      new File(['external disk content'], 'note.md'),
+    );
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: NOTE_WS_PATH,
+      sender: SELF_WATCHER_SENDER,
+    });
+
+    await writeNote(services, NOTE_WS_PATH, 'v3 local overwrite');
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    const newest = await services.noteSnapshot.getSnapshot(
+      snapshots[0]?.id ?? '',
+    );
+    expect(newest?.content).toBe('external disk content');
+    controller.abort();
+  });
+
+  it('does not snapshot a same-tab watcher echo as external content', async () => {
+    const { controller, services, testEnv } = await setup({
+      minCaptureIntervalMs: 60_000,
+    });
+    await services.fileSystem.createTextFile(NOTE_WS_PATH, 'v1');
+    await writeNote(services, NOTE_WS_PATH, 'v2 from this tab');
+
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: NOTE_WS_PATH,
+      sender: SELF_WATCHER_SENDER,
+    });
+    await writeNote(services, NOTE_WS_PATH, 'v3 from this tab');
+
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    expect(snapshots).toHaveLength(1);
+    await expect(
+      services.noteSnapshot.getSnapshot(snapshots[0]?.id ?? ''),
+    ).resolves.toMatchObject({ content: 'v1' });
     controller.abort();
   });
 

--- a/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
@@ -25,10 +25,24 @@ function createDeferred<T>() {
 
 async function setupWorkspaceStateService({
   controller = new AbortController(),
+  hasPendingOrFailedSave,
 }: {
   controller?: AbortController;
+  hasPendingOrFailedSave?: (wsPath: string) => boolean;
 } = {}) {
-  const testEnv = createTestEnvironment({ controller });
+  const testEnv = createTestEnvironment({
+    controller,
+    ...(hasPendingOrFailedSave
+      ? {
+          coreConfigOverrides: {
+            workspaceState: (base) => ({
+              ...base,
+              hasPendingOrFailedSave,
+            }),
+          },
+        }
+      : {}),
+  });
   const services = testEnv.instantiateAll();
   await testEnv.mountAll();
 
@@ -514,6 +528,32 @@ describe('WorkspaceStateService file tree updates', () => {
     });
     expect(services.navigation.resolveAtoms().activeWsFilePath?.wsPath).toBe(
       SOURCE_WIKI,
+    );
+  });
+
+  it('does not follow an external rename while the active path has an unsaved editor', async () => {
+    const { rootEmitter, services } = await setupWorkspaceStateService({
+      controller,
+      hasPendingOrFailedSave: (wsPath) => wsPath === TARGET,
+    });
+    const renamedWsPath = `${WS_NAME}:ExternallyRenamed.md`;
+
+    rootEmitter.emit('event::file:update', {
+      type: 'file-rename',
+      oldWsPath: TARGET,
+      wsPath: renamedWsPath,
+      sender: { id: 'another-tab', tag: 'file-system' },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        services.workspaceState
+          .resolveAtoms()
+          .wsPaths.map((path) => path.wsPath),
+      ).toContain(renamedWsPath);
+    });
+    expect(services.navigation.resolveAtoms().activeWsFilePath?.wsPath).toBe(
+      TARGET,
     );
   });
 

--- a/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
@@ -1,5 +1,8 @@
 import { throwAppError } from '@bangle.io/base-utils';
-import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import {
+  EXTERNAL_FILE_CHANGE_SENDER_TAG,
+  WORKSPACE_STORAGE_TYPE,
+} from '@bangle.io/constants';
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -271,6 +274,42 @@ describe('WorkspaceStateService backlink index', () => {
     expect(
       new Set(readFileAsText.mock.calls.map(([wsPath]) => wsPath)),
     ).toEqual(new Set([TARGET, SOURCE_MARKDOWN, SOURCE_WIKI, PLAIN_MENTION]));
+  });
+
+  it('rebuilds backlinks when an external create replaces an existing path', async () => {
+    const { rootEmitter, services, store } = await setupWorkspaceStateService({
+      controller,
+    });
+    await vi.waitUntil(() => {
+      const next = store.get(services.workspaceState.$backlinkIndex);
+      const sources = next.byTargetWsPath.get(TARGET) ?? [];
+      return next.status === 'ready' && sources.length > 0 ? next : undefined;
+    });
+
+    // Atomic temp-to-target commits are reported as creates even when they
+    // replace an existing file. Bypass FileSystemService for the disk write,
+    // then emit the watcher shape that must invalidate content indexes.
+    await services.fileStorageMemory.writeFile(
+      SOURCE_WIKI,
+      new File(['No link now'], 'SourceWiki.md', { type: 'text/plain' }),
+    );
+    rootEmitter.emit('event::file:update', {
+      type: 'file-create',
+      wsPath: SOURCE_WIKI,
+      sender: {
+        id: 'external-watcher',
+        tag: EXTERNAL_FILE_CHANGE_SENDER_TAG,
+      },
+    });
+
+    await vi.waitUntil(() => {
+      const next = store.get(services.workspaceState.$backlinkIndex);
+      const sources = next.byTargetWsPath.get(TARGET) ?? [];
+      return next.status === 'ready' &&
+        sources.map((path) => path.wsPath).join(',') === SOURCE_MARKDOWN
+        ? next
+        : undefined;
+    });
   });
 
   it('reports an error without reusing stale backlink data when a rebuild read fails', async () => {

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -57,6 +57,8 @@ export type ExternalFileChangeEvent = {
     | 'file-rename'
     | 'refresh';
   wsPath?: string;
+  /** For `refresh`: the workspace the refresh concerns; absent = app-wide. */
+  wsName?: string;
 };
 
 type FileReadOptions = {
@@ -137,7 +139,10 @@ export class FileSystemService extends BaseService {
         this.store.set(this.$fileRenameCount, (c) => c + 1);
         this.store.set(this.$fileForceUpdateCount, (c) => c + 1);
         if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
-          this.setExternalFileChangeEvent({ type: 'refresh' });
+          this.setExternalFileChangeEvent({
+            type: 'refresh',
+            wsName: event.wsName,
+          });
         }
       },
       this.abortSignal,

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -37,16 +37,17 @@ export type FileCreateEvent = {
 };
 
 export type FileRenameEvent = {
+  external: boolean;
   oldWsPath: string;
   sequence: number;
   wsPath: string;
 };
 
 /**
- * A file change that did NOT originate from this app's own writes — detected
+ * A file change that did NOT originate from this browsing context — detected
  * by a storage watcher (e.g. a sync tool editing a Native FS workspace) or
- * broadcast from another tab's watcher. `refresh` means "something changed,
- * re-read what you depend on" without a specific path.
+ * broadcast from another tab. `refresh` means "something changed, re-read
+ * what you depend on" without a specific path.
  */
 type ExternalFileChangePayload =
   | {
@@ -128,6 +129,8 @@ export class FileSystemService extends BaseService {
     private config: {
       emitter: ScopedEmitter<'event::file:update' | 'event::file:force-update'>;
       getFileStorageServices: () => Record<string, BaseFileStorageService>;
+      /** This browsing context's event-sender id (BROWSING_CONTEXT_ID). */
+      selfSenderId: string;
     },
   ) {
     super(SERVICE_NAME.fileSystemService, context, dependencies);
@@ -147,7 +150,7 @@ export class FileSystemService extends BaseService {
         this.store.set(this.$fileDeleteCount, (c) => c + 1);
         this.store.set(this.$fileRenameCount, (c) => c + 1);
         this.store.set(this.$fileForceUpdateCount, (c) => c + 1);
-        if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+        if (this.isExternalSender(event.sender)) {
           this.setExternalFileChangeEvent({
             type: 'refresh',
             wsName: event.wsName,
@@ -160,7 +163,8 @@ export class FileSystemService extends BaseService {
     this.config.emitter.on(
       'event::file:update',
       (event) => {
-        if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+        const isExternal = this.isExternalSender(event.sender);
+        if (isExternal) {
           if (event.type === 'file-rename') {
             if (event.oldWsPath !== undefined) {
               this.setExternalFileChangeEvent({
@@ -194,7 +198,7 @@ export class FileSystemService extends BaseService {
             // Observers cannot distinguish a new path from an atomic
             // temp-to-target replacement. External creates therefore also
             // invalidate indexes derived from file content.
-            if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+            if (isExternal) {
               this.recordFileContentUpdate(event.wsPath);
             }
             break;
@@ -211,6 +215,7 @@ export class FileSystemService extends BaseService {
             if (event.oldWsPath) {
               this.fileRenameSequence += 1;
               this.store.set(this.$fileRenameEvent, {
+                external: isExternal,
                 oldWsPath: event.oldWsPath,
                 sequence: this.fileRenameSequence,
                 wsPath: event.wsPath,
@@ -225,6 +230,13 @@ export class FileSystemService extends BaseService {
         }
       },
       this.abortSignal,
+    );
+  }
+
+  private isExternalSender(sender: { id: string; tag?: string }): boolean {
+    return (
+      sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG ||
+      sender.id !== this.config.selfSenderId
     );
   }
 

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -191,15 +191,16 @@ export class FileSystemService extends BaseService {
               sequence: this.fileCreateSequence,
               wsPath: event.wsPath,
             });
+            // Observers cannot distinguish a new path from an atomic
+            // temp-to-target replacement. External creates therefore also
+            // invalidate indexes derived from file content.
+            if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+              this.recordFileContentUpdate(event.wsPath);
+            }
             break;
           }
           case 'file-content-update': {
-            this.store.set(this.$fileContentUpdateCount, (c) => c + 1);
-            this.fileContentUpdateSequence += 1;
-            this.store.set(this.$fileContentUpdateEvent, {
-              sequence: this.fileContentUpdateSequence,
-              wsPath: event.wsPath,
-            });
+            this.recordFileContentUpdate(event.wsPath);
             break;
           }
           case 'file-delete': {
@@ -232,6 +233,15 @@ export class FileSystemService extends BaseService {
     this.store.set(this.$externalFileChangeEvent, {
       sequence: this.externalFileChangeSequence,
       ...event,
+    });
+  }
+
+  private recordFileContentUpdate(wsPath: string): void {
+    this.store.set(this.$fileContentUpdateCount, (count) => count + 1);
+    this.fileContentUpdateSequence += 1;
+    this.store.set(this.$fileContentUpdateEvent, {
+      sequence: this.fileContentUpdateSequence,
+      wsPath,
     });
   }
 

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -6,6 +6,7 @@ import {
   throwAppError,
 } from '@bangle.io/base-utils';
 import {
+  EXTERNAL_FILE_CHANGE_SENDER_TAG,
   SERVICE_NAME,
   WORKSPACE_STORAGE_TYPE,
   type WorkspaceStorageType,
@@ -41,6 +42,23 @@ export type FileRenameEvent = {
   wsPath: string;
 };
 
+/**
+ * A file change that did NOT originate from this app's own writes — detected
+ * by a storage watcher (e.g. a sync tool editing a Native FS workspace) or
+ * broadcast from another tab's watcher. `refresh` means "something changed,
+ * re-read what you depend on" without a specific path.
+ */
+export type ExternalFileChangeEvent = {
+  sequence: number;
+  type:
+    | 'file-create'
+    | 'file-content-update'
+    | 'file-delete'
+    | 'file-rename'
+    | 'refresh';
+  wsPath?: string;
+};
+
 type FileReadOptions = {
   signal?: AbortSignal;
 };
@@ -70,10 +88,14 @@ export class FileSystemService extends BaseService {
   $fileCreateEvent = atom<FileCreateEvent | undefined>(undefined);
   $fileContentUpdateEvent = atom<FileContentUpdateEvent | undefined>(undefined);
   $fileRenameEvent = atom<FileRenameEvent | undefined>(undefined);
+  $externalFileChangeEvent = atom<ExternalFileChangeEvent | undefined>(
+    undefined,
+  );
 
   private fileCreateSequence = 0;
   private fileContentUpdateSequence = 0;
   private fileRenameSequence = 0;
+  private externalFileChangeSequence = 0;
 
   $fileTreeChangeCount = atom((get) => {
     return (
@@ -108,12 +130,15 @@ export class FileSystemService extends BaseService {
 
     this.config.emitter.on(
       'event::file:force-update',
-      () => {
+      (event) => {
         this.store.set(this.$fileCreateCount, (c) => c + 1);
         this.store.set(this.$fileContentUpdateCount, (c) => c + 1);
         this.store.set(this.$fileDeleteCount, (c) => c + 1);
         this.store.set(this.$fileRenameCount, (c) => c + 1);
         this.store.set(this.$fileForceUpdateCount, (c) => c + 1);
+        if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+          this.setExternalFileChangeEvent({ type: 'refresh' });
+        }
       },
       this.abortSignal,
     );
@@ -121,6 +146,12 @@ export class FileSystemService extends BaseService {
     this.config.emitter.on(
       'event::file:update',
       (event) => {
+        if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+          this.setExternalFileChangeEvent({
+            type: event.type,
+            wsPath: event.wsPath,
+          });
+        }
         switch (event.type) {
           case 'file-create': {
             this.store.set(this.$fileCreateCount, (c) => c + 1);
@@ -163,6 +194,20 @@ export class FileSystemService extends BaseService {
       },
       this.abortSignal,
     );
+  }
+
+  private setExternalFileChangeEvent(
+    event: Omit<ExternalFileChangeEvent, 'sequence'>,
+  ): void {
+    this.externalFileChangeSequence += 1;
+    this.store.set(this.$externalFileChangeEvent, {
+      sequence: this.externalFileChangeSequence,
+      ...event,
+    });
+  }
+
+  private isWorkspaceFileVisible(wsPath: string) {
+    return isVisibleWorkspaceFilePath(wsPath);
   }
 
   /**

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -257,10 +257,6 @@ export class FileSystemService extends BaseService {
     });
   }
 
-  private isWorkspaceFileVisible(wsPath: string) {
-    return isVisibleWorkspaceFilePath(wsPath);
-  }
-
   /**
    * Triggers a rescan of the workspace file listing without touching open
    * editors. Used to recover after a failed file tree scan.

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -2,17 +2,18 @@ import {
   assertIsDefined,
   BaseService,
   type BaseServiceContext,
+  classifyEventSender,
   getEventSenderMetadata,
   throwAppError,
 } from '@bangle.io/base-utils';
 import {
-  EXTERNAL_FILE_CHANGE_SENDER_TAG,
   SERVICE_NAME,
   WORKSPACE_STORAGE_TYPE,
   type WorkspaceStorageType,
 } from '@bangle.io/constants';
 import type {
   BaseFileStorageService,
+  EventSenderMetadata,
   FileStat,
   ScopedEmitter,
 } from '@bangle.io/types';
@@ -218,11 +219,8 @@ export class FileSystemService extends BaseService {
     );
   }
 
-  private isExternalSender(sender: { id: string; tag?: string }): boolean {
-    return (
-      sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG ||
-      sender.id !== this.config.selfSenderId
-    );
+  private isExternalSender(sender: EventSenderMetadata): boolean {
+    return classifyEventSender(sender, this.config.selfSenderId).external;
   }
 
   private setExternalFileChangeEvent(event: ExternalFileChangePayload): void {

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -48,18 +48,27 @@ export type FileRenameEvent = {
  * broadcast from another tab's watcher. `refresh` means "something changed,
  * re-read what you depend on" without a specific path.
  */
+type ExternalFileChangePayload =
+  | {
+      type: 'file-create' | 'file-content-update' | 'file-delete';
+      wsPath: string;
+    }
+  | {
+      type: 'file-rename';
+      /** The path the file now lives at. */
+      wsPath: string;
+      /** The path the file was renamed away from. */
+      oldWsPath: string;
+    }
+  | {
+      type: 'refresh';
+      /** The workspace the refresh concerns; absent = app-wide. */
+      wsName?: string;
+    };
+
 export type ExternalFileChangeEvent = {
   sequence: number;
-  type:
-    | 'file-create'
-    | 'file-content-update'
-    | 'file-delete'
-    | 'file-rename'
-    | 'refresh';
-  wsPath?: string;
-  /** For `refresh`: the workspace the refresh concerns; absent = app-wide. */
-  wsName?: string;
-};
+} & ExternalFileChangePayload;
 
 type FileReadOptions = {
   signal?: AbortSignal;
@@ -152,10 +161,27 @@ export class FileSystemService extends BaseService {
       'event::file:update',
       (event) => {
         if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
-          this.setExternalFileChangeEvent({
-            type: event.type,
-            wsPath: event.wsPath,
-          });
+          if (event.type === 'file-rename') {
+            if (event.oldWsPath !== undefined) {
+              this.setExternalFileChangeEvent({
+                type: 'file-rename',
+                wsPath: event.wsPath,
+                oldWsPath: event.oldWsPath,
+              });
+            } else {
+              // A rename without its origin cannot be acted on per-path;
+              // degrade to a workspace-scoped refresh.
+              this.setExternalFileChangeEvent({
+                type: 'refresh',
+                wsName: WsPath.safeParse(event.wsPath).data?.wsName,
+              });
+            }
+          } else {
+            this.setExternalFileChangeEvent({
+              type: event.type,
+              wsPath: event.wsPath,
+            });
+          }
         }
         switch (event.type) {
           case 'file-create': {
@@ -201,9 +227,7 @@ export class FileSystemService extends BaseService {
     );
   }
 
-  private setExternalFileChangeEvent(
-    event: Omit<ExternalFileChangeEvent, 'sequence'>,
-  ): void {
+  private setExternalFileChangeEvent(event: ExternalFileChangePayload): void {
     this.externalFileChangeSequence += 1;
     this.store.set(this.$externalFileChangeEvent, {
       sequence: this.externalFileChangeSequence,

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -55,13 +55,6 @@ type ExternalFileChangePayload =
       wsPath: string;
     }
   | {
-      type: 'file-rename';
-      /** The path the file now lives at. */
-      wsPath: string;
-      /** The path the file was renamed away from. */
-      oldWsPath: string;
-    }
-  | {
       type: 'refresh';
       /** The workspace the refresh concerns; absent = app-wide. */
       wsName?: string;
@@ -164,28 +157,11 @@ export class FileSystemService extends BaseService {
       'event::file:update',
       (event) => {
         const isExternal = this.isExternalSender(event.sender);
-        if (isExternal) {
-          if (event.type === 'file-rename') {
-            if (event.oldWsPath !== undefined) {
-              this.setExternalFileChangeEvent({
-                type: 'file-rename',
-                wsPath: event.wsPath,
-                oldWsPath: event.oldWsPath,
-              });
-            } else {
-              // A rename without its origin cannot be acted on per-path;
-              // degrade to a workspace-scoped refresh.
-              this.setExternalFileChangeEvent({
-                type: 'refresh',
-                wsName: WsPath.safeParse(event.wsPath).data?.wsName,
-              });
-            }
-          } else {
-            this.setExternalFileChangeEvent({
-              type: event.type,
-              wsPath: event.wsPath,
-            });
-          }
+        if (isExternal && event.type !== 'file-rename') {
+          this.setExternalFileChangeEvent({
+            type: event.type,
+            wsPath: event.wsPath,
+          });
         }
         switch (event.type) {
           case 'file-create': {
@@ -222,6 +198,15 @@ export class FileSystemService extends BaseService {
               });
             }
             this.store.set(this.$fileRenameCount, (c) => c + 1);
+            if (isExternal) {
+              // $fileRenameEvent retargets editors when the origin is known.
+              // A coarse refresh then reconciles their content and also
+              // covers origin-less rename events.
+              this.setExternalFileChangeEvent({
+                type: 'refresh',
+                wsName: WsPath.safeParse(event.wsPath).data?.wsName,
+              });
+            }
             break;
           }
           default: {

--- a/packages/core/service-core/src/index.ts
+++ b/packages/core/service-core/src/index.ts
@@ -4,6 +4,7 @@ export { CommandRegistryService } from './command-registry-service';
 export { waitForSaveQueueToDrain } from './editor-save-status';
 export { EditorService } from './editor-service';
 export type {
+  ExternalFileChangeEvent,
   FileContentUpdateEvent,
   FileCreateEvent,
 } from './file-system-service';

--- a/packages/core/service-core/src/index.ts
+++ b/packages/core/service-core/src/index.ts
@@ -19,7 +19,10 @@ export type {
   NoteSnapshotMetadata,
   NoteSnapshotRecord,
 } from './note-snapshot-service';
-export { NoteSnapshotService } from './note-snapshot-service';
+export {
+  NoteSnapshotService,
+  type PreserveOutcome,
+} from './note-snapshot-service';
 export type { ShortcutServiceConfig } from './shortcut-service';
 export { ShortcutService } from './shortcut-service';
 export { UserActivityService } from './user-activity-service';

--- a/packages/core/service-core/src/note-snapshot-service.ts
+++ b/packages/core/service-core/src/note-snapshot-service.ts
@@ -1,5 +1,9 @@
 import { BaseService, type BaseServiceContext } from '@bangle.io/base-utils';
-import { DATABASE_TABLE_NAME, SERVICE_NAME } from '@bangle.io/constants';
+import {
+  DATABASE_TABLE_NAME,
+  EXTERNAL_FILE_CHANGE_SENDER_TAG,
+  SERVICE_NAME,
+} from '@bangle.io/constants';
 import { type InferType, T } from '@bangle.io/mini-js-utils';
 import type { BaseDatabaseService, ScopedEmitter } from '@bangle.io/types';
 import { WsPath } from '@bangle.io/ws-path';
@@ -144,8 +148,17 @@ export class NoteSnapshotService extends BaseService {
     this.config.emitter.on(
       'event::file:update',
       (event) => {
-        if (event.type === 'file-create' || event.type === 'file-delete') {
+        if (event.type === 'file-delete') {
           this.clearPathState(event.wsPath);
+        } else if (event.type === 'file-create') {
+          // A watcher can report our own atomic replace as a visible create
+          // after the temporary file is renamed. Reset capture throttling,
+          // but retain the just-written outgoing version so a later foreign
+          // overwrite can still preserve it.
+          this.lastCaptureAt.delete(event.wsPath);
+          if (event.sender.tag !== EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+            this.lastWrittenContent.delete(event.wsPath);
+          }
         } else if (event.type === 'file-rename') {
           this.relocatePathState(event.oldWsPath, event.wsPath);
           if (event.oldWsPath) {

--- a/packages/core/service-core/src/note-snapshot-service.ts
+++ b/packages/core/service-core/src/note-snapshot-service.ts
@@ -50,6 +50,13 @@ const NOTE_SNAPSHOT_MAX_CONTENT_BYTES = 4 * 1024 * 1024;
 const OUTGOING_WRITE_CACHE_SIZE = 32;
 const SNAPSHOT_LOCK_PREFIX = 'bangle:note-snapshots:';
 
+/**
+ * Outcome of preserving content that is about to be destroyed by a write this
+ * service did not perform. `unpreservable` means no copy can ever be stored,
+ * so the caller must not go ahead with the destructive replacement.
+ */
+export type PreserveOutcome = 'preserved' | 'retry' | 'unpreservable';
+
 export function countWords(content: string): number {
   const words = content.match(/\S+/g);
   return words ? words.length : 0;
@@ -150,48 +157,50 @@ export class NoteSnapshotService extends BaseService {
     this.config.emitter.on(
       'event::file:update',
       (event) => {
+        const isWatcher = event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG;
+        const isForeignTab = event.sender.id !== this.config.selfSenderId;
+
         if (event.type === 'file-delete') {
           this.clearPathState(event.wsPath);
         } else if (event.type === 'file-create') {
-          // A watcher can report our own atomic replace as a visible create
-          // after the temporary file is renamed. Reset capture throttling,
-          // but retain the just-written outgoing version so a later foreign
-          // overwrite can still preserve it.
-          this.lastCaptureAt.delete(event.wsPath);
-          if (event.sender.tag !== EXTERNAL_FILE_CHANGE_SENDER_TAG) {
-            this.lastWrittenContent.delete(event.wsPath);
-            this.watcherUpdatePending.delete(event.wsPath);
-          } else {
+          if (isWatcher) {
+            // A watcher can report our own atomic replace as a visible create
+            // after the temporary file is renamed. Retain the just-written
+            // outgoing version so a later foreign overwrite can preserve it.
             this.watcherUpdatePending.add(event.wsPath);
+          } else {
+            this.clearPathState(event.wsPath);
           }
         } else if (event.type === 'file-rename') {
           this.relocatePathState(event.oldWsPath, event.wsPath);
           if (event.oldWsPath) {
             void this.migratePersistedSnapshots(event.oldWsPath, event.wsPath);
           }
-        } else if (
-          event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG ||
-          event.sender.id !== this.config.selfSenderId
-        ) {
-          // A watcher or another tab changed this note. Drop the local
-          // throttle so the next save re-captures external disk content it is
-          // about to overwrite. `capture` filters watcher echoes by content.
-          this.lastCaptureAt.delete(event.wsPath);
-          if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+        } else if (isWatcher || isForeignTab) {
+          if (isWatcher) {
+            // A same-tab watcher also reports this tab's own writes, so the
+            // event alone does not prove the disk content is foreign. `capture`
+            // lifts the throttle only once it has read content we did not
+            // write; lifting it here would suppress ordinary local snapshots.
             this.watcherUpdatePending.add(event.wsPath);
           }
-          if (event.sender.id !== this.config.selfSenderId) {
-            // Preserve what this tab last wrote when a foreign tab wins the
-            // race. Same-tab watcher events may be our own echo, so their
-            // outgoing content is preserved by editor reconciliation instead.
+          if (isForeignTab) {
+            // Another tab definitely changed this note: drop the throttle so
+            // the next save captures the disk content it is about to
+            // overwrite, and preserve what this tab last wrote in case that
+            // write just lost the race.
+            this.lastCaptureAt.delete(event.wsPath);
             const outgoing = this.lastWrittenContent.get(event.wsPath);
             if (outgoing && !outgoing.preserved) {
+              // Marked eagerly so overlapping foreign events do not preserve
+              // twice; reset on storage failure so a later foreign event
+              // retries instead of silently dropping the only copy.
               outgoing.preserved = true;
               void this.preserveExternalOverwrite(
                 event.wsPath,
                 outgoing.content,
-              ).then((preserved) => {
-                if (!preserved) {
+              ).then((outcome) => {
+                if (outcome === 'retry') {
                   outgoing.preserved = false;
                 }
               });
@@ -371,10 +380,14 @@ export class NoteSnapshotService extends BaseService {
 
     const now = Date.now();
     const lastCapture = this.lastCaptureAt.get(wsPath);
-    if (
+    const throttled =
       lastCapture !== undefined &&
-      now - lastCapture < this.minCaptureIntervalMs
-    ) {
+      now - lastCapture < this.minCaptureIntervalMs;
+    // A watcher reports this tab's own writes too, so its event only earns a
+    // *provisional* throttle bypass: the content is read, and the bypass is
+    // honoured only if the disk copy is not the one we just wrote.
+    const watcherUpdatePending = this.watcherUpdatePending.delete(wsPath);
+    if (throttled && !watcherUpdatePending) {
       return;
     }
 
@@ -390,16 +403,8 @@ export class NoteSnapshotService extends BaseService {
       return;
     }
     const content = await file.text();
-    // A tagged watcher also observes this tab's own writes. Its event clears
-    // the throttle so a genuine external overwrite is recoverable, but the
-    // next save must not snapshot our unchanged outgoing version as if it
-    // were foreign content.
-    const watcherUpdatePending = this.watcherUpdatePending.delete(wsPath);
-    if (
-      watcherUpdatePending &&
-      this.lastWrittenContent.get(wsPath)?.content === content
-    ) {
-      this.lastCaptureAt.set(wsPath, now);
+    if (throttled && this.lastWrittenContent.get(wsPath)?.content === content) {
+      // Our own echo: nothing foreign to rescue, so the throttle stands.
       return;
     }
     // A note that was created but never given content has nothing worth
@@ -418,30 +423,34 @@ export class NoteSnapshotService extends BaseService {
    * Best-effort preservation of content displaced by a write outside the
    * normal FileSystemService path. The external-change editor sync calls this
    * immediately before replacing a clean editor with the new disk version.
-   * Never throws. Returns false only for a storage failure worth retrying;
-   * empty content and invalid paths count as done.
+   * Never throws. Empty content and invalid paths count as preserved: there is
+   * nothing worth recovering.
    */
   async preserveExternalOverwrite(
     wsPath: string,
     content: string,
-  ): Promise<boolean> {
+  ): Promise<PreserveOutcome> {
     try {
       const filePath = WsPath.fromString(wsPath).asFile();
-      if (
-        !filePath?.isMarkdown() ||
-        content.trim() === '' ||
-        new Blob([content]).size > NOTE_SNAPSHOT_MAX_CONTENT_BYTES
-      ) {
-        return true;
+      if (!filePath?.isMarkdown() || content.trim() === '') {
+        return 'preserved';
+      }
+      if (new Blob([content]).size > NOTE_SNAPSHOT_MAX_CONTENT_BYTES) {
+        // No copy can ever be stored, so the caller must keep this content
+        // rather than let it be destroyed unrecoverably.
+        this.logger.warn(
+          `cannot preserve ${wsPath}: content exceeds the snapshot size limit`,
+        );
+        return 'unpreservable';
       }
       await this.storeSnapshot(wsPath, content);
-      return true;
+      return 'preserved';
     } catch (error) {
       this.logger.warn(
         `could not preserve outgoing content for ${wsPath}`,
         error,
       );
-      return false;
+      return 'retry';
     }
   }
 

--- a/packages/core/service-core/src/note-snapshot-service.ts
+++ b/packages/core/service-core/src/note-snapshot-service.ts
@@ -163,13 +163,14 @@ export class NoteSnapshotService extends BaseService {
             // twice; reset on storage failure so a later foreign event
             // retries instead of silently dropping the only copy.
             outgoing.preserved = true;
-            void this.preserveContent(event.wsPath, outgoing.content).then(
-              (preserved) => {
-                if (!preserved) {
-                  outgoing.preserved = false;
-                }
-              },
-            );
+            void this.preserveExternalOverwrite(
+              event.wsPath,
+              outgoing.content,
+            ).then((preserved) => {
+              if (!preserved) {
+                outgoing.preserved = false;
+              }
+            });
           }
         }
       },
@@ -372,11 +373,13 @@ export class NoteSnapshotService extends BaseService {
   }
 
   /**
-   * Best-effort preservation of this tab's outgoing content. Never throws.
-   * Returns false only for a storage failure worth retrying; empty content
-   * and invalid paths count as done.
+   * Best-effort preservation of content displaced by a write outside the
+   * normal FileSystemService path. The external-change editor sync calls this
+   * immediately before replacing a clean editor with the new disk version.
+   * Never throws. Returns false only for a storage failure worth retrying;
+   * empty content and invalid paths count as done.
    */
-  private async preserveContent(
+  async preserveExternalOverwrite(
     wsPath: string,
     content: string,
   ): Promise<boolean> {

--- a/packages/core/service-core/src/note-snapshot-service.ts
+++ b/packages/core/service-core/src/note-snapshot-service.ts
@@ -1,9 +1,9 @@
-import { BaseService, type BaseServiceContext } from '@bangle.io/base-utils';
 import {
-  DATABASE_TABLE_NAME,
-  EXTERNAL_FILE_CHANGE_SENDER_TAG,
-  SERVICE_NAME,
-} from '@bangle.io/constants';
+  BaseService,
+  type BaseServiceContext,
+  classifyEventSender,
+} from '@bangle.io/base-utils';
+import { DATABASE_TABLE_NAME, SERVICE_NAME } from '@bangle.io/constants';
 import { type InferType, T } from '@bangle.io/mini-js-utils';
 import type { BaseDatabaseService, ScopedEmitter } from '@bangle.io/types';
 import { WsPath } from '@bangle.io/ws-path';
@@ -157,13 +157,15 @@ export class NoteSnapshotService extends BaseService {
     this.config.emitter.on(
       'event::file:update',
       (event) => {
-        const isWatcher = event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG;
-        const isForeignTab = event.sender.id !== this.config.selfSenderId;
+        const { foreignTab, watcher } = classifyEventSender(
+          event.sender,
+          this.config.selfSenderId,
+        );
 
         if (event.type === 'file-delete') {
           this.clearPathState(event.wsPath);
         } else if (event.type === 'file-create') {
-          if (isWatcher) {
+          if (watcher) {
             // A watcher can report our own atomic replace as a visible create
             // after the temporary file is renamed. Retain the just-written
             // outgoing version so a later foreign overwrite can preserve it.
@@ -176,15 +178,15 @@ export class NoteSnapshotService extends BaseService {
           if (event.oldWsPath) {
             void this.migratePersistedSnapshots(event.oldWsPath, event.wsPath);
           }
-        } else if (isWatcher || isForeignTab) {
-          if (isWatcher) {
+        } else if (watcher || foreignTab) {
+          if (watcher) {
             // A same-tab watcher also reports this tab's own writes, so the
             // event alone does not prove the disk content is foreign. `capture`
             // lifts the throttle only once it has read content we did not
             // write; lifting it here would suppress ordinary local snapshots.
             this.watcherUpdatePending.add(event.wsPath);
           }
-          if (isForeignTab) {
+          if (foreignTab) {
             // Another tab definitely changed this note: drop the throttle so
             // the next save captures the disk content it is about to
             // overwrite, and preserve what this tab last wrote in case that

--- a/packages/core/service-core/src/note-snapshot-service.ts
+++ b/packages/core/service-core/src/note-snapshot-service.ts
@@ -103,6 +103,8 @@ export class NoteSnapshotService extends BaseService {
     string,
     { content: string; preserved: boolean }
   >();
+  /** Paths whose next capture must distinguish a watcher echo from a change. */
+  private watcherUpdatePending = new Set<string>();
   private lastIssuedCreatedAt = 0;
   private localSnapshotLockTails = new Map<string, Promise<void>>();
 
@@ -158,32 +160,42 @@ export class NoteSnapshotService extends BaseService {
           this.lastCaptureAt.delete(event.wsPath);
           if (event.sender.tag !== EXTERNAL_FILE_CHANGE_SENDER_TAG) {
             this.lastWrittenContent.delete(event.wsPath);
+            this.watcherUpdatePending.delete(event.wsPath);
+          } else {
+            this.watcherUpdatePending.add(event.wsPath);
           }
         } else if (event.type === 'file-rename') {
           this.relocatePathState(event.oldWsPath, event.wsPath);
           if (event.oldWsPath) {
             void this.migratePersistedSnapshots(event.oldWsPath, event.wsPath);
           }
-        } else if (event.sender.id !== this.config.selfSenderId) {
-          // Another tab changed this note. Drop the local throttle so this
-          // tab's next save re-captures the content it is about to overwrite.
+        } else if (
+          event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG ||
+          event.sender.id !== this.config.selfSenderId
+        ) {
+          // A watcher or another tab changed this note. Drop the local
+          // throttle so the next save re-captures external disk content it is
+          // about to overwrite. `capture` filters watcher echoes by content.
           this.lastCaptureAt.delete(event.wsPath);
-          // And preserve what this tab last wrote: if that write just lost the
-          // race, its content only exists in this map now.
-          const outgoing = this.lastWrittenContent.get(event.wsPath);
-          if (outgoing && !outgoing.preserved) {
-            // Marked eagerly so overlapping foreign events do not preserve
-            // twice; reset on storage failure so a later foreign event
-            // retries instead of silently dropping the only copy.
-            outgoing.preserved = true;
-            void this.preserveExternalOverwrite(
-              event.wsPath,
-              outgoing.content,
-            ).then((preserved) => {
-              if (!preserved) {
-                outgoing.preserved = false;
-              }
-            });
+          if (event.sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG) {
+            this.watcherUpdatePending.add(event.wsPath);
+          }
+          if (event.sender.id !== this.config.selfSenderId) {
+            // Preserve what this tab last wrote when a foreign tab wins the
+            // race. Same-tab watcher events may be our own echo, so their
+            // outgoing content is preserved by editor reconciliation instead.
+            const outgoing = this.lastWrittenContent.get(event.wsPath);
+            if (outgoing && !outgoing.preserved) {
+              outgoing.preserved = true;
+              void this.preserveExternalOverwrite(
+                event.wsPath,
+                outgoing.content,
+              ).then((preserved) => {
+                if (!preserved) {
+                  outgoing.preserved = false;
+                }
+              });
+            }
           }
         }
       },
@@ -194,6 +206,7 @@ export class NoteSnapshotService extends BaseService {
   private clearPathState(wsPath: string): void {
     this.lastCaptureAt.delete(wsPath);
     this.lastWrittenContent.delete(wsPath);
+    this.watcherUpdatePending.delete(wsPath);
   }
 
   private relocatePathState(oldWsPath: string | undefined, wsPath: string) {
@@ -204,12 +217,16 @@ export class NoteSnapshotService extends BaseService {
 
     const lastCaptureAt = this.lastCaptureAt.get(oldWsPath);
     const lastWrittenContent = this.lastWrittenContent.get(oldWsPath);
+    const watcherUpdatePending = this.watcherUpdatePending.has(oldWsPath);
     this.clearPathState(oldWsPath);
     if (lastCaptureAt !== undefined) {
       this.lastCaptureAt.set(wsPath, lastCaptureAt);
     }
     if (lastWrittenContent !== undefined) {
       this.lastWrittenContent.set(wsPath, lastWrittenContent);
+    }
+    if (watcherUpdatePending) {
+      this.watcherUpdatePending.add(wsPath);
     }
   }
 
@@ -373,6 +390,18 @@ export class NoteSnapshotService extends BaseService {
       return;
     }
     const content = await file.text();
+    // A tagged watcher also observes this tab's own writes. Its event clears
+    // the throttle so a genuine external overwrite is recoverable, but the
+    // next save must not snapshot our unchanged outgoing version as if it
+    // were foreign content.
+    const watcherUpdatePending = this.watcherUpdatePending.delete(wsPath);
+    if (
+      watcherUpdatePending &&
+      this.lastWrittenContent.get(wsPath)?.content === content
+    ) {
+      this.lastCaptureAt.set(wsPath, now);
+      return;
+    }
     // A note that was created but never given content has nothing worth
     // recovering; skip it instead of storing an empty snapshot.
     if (content.trim() === '') {

--- a/packages/core/service-core/src/note-snapshot-service.ts
+++ b/packages/core/service-core/src/note-snapshot-service.ts
@@ -384,7 +384,12 @@ export class NoteSnapshotService extends BaseService {
     content: string,
   ): Promise<boolean> {
     try {
-      if (content.trim() === '') {
+      const filePath = WsPath.fromString(wsPath).asFile();
+      if (
+        !filePath?.isMarkdown() ||
+        content.trim() === '' ||
+        new Blob([content]).size > NOTE_SNAPSHOT_MAX_CONTENT_BYTES
+      ) {
         return true;
       }
       await this.storeSnapshot(wsPath, content);

--- a/packages/core/service-core/src/workspace-state-service.ts
+++ b/packages/core/service-core/src/workspace-state-service.ts
@@ -413,6 +413,9 @@ export class WorkspaceStateService extends BaseService {
       fileSystem: FileSystemService;
       workspaceOps: WorkspaceOpsService;
     },
+    private config: {
+      hasPendingOrFailedSave: (wsPath: string) => boolean;
+    },
   ) {
     super(SERVICE_NAME.workspaceStateService, context, dep);
   }
@@ -623,7 +626,9 @@ export class WorkspaceStateService extends BaseService {
 
           if (
             get(this.navigation.$activeWsFilePath)?.wsPath ===
-            oldFilePath.wsPath
+              oldFilePath.wsPath &&
+            (!renameEvent.external ||
+              !this.config.hasPendingOrFailedSave(oldFilePath.wsPath))
           ) {
             this.navigation.goWsPath(newFilePath.wsPath);
           }

--- a/packages/js-lib/native-fs/src/__tests__/native-fs.spec.ts
+++ b/packages/js-lib/native-fs/src/__tests__/native-fs.spec.ts
@@ -717,13 +717,13 @@ describe('cross-tab locking', () => {
 });
 
 describe('watch', () => {
-  it('returns false when FileSystemObserver is unavailable', async () => {
+  it('reports not armed when FileSystemObserver is unavailable', async () => {
     const { fs } = setup();
     const controller = new AbortController();
-    const supported = await fs.watch(() => undefined, {
+    const { armed } = await fs.watch(() => undefined, {
       signal: controller.signal,
     });
-    expect(supported).toBe(false);
+    expect(armed).toBe(false);
   });
 
   it('maps change records and disconnects on abort', async () => {
@@ -745,10 +745,10 @@ describe('watch', () => {
 
     const controller = new AbortController();
     const batches: unknown[] = [];
-    const supported = await fs.watch((changes) => batches.push(changes), {
+    const { armed } = await fs.watch((changes) => batches.push(changes), {
       signal: controller.signal,
     });
-    expect(supported).toBe(true);
+    expect(armed).toBe(true);
     expect(observe).toHaveBeenCalledWith(fs.rootHandle, { recursive: true });
 
     capturedCallback?.(
@@ -777,6 +777,29 @@ describe('watch', () => {
       ],
     ]);
 
+    controller.abort();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop disconnects once and survives a later abort', async () => {
+    const { fs } = setup();
+    const disconnect = vi.fn();
+    class FakeObserver {
+      observe = vi.fn(async () => undefined);
+      disconnect = disconnect;
+    }
+    vi.stubGlobal('FileSystemObserver', FakeObserver);
+
+    const controller = new AbortController();
+    const { armed, stop } = await fs.watch(() => undefined, {
+      signal: controller.signal,
+    });
+    expect(armed).toBe(true);
+
+    // Callers re-arming a watcher stop the old one; the signal firing later
+    // must not disconnect a second time.
+    stop();
+    stop();
     controller.abort();
     expect(disconnect).toHaveBeenCalledTimes(1);
   });

--- a/packages/js-lib/native-fs/src/index.ts
+++ b/packages/js-lib/native-fs/src/index.ts
@@ -12,6 +12,7 @@ export {
   type NativeFsChange,
   type NativeFsOpts,
   type NativeFsStat,
+  type NativeFsWatchHandle,
 } from './native-fs';
 export { joinPath, splitFilePath, splitPath } from './path';
 export {

--- a/packages/js-lib/native-fs/src/native-fs.ts
+++ b/packages/js-lib/native-fs/src/native-fs.ts
@@ -40,6 +40,13 @@ export interface NativeFsStat {
   sizeBytes: number;
 }
 
+export interface NativeFsWatchHandle {
+  /** False when `FileSystemObserver` is unavailable or the signal aborted. */
+  armed: boolean;
+  /** Disconnects this observer. Idempotent, and implied by the signal. */
+  stop: () => void;
+}
+
 export interface NativeFsChange {
   type: FileSystemChangeType;
   /** Root-relative path of the changed entry; `''` is the root itself. */
@@ -465,9 +472,13 @@ export class NativeFs {
 
   /**
    * Observes external changes under the root via `FileSystemObserver`
-   * (Chrome 133+ desktop). Returns `false` when the API is unavailable so
-   * callers can fall back to polling/manual refresh. Observation stops when
-   * `signal` aborts.
+   * (Chrome 133+ desktop). `armed` is false when the API is unavailable, so
+   * callers can fall back to polling/manual refresh.
+   *
+   * Observation stops when `signal` aborts or when the returned `stop` is
+   * called, whichever happens first. Callers that re-arm a watcher (e.g.
+   * after an `errored` record) must `stop` the previous one, otherwise both
+   * observers stay attached for the lifetime of `signal`.
    *
    * Change records from the OS can be coarse (`unknown` type, or `errored`
    * when observation breaks, e.g. on permission loss) — treat them as hints
@@ -476,13 +487,13 @@ export class NativeFs {
   async watch(
     onChanges: (changes: NativeFsChange[]) => void,
     opts: { signal: AbortSignal; recursive?: boolean },
-  ): Promise<boolean> {
+  ): Promise<NativeFsWatchHandle> {
     const { signal, recursive = true } = opts;
     const ObserverCtor = (
       globalThis as { FileSystemObserver?: FileSystemObserverConstructor }
     ).FileSystemObserver;
     if (typeof ObserverCtor !== 'function' || signal.aborted) {
-      return false;
+      return { armed: false, stop: () => {} };
     }
 
     return guardNativeFsOp('watch', async () => {
@@ -493,6 +504,15 @@ export class NativeFs {
           onChanges(changes);
         }
       });
+      let stopped = false;
+      const stop = () => {
+        if (stopped) {
+          return;
+        }
+        stopped = true;
+        signal.removeEventListener('abort', stop);
+        observer.disconnect();
+      };
       try {
         await observer.observe(this.rootHandle, { recursive });
       } catch (error) {
@@ -501,12 +521,10 @@ export class NativeFs {
       }
       if (signal.aborted) {
         observer.disconnect();
-        return false;
+        return { armed: false, stop: () => {} };
       }
-      signal.addEventListener('abort', () => observer.disconnect(), {
-        once: true,
-      });
-      return true;
+      signal.addEventListener('abort', stop, { once: true });
+      return { armed: true, stop };
     });
   }
 

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -204,6 +204,18 @@ function stubFileSystemObserver() {
   };
 }
 
+async function setupExternalChangeWatching() {
+  const observer = stubFileSystemObserver();
+  const testSetup = await setup(undefined, 'myWorkspace', {
+    withExternalChange: true,
+  });
+  await testSetup.service.fileExists('myWorkspace:seed.md');
+  await vi.waitFor(() => {
+    expect(observer.observe).toHaveBeenCalledTimes(1);
+  });
+  return { observer, ...testSetup };
+}
+
 describe('FileStorageNativeFs', () => {
   testCrossWorkspaceRenameContract(setup);
 
@@ -431,20 +443,7 @@ describe('external change watching', () => {
   });
 
   it('maps visible file records and degrades ambiguous moves to a refresh', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-
-    // First storage access boots the watcher for the workspace.
-    await service.fileExists('myWorkspace:seed.md');
-    await vi.waitFor(() => {
-      expect(observer.observe).toHaveBeenCalledTimes(1);
-    });
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     await observer.emitRecords([
       {
@@ -487,18 +486,7 @@ describe('external change watching', () => {
   });
 
   it('coalesces one observer burst: duplicates collapse, a coarse record wins alone', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-    await service.createFile('myWorkspace:seed.md', new File(['x'], 'seed.md'));
-    await vi.waitFor(() => {
-      expect(observer.observe).toHaveBeenCalledTimes(1);
-    });
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     // Duplicate records for the same path collapse into one event.
     await observer.emitRecords([
@@ -582,15 +570,7 @@ describe('external change watching', () => {
   });
 
   it('ignores hidden paths and coalesces unmappable records into one refresh', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-    await service.fileExists('myWorkspace:seed.md');
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     await observer.emitRecords([
       // Hidden/system files are invisible to the app: ignored entirely.
@@ -616,18 +596,7 @@ describe('external change watching', () => {
   });
 
   it('coarse-refreshes a deleted directory, whose record has no handle to say so', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-    await service.fileExists('myWorkspace:seed.md');
-    await vi.waitFor(() => {
-      expect(observer.observe).toHaveBeenCalledTimes(1);
-    });
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     // Real Chrome delivers `disappeared` with changedHandle: null, so a
     // deleted DIRECTORY is indistinguishable from a file by `kind`. Its
@@ -642,18 +611,7 @@ describe('external change watching', () => {
   });
 
   it('keeps invisible-to-visible atomic writes targeted but refreshes ambiguous visible moves', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-    await service.fileExists('myWorkspace:seed.md');
-    await vi.waitFor(() => {
-      expect(observer.observe).toHaveBeenCalledTimes(1);
-    });
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     await observer.emitRecords([
       // Chromium's own createWritable commit / sync tools' write-to-temp:
@@ -696,18 +654,7 @@ describe('external change watching', () => {
   });
 
   it('reports changes to visible temp-suffix files', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-    await service.fileExists('myWorkspace:seed.md');
-    await vi.waitFor(() => {
-      expect(observer.observe).toHaveBeenCalledTimes(1);
-    });
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     // The listing policy deliberately treats `.tmp`/`.swp` as legitimate
     // user files, so their watcher updates must not be silently dropped.
@@ -769,18 +716,8 @@ describe('external change watching', () => {
   });
 
   it('skips the refresh on plain refocus while a watcher is armed and healthy', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange, triggerPageReturn } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-    await service.fileExists('myWorkspace:seed.md');
-    await vi.waitFor(() => {
-      expect(observer.observe).toHaveBeenCalledTimes(1);
-    });
+    const { onExternalChange, triggerPageReturn } =
+      await setupExternalChangeWatching();
 
     // The page stayed visible the whole time and the observer was armed:
     // nothing was missed, so refreshing would re-list the workspace and
@@ -849,18 +786,8 @@ describe('external change watching', () => {
   });
 
   it('re-arms a dead watcher on page return after the observer errored', async () => {
-    const observer = stubFileSystemObserver();
-    const { service, onExternalChange, triggerPageReturn } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
-    await service.fileExists('myWorkspace:seed.md');
-    await vi.waitFor(() => {
-      expect(observer.observe).toHaveBeenCalledTimes(1);
-    });
+    const { observer, onExternalChange, triggerPageReturn } =
+      await setupExternalChangeWatching();
 
     // Observation broke (e.g. permission loss): one coarse refresh goes out.
     await observer.emitRecords([

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -532,32 +532,48 @@ describe('external change watching', () => {
     ]);
   });
 
-  it('revalidates opened workspaces on page return, throttled', async () => {
-    // Works with or without the observer API; here it is absent, making
-    // page-return revalidation the only refresh path.
-    const { service, onExternalChange, triggerPageReturn } = await setup(
-      undefined,
-      'myWorkspace',
-      {
-        withExternalChange: true,
-      },
-    );
+  it('revalidates opened workspaces on page return, deduping one return burst', async () => {
+    vi.useFakeTimers();
+    try {
+      // Works with or without the observer API; here it is absent, making
+      // page-return revalidation the only refresh path.
+      const { service, onExternalChange, triggerPageReturn } = await setup(
+        undefined,
+        'myWorkspace',
+        {
+          withExternalChange: true,
+        },
+      );
 
-    // Before any workspace is opened, a page return is a no-op.
-    triggerPageReturn();
-    expect(onExternalChange).not.toHaveBeenCalled();
+      // Before any workspace is opened, a page return is a no-op.
+      triggerPageReturn();
+      expect(onExternalChange).not.toHaveBeenCalled();
 
-    await service.fileExists('myWorkspace:seed.md');
-    triggerPageReturn();
-    expect(onExternalChange).toHaveBeenCalledWith({
-      type: 'refresh',
-      wsName: 'myWorkspace',
-    });
+      await service.fileExists('myWorkspace:seed.md');
+      triggerPageReturn();
+      expect(onExternalChange).toHaveBeenCalledWith({
+        type: 'refresh',
+        wsName: 'myWorkspace',
+      });
 
-    // A second return within the throttle window does not refresh again.
-    onExternalChange.mockClear();
-    triggerPageReturn();
-    expect(onExternalChange).not.toHaveBeenCalled();
+      // The same return fires visibilitychange and focus back-to-back;
+      // the duplicate notification does not refresh again.
+      onExternalChange.mockClear();
+      triggerPageReturn();
+      expect(onExternalChange).not.toHaveBeenCalled();
+
+      // A genuinely separate leave→edit→return cycle moments later MUST
+      // refresh: without an observer this is the only reconciliation, so a
+      // wall-clock throttle would permanently miss that cycle's edits.
+      vi.advanceTimersByTime(1_500);
+      triggerPageReturn();
+      expect(onExternalChange).toHaveBeenCalledWith({
+        type: 'refresh',
+        wsName: 'myWorkspace',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('re-arms a dead watcher on page return after the observer errored', async () => {

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -4,6 +4,7 @@
 
 import { FILE_STORAGE_MAX_FILE_SIZE_BYTES } from '@bangle.io/constants';
 import { isAbortError } from '@bangle.io/mini-js-utils';
+import { NativeFs } from '@bangle.io/native-fs';
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FileStorageNativeFs } from '../file-storage-nativefs';
@@ -107,6 +108,7 @@ class FakeDirectoryHandle {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -752,19 +754,18 @@ describe('external change watching', () => {
     triggerPageReturn();
     expect(onExternalChange).not.toHaveBeenCalled();
 
-    await service.fileExists('myWorkspace:seed.md');
+    await Promise.all([
+      service.fileExists('myWorkspace:seed.md'),
+      service.fileExists('secondWorkspace:seed.md'),
+    ]);
     triggerPageReturn({ returnedFromHidden: true });
-    expect(onExternalChange).toHaveBeenCalledWith({
-      type: 'refresh',
-      wsName: 'myWorkspace',
-    });
+    expect(onExternalChange).toHaveBeenCalledTimes(1);
+    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
 
     onExternalChange.mockClear();
     triggerPageReturn({ returnedFromHidden: false });
-    expect(onExternalChange).toHaveBeenCalledWith({
-      type: 'refresh',
-      wsName: 'myWorkspace',
-    });
+    expect(onExternalChange).toHaveBeenCalledTimes(1);
+    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
   });
 
   it('skips the refresh on plain refocus while a watcher is armed and healthy', async () => {
@@ -790,10 +791,61 @@ describe('external change watching', () => {
     // A return from a hidden/frozen tab refreshes even with a live watcher:
     // the browser may have starved the observer while the tab was away.
     triggerPageReturn({ returnedFromHidden: true });
-    expect(onExternalChange).toHaveBeenCalledWith({
-      type: 'refresh',
-      wsName: 'myWorkspace',
+    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+  });
+
+  it('retries when NativeFs reports that a watcher did not arm', async () => {
+    stubFileSystemObserver();
+    const watchSpy = vi
+      .spyOn(NativeFs.prototype, 'watch')
+      .mockResolvedValue(false);
+    const { service, onExternalChange, triggerPageReturn } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+
+    await service.fileExists('myWorkspace:seed.md');
+    await vi.waitFor(() => {
+      expect(watchSpy).toHaveBeenCalledTimes(1);
     });
+
+    triggerPageReturn({ returnedFromHidden: false });
+    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    await vi.waitFor(() => {
+      expect(watchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('refreshes on refocus while a watcher is still starting', async () => {
+    stubFileSystemObserver();
+    let resolveWatch!: (armed: boolean) => void;
+    const watchResult = new Promise<boolean>((resolve) => {
+      resolveWatch = resolve;
+    });
+    const watchSpy = vi
+      .spyOn(NativeFs.prototype, 'watch')
+      .mockReturnValue(watchResult);
+    const { service, onExternalChange, triggerPageReturn } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+
+    await service.fileExists('myWorkspace:seed.md');
+    expect(watchSpy).toHaveBeenCalledTimes(1);
+
+    // Starting prevents duplicate setup, but is not yet healthy enough to
+    // assume that the observer saw everything before this refocus.
+    triggerPageReturn({ returnedFromHidden: false });
+    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    expect(watchSpy).toHaveBeenCalledTimes(1);
+
+    resolveWatch(true);
   });
 
   it('re-arms a dead watcher on page return after the observer errored', async () => {
@@ -822,10 +874,7 @@ describe('external change watching', () => {
     // the watcher dead, anything could have been missed meanwhile.
     onExternalChange.mockClear();
     triggerPageReturn({ returnedFromHidden: false });
-    expect(onExternalChange).toHaveBeenCalledWith({
-      type: 'refresh',
-      wsName: 'myWorkspace',
-    });
+    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
     await vi.waitFor(() => {
       expect(observer.observe).toHaveBeenCalledTimes(2);
     });

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -705,14 +705,20 @@ describe('external change watching', () => {
       service.fileExists('myWorkspace:seed.md'),
       service.fileExists('secondWorkspace:seed.md'),
     ]);
+    // Each opened workspace is refreshed by name, so consumers never have to
+    // re-read workspaces this provider does not even hold.
     triggerPageReturn({ returnedFromHidden: true });
-    expect(onExternalChange).toHaveBeenCalledTimes(1);
-    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+      { type: 'refresh', wsName: 'secondWorkspace' },
+    ]);
 
     onExternalChange.mockClear();
     triggerPageReturn({ returnedFromHidden: false });
-    expect(onExternalChange).toHaveBeenCalledTimes(1);
-    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+      { type: 'refresh', wsName: 'secondWorkspace' },
+    ]);
   });
 
   it('skips the refresh on plain refocus while a watcher is armed and healthy', async () => {
@@ -728,7 +734,10 @@ describe('external change watching', () => {
     // A return from a hidden/frozen tab refreshes even with a live watcher:
     // the browser may have starved the observer while the tab was away.
     triggerPageReturn({ returnedFromHidden: true });
-    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
   });
 
   it('retries when NativeFs reports that a watcher did not arm', async () => {
@@ -750,7 +759,10 @@ describe('external change watching', () => {
     });
 
     triggerPageReturn({ returnedFromHidden: false });
-    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
     await vi.waitFor(() => {
       expect(watchSpy).toHaveBeenCalledTimes(2);
     });
@@ -779,7 +791,10 @@ describe('external change watching', () => {
     // Starting prevents duplicate setup, but is not yet healthy enough to
     // assume that the observer saw everything before this refocus.
     triggerPageReturn({ returnedFromHidden: false });
-    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
     expect(watchSpy).toHaveBeenCalledTimes(1);
 
     resolveWatch(true);
@@ -801,7 +816,10 @@ describe('external change watching', () => {
     // the watcher dead, anything could have been missed meanwhile.
     onExternalChange.mockClear();
     triggerPageReturn({ returnedFromHidden: false });
-    expect(onExternalChange).toHaveBeenCalledWith({ type: 'refresh' });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
     await vi.waitFor(() => {
       expect(observer.observe).toHaveBeenCalledTimes(2);
     });

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -4,7 +4,7 @@
 
 import { FILE_STORAGE_MAX_FILE_SIZE_BYTES } from '@bangle.io/constants';
 import { isAbortError } from '@bangle.io/mini-js-utils';
-import { NativeFs } from '@bangle.io/native-fs';
+import { NativeFs, type NativeFsWatchHandle } from '@bangle.io/native-fs';
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FileStorageNativeFs } from '../file-storage-nativefs';
@@ -744,7 +744,7 @@ describe('external change watching', () => {
     stubFileSystemObserver();
     const watchSpy = vi
       .spyOn(NativeFs.prototype, 'watch')
-      .mockResolvedValue(false);
+      .mockResolvedValue({ armed: false, stop: () => {} });
     const { service, onExternalChange, triggerPageReturn } = await setup(
       undefined,
       'myWorkspace',
@@ -770,8 +770,8 @@ describe('external change watching', () => {
 
   it('refreshes on refocus while a watcher is still starting', async () => {
     stubFileSystemObserver();
-    let resolveWatch!: (armed: boolean) => void;
-    const watchResult = new Promise<boolean>((resolve) => {
+    let resolveWatch!: (handle: NativeFsWatchHandle) => void;
+    const watchResult = new Promise<NativeFsWatchHandle>((resolve) => {
       resolveWatch = resolve;
     });
     const watchSpy = vi
@@ -797,7 +797,7 @@ describe('external change watching', () => {
     });
     expect(watchSpy).toHaveBeenCalledTimes(1);
 
-    resolveWatch(true);
+    resolveWatch({ armed: true, stop: () => {} });
   });
 
   it('re-arms a dead watcher on page return after the observer errored', async () => {
@@ -823,5 +823,8 @@ describe('external change watching', () => {
     await vi.waitFor(() => {
       expect(observer.observe).toHaveBeenCalledTimes(2);
     });
+    // The broken observer is disconnected rather than left attached: stacking
+    // observers would replay every later change once per error cycle.
+    expect(observer.disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -117,6 +117,12 @@ async function setup(
   const { commonOpts } = createTestEnvironment();
   const onChange = vi.fn();
   const onExternalChange = vi.fn();
+  // Captures the page-return listener the service registers so tests can
+  // simulate the user coming back to the tab.
+  let pageReturnListener: (() => void) | undefined;
+  const triggerPageReturn = () => {
+    pageReturnListener?.();
+  };
   const rootDirHandle = new FakeDirectoryHandle(
     rootName,
     onEntryVisited,
@@ -132,11 +138,24 @@ async function setup(
     {
       getRootDirHandle: async () => ({ handle: rootDirHandle }),
       onChange,
-      ...(options.withExternalChange ? { onExternalChange } : {}),
+      ...(options.withExternalChange
+        ? {
+            onExternalChange,
+            subscribePageReturn: (listener: () => void) => {
+              pageReturnListener = listener;
+            },
+          }
+        : {}),
     },
   );
   await service.mount();
-  return { service, onChange, onExternalChange, rootDirHandle };
+  return {
+    service,
+    onChange,
+    onExternalChange,
+    rootDirHandle,
+    triggerPageReturn,
+  };
 }
 
 type ObservedRecord = {
@@ -514,9 +533,37 @@ describe('external change watching', () => {
     ]);
   });
 
-  it('falls back to throttled focus revalidation when the observer API is unavailable', async () => {
-    // No FileSystemObserver global installed.
-    const { service, onExternalChange } = await setup(
+  it('revalidates opened workspaces on page return, throttled', async () => {
+    // Works with or without the observer API; here it is absent, making
+    // page-return revalidation the only refresh path.
+    const { service, onExternalChange, triggerPageReturn } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+
+    // Before any workspace is opened, a page return is a no-op.
+    triggerPageReturn();
+    expect(onExternalChange).not.toHaveBeenCalled();
+
+    await service.fileExists('myWorkspace:seed.md');
+    triggerPageReturn();
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
+
+    // A second return within the throttle window does not refresh again.
+    onExternalChange.mockClear();
+    triggerPageReturn();
+    expect(onExternalChange).not.toHaveBeenCalled();
+  });
+
+  it('re-arms a dead watcher on page return after the observer errored', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange, triggerPageReturn } = await setup(
       undefined,
       'myWorkspace',
       {
@@ -524,18 +571,22 @@ describe('external change watching', () => {
       },
     );
     await service.fileExists('myWorkspace:seed.md');
-
     await vi.waitFor(() => {
-      window.dispatchEvent(new Event('focus'));
-      expect(onExternalChange).toHaveBeenCalledWith({
-        type: 'refresh',
-        wsName: 'myWorkspace',
-      });
+      expect(observer.observe).toHaveBeenCalledTimes(1);
     });
 
-    // A second focus within the throttle window does not refresh again.
-    onExternalChange.mockClear();
-    window.dispatchEvent(new Event('focus'));
-    expect(onExternalChange).not.toHaveBeenCalled();
+    // Observation broke (e.g. permission loss): one coarse refresh goes out.
+    await observer.emitRecords([
+      { type: 'errored', relativePathComponents: [] },
+    ]);
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+    ]);
+
+    // Coming back to the page re-establishes the observer.
+    triggerPageReturn();
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -653,6 +653,68 @@ describe('external change watching', () => {
     ]);
   });
 
+  it('ignores churn inside locations the listing never shows', async () => {
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
+
+    // A workspace pointed at a code repo sees constant `git`/`npm` activity.
+    // None of it can change the workspace listing, and most of these paths
+    // are extensionless so they do not parse as files — without the ignore
+    // check running first, each one would force a full re-list.
+    await observer.emitRecords([
+      {
+        type: 'modified',
+        relativePathComponents: ['.git', 'HEAD'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'modified',
+        relativePathComponents: ['.git', 'index'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'appeared',
+        relativePathComponents: ['.git', 'COMMIT_EDITMSG'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'appeared',
+        relativePathComponents: ['.git', 'objects', 'ab'],
+        changedHandle: { kind: 'directory' },
+      },
+      {
+        type: 'modified',
+        relativePathComponents: ['node_modules', '.bin', 'tsc'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'moved',
+        relativePathComponents: ['.git', 'index'],
+        relativePathMovedFrom: ['.git', 'index.lock'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
+
+    expect(onExternalChange).not.toHaveBeenCalled();
+  });
+
+  it('still refreshes when a visible directory changes', async () => {
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
+
+    // The ignore check must not swallow real directory changes: adding or
+    // removing a visible folder does change the listing.
+    await observer.emitRecords([
+      {
+        type: 'appeared',
+        relativePathComponents: ['notes'],
+        changedHandle: { kind: 'directory' },
+      },
+    ]);
+
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+    ]);
+  });
+
   it('reports changes to visible temp-suffix files', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -412,6 +412,22 @@ describe('FileStorageNativeFs', () => {
 });
 
 describe('external change watching', () => {
+  it('arms one observer for concurrent first access to a workspace', async () => {
+    const observer = stubFileSystemObserver();
+    const { service } = await setup(undefined, 'myWorkspace', {
+      withExternalChange: true,
+    });
+
+    await Promise.all([
+      service.fileExists('myWorkspace:first.md'),
+      service.readFile('myWorkspace:second.md'),
+    ]);
+
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('maps visible file records and degrades ambiguous moves to a refresh', async () => {
     const observer = stubFileSystemObserver();
     const { service, onExternalChange } = await setup(

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -5,7 +5,7 @@
 import { FILE_STORAGE_MAX_FILE_SIZE_BYTES } from '@bangle.io/constants';
 import { isAbortError } from '@bangle.io/mini-js-utils';
 import { createTestEnvironment } from '@bangle.io/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FileStorageNativeFs } from '../file-storage-nativefs';
 import { testCrossWorkspaceRenameContract } from './file-storage-rename-contract';
 
@@ -105,9 +105,18 @@ class FakeDirectoryHandle {
   }
 }
 
-async function setup(onEntryVisited?: () => void, rootName = 'myWorkspace') {
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function setup(
+  onEntryVisited?: () => void,
+  rootName = 'myWorkspace',
+  options: { withExternalChange?: boolean } = {},
+) {
   const { commonOpts } = createTestEnvironment();
   const onChange = vi.fn();
+  const onExternalChange = vi.fn();
   const rootDirHandle = new FakeDirectoryHandle(
     rootName,
     onEntryVisited,
@@ -123,10 +132,52 @@ async function setup(onEntryVisited?: () => void, rootName = 'myWorkspace') {
     {
       getRootDirHandle: async () => ({ handle: rootDirHandle }),
       onChange,
+      ...(options.withExternalChange ? { onExternalChange } : {}),
     },
   );
   await service.mount();
-  return { service, onChange, rootDirHandle };
+  return { service, onChange, onExternalChange, rootDirHandle };
+}
+
+type ObservedRecord = {
+  type?: string;
+  relativePathComponents?: readonly string[];
+  relativePathMovedFrom?: readonly string[] | null;
+  changedHandle?: { kind: string };
+};
+
+/**
+ * Installs a fake `FileSystemObserver` global and returns a trigger that
+ * feeds change records to whatever callback the adapter registered.
+ */
+function stubFileSystemObserver() {
+  let capturedCallback:
+    | ((records: readonly ObservedRecord[], observer: unknown) => void)
+    | undefined;
+  const observe = vi.fn(async () => undefined);
+  const disconnect = vi.fn();
+
+  class FakeFileSystemObserver {
+    constructor(
+      callback: (records: readonly ObservedRecord[], observer: unknown) => void,
+    ) {
+      capturedCallback = callback;
+    }
+    observe = observe;
+    disconnect = disconnect;
+  }
+  vi.stubGlobal('FileSystemObserver', FakeFileSystemObserver);
+
+  return {
+    observe,
+    disconnect,
+    async emitRecords(records: ObservedRecord[]) {
+      await vi.waitFor(() => {
+        expect(capturedCallback).toBeDefined();
+      });
+      capturedCallback?.(records, undefined);
+    },
+  };
 }
 
 describe('FileStorageNativeFs', () => {
@@ -335,5 +386,156 @@ describe('FileStorageNativeFs', () => {
       oldWsPath: 'myWorkspace:a.md',
       newWsPath: 'myWorkspace:sub/b.md',
     });
+  });
+});
+
+describe('external change watching', () => {
+  it('maps observer records for visible files to external change events', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+
+    // First storage access boots the watcher for the workspace.
+    await service.fileExists('myWorkspace:seed.md');
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
+
+    await observer.emitRecords([
+      {
+        type: 'appeared',
+        relativePathComponents: ['sub', 'new.md'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'modified',
+        relativePathComponents: ['existing.md'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'disappeared',
+        relativePathComponents: ['gone.md'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'moved',
+        relativePathComponents: ['renamed.md'],
+        relativePathMovedFrom: ['old-name.md'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
+
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'create', wsPath: 'myWorkspace:sub/new.md' },
+      { type: 'update', wsPath: 'myWorkspace:existing.md' },
+      { type: 'delete', wsPath: 'myWorkspace:gone.md' },
+      {
+        type: 'rename',
+        oldWsPath: 'myWorkspace:old-name.md',
+        newWsPath: 'myWorkspace:renamed.md',
+      },
+    ]);
+  });
+
+  it("suppresses the observer echo of the app's own writes", async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+
+    await service.createFile(
+      'myWorkspace:mine.md',
+      new File(['from the app'], 'mine.md'),
+    );
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
+
+    // The OS-level record produced by our own write arrives shortly after.
+    await observer.emitRecords([
+      {
+        type: 'appeared',
+        relativePathComponents: ['mine.md'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'modified',
+        relativePathComponents: ['truly-external.md'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
+
+    // Only the genuinely external change comes through.
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'update', wsPath: 'myWorkspace:truly-external.md' },
+    ]);
+  });
+
+  it('ignores hidden paths and coalesces unmappable records into one refresh', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+    await service.fileExists('myWorkspace:seed.md');
+
+    await observer.emitRecords([
+      // Hidden/system files are invisible to the app: ignored entirely.
+      {
+        type: 'modified',
+        relativePathComponents: ['.obsidian', 'config.json'],
+        changedHandle: { kind: 'file' },
+      },
+      // Directory records and unknown/errored records only say "something
+      // changed": they collapse into a single coarse refresh.
+      {
+        type: 'appeared',
+        relativePathComponents: ['new-dir'],
+        changedHandle: { kind: 'directory' },
+      },
+      { type: 'unknown', relativePathComponents: [] },
+      { type: 'errored', relativePathComponents: [] },
+    ]);
+
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+    ]);
+  });
+
+  it('falls back to throttled focus revalidation when the observer API is unavailable', async () => {
+    // No FileSystemObserver global installed.
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+    await service.fileExists('myWorkspace:seed.md');
+
+    await vi.waitFor(() => {
+      window.dispatchEvent(new Event('focus'));
+      expect(onExternalChange).toHaveBeenCalledWith({
+        type: 'refresh',
+        wsName: 'myWorkspace',
+      });
+    });
+
+    // A second focus within the throttle window does not refresh again.
+    onExternalChange.mockClear();
+    window.dispatchEvent(new Event('focus'));
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -653,6 +653,27 @@ describe('external change watching', () => {
     ]);
   });
 
+  it('coarse-refreshes a moved directory whose dot-named path looks like a file', async () => {
+    const { observer, onExternalChange } = await setupExternalChangeWatching();
+
+    // A directory materializing from an invisible path matches the atomic-write
+    // move shape, but its handle says directory: a targeted file-create here
+    // would tell the app a note named like the folder appeared. Only a re-list
+    // reconciles the tree with the directory's contents.
+    await observer.emitRecords([
+      {
+        type: 'moved',
+        relativePathComponents: ['archive.md'],
+        relativePathMovedFrom: ['archive.md.crswap'],
+        changedHandle: { kind: 'directory' },
+      },
+    ]);
+
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+    ]);
+  });
+
   it('ignores churn inside locations the listing never shows', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
@@ -827,6 +848,39 @@ describe('external change watching', () => {
     });
     await vi.waitFor(() => {
       expect(watchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('re-arms on page return after watch setup rejects', async () => {
+    stubFileSystemObserver();
+    const watchSpy = vi
+      .spyOn(NativeFs.prototype, 'watch')
+      .mockRejectedValueOnce(new Error('observer setup failed'))
+      .mockResolvedValue({ armed: true, stop: () => {} });
+    const { service, onExternalChange, triggerPageReturn } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+
+    await service.fileExists('myWorkspace:seed.md');
+    await vi.waitFor(() => {
+      expect(watchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // The rejection must settle the watcher back to idle — a state stuck at
+    // `starting` would permanently disable re-arming — so a page return both
+    // refreshes and retries the observer. Retriggering inside waitFor keeps
+    // the test independent of how fast the rejection handler runs.
+    await vi.waitFor(() => {
+      triggerPageReturn({ returnedFromHidden: false });
+      expect(watchSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
     });
   });
 

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -461,7 +461,11 @@ describe('external change watching', () => {
     ]);
   });
 
-  it("suppresses the observer echo of the app's own writes", async () => {
+  it('still reports external changes to a path the app itself just wrote', async () => {
+    // Regression for a removed "self-write echo" ledger: a path+time filter
+    // cannot tell the app's own echo from a sync tool overwriting the same
+    // file moments after a local save, and silently dropped the latter.
+    // Echoes are instead coalesced downstream by content comparison.
     const observer = stubFileSystemObserver();
     const { service, onExternalChange } = await setup(
       undefined,
@@ -479,23 +483,18 @@ describe('external change watching', () => {
       expect(observer.observe).toHaveBeenCalledTimes(1);
     });
 
-    // The OS-level record produced by our own write arrives shortly after.
+    // A record for the just-written path (echo or a genuinely external
+    // overwrite — indistinguishable here) must flow through.
     await observer.emitRecords([
       {
-        type: 'appeared',
-        relativePathComponents: ['mine.md'],
-        changedHandle: { kind: 'file' },
-      },
-      {
         type: 'modified',
-        relativePathComponents: ['truly-external.md'],
+        relativePathComponents: ['mine.md'],
         changedHandle: { kind: 'file' },
       },
     ]);
 
-    // Only the genuinely external change comes through.
     expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'update', wsPath: 'myWorkspace:truly-external.md' },
+      { type: 'update', wsPath: 'myWorkspace:mine.md' },
     ]);
   });
 

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -461,6 +461,64 @@ describe('external change watching', () => {
     ]);
   });
 
+  it('coalesces one observer burst: duplicates collapse, a coarse record wins alone', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+    await service.createFile('myWorkspace:seed.md', new File(['x'], 'seed.md'));
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
+
+    // Duplicate records for the same path collapse into one event.
+    await observer.emitRecords([
+      {
+        type: 'modified',
+        relativePathComponents: ['a.md'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'modified',
+        relativePathComponents: ['a.md'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'modified',
+        relativePathComponents: ['b.md'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'update', wsPath: 'myWorkspace:a.md' },
+      { type: 'update', wsPath: 'myWorkspace:b.md' },
+    ]);
+
+    // Once any record in the batch demands a coarse refresh, the refresh is
+    // emitted alone — it re-lists the workspace and revalidates open notes,
+    // so per-path events in the same batch would only duplicate that work.
+    onExternalChange.mockClear();
+    await observer.emitRecords([
+      {
+        type: 'modified',
+        relativePathComponents: ['a.md'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'appeared',
+        relativePathComponents: ['sub'],
+        changedHandle: { kind: 'directory' },
+      },
+    ]);
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+    ]);
+  });
+
   it('still reports external changes to a path the app itself just wrote', async () => {
     // Regression for a removed "self-write echo" ledger: a path+time filter
     // cannot tell the app's own echo from a sync tool overwriting the same

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -7,6 +7,7 @@ import { isAbortError } from '@bangle.io/mini-js-utils';
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FileStorageNativeFs } from '../file-storage-nativefs';
+import type { PageReturnInfo } from '../router/page-return';
 import { testCrossWorkspaceRenameContract } from './file-storage-rename-contract';
 
 class FakeFileHandle {
@@ -119,9 +120,11 @@ async function setup(
   const onExternalChange = vi.fn();
   // Captures the page-return listener the service registers so tests can
   // simulate the user coming back to the tab.
-  let pageReturnListener: (() => void) | undefined;
-  const triggerPageReturn = () => {
-    pageReturnListener?.();
+  let pageReturnListener: ((info: PageReturnInfo) => void) | undefined;
+  const triggerPageReturn = (
+    info: PageReturnInfo = { returnedFromHidden: true },
+  ) => {
+    pageReturnListener?.(info);
   };
   const rootDirHandle = new FakeDirectoryHandle(
     rootName,
@@ -141,7 +144,7 @@ async function setup(
       ...(options.withExternalChange
         ? {
             onExternalChange,
-            subscribePageReturn: (listener: () => void) => {
+            subscribePageReturn: (listener: (info: PageReturnInfo) => void) => {
               pageReturnListener = listener;
             },
           }
@@ -437,9 +440,10 @@ describe('external change watching', () => {
         changedHandle: { kind: 'file' },
       },
       {
+        // Deleted entries carry no handle in real Chrome (kind unknowable);
+        // classification must come from the path shape.
         type: 'disappeared',
         relativePathComponents: ['gone.md'],
-        changedHandle: { kind: 'file' },
       },
       {
         type: 'moved',
@@ -590,48 +594,180 @@ describe('external change watching', () => {
     ]);
   });
 
-  it('revalidates opened workspaces on page return, deduping one return burst', async () => {
-    vi.useFakeTimers();
-    try {
-      // Works with or without the observer API; here it is absent, making
-      // page-return revalidation the only refresh path.
-      const { service, onExternalChange, triggerPageReturn } = await setup(
-        undefined,
-        'myWorkspace',
-        {
-          withExternalChange: true,
-        },
-      );
+  it('coarse-refreshes a deleted directory, whose record has no handle to say so', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+    await service.fileExists('myWorkspace:seed.md');
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
 
-      // Before any workspace is opened, a page return is a no-op.
-      triggerPageReturn();
-      expect(onExternalChange).not.toHaveBeenCalled();
+    // Real Chrome delivers `disappeared` with changedHandle: null, so a
+    // deleted DIRECTORY is indistinguishable from a file by `kind`. Its
+    // extensionless path is directory-shaped, and its descendants get no
+    // records of their own — only a re-list reconciles the tree.
+    await observer.emitRecords([
+      { type: 'disappeared', relativePathComponents: ['archive'] },
+    ]);
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'refresh', wsName: 'myWorkspace' },
+    ]);
+  });
 
-      await service.fileExists('myWorkspace:seed.md');
-      triggerPageReturn();
-      expect(onExternalChange).toHaveBeenCalledWith({
-        type: 'refresh',
-        wsName: 'myWorkspace',
-      });
+  it('degrades atomic-write moves to per-path events instead of workspace refreshes', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+    await service.fileExists('myWorkspace:seed.md');
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
 
-      // The same return fires visibilitychange and focus back-to-back;
-      // the duplicate notification does not refresh again.
-      onExternalChange.mockClear();
-      triggerPageReturn();
-      expect(onExternalChange).not.toHaveBeenCalled();
+    await observer.emitRecords([
+      // Chromium's own createWritable commit / sync tools' write-to-temp:
+      // the visible file materialized from a transient path. A workspace
+      // refresh here would re-list on EVERY local save (self-writes are
+      // deliberately unfiltered).
+      {
+        type: 'moved',
+        relativePathComponents: ['note.md'],
+        relativePathMovedFrom: ['note.md.crswap'],
+        changedHandle: { kind: 'file' },
+      },
+      // Visible file moved onto a transient path: gone as far as the app
+      // is concerned.
+      {
+        type: 'moved',
+        relativePathComponents: ['trash.md.tmp'],
+        relativePathMovedFrom: ['trash.md'],
+        changedHandle: { kind: 'file' },
+      },
+      // Transient-to-transient shuffle: never shown, fully ignored.
+      {
+        type: 'moved',
+        relativePathComponents: ['b.md.tmp'],
+        relativePathMovedFrom: ['a.md.tmp'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
 
-      // A genuinely separate leave→edit→return cycle moments later MUST
-      // refresh: without an observer this is the only reconciliation, so a
-      // wall-clock throttle would permanently miss that cycle's edits.
-      vi.advanceTimersByTime(1_500);
-      triggerPageReturn();
-      expect(onExternalChange).toHaveBeenCalledWith({
-        type: 'refresh',
-        wsName: 'myWorkspace',
-      });
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'create', wsPath: 'myWorkspace:note.md' },
+      { type: 'delete', wsPath: 'myWorkspace:trash.md' },
+    ]);
+  });
+
+  it('suppresses transient temp-suffix churn without hiding those files from listings', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+    await service.fileExists('myWorkspace:seed.md');
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
+
+    // Editors/sync tools churn `.tmp`/`.swp` scratch files constantly; the
+    // watcher drops them (the shared listing policy deliberately does NOT —
+    // a pre-existing `export.tmp` can be a legitimate user file).
+    await observer.emitRecords([
+      {
+        type: 'modified',
+        relativePathComponents: ['export.tmp'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'appeared',
+        relativePathComponents: ['recovered.swp'],
+        changedHandle: { kind: 'file' },
+      },
+      {
+        type: 'modified',
+        relativePathComponents: ['real-note.md'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
+
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'update', wsPath: 'myWorkspace:real-note.md' },
+    ]);
+  });
+
+  it('revalidates opened workspaces on every page return when no observer exists', async () => {
+    // The observer API is absent here, so watchers can never arm and
+    // page-return revalidation is the only refresh path — it must fire for
+    // hidden-returns AND plain refocus alike. (Collapsing one return's
+    // visibilitychange+focus burst is owned by onPageReturn and covered in
+    // page-return.spec.ts.)
+    const { service, onExternalChange, triggerPageReturn } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+
+    // Before any workspace is opened, a page return is a no-op.
+    triggerPageReturn();
+    expect(onExternalChange).not.toHaveBeenCalled();
+
+    await service.fileExists('myWorkspace:seed.md');
+    triggerPageReturn({ returnedFromHidden: true });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
+
+    onExternalChange.mockClear();
+    triggerPageReturn({ returnedFromHidden: false });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
+  });
+
+  it('skips the refresh on plain refocus while a watcher is armed and healthy', async () => {
+    const observer = stubFileSystemObserver();
+    const { service, onExternalChange, triggerPageReturn } = await setup(
+      undefined,
+      'myWorkspace',
+      {
+        withExternalChange: true,
+      },
+    );
+    await service.fileExists('myWorkspace:seed.md');
+    await vi.waitFor(() => {
+      expect(observer.observe).toHaveBeenCalledTimes(1);
+    });
+
+    // The page stayed visible the whole time and the observer was armed:
+    // nothing was missed, so refreshing would re-list the workspace and
+    // re-read every open note on every alt-tab for no reason.
+    triggerPageReturn({ returnedFromHidden: false });
+    expect(onExternalChange).not.toHaveBeenCalled();
+
+    // A return from a hidden/frozen tab refreshes even with a live watcher:
+    // the browser may have starved the observer while the tab was away.
+    triggerPageReturn({ returnedFromHidden: true });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
   });
 
   it('re-arms a dead watcher on page return after the observer errored', async () => {
@@ -656,8 +792,14 @@ describe('external change watching', () => {
       { type: 'refresh', wsName: 'myWorkspace' },
     ]);
 
-    // Coming back to the page re-establishes the observer.
-    triggerPageReturn();
+    // Even a plain refocus re-establishes the observer AND refreshes: with
+    // the watcher dead, anything could have been missed meanwhile.
+    onExternalChange.mockClear();
+    triggerPageReturn({ returnedFromHidden: false });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
     await vi.waitFor(() => {
       expect(observer.observe).toHaveBeenCalledTimes(2);
     });

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -412,7 +412,7 @@ describe('FileStorageNativeFs', () => {
 });
 
 describe('external change watching', () => {
-  it('maps observer records for visible files to external change events', async () => {
+  it('maps visible file records and degrades ambiguous moves to a refresh', async () => {
     const observer = stubFileSystemObserver();
     const { service, onExternalChange } = await setup(
       undefined,
@@ -445,6 +445,16 @@ describe('external change watching', () => {
         type: 'disappeared',
         relativePathComponents: ['gone.md'],
       },
+    ]);
+
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'create', wsPath: 'myWorkspace:sub/new.md' },
+      { type: 'update', wsPath: 'myWorkspace:existing.md' },
+      { type: 'delete', wsPath: 'myWorkspace:gone.md' },
+    ]);
+
+    onExternalChange.mockClear();
+    await observer.emitRecords([
       {
         type: 'moved',
         relativePathComponents: ['renamed.md'],
@@ -452,17 +462,10 @@ describe('external change watching', () => {
         changedHandle: { kind: 'file' },
       },
     ]);
-
-    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'create', wsPath: 'myWorkspace:sub/new.md' },
-      { type: 'update', wsPath: 'myWorkspace:existing.md' },
-      { type: 'delete', wsPath: 'myWorkspace:gone.md' },
-      {
-        type: 'rename',
-        oldWsPath: 'myWorkspace:old-name.md',
-        newWsPath: 'myWorkspace:renamed.md',
-      },
-    ]);
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
   });
 
   it('coalesces one observer burst: duplicates collapse, a coarse record wins alone', async () => {
@@ -620,7 +623,7 @@ describe('external change watching', () => {
     ]);
   });
 
-  it('degrades atomic-write moves to per-path events instead of workspace refreshes', async () => {
+  it('keeps invisible-to-visible atomic writes targeted but refreshes ambiguous visible moves', async () => {
     const observer = stubFileSystemObserver();
     const { service, onExternalChange } = await setup(
       undefined,
@@ -645,15 +648,22 @@ describe('external change watching', () => {
         relativePathMovedFrom: ['note.md.crswap'],
         changedHandle: { kind: 'file' },
       },
-      // Visible file moved onto a transient path: gone as far as the app
-      // is concerned.
+    ]);
+    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'create', wsPath: 'myWorkspace:note.md' },
+    ]);
+
+    onExternalChange.mockClear();
+    await observer.emitRecords([
+      // `.tmp` is visible workspace content. A visible-to-visible watcher
+      // move can be either a rename or an atomic target replacement, so the
+      // safe interpretation is a workspace refresh.
       {
         type: 'moved',
         relativePathComponents: ['trash.md.tmp'],
         relativePathMovedFrom: ['trash.md'],
         changedHandle: { kind: 'file' },
       },
-      // Transient-to-transient shuffle: never shown, fully ignored.
       {
         type: 'moved',
         relativePathComponents: ['b.md.tmp'],
@@ -663,12 +673,11 @@ describe('external change watching', () => {
     ]);
 
     expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'create', wsPath: 'myWorkspace:note.md' },
-      { type: 'delete', wsPath: 'myWorkspace:trash.md' },
+      { type: 'refresh', wsName: 'myWorkspace' },
     ]);
   });
 
-  it('suppresses transient temp-suffix churn without hiding those files from listings', async () => {
+  it('reports changes to visible temp-suffix files', async () => {
     const observer = stubFileSystemObserver();
     const { service, onExternalChange } = await setup(
       undefined,
@@ -682,9 +691,8 @@ describe('external change watching', () => {
       expect(observer.observe).toHaveBeenCalledTimes(1);
     });
 
-    // Editors/sync tools churn `.tmp`/`.swp` scratch files constantly; the
-    // watcher drops them (the shared listing policy deliberately does NOT —
-    // a pre-existing `export.tmp` can be a legitimate user file).
+    // The listing policy deliberately treats `.tmp`/`.swp` as legitimate
+    // user files, so their watcher updates must not be silently dropped.
     await observer.emitRecords([
       {
         type: 'modified',
@@ -704,6 +712,8 @@ describe('external change watching', () => {
     ]);
 
     expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
+      { type: 'update', wsPath: 'myWorkspace:export.tmp' },
+      { type: 'create', wsPath: 'myWorkspace:recovered.swp' },
       { type: 'update', wsPath: 'myWorkspace:real-note.md' },
     ]);
   });

--- a/packages/platform/service-platform/src/__tests__/page-return.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/page-return.spec.ts
@@ -90,7 +90,7 @@ describe('onPageReturn', () => {
     // A genuinely separate leave→return cycle moments later must fire —
     // consumers without an observer rely on returns as their only
     // reconciliation, so this must be a burst dedupe, not a throttle.
-    vi.advanceTimersByTime(1_500);
+    vi.advanceTimersByTime(100);
     emit('active', 'hidden');
     emit('hidden', 'active');
     expect(fired).toEqual([

--- a/packages/platform/service-platform/src/__tests__/page-return.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/page-return.spec.ts
@@ -1,7 +1,11 @@
 import { Emitter } from '@bangle.io/mini-js-utils';
 import type { BaseRouter, PageLifeCycleState } from '@bangle.io/types';
-import { describe, expect, it } from 'vitest';
-import { isPageReturnTransition, onPageReturn } from '../router/page-return';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  isPageReturnTransition,
+  onPageReturn,
+  type PageReturnInfo,
+} from '../router/page-return';
 
 describe('isPageReturnTransition', () => {
   it.each<[PageLifeCycleState, PageLifeCycleState, boolean]>([
@@ -27,13 +31,18 @@ describe('isPageReturnTransition', () => {
 });
 
 describe('onPageReturn', () => {
-  it('fires only for return transitions and stops on abort', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setup() {
     const emitter: BaseRouter['emitter'] = new Emitter();
     const controller = new AbortController();
-    let fired = 0;
-
-    onPageReturn(emitter, () => (fired += 1), controller.signal);
-
+    const fired: PageReturnInfo[] = [];
+    onPageReturn(emitter, (info) => fired.push(info), controller.signal);
     const emit = (
       previous: PageLifeCycleState,
       current: PageLifeCycleState,
@@ -43,19 +52,50 @@ describe('onPageReturn', () => {
         previous,
       });
     };
+    return { emit, fired, controller };
+  }
+
+  it('fires only for return transitions, reporting where the user came from', () => {
+    const { emit, fired, controller } = setup();
 
     emit(undefined, 'active'); // initial load
-    expect(fired).toBe(0);
+    expect(fired).toEqual([]);
     emit('active', 'hidden'); // user leaves
-    expect(fired).toBe(0);
+    expect(fired).toEqual([]);
     emit('hidden', 'passive'); // tab visible again
-    expect(fired).toBe(1);
-    emit('passive', 'active'); // window focused
-    expect(fired).toBe(2);
+    expect(fired).toEqual([{ returnedFromHidden: true }]);
+
+    vi.advanceTimersByTime(2_000);
+    emit('passive', 'active'); // window focused later, page stayed visible
+    expect(fired).toEqual([
+      { returnedFromHidden: true },
+      { returnedFromHidden: false },
+    ]);
 
     controller.abort();
+    vi.advanceTimersByTime(2_000);
     emit('active', 'hidden');
     emit('hidden', 'active');
-    expect(fired).toBe(2);
+    expect(fired).toHaveLength(2);
+  });
+
+  it('collapses one return burst (hidden → passive → active) into one call', () => {
+    const { emit, fired } = setup();
+
+    emit('active', 'hidden');
+    emit('hidden', 'passive');
+    emit('passive', 'active'); // same return, milliseconds later
+    expect(fired).toEqual([{ returnedFromHidden: true }]);
+
+    // A genuinely separate leave→return cycle moments later must fire —
+    // consumers without an observer rely on returns as their only
+    // reconciliation, so this must be a burst dedupe, not a throttle.
+    vi.advanceTimersByTime(1_500);
+    emit('active', 'hidden');
+    emit('hidden', 'active');
+    expect(fired).toEqual([
+      { returnedFromHidden: true },
+      { returnedFromHidden: true },
+    ]);
   });
 });

--- a/packages/platform/service-platform/src/__tests__/page-return.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/page-return.spec.ts
@@ -1,0 +1,61 @@
+import { Emitter } from '@bangle.io/mini-js-utils';
+import type { BaseRouter, PageLifeCycleState } from '@bangle.io/types';
+import { describe, expect, it } from 'vitest';
+import { isPageReturnTransition, onPageReturn } from '../router/page-return';
+
+describe('isPageReturnTransition', () => {
+  it.each<[PageLifeCycleState, PageLifeCycleState, boolean]>([
+    // Coming back from a hidden/frozen tab.
+    ['hidden', 'active', true],
+    ['hidden', 'passive', true],
+    ['frozen', 'active', true],
+    ['frozen', 'passive', true],
+    // Window regains focus while already visible.
+    ['passive', 'active', true],
+    // Initial page load is not a return — content is freshly read.
+    [undefined, 'active', false],
+    [undefined, 'passive', false],
+    // Going away is not a return.
+    ['active', 'passive', false],
+    ['active', 'hidden', false],
+    ['passive', 'hidden', false],
+    ['active', 'frozen', false],
+    ['hidden', 'terminated', false],
+  ])('previous=%s current=%s -> %s', (previous, current, expected) => {
+    expect(isPageReturnTransition(current, previous)).toBe(expected);
+  });
+});
+
+describe('onPageReturn', () => {
+  it('fires only for return transitions and stops on abort', () => {
+    const emitter: BaseRouter['emitter'] = new Emitter();
+    const controller = new AbortController();
+    let fired = 0;
+
+    onPageReturn(emitter, () => (fired += 1), controller.signal);
+
+    const emit = (
+      previous: PageLifeCycleState,
+      current: PageLifeCycleState,
+    ) => {
+      emitter.emit('event::router:page-lifecycle-state', {
+        current,
+        previous,
+      });
+    };
+
+    emit(undefined, 'active'); // initial load
+    expect(fired).toBe(0);
+    emit('active', 'hidden'); // user leaves
+    expect(fired).toBe(0);
+    emit('hidden', 'passive'); // tab visible again
+    expect(fired).toBe(1);
+    emit('passive', 'active'); // window focused
+    expect(fired).toBe(2);
+
+    controller.abort();
+    emit('active', 'hidden');
+    emit('hidden', 'active');
+    expect(fired).toBe(2);
+  });
+});

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -14,12 +14,18 @@ import {
   isNativeFsError,
   NATIVE_FS_ERROR_CODE,
   NativeFs,
+  type NativeFsChange,
 } from '@bangle.io/native-fs';
 import type {
   BaseFileStorageProvider,
   FileStorageChangeEvent,
+  FileStorageExternalChangeEvent,
 } from '@bangle.io/types';
-import { isVisibleWorkspaceDirectoryName, WsPath } from '@bangle.io/ws-path';
+import {
+  isVisibleWorkspaceDirectoryName,
+  isVisibleWorkspaceFilePath,
+  WsPath,
+} from '@bangle.io/ws-path';
 import { assertSameWorkspaceRename } from './file-storage-utils';
 
 type Config = {
@@ -27,7 +33,28 @@ type Config = {
     wsName: string,
   ) => Promise<{ handle: FileSystemDirectoryHandle }>;
   onChange: (event: FileStorageChangeEvent) => void;
+  /**
+   * Invoked for changes made to workspace files by something other than this
+   * app instance (sync tools, other editors). Providing it turns on
+   * FileSystemObserver watching (Chrome 133+) per opened workspace, with a
+   * throttled focus/visibility re-list fallback when the observer API is
+   * unavailable.
+   */
+  onExternalChange?: (event: FileStorageExternalChangeEvent) => void;
 };
+
+/**
+ * How long after one of our own mutations a watcher record for the same
+ * wsPath is treated as the echo of that mutation and dropped. Covers the
+ * observer's callback latency plus slack for slow disk writes.
+ */
+const SELF_WRITE_ECHO_WINDOW_MS = 5_000;
+
+/**
+ * Minimum spacing between coarse refreshes triggered by window focus /
+ * visibility when the FileSystemObserver API is unavailable.
+ */
+const FOCUS_REVALIDATE_MIN_INTERVAL_MS = 15_000;
 
 export class FileStorageNativeFs
   extends BaseService
@@ -37,6 +64,8 @@ export class FileStorageNativeFs
   public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.nativeFs;
 
   private fsCache: Map<string, NativeFs> = new Map();
+  private watchedWorkspaces = new Set<string>();
+  private recentSelfWrites = new Map<string, number>();
 
   constructor(
     context: BaseServiceContext,
@@ -50,6 +79,8 @@ export class FileStorageNativeFs
     assertIsDefined(this.config.getRootDirHandle, 'getRootDirHandle');
     this.addCleanup(() => {
       this.fsCache.clear();
+      this.watchedWorkspaces.clear();
+      this.recentSelfWrites.clear();
     });
   }
 
@@ -105,7 +136,163 @@ export class FileStorageNativeFs
     });
 
     this.fsCache.set(wsName, fs);
+    this.startWatching(wsName, fs);
     return fs;
+  }
+
+  // ---- external change watching ----
+
+  private startWatching(wsName: string, fs: NativeFs): void {
+    if (!this.config.onExternalChange || this.watchedWorkspaces.has(wsName)) {
+      return;
+    }
+    this.watchedWorkspaces.add(wsName);
+
+    // Watching is best-effort: a failure to observe must never break file
+    // operations, so errors are logged rather than propagated.
+    void fs
+      .watch((changes) => this.handleWatchChanges(wsName, changes), {
+        signal: this.abortSignal,
+      })
+      .then((supported) => {
+        if (!supported) {
+          this.startFocusRevalidation(wsName);
+        }
+      })
+      .catch((error) => {
+        this.logger.warn(
+          `Unable to watch native FS workspace "${wsName}" for external changes`,
+          error,
+        );
+      });
+  }
+
+  /**
+   * Coarse fallback when `FileSystemObserver` is unavailable: emit a
+   * throttled workspace refresh whenever the window regains focus or becomes
+   * visible, since that is when externally synced changes become relevant.
+   */
+  private startFocusRevalidation(wsName: string): void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      return;
+    }
+    let lastRefresh = 0;
+    const trigger = () => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+      const now = Date.now();
+      if (now - lastRefresh < FOCUS_REVALIDATE_MIN_INTERVAL_MS) {
+        return;
+      }
+      lastRefresh = now;
+      this.config.onExternalChange?.({ type: 'refresh', wsName });
+    };
+    window.addEventListener('focus', trigger, { signal: this.abortSignal });
+    document.addEventListener('visibilitychange', trigger, {
+      signal: this.abortSignal,
+    });
+  }
+
+  private noteSelfWrite(...wsPaths: string[]): void {
+    const now = Date.now();
+    for (const [path, at] of this.recentSelfWrites) {
+      if (now - at > SELF_WRITE_ECHO_WINDOW_MS) {
+        this.recentSelfWrites.delete(path);
+      }
+    }
+    for (const wsPath of wsPaths) {
+      this.recentSelfWrites.set(wsPath, now);
+    }
+  }
+
+  private isRecentSelfWrite(wsPath: string): boolean {
+    const at = this.recentSelfWrites.get(wsPath);
+    return at !== undefined && Date.now() - at <= SELF_WRITE_ECHO_WINDOW_MS;
+  }
+
+  private handleWatchChanges(wsName: string, changes: NativeFsChange[]): void {
+    const onExternalChange = this.config.onExternalChange;
+    if (!onExternalChange) {
+      return;
+    }
+
+    let refreshEmitted = false;
+    const emitRefresh = () => {
+      if (!refreshEmitted) {
+        refreshEmitted = true;
+        onExternalChange({ type: 'refresh', wsName });
+      }
+    };
+    const toVisibleWsPath = (relativePath: string): string | undefined => {
+      const result = WsPath.safeFromParts(wsName, relativePath);
+      const wsPath = result.ok && result.data ? result.data.wsPath : undefined;
+      if (wsPath === undefined) {
+        return undefined;
+      }
+      return isVisibleWorkspaceFilePath(wsPath) ? wsPath : undefined;
+    };
+
+    for (const change of changes) {
+      // Directory-level records and records the observer could not classify
+      // only tell us "something under this workspace changed" — fall back to
+      // one coarse refresh instead of guessing per-file events.
+      if (
+        change.type === 'unknown' ||
+        change.type === 'errored' ||
+        change.kind === 'directory'
+      ) {
+        emitRefresh();
+        continue;
+      }
+
+      if (change.type === 'moved') {
+        const newWsPath = toVisibleWsPath(change.path);
+        const oldWsPath =
+          change.movedFromPath === undefined
+            ? undefined
+            : toVisibleWsPath(change.movedFromPath);
+        if (!newWsPath || !oldWsPath) {
+          emitRefresh();
+          continue;
+        }
+        if (
+          this.isRecentSelfWrite(newWsPath) ||
+          this.isRecentSelfWrite(oldWsPath)
+        ) {
+          continue;
+        }
+        onExternalChange({ type: 'rename', oldWsPath, newWsPath });
+        continue;
+      }
+
+      const wsPath = toVisibleWsPath(change.path);
+      if (wsPath === undefined) {
+        // Hidden/system/unparseable paths (sync temp files, dotfiles) are
+        // invisible to the app; ignore them entirely.
+        continue;
+      }
+      if (this.isRecentSelfWrite(wsPath)) {
+        continue;
+      }
+      switch (change.type) {
+        case 'appeared': {
+          onExternalChange({ type: 'create', wsPath });
+          break;
+        }
+        case 'modified': {
+          onExternalChange({ type: 'update', wsPath });
+          break;
+        }
+        case 'disappeared': {
+          onExternalChange({ type: 'delete', wsPath });
+          break;
+        }
+        default: {
+          const _exhaustiveCheck: never = change.type;
+        }
+      }
+    }
   }
 
   /**
@@ -120,6 +307,7 @@ export class FileStorageNativeFs
   async createFile(wsPath: string, file: File): Promise<void> {
     await this.mountPromise;
     const fs = await this.getFs({ wsPath });
+    this.noteSelfWrite(wsPath);
     try {
       await fs.createFile(this.toRelativePath(wsPath), file);
     } catch (error) {
@@ -140,6 +328,7 @@ export class FileStorageNativeFs
   async deleteFile(wsPath: string): Promise<void> {
     await this.mountPromise;
     const fs = await this.getFs({ wsPath });
+    this.noteSelfWrite(wsPath);
     try {
       await fs.deleteFile(this.toRelativePath(wsPath));
     } catch (error) {
@@ -250,6 +439,7 @@ export class FileStorageNativeFs
     await this.mountPromise;
     assertSameWorkspaceRename(wsPath, newWsPath);
     const fs = await this.getFs({ wsPath });
+    this.noteSelfWrite(wsPath, newWsPath);
     try {
       await fs.moveFile(
         this.toRelativePath(wsPath),
@@ -287,6 +477,7 @@ export class FileStorageNativeFs
   async writeFile(wsPath: string, file: File): Promise<void> {
     await this.mountPromise;
     const fs = await this.getFs({ wsPath });
+    this.noteSelfWrite(wsPath);
     try {
       await fs.writeFile(this.toRelativePath(wsPath), file, { create: false });
     } catch (error) {

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -15,6 +15,7 @@ import {
   NATIVE_FS_ERROR_CODE,
   NativeFs,
   type NativeFsChange,
+  supportsFileSystemObserver,
 } from '@bangle.io/native-fs';
 import type {
   BaseFileStorageProvider,
@@ -27,6 +28,7 @@ import {
   WsPath,
 } from '@bangle.io/ws-path';
 import { assertSameWorkspaceRename } from './file-storage-utils';
+import type { PageReturnInfo } from './router/page-return';
 
 type Config = {
   getRootDirHandle: (
@@ -50,26 +52,46 @@ type Config = {
    * Subscribes `listener` to "the user returned to the page" transitions
    * (tab became visible again, window regained focus). The composition root
    * wires this to the platform router's page-lifecycle stream (see
-   * `onPageReturn` in this package), keeping the visibility source swappable
-   * and out of this service.
+   * `onPageReturn` in this package, which also collapses one return's
+   * transition burst into a single notification), keeping the visibility
+   * source swappable and out of this service.
    *
-   * On each return the service re-emits a throttled coarse refresh for every
-   * opened workspace and re-arms watchers that died — OS file watchers are
-   * best-effort (frozen tabs, permission loss, network drives), so returning
-   * to the page is the natural moment to reconcile.
+   * On each return the service re-arms watchers that died and re-emits a
+   * coarse refresh where the watcher may have missed something — OS file
+   * watchers are best-effort (frozen tabs, permission loss, network drives),
+   * so returning to the page is the natural moment to reconcile.
    */
-  subscribePageReturn?: (listener: () => void, signal: AbortSignal) => void;
+  subscribePageReturn?: (
+    listener: (info: PageReturnInfo) => void,
+    signal: AbortSignal,
+  ) => void;
 };
 
 /**
- * Window within which page-return notifications are treated as one return:
- * a single return fires both `visibilitychange` and `focus` back-to-back,
- * and only the first should refresh. Kept short deliberately — for browsers
- * without `FileSystemObserver` this refresh is the only reconciliation, so a
- * genuinely separate leave→edit→return cycle moments later must not be
- * swallowed by a wall-clock throttle.
+ * Transient-file suffixes suppressed from WATCHER events only: other
+ * software's scratch files churn constantly next to real content and would
+ * otherwise spam per-path refreshes. Unlike the shared workspace file policy
+ * (which hides `.crswap` everywhere), these stay visible in listings — a
+ * pre-existing `export.tmp` can be a legitimate user file; only its change
+ * noise is unwanted.
  */
-const PAGE_RETURN_DEDUPE_MS = 1_000;
+const TRANSIENT_WATCH_SUFFIXES = ['.tmp', '.swp'];
+
+/** How the watcher should treat a path from an observer record. */
+type WatchPathClass =
+  | { kind: 'file'; wsPath: string }
+  | { kind: 'ignored' }
+  | { kind: 'coarse' };
+
+type FsCacheEntry = {
+  fs: NativeFs;
+  /**
+   * Whether a watch is (believed to be) armed for this workspace. Set
+   * optimistically when a watch starts; cleared when starting fails or the
+   * observer reports an `errored` record, so the next page return re-arms.
+   */
+  watching: boolean;
+};
 
 export class FileStorageNativeFs
   extends BaseService
@@ -78,9 +100,7 @@ export class FileStorageNativeFs
   public readonly workspaceType = WORKSPACE_STORAGE_TYPE.NativeFS;
   public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.nativeFs;
 
-  private fsCache: Map<string, NativeFs> = new Map();
-  private watchedWorkspaces = new Set<string>();
-  private lastPageReturnRevalidation = 0;
+  private fsCache: Map<string, FsCacheEntry> = new Map();
 
   constructor(
     context: BaseServiceContext,
@@ -94,13 +114,12 @@ export class FileStorageNativeFs
     assertIsDefined(this.config.getRootDirHandle, 'getRootDirHandle');
     if (this.config.onExternalChange) {
       this.config.subscribePageReturn?.(
-        () => this.revalidateOnPageReturn(),
+        (info) => this.revalidateOnPageReturn(info),
         this.abortSignal,
       );
     }
     this.addCleanup(() => {
       this.fsCache.clear();
-      this.watchedWorkspaces.clear();
     });
   }
 
@@ -140,9 +159,9 @@ export class FileStorageNativeFs
       );
     }
 
-    const cachedFs = this.fsCache.get(wsName);
-    if (cachedFs) {
-      return cachedFs;
+    const cached = this.fsCache.get(wsName);
+    if (cached) {
+      return cached.fs;
     }
 
     const { handle: rootDirHandle } =
@@ -155,28 +174,36 @@ export class FileStorageNativeFs
       lockScope: wsName,
     });
 
-    this.fsCache.set(wsName, fs);
-    this.startWatching(wsName, fs);
+    const entry: FsCacheEntry = { fs, watching: false };
+    this.fsCache.set(wsName, entry);
+    this.startWatching(wsName, entry);
     return fs;
   }
 
   // ---- external change watching ----
 
-  private startWatching(wsName: string, fs: NativeFs): void {
-    if (!this.config.onExternalChange || this.watchedWorkspaces.has(wsName)) {
+  private startWatching(wsName: string, entry: FsCacheEntry): void {
+    if (
+      !this.config.onExternalChange ||
+      entry.watching ||
+      // Without the observer API, watching can never arm; leaving the entry
+      // unmarked keeps page-return revalidation as the refresh path (and
+      // avoids arming optimistically only to fail asynchronously each time).
+      !supportsFileSystemObserver()
+    ) {
       return;
     }
-    this.watchedWorkspaces.add(wsName);
+    entry.watching = true;
 
     // Watching is best-effort: a failure to observe must never break file
     // operations, so errors are logged rather than propagated. A failed
     // start leaves the workspace unmarked so the next page return retries.
-    void fs
+    void entry.fs
       .watch((changes) => this.handleWatchChanges(wsName, changes), {
         signal: this.abortSignal,
       })
       .catch((error) => {
-        this.watchedWorkspaces.delete(wsName);
+        entry.watching = false;
         this.logger.warn(
           `Unable to watch native FS workspace "${wsName}" for external changes`,
           error,
@@ -185,27 +212,68 @@ export class FileStorageNativeFs
   }
 
   /**
-   * The user came back to the page: emit a throttled coarse refresh for
-   * every opened workspace and retry watchers that failed or died. This is
+   * The user came back to the page: retry watchers that failed or died, and
+   * emit a coarse refresh where the watcher may have missed changes. This is
    * the safety net for everything the observer cannot promise — events
    * missed while the tab was frozen, watchers killed by permission loss,
    * filesystems where OS watching is unreliable — and the only refresh
    * mechanism at all when `FileSystemObserver` is unsupported.
+   *
+   * A return from a hidden/frozen tab refreshes every opened workspace: the
+   * browser may have starved the observer while the tab was away. A mere
+   * window refocus (the page stayed visible throughout) misses nothing while
+   * a watcher is armed, so only workspaces without a live watcher — observer
+   * unsupported, or the watch died — are refreshed; anything else would
+   * re-list every workspace and re-read every open note on each alt-tab.
    */
-  private revalidateOnPageReturn(): void {
+  private revalidateOnPageReturn(info: PageReturnInfo): void {
     const onExternalChange = this.config.onExternalChange;
     if (!onExternalChange || this.fsCache.size === 0) {
       return;
     }
-    const now = Date.now();
-    if (now - this.lastPageReturnRevalidation < PAGE_RETURN_DEDUPE_MS) {
-      return;
+    for (const [wsName, entry] of this.fsCache) {
+      const wasWatching = entry.watching;
+      this.startWatching(wsName, entry);
+      if (info.returnedFromHidden || !wasWatching) {
+        onExternalChange({ type: 'refresh', wsName });
+      }
     }
-    this.lastPageReturnRevalidation = now;
-    for (const [wsName, fs] of this.fsCache) {
-      this.startWatching(wsName, fs);
-      onExternalChange({ type: 'refresh', wsName });
+  }
+
+  /**
+   * How the watcher should treat a record's path:
+   *
+   * - `file`: a visible workspace file — emit a targeted per-path event.
+   * - `ignored`: invisible to the app (dotfiles, ignored directories,
+   *   `.crswap`, transient watch suffixes) — drop the record entirely.
+   * - `coarse`: directory-shaped or unparseable — the record cannot be
+   *   mapped to per-path events; only a workspace re-list reconciles it.
+   *   Deleted entries carry no handle (`kind` is unknowable for
+   *   `disappeared` records), so path shape is the only directory signal
+   *   left. A dotted directory name is indistinguishable from a file here;
+   *   the resulting per-path event is wrong but harmless — the counter bump
+   *   still re-lists the tree.
+   */
+  private classifyWatchPath(
+    wsName: string,
+    relativePath: string,
+  ): WatchPathClass {
+    const result = WsPath.safeFromParts(wsName, relativePath);
+    const wsPath = result.ok && result.data ? result.data.wsPath : undefined;
+    if (wsPath === undefined) {
+      return { kind: 'coarse' };
     }
+    if (!WsPath.safeParseFile(wsPath).data) {
+      return { kind: 'coarse' };
+    }
+    if (!isVisibleWorkspaceFilePath(wsPath)) {
+      return { kind: 'ignored' };
+    }
+    const lowerPath = relativePath.toLowerCase();
+    if (TRANSIENT_WATCH_SUFFIXES.some((suffix) => lowerPath.endsWith(suffix))) {
+      return { kind: 'ignored' };
+    }
+    return { kind: 'file', wsPath };
   }
 
   private handleWatchChanges(wsName: string, changes: NativeFsChange[]): void {
@@ -213,15 +281,6 @@ export class FileStorageNativeFs
     if (!onExternalChange) {
       return;
     }
-
-    const toVisibleWsPath = (relativePath: string): string | undefined => {
-      const result = WsPath.safeFromParts(wsName, relativePath);
-      const wsPath = result.ok && result.data ? result.data.wsPath : undefined;
-      if (wsPath === undefined) {
-        return undefined;
-      }
-      return isVisibleWorkspaceFilePath(wsPath) ? wsPath : undefined;
-    };
 
     // One observer callback can deliver a burst (a sync tool touching many
     // files at once), so the batch is coalesced before anything is emitted:
@@ -236,8 +295,16 @@ export class FileStorageNativeFs
       // watched directory disappeared). Un-mark the workspace so the next
       // page return re-arms the watcher, and refresh what we may have missed.
       if (change.type === 'errored') {
-        this.watchedWorkspaces.delete(wsName);
+        const entry = this.fsCache.get(wsName);
+        if (entry) {
+          entry.watching = false;
+        }
         needsRefresh = true;
+        continue;
+      }
+      if (needsRefresh) {
+        // The coarse refresh subsumes every per-path event in this batch;
+        // only further `errored` records (handled above) still matter.
         continue;
       }
       // Directory-level records and records the observer could not classify
@@ -249,29 +316,59 @@ export class FileStorageNativeFs
       }
 
       if (change.type === 'moved') {
-        const newWsPath = toVisibleWsPath(change.path);
-        const oldWsPath =
-          change.movedFromPath === undefined
-            ? undefined
-            : toVisibleWsPath(change.movedFromPath);
-        if (!newWsPath || !oldWsPath) {
+        if (change.movedFromPath === undefined) {
+          // Origin unknown (platform watchers cannot always pair renames):
+          // a visible file may have been renamed away, and only a re-list
+          // can tell.
           needsRefresh = true;
           continue;
         }
-        specificEvents.set(`rename:${oldWsPath}->${newWsPath}`, {
-          type: 'rename',
-          oldWsPath,
-          newWsPath,
-        });
+        const from = this.classifyWatchPath(wsName, change.movedFromPath);
+        const to = this.classifyWatchPath(wsName, change.path);
+        if (from.kind === 'coarse' || to.kind === 'coarse') {
+          needsRefresh = true;
+        } else if (from.kind === 'file' && to.kind === 'file') {
+          specificEvents.set(`rename:${from.wsPath}->${to.wsPath}`, {
+            type: 'rename',
+            oldWsPath: from.wsPath,
+            newWsPath: to.wsPath,
+          });
+        } else if (to.kind === 'file') {
+          // Atomic-write pattern (Chromium's own `.crswap` commit, sync
+          // tools' write-to-temp-then-rename): content materialized at the
+          // visible path from a transient one the app never showed. Treat it
+          // as the visible file appearing rather than refreshing the whole
+          // workspace — with self-writes deliberately unfiltered, a coarse
+          // refresh here would re-list on every local save.
+          specificEvents.set(`create:${to.wsPath}`, {
+            type: 'create',
+            wsPath: to.wsPath,
+          });
+        } else if (from.kind === 'file') {
+          // Visible file moved to an invisible path — gone as far as the
+          // app is concerned.
+          specificEvents.set(`delete:${from.wsPath}`, {
+            type: 'delete',
+            wsPath: from.wsPath,
+          });
+        }
+        // Both endpoints invisible: a transient-to-transient shuffle the
+        // app never shows — drop it like the equivalent appeared/disappeared
+        // records.
         continue;
       }
 
-      const wsPath = toVisibleWsPath(change.path);
-      if (wsPath === undefined) {
-        // Hidden/system/unparseable paths (sync temp files, dotfiles) are
+      const classified = this.classifyWatchPath(wsName, change.path);
+      if (classified.kind === 'coarse') {
+        needsRefresh = true;
+        continue;
+      }
+      if (classified.kind === 'ignored') {
+        // Hidden/system/transient paths (sync temp files, dotfiles) are
         // invisible to the app; ignore them entirely.
         continue;
       }
+      const wsPath = classified.wsPath;
       switch (change.type) {
         case 'appeared': {
           specificEvents.set(`create:${wsPath}`, { type: 'create', wsPath });

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -91,6 +91,7 @@ export class FileStorageNativeFs
   public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.nativeFs;
 
   private fsCache: Map<string, FsCacheEntry> = new Map();
+  private fsLoads: Map<string, Promise<FsCacheEntry>> = new Map();
 
   constructor(
     context: BaseServiceContext,
@@ -110,6 +111,7 @@ export class FileStorageNativeFs
     }
     this.addCleanup(() => {
       this.fsCache.clear();
+      this.fsLoads.clear();
     });
   }
 
@@ -153,21 +155,26 @@ export class FileStorageNativeFs
     if (cached) {
       return cached.fs;
     }
-
-    const { handle: rootDirHandle } =
-      await this.config.getRootDirHandle(wsName);
-
-    // The lock scope is the workspace name (not the folder basename) so
-    // cross-tab write serialization stays keyed to the workspace identity.
-    const fs = new NativeFs({
-      rootHandle: rootDirHandle,
-      lockScope: wsName,
-    });
-
-    const entry: FsCacheEntry = { fs, watching: false };
-    this.fsCache.set(wsName, entry);
-    this.startWatching(wsName, entry);
-    return fs;
+    let load = this.fsLoads.get(wsName);
+    if (!load) {
+      load = this.config.getRootDirHandle(wsName).then(({ handle }) => {
+        // The lock scope is the workspace name (not the folder basename) so
+        // cross-tab write serialization stays keyed to the workspace identity.
+        const fs = new NativeFs({ rootHandle: handle, lockScope: wsName });
+        const entry: FsCacheEntry = { fs, watching: false };
+        this.fsCache.set(wsName, entry);
+        this.startWatching(wsName, entry);
+        return entry;
+      });
+      this.fsLoads.set(wsName, load);
+    }
+    try {
+      return (await load).fs;
+    } finally {
+      if (this.fsLoads.get(wsName) === load) {
+        this.fsLoads.delete(wsName);
+      }
+    }
   }
 
   // ---- external change watching ----

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -67,16 +67,6 @@ type Config = {
   ) => void;
 };
 
-/**
- * Transient-file suffixes suppressed from WATCHER events only: other
- * software's scratch files churn constantly next to real content and would
- * otherwise spam per-path refreshes. Unlike the shared workspace file policy
- * (which hides `.crswap` everywhere), these stay visible in listings — a
- * pre-existing `export.tmp` can be a legitimate user file; only its change
- * noise is unwanted.
- */
-const TRANSIENT_WATCH_SUFFIXES = ['.tmp', '.swp'];
-
 /** How the watcher should treat a path from an observer record. */
 type WatchPathClass =
   | { kind: 'file'; wsPath: string }
@@ -245,7 +235,7 @@ export class FileStorageNativeFs
    *
    * - `file`: a visible workspace file — emit a targeted per-path event.
    * - `ignored`: invisible to the app (dotfiles, ignored directories,
-   *   `.crswap`, transient watch suffixes) — drop the record entirely.
+   *   `.crswap`) — drop the record entirely.
    * - `coarse`: directory-shaped or unparseable — the record cannot be
    *   mapped to per-path events; only a workspace re-list reconciles it.
    *   Deleted entries carry no handle (`kind` is unknowable for
@@ -267,10 +257,6 @@ export class FileStorageNativeFs
       return { kind: 'coarse' };
     }
     if (!isVisibleWorkspaceFilePath(wsPath)) {
-      return { kind: 'ignored' };
-    }
-    const lowerPath = relativePath.toLowerCase();
-    if (TRANSIENT_WATCH_SUFFIXES.some((suffix) => lowerPath.endsWith(suffix))) {
       return { kind: 'ignored' };
     }
     return { kind: 'file', wsPath };
@@ -328,15 +314,16 @@ export class FileStorageNativeFs
         if (from.kind === 'coarse' || to.kind === 'coarse') {
           needsRefresh = true;
         } else if (from.kind === 'file' && to.kind === 'file') {
-          specificEvents.set(`rename:${from.wsPath}->${to.wsPath}`, {
-            type: 'rename',
-            oldWsPath: from.wsPath,
-            newWsPath: to.wsPath,
-          });
+          // A watcher `moved` record does not prove a user-visible rename: it
+          // can also be an atomic replacement of an existing target. Sending
+          // it through the app's rename pipeline would retarget pending saves
+          // from the source and leave an open target stale. Re-list and
+          // revalidate open notes instead; watcher moves are infrequent and
+          // correctness matters more than a speculative per-path shortcut.
+          needsRefresh = true;
         } else if (to.kind === 'file') {
-          // Atomic-write pattern (Chromium's own `.crswap` commit, sync
-          // tools' write-to-temp-then-rename): content materialized at the
-          // visible path from a transient one the app never showed. Treat it
+          // Atomic-write pattern (Chromium's own `.crswap` commit): content
+          // materialized at the visible path from one the app never showed. Treat it
           // as appearing or replaced. External creates invalidate downstream
           // content indexes without a coarse re-list on every local save.
           specificEvents.set(`create:${to.wsPath}`, {
@@ -344,16 +331,15 @@ export class FileStorageNativeFs
             wsPath: to.wsPath,
           });
         } else if (from.kind === 'file') {
-          // Visible file moved to an invisible path — gone as far as the
-          // app is concerned.
+          // Visible file moved to an invisible path — gone as far as the app
+          // is concerned.
           specificEvents.set(`delete:${from.wsPath}`, {
             type: 'delete',
             wsPath: from.wsPath,
           });
         }
-        // Both endpoints invisible: a transient-to-transient shuffle the
-        // app never shows — drop it like the equivalent appeared/disappeared
-        // records.
+        // Both endpoints invisible: drop the move like the equivalent
+        // appeared/disappeared records.
         continue;
       }
 
@@ -363,8 +349,7 @@ export class FileStorageNativeFs
         continue;
       }
       if (classified.kind === 'ignored') {
-        // Hidden/system/transient paths (sync temp files, dotfiles) are
-        // invisible to the app; ignore them entirely.
+        // Hidden/system paths are invisible to the app; ignore them entirely.
         continue;
       }
       const wsPath = classified.wsPath;

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -142,8 +142,12 @@ export class FileStorageNativeFs
         // cross-tab write serialization stays keyed to the workspace identity.
         const fs = new NativeFs({ rootHandle: handle, lockScope: wsName });
         const entry: FsCacheEntry = { fs, watchState: 'idle' };
-        this.fsCache.set(wsName, entry);
-        this.startWatching(wsName, entry);
+        if (!this.abortSignal.aborted) {
+          // A load that outlived teardown must not refill the cache the
+          // cleanup just cleared.
+          this.fsCache.set(wsName, entry);
+          this.startWatching(wsName, entry);
+        }
         return entry;
       });
       this.fsLoads.set(wsName, load);
@@ -190,23 +194,20 @@ export class FileStorageNativeFs
   /**
    * Re-arms unhealthy watchers. Hidden returns always refresh because the
    * browser may have starved observers; plain refocus refreshes only when a
-   * watcher is unavailable. One app-wide event covers all workspaces.
+   * watcher is unavailable. Refreshes are scoped to the workspaces this
+   * provider actually holds, so unrelated workspaces are left alone.
    */
   private revalidateOnPageReturn(info: PageReturnInfo): void {
     const onExternalChange = this.config.onExternalChange;
-    if (!onExternalChange || this.fsCache.size === 0) {
+    if (!onExternalChange) {
       return;
     }
-    let shouldRefresh = false;
     for (const [wsName, entry] of this.fsCache) {
       const wasArmed = entry.watchState === 'armed';
       this.startWatching(wsName, entry);
       if (info.returnedFromHidden || !wasArmed) {
-        shouldRefresh = true;
+        onExternalChange({ type: 'refresh', wsName });
       }
-    }
-    if (shouldRefresh) {
-      onExternalChange({ type: 'refresh' });
     }
   }
 

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -62,12 +62,14 @@ type Config = {
 };
 
 /**
- * Minimum spacing between coarse refreshes triggered by returning to the
- * page. A refresh re-lists the workspace and revalidates open notes, so it
- * must not fire on every alt-tab; anything the observer already reported has
- * flowed through the fine-grained path regardless.
+ * Window within which page-return notifications are treated as one return:
+ * a single return fires both `visibilitychange` and `focus` back-to-back,
+ * and only the first should refresh. Kept short deliberately — for browsers
+ * without `FileSystemObserver` this refresh is the only reconciliation, so a
+ * genuinely separate leave→edit→return cycle moments later must not be
+ * swallowed by a wall-clock throttle.
  */
-const PAGE_RETURN_REVALIDATE_MIN_INTERVAL_MS = 15_000;
+const PAGE_RETURN_DEDUPE_MS = 1_000;
 
 export class FileStorageNativeFs
   extends BaseService
@@ -196,10 +198,7 @@ export class FileStorageNativeFs
       return;
     }
     const now = Date.now();
-    if (
-      now - this.lastPageReturnRevalidation <
-      PAGE_RETURN_REVALIDATE_MIN_INTERVAL_MS
-    ) {
+    if (now - this.lastPageReturnRevalidation < PAGE_RETURN_DEDUPE_MS) {
       return;
     }
     this.lastPageReturnRevalidation = now;

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -36,30 +36,14 @@ type Config = {
   ) => Promise<{ handle: FileSystemDirectoryHandle }>;
   onChange: (event: FileStorageChangeEvent) => void;
   /**
-   * Invoked for changes made to workspace files by something other than this
-   * app instance (sync tools, other editors). Providing it turns on
-   * FileSystemObserver watching (Chrome 133+) per opened workspace, plus the
-   * page-return revalidation below when `subscribePageReturn` is supplied.
-   *
-   * Records caused by the app's own writes are NOT filtered here: a
-   * path+time ledger cannot distinguish an echo from a genuine external
-   * overwrite of the same file moments after a local save. Downstream
-   * consumers coalesce echoes by comparing content, which is cheap and
-   * cannot drop a real edit.
+   * External watcher events. Self-write records intentionally flow through;
+   * downstream content comparison coalesces echoes without hiding a real
+   * overwrite that happened just after a local save.
    */
   onExternalChange?: (event: FileStorageExternalChangeEvent) => void;
   /**
-   * Subscribes `listener` to "the user returned to the page" transitions
-   * (tab became visible again, window regained focus). The composition root
-   * wires this to the platform router's page-lifecycle stream (see
-   * `onPageReturn` in this package, which also collapses one return's
-   * transition burst into a single notification), keeping the visibility
-   * source swappable and out of this service.
-   *
-   * On each return the service re-arms watchers that died and re-emits a
-   * coarse refresh where the watcher may have missed something — OS file
-   * watchers are best-effort (frozen tabs, permission loss, network drives),
-   * so returning to the page is the natural moment to reconcile.
+   * Page-return fallback for unsupported, failed, or potentially starved
+   * observers.
    */
   subscribePageReturn?: (
     listener: (info: PageReturnInfo) => void,
@@ -75,11 +59,7 @@ type WatchPathClass =
 
 type FsCacheEntry = {
   fs: NativeFs;
-  /**
-   * Only `armed` is healthy enough to skip page-return revalidation.
-   * `starting` prevents duplicate observer setup without pretending the
-   * workspace is already protected from missed changes.
-   */
+  /** `starting` deduplicates setup; only `armed` may skip revalidation. */
   watchState: 'idle' | 'starting' | 'armed';
 };
 
@@ -183,18 +163,14 @@ export class FileStorageNativeFs
     if (
       !this.config.onExternalChange ||
       entry.watchState !== 'idle' ||
-      // Without the observer API, watching can never arm; leaving the entry
-      // unmarked keeps page-return revalidation as the refresh path (and
-      // avoids arming optimistically only to fail asynchronously each time).
+      // Unsupported browsers use page-return revalidation.
       !supportsFileSystemObserver()
     ) {
       return;
     }
     entry.watchState = 'starting';
 
-    // Watching is best-effort: a failure to observe must never break file
-    // operations, so errors are logged rather than propagated. A failed
-    // start leaves the workspace unmarked so the next page return retries.
+    // Watching is best-effort; page return retries a failed start.
     void entry.fs
       .watch((changes) => this.handleWatchChanges(wsName, changes), {
         signal: this.abortSignal,
@@ -212,19 +188,9 @@ export class FileStorageNativeFs
   }
 
   /**
-   * The user came back to the page: retry watchers that failed or died, and
-   * emit a coarse refresh where the watcher may have missed changes. This is
-   * the safety net for everything the observer cannot promise — events
-   * missed while the tab was frozen, watchers killed by permission loss,
-   * filesystems where OS watching is unreliable — and the only refresh
-   * mechanism at all when `FileSystemObserver` is unsupported.
-   *
-   * A return from a hidden/frozen tab refreshes if any workspace has been
-   * opened: the browser may have starved observers while the tab was away. A
-   * mere window refocus (the page stayed visible throughout) misses nothing
-   * while every watcher is armed, so it refreshes only when at least one
-   * watcher is unavailable. One app-wide event covers all qualifying
-   * workspaces without repeatedly invalidating global consumers.
+   * Re-arms unhealthy watchers. Hidden returns always refresh because the
+   * browser may have starved observers; plain refocus refreshes only when a
+   * watcher is unavailable. One app-wide event covers all workspaces.
    */
   private revalidateOnPageReturn(info: PageReturnInfo): void {
     const onExternalChange = this.config.onExternalChange;
@@ -245,18 +211,8 @@ export class FileStorageNativeFs
   }
 
   /**
-   * How the watcher should treat a record's path:
-   *
-   * - `file`: a visible workspace file — emit a targeted per-path event.
-   * - `ignored`: invisible to the app (dotfiles, ignored directories,
-   *   `.crswap`) — drop the record entirely.
-   * - `coarse`: directory-shaped or unparseable — the record cannot be
-   *   mapped to per-path events; only a workspace re-list reconciles it.
-   *   Deleted entries carry no handle (`kind` is unknowable for
-   *   `disappeared` records), so path shape is the only directory signal
-   *   left. A dotted directory name is indistinguishable from a file here;
-   *   the resulting per-path event is wrong but harmless — the counter bump
-   *   still re-lists the tree.
+   * Classifies a record as a targeted visible file, an ignored hidden path,
+   * or a coarse refresh when path shape is ambiguous.
    */
   private classifyWatchPath(
     wsName: string,
@@ -282,18 +238,11 @@ export class FileStorageNativeFs
       return;
     }
 
-    // One observer callback can deliver a burst (a sync tool touching many
-    // files at once), so the batch is coalesced before anything is emitted:
-    // identical records collapse to one event, and once any record demands a
-    // coarse refresh the refresh alone is emitted — it re-lists the workspace
-    // and revalidates its open notes, subsuming every per-path event in the
-    // same batch.
+    // Coalesce duplicate records; a coarse refresh subsumes targeted events.
     let needsRefresh = false;
     const specificEvents = new Map<string, FileStorageExternalChangeEvent>();
     for (const change of changes) {
-      // An `errored` record means observation broke (permission loss, the
-      // watched directory disappeared). Un-mark the workspace so the next
-      // page return re-arms the watcher, and refresh what we may have missed.
+      // Re-arm a broken observer on the next page return.
       if (change.type === 'errored') {
         const entry = this.fsCache.get(wsName);
         if (entry) {
@@ -303,13 +252,8 @@ export class FileStorageNativeFs
         continue;
       }
       if (needsRefresh) {
-        // The coarse refresh subsumes every per-path event in this batch;
-        // only further `errored` records (handled above) still matter.
         continue;
       }
-      // Directory-level records and records the observer could not classify
-      // only tell us "something under this workspace changed" — fall back to
-      // one coarse refresh instead of guessing per-file events.
       if (change.type === 'unknown' || change.kind === 'directory') {
         needsRefresh = true;
         continue;
@@ -317,9 +261,7 @@ export class FileStorageNativeFs
 
       if (change.type === 'moved') {
         if (change.movedFromPath === undefined) {
-          // Origin unknown (platform watchers cannot always pair renames):
-          // a visible file may have been renamed away, and only a re-list
-          // can tell.
+          // The origin is required to determine visibility.
           needsRefresh = true;
           continue;
         }
@@ -328,32 +270,21 @@ export class FileStorageNativeFs
         if (from.kind === 'coarse' || to.kind === 'coarse') {
           needsRefresh = true;
         } else if (from.kind === 'file' && to.kind === 'file') {
-          // A watcher `moved` record does not prove a user-visible rename: it
-          // can also be an atomic replacement of an existing target. Sending
-          // it through the app's rename pipeline would retarget pending saves
-          // from the source and leave an open target stale. Re-list and
-          // revalidate open notes instead; watcher moves are infrequent and
-          // correctness matters more than a speculative per-path shortcut.
+          // Visible moves may be renames or atomic replacements.
           needsRefresh = true;
         } else if (to.kind === 'file') {
-          // Atomic-write pattern (Chromium's own `.crswap` commit): content
-          // materialized at the visible path from one the app never showed. Treat it
-          // as appearing or replaced. External creates invalidate downstream
-          // content indexes without a coarse re-list on every local save.
+          // Atomic write from an invisible temporary path.
           specificEvents.set(`create:${to.wsPath}`, {
             type: 'create',
             wsPath: to.wsPath,
           });
         } else if (from.kind === 'file') {
-          // Visible file moved to an invisible path — gone as far as the app
-          // is concerned.
+          // A visible file moved out of the app's listing.
           specificEvents.set(`delete:${from.wsPath}`, {
             type: 'delete',
             wsPath: from.wsPath,
           });
         }
-        // Both endpoints invisible: drop the move like the equivalent
-        // appeared/disappeared records.
         continue;
       }
 
@@ -363,7 +294,6 @@ export class FileStorageNativeFs
         continue;
       }
       if (classified.kind === 'ignored') {
-        // Hidden/system paths are invisible to the app; ignore them entirely.
         continue;
       }
       const wsPath = classified.wsPath;

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -214,13 +214,6 @@ export class FileStorageNativeFs
       return;
     }
 
-    let refreshEmitted = false;
-    const emitRefresh = () => {
-      if (!refreshEmitted) {
-        refreshEmitted = true;
-        onExternalChange({ type: 'refresh', wsName });
-      }
-    };
     const toVisibleWsPath = (relativePath: string): string | undefined => {
       const result = WsPath.safeFromParts(wsName, relativePath);
       const wsPath = result.ok && result.data ? result.data.wsPath : undefined;
@@ -230,20 +223,28 @@ export class FileStorageNativeFs
       return isVisibleWorkspaceFilePath(wsPath) ? wsPath : undefined;
     };
 
+    // One observer callback can deliver a burst (a sync tool touching many
+    // files at once), so the batch is coalesced before anything is emitted:
+    // identical records collapse to one event, and once any record demands a
+    // coarse refresh the refresh alone is emitted — it re-lists the workspace
+    // and revalidates its open notes, subsuming every per-path event in the
+    // same batch.
+    let needsRefresh = false;
+    const specificEvents = new Map<string, FileStorageExternalChangeEvent>();
     for (const change of changes) {
       // An `errored` record means observation broke (permission loss, the
       // watched directory disappeared). Un-mark the workspace so the next
       // page return re-arms the watcher, and refresh what we may have missed.
       if (change.type === 'errored') {
         this.watchedWorkspaces.delete(wsName);
-        emitRefresh();
+        needsRefresh = true;
         continue;
       }
       // Directory-level records and records the observer could not classify
       // only tell us "something under this workspace changed" — fall back to
       // one coarse refresh instead of guessing per-file events.
       if (change.type === 'unknown' || change.kind === 'directory') {
-        emitRefresh();
+        needsRefresh = true;
         continue;
       }
 
@@ -254,10 +255,14 @@ export class FileStorageNativeFs
             ? undefined
             : toVisibleWsPath(change.movedFromPath);
         if (!newWsPath || !oldWsPath) {
-          emitRefresh();
+          needsRefresh = true;
           continue;
         }
-        onExternalChange({ type: 'rename', oldWsPath, newWsPath });
+        specificEvents.set(`rename:${oldWsPath}->${newWsPath}`, {
+          type: 'rename',
+          oldWsPath,
+          newWsPath,
+        });
         continue;
       }
 
@@ -269,21 +274,29 @@ export class FileStorageNativeFs
       }
       switch (change.type) {
         case 'appeared': {
-          onExternalChange({ type: 'create', wsPath });
+          specificEvents.set(`create:${wsPath}`, { type: 'create', wsPath });
           break;
         }
         case 'modified': {
-          onExternalChange({ type: 'update', wsPath });
+          specificEvents.set(`update:${wsPath}`, { type: 'update', wsPath });
           break;
         }
         case 'disappeared': {
-          onExternalChange({ type: 'delete', wsPath });
+          specificEvents.set(`delete:${wsPath}`, { type: 'delete', wsPath });
           break;
         }
         default: {
           const _exhaustiveCheck: never = change.type;
         }
       }
+    }
+
+    if (needsRefresh) {
+      onExternalChange({ type: 'refresh', wsName });
+      return;
+    }
+    for (const event of specificEvents.values()) {
+      onExternalChange(event);
     }
   }
 

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -36,11 +36,23 @@ type Config = {
   /**
    * Invoked for changes made to workspace files by something other than this
    * app instance (sync tools, other editors). Providing it turns on
-   * FileSystemObserver watching (Chrome 133+) per opened workspace, with a
-   * throttled focus/visibility re-list fallback when the observer API is
-   * unavailable.
+   * FileSystemObserver watching (Chrome 133+) per opened workspace, plus the
+   * page-return revalidation below when `subscribePageReturn` is supplied.
    */
   onExternalChange?: (event: FileStorageExternalChangeEvent) => void;
+  /**
+   * Subscribes `listener` to "the user returned to the page" transitions
+   * (tab became visible again, window regained focus). The composition root
+   * wires this to the platform router's page-lifecycle stream (see
+   * `onPageReturn` in this package), keeping the visibility source swappable
+   * and out of this service.
+   *
+   * On each return the service re-emits a throttled coarse refresh for every
+   * opened workspace and re-arms watchers that died — OS file watchers are
+   * best-effort (frozen tabs, permission loss, network drives), so returning
+   * to the page is the natural moment to reconcile.
+   */
+  subscribePageReturn?: (listener: () => void, signal: AbortSignal) => void;
 };
 
 /**
@@ -51,10 +63,12 @@ type Config = {
 const SELF_WRITE_ECHO_WINDOW_MS = 5_000;
 
 /**
- * Minimum spacing between coarse refreshes triggered by window focus /
- * visibility when the FileSystemObserver API is unavailable.
+ * Minimum spacing between coarse refreshes triggered by returning to the
+ * page. A refresh re-lists the workspace and revalidates open notes, so it
+ * must not fire on every alt-tab; anything the observer already reported has
+ * flowed through the fine-grained path regardless.
  */
-const FOCUS_REVALIDATE_MIN_INTERVAL_MS = 15_000;
+const PAGE_RETURN_REVALIDATE_MIN_INTERVAL_MS = 15_000;
 
 export class FileStorageNativeFs
   extends BaseService
@@ -66,6 +80,7 @@ export class FileStorageNativeFs
   private fsCache: Map<string, NativeFs> = new Map();
   private watchedWorkspaces = new Set<string>();
   private recentSelfWrites = new Map<string, number>();
+  private lastPageReturnRevalidation = 0;
 
   constructor(
     context: BaseServiceContext,
@@ -77,6 +92,12 @@ export class FileStorageNativeFs
 
   async hookMount(): Promise<void> {
     assertIsDefined(this.config.getRootDirHandle, 'getRootDirHandle');
+    if (this.config.onExternalChange) {
+      this.config.subscribePageReturn?.(
+        () => this.revalidateOnPageReturn(),
+        this.abortSignal,
+      );
+    }
     this.addCleanup(() => {
       this.fsCache.clear();
       this.watchedWorkspaces.clear();
@@ -149,17 +170,14 @@ export class FileStorageNativeFs
     this.watchedWorkspaces.add(wsName);
 
     // Watching is best-effort: a failure to observe must never break file
-    // operations, so errors are logged rather than propagated.
+    // operations, so errors are logged rather than propagated. A failed
+    // start leaves the workspace unmarked so the next page return retries.
     void fs
       .watch((changes) => this.handleWatchChanges(wsName, changes), {
         signal: this.abortSignal,
       })
-      .then((supported) => {
-        if (!supported) {
-          this.startFocusRevalidation(wsName);
-        }
-      })
       .catch((error) => {
+        this.watchedWorkspaces.delete(wsName);
         this.logger.warn(
           `Unable to watch native FS workspace "${wsName}" for external changes`,
           error,
@@ -168,30 +186,30 @@ export class FileStorageNativeFs
   }
 
   /**
-   * Coarse fallback when `FileSystemObserver` is unavailable: emit a
-   * throttled workspace refresh whenever the window regains focus or becomes
-   * visible, since that is when externally synced changes become relevant.
+   * The user came back to the page: emit a throttled coarse refresh for
+   * every opened workspace and retry watchers that failed or died. This is
+   * the safety net for everything the observer cannot promise — events
+   * missed while the tab was frozen, watchers killed by permission loss,
+   * filesystems where OS watching is unreliable — and the only refresh
+   * mechanism at all when `FileSystemObserver` is unsupported.
    */
-  private startFocusRevalidation(wsName: string): void {
-    if (typeof window === 'undefined' || typeof document === 'undefined') {
+  private revalidateOnPageReturn(): void {
+    const onExternalChange = this.config.onExternalChange;
+    if (!onExternalChange || this.fsCache.size === 0) {
       return;
     }
-    let lastRefresh = 0;
-    const trigger = () => {
-      if (document.visibilityState !== 'visible') {
-        return;
-      }
-      const now = Date.now();
-      if (now - lastRefresh < FOCUS_REVALIDATE_MIN_INTERVAL_MS) {
-        return;
-      }
-      lastRefresh = now;
-      this.config.onExternalChange?.({ type: 'refresh', wsName });
-    };
-    window.addEventListener('focus', trigger, { signal: this.abortSignal });
-    document.addEventListener('visibilitychange', trigger, {
-      signal: this.abortSignal,
-    });
+    const now = Date.now();
+    if (
+      now - this.lastPageReturnRevalidation <
+      PAGE_RETURN_REVALIDATE_MIN_INTERVAL_MS
+    ) {
+      return;
+    }
+    this.lastPageReturnRevalidation = now;
+    for (const [wsName, fs] of this.fsCache) {
+      this.startWatching(wsName, fs);
+      onExternalChange({ type: 'refresh', wsName });
+    }
   }
 
   private noteSelfWrite(...wsPaths: string[]): void {
@@ -234,14 +252,18 @@ export class FileStorageNativeFs
     };
 
     for (const change of changes) {
+      // An `errored` record means observation broke (permission loss, the
+      // watched directory disappeared). Un-mark the workspace so the next
+      // page return re-arms the watcher, and refresh what we may have missed.
+      if (change.type === 'errored') {
+        this.watchedWorkspaces.delete(wsName);
+        emitRefresh();
+        continue;
+      }
       // Directory-level records and records the observer could not classify
       // only tell us "something under this workspace changed" — fall back to
       // one coarse refresh instead of guessing per-file events.
-      if (
-        change.type === 'unknown' ||
-        change.type === 'errored' ||
-        change.kind === 'directory'
-      ) {
+      if (change.type === 'unknown' || change.kind === 'directory') {
         emitRefresh();
         continue;
       }

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -76,11 +76,11 @@ type WatchPathClass =
 type FsCacheEntry = {
   fs: NativeFs;
   /**
-   * Whether a watch is (believed to be) armed for this workspace. Set
-   * optimistically when a watch starts; cleared when starting fails or the
-   * observer reports an `errored` record, so the next page return re-arms.
+   * Only `armed` is healthy enough to skip page-return revalidation.
+   * `starting` prevents duplicate observer setup without pretending the
+   * workspace is already protected from missed changes.
    */
-  watching: boolean;
+  watchState: 'idle' | 'starting' | 'armed';
 };
 
 export class FileStorageNativeFs
@@ -161,7 +161,7 @@ export class FileStorageNativeFs
         // The lock scope is the workspace name (not the folder basename) so
         // cross-tab write serialization stays keyed to the workspace identity.
         const fs = new NativeFs({ rootHandle: handle, lockScope: wsName });
-        const entry: FsCacheEntry = { fs, watching: false };
+        const entry: FsCacheEntry = { fs, watchState: 'idle' };
         this.fsCache.set(wsName, entry);
         this.startWatching(wsName, entry);
         return entry;
@@ -182,7 +182,7 @@ export class FileStorageNativeFs
   private startWatching(wsName: string, entry: FsCacheEntry): void {
     if (
       !this.config.onExternalChange ||
-      entry.watching ||
+      entry.watchState !== 'idle' ||
       // Without the observer API, watching can never arm; leaving the entry
       // unmarked keeps page-return revalidation as the refresh path (and
       // avoids arming optimistically only to fail asynchronously each time).
@@ -190,7 +190,7 @@ export class FileStorageNativeFs
     ) {
       return;
     }
-    entry.watching = true;
+    entry.watchState = 'starting';
 
     // Watching is best-effort: a failure to observe must never break file
     // operations, so errors are logged rather than propagated. A failed
@@ -199,8 +199,11 @@ export class FileStorageNativeFs
       .watch((changes) => this.handleWatchChanges(wsName, changes), {
         signal: this.abortSignal,
       })
+      .then((armed) => {
+        entry.watchState = armed ? 'armed' : 'idle';
+      })
       .catch((error) => {
-        entry.watching = false;
+        entry.watchState = 'idle';
         this.logger.warn(
           `Unable to watch native FS workspace "${wsName}" for external changes`,
           error,
@@ -216,24 +219,28 @@ export class FileStorageNativeFs
    * filesystems where OS watching is unreliable — and the only refresh
    * mechanism at all when `FileSystemObserver` is unsupported.
    *
-   * A return from a hidden/frozen tab refreshes every opened workspace: the
-   * browser may have starved the observer while the tab was away. A mere
-   * window refocus (the page stayed visible throughout) misses nothing while
-   * a watcher is armed, so only workspaces without a live watcher — observer
-   * unsupported, or the watch died — are refreshed; anything else would
-   * re-list every workspace and re-read every open note on each alt-tab.
+   * A return from a hidden/frozen tab refreshes if any workspace has been
+   * opened: the browser may have starved observers while the tab was away. A
+   * mere window refocus (the page stayed visible throughout) misses nothing
+   * while every watcher is armed, so it refreshes only when at least one
+   * watcher is unavailable. One app-wide event covers all qualifying
+   * workspaces without repeatedly invalidating global consumers.
    */
   private revalidateOnPageReturn(info: PageReturnInfo): void {
     const onExternalChange = this.config.onExternalChange;
     if (!onExternalChange || this.fsCache.size === 0) {
       return;
     }
+    let shouldRefresh = false;
     for (const [wsName, entry] of this.fsCache) {
-      const wasWatching = entry.watching;
+      const wasArmed = entry.watchState === 'armed';
       this.startWatching(wsName, entry);
-      if (info.returnedFromHidden || !wasWatching) {
-        onExternalChange({ type: 'refresh', wsName });
+      if (info.returnedFromHidden || !wasArmed) {
+        shouldRefresh = true;
       }
+    }
+    if (shouldRefresh) {
+      onExternalChange({ type: 'refresh' });
     }
   }
 
@@ -290,7 +297,7 @@ export class FileStorageNativeFs
       if (change.type === 'errored') {
         const entry = this.fsCache.get(wsName);
         if (entry) {
-          entry.watching = false;
+          entry.watchState = 'idle';
         }
         needsRefresh = true;
         continue;

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -61,6 +61,8 @@ type FsCacheEntry = {
   fs: NativeFs;
   /** `starting` deduplicates setup; only `armed` may skip revalidation. */
   watchState: 'idle' | 'starting' | 'armed';
+  /** Disconnects the current observer, so re-arming cannot stack a second. */
+  stopWatch?: () => void;
 };
 
 export class FileStorageNativeFs
@@ -173,14 +175,20 @@ export class FileStorageNativeFs
       return;
     }
     entry.watchState = 'starting';
+    // A re-arm (after an `errored` record) must disconnect the broken
+    // observer; otherwise every error cycle leaves another one attached,
+    // duplicating every change it still reports.
+    entry.stopWatch?.();
+    entry.stopWatch = undefined;
 
     // Watching is best-effort; page return retries a failed start.
     void entry.fs
       .watch((changes) => this.handleWatchChanges(wsName, changes), {
         signal: this.abortSignal,
       })
-      .then((armed) => {
+      .then(({ armed, stop }) => {
         entry.watchState = armed ? 'armed' : 'idle';
+        entry.stopWatch = armed ? stop : undefined;
       })
       .catch((error) => {
         entry.watchState = 'idle';
@@ -233,82 +241,83 @@ export class FileStorageNativeFs
     return { kind: 'file', wsPath };
   }
 
-  private handleWatchChanges(wsName: string, changes: NativeFsChange[]): void {
-    const onExternalChange = this.config.onExternalChange;
-    if (!onExternalChange) {
-      return;
+  /**
+   * Whether a record is too coarse to translate into a targeted event, so the
+   * whole workspace has to be re-read.
+   */
+  private needsCoarseRefresh(wsName: string, change: NativeFsChange): boolean {
+    if (change.type === 'unknown' || change.kind === 'directory') {
+      return true;
     }
+    if (change.type !== 'moved') {
+      return this.classifyWatchPath(wsName, change.path).kind === 'coarse';
+    }
+    if (change.movedFromPath === undefined) {
+      // The origin is required to determine visibility.
+      return true;
+    }
+    const from = this.classifyWatchPath(wsName, change.movedFromPath);
+    const to = this.classifyWatchPath(wsName, change.path);
+    return (
+      from.kind === 'coarse' ||
+      to.kind === 'coarse' ||
+      // Visible moves may be renames or atomic replacements.
+      (from.kind === 'file' && to.kind === 'file')
+    );
+  }
 
-    // Coalesce duplicate records; a coarse refresh subsumes targeted events.
-    let needsRefresh = false;
-    const specificEvents = new Map<string, FileStorageExternalChangeEvent>();
+  /** Targeted events for a burst, deduplicated and in arrival order. */
+  private toTargetedEvents(
+    wsName: string,
+    changes: NativeFsChange[],
+  ): Map<string, FileStorageExternalChangeEvent> {
+    const events = new Map<string, FileStorageExternalChangeEvent>();
+    const add = (
+      event: FileStorageExternalChangeEvent & { wsPath: string },
+    ) => {
+      events.set(`${event.type}:${event.wsPath}`, event);
+    };
+
     for (const change of changes) {
-      // Re-arm a broken observer on the next page return.
-      if (change.type === 'errored') {
-        const entry = this.fsCache.get(wsName);
-        if (entry) {
-          entry.watchState = 'idle';
-        }
-        needsRefresh = true;
+      if (change.type === 'errored' || change.type === 'unknown') {
+        // Both force a coarse refresh, so this pass never runs for them.
         continue;
       }
-      if (needsRefresh) {
-        continue;
-      }
-      if (change.type === 'unknown' || change.kind === 'directory') {
-        needsRefresh = true;
-        continue;
-      }
-
       if (change.type === 'moved') {
         if (change.movedFromPath === undefined) {
-          // The origin is required to determine visibility.
-          needsRefresh = true;
+          // Unknown origin already forced a coarse refresh.
           continue;
         }
+        // Only one side can be visible here; a visible-to-visible move was
+        // already classified as needing a coarse refresh.
         const from = this.classifyWatchPath(wsName, change.movedFromPath);
         const to = this.classifyWatchPath(wsName, change.path);
-        if (from.kind === 'coarse' || to.kind === 'coarse') {
-          needsRefresh = true;
-        } else if (from.kind === 'file' && to.kind === 'file') {
-          // Visible moves may be renames or atomic replacements.
-          needsRefresh = true;
-        } else if (to.kind === 'file') {
+        if (to.kind === 'file') {
           // Atomic write from an invisible temporary path.
-          specificEvents.set(`create:${to.wsPath}`, {
-            type: 'create',
-            wsPath: to.wsPath,
-          });
+          add({ type: 'create', wsPath: to.wsPath });
         } else if (from.kind === 'file') {
           // A visible file moved out of the app's listing.
-          specificEvents.set(`delete:${from.wsPath}`, {
-            type: 'delete',
-            wsPath: from.wsPath,
-          });
+          add({ type: 'delete', wsPath: from.wsPath });
         }
         continue;
       }
 
       const classified = this.classifyWatchPath(wsName, change.path);
-      if (classified.kind === 'coarse') {
-        needsRefresh = true;
-        continue;
-      }
-      if (classified.kind === 'ignored') {
+      if (classified.kind !== 'file') {
         continue;
       }
       const wsPath = classified.wsPath;
       switch (change.type) {
         case 'appeared': {
-          specificEvents.set(`create:${wsPath}`, { type: 'create', wsPath });
+          add({ type: 'create', wsPath });
           break;
         }
         case 'modified': {
-          specificEvents.set(`update:${wsPath}`, { type: 'update', wsPath });
+          add({ type: 'update', wsPath });
           break;
         }
         case 'disappeared': {
-          specificEvents.set(`delete:${wsPath}`, { type: 'delete', wsPath });
+          add({ type: 'delete', wsPath });
           break;
         }
         default: {
@@ -316,12 +325,29 @@ export class FileStorageNativeFs
         }
       }
     }
+    return events;
+  }
 
-    if (needsRefresh) {
+  private handleWatchChanges(wsName: string, changes: NativeFsChange[]): void {
+    const onExternalChange = this.config.onExternalChange;
+    if (!onExternalChange) {
+      return;
+    }
+
+    if (changes.some((change) => change.type === 'errored')) {
+      // Observation broke; re-arm on the next page return.
+      const entry = this.fsCache.get(wsName);
+      if (entry) {
+        entry.watchState = 'idle';
+      }
       onExternalChange({ type: 'refresh', wsName });
       return;
     }
-    for (const event of specificEvents.values()) {
+    if (changes.some((change) => this.needsCoarseRefresh(wsName, change))) {
+      onExternalChange({ type: 'refresh', wsName });
+      return;
+    }
+    for (const event of this.toTargetedEvents(wsName, changes).values()) {
       onExternalChange(event);
     }
   }

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -268,6 +268,12 @@ export class FileStorageNativeFs
       if (from.kind === 'ignored' && to.kind === 'ignored') {
         return false;
       }
+      // Same as the plain branch below: a visible directory moving changes
+      // the listing wholesale, and a dot-named directory would otherwise pass
+      // for a file on path shape alone.
+      if (change.kind === 'directory') {
+        return true;
+      }
       return (
         from.kind === 'coarse' ||
         to.kind === 'coarse' ||

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -337,9 +337,8 @@ export class FileStorageNativeFs
           // Atomic-write pattern (Chromium's own `.crswap` commit, sync
           // tools' write-to-temp-then-rename): content materialized at the
           // visible path from a transient one the app never showed. Treat it
-          // as the visible file appearing rather than refreshing the whole
-          // workspace — with self-writes deliberately unfiltered, a coarse
-          // refresh here would re-list on every local save.
+          // as appearing or replaced. External creates invalidate downstream
+          // content indexes without a coarse re-list on every local save.
           specificEvents.set(`create:${to.wsPath}`, {
             type: 'create',
             wsPath: to.wsPath,

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -38,6 +38,12 @@ type Config = {
    * app instance (sync tools, other editors). Providing it turns on
    * FileSystemObserver watching (Chrome 133+) per opened workspace, plus the
    * page-return revalidation below when `subscribePageReturn` is supplied.
+   *
+   * Records caused by the app's own writes are NOT filtered here: a
+   * path+time ledger cannot distinguish an echo from a genuine external
+   * overwrite of the same file moments after a local save. Downstream
+   * consumers coalesce echoes by comparing content, which is cheap and
+   * cannot drop a real edit.
    */
   onExternalChange?: (event: FileStorageExternalChangeEvent) => void;
   /**
@@ -56,13 +62,6 @@ type Config = {
 };
 
 /**
- * How long after one of our own mutations a watcher record for the same
- * wsPath is treated as the echo of that mutation and dropped. Covers the
- * observer's callback latency plus slack for slow disk writes.
- */
-const SELF_WRITE_ECHO_WINDOW_MS = 5_000;
-
-/**
  * Minimum spacing between coarse refreshes triggered by returning to the
  * page. A refresh re-lists the workspace and revalidates open notes, so it
  * must not fire on every alt-tab; anything the observer already reported has
@@ -79,7 +78,6 @@ export class FileStorageNativeFs
 
   private fsCache: Map<string, NativeFs> = new Map();
   private watchedWorkspaces = new Set<string>();
-  private recentSelfWrites = new Map<string, number>();
   private lastPageReturnRevalidation = 0;
 
   constructor(
@@ -101,7 +99,6 @@ export class FileStorageNativeFs
     this.addCleanup(() => {
       this.fsCache.clear();
       this.watchedWorkspaces.clear();
-      this.recentSelfWrites.clear();
     });
   }
 
@@ -212,23 +209,6 @@ export class FileStorageNativeFs
     }
   }
 
-  private noteSelfWrite(...wsPaths: string[]): void {
-    const now = Date.now();
-    for (const [path, at] of this.recentSelfWrites) {
-      if (now - at > SELF_WRITE_ECHO_WINDOW_MS) {
-        this.recentSelfWrites.delete(path);
-      }
-    }
-    for (const wsPath of wsPaths) {
-      this.recentSelfWrites.set(wsPath, now);
-    }
-  }
-
-  private isRecentSelfWrite(wsPath: string): boolean {
-    const at = this.recentSelfWrites.get(wsPath);
-    return at !== undefined && Date.now() - at <= SELF_WRITE_ECHO_WINDOW_MS;
-  }
-
   private handleWatchChanges(wsName: string, changes: NativeFsChange[]): void {
     const onExternalChange = this.config.onExternalChange;
     if (!onExternalChange) {
@@ -278,12 +258,6 @@ export class FileStorageNativeFs
           emitRefresh();
           continue;
         }
-        if (
-          this.isRecentSelfWrite(newWsPath) ||
-          this.isRecentSelfWrite(oldWsPath)
-        ) {
-          continue;
-        }
         onExternalChange({ type: 'rename', oldWsPath, newWsPath });
         continue;
       }
@@ -292,9 +266,6 @@ export class FileStorageNativeFs
       if (wsPath === undefined) {
         // Hidden/system/unparseable paths (sync temp files, dotfiles) are
         // invisible to the app; ignore them entirely.
-        continue;
-      }
-      if (this.isRecentSelfWrite(wsPath)) {
         continue;
       }
       switch (change.type) {
@@ -329,7 +300,6 @@ export class FileStorageNativeFs
   async createFile(wsPath: string, file: File): Promise<void> {
     await this.mountPromise;
     const fs = await this.getFs({ wsPath });
-    this.noteSelfWrite(wsPath);
     try {
       await fs.createFile(this.toRelativePath(wsPath), file);
     } catch (error) {
@@ -350,7 +320,6 @@ export class FileStorageNativeFs
   async deleteFile(wsPath: string): Promise<void> {
     await this.mountPromise;
     const fs = await this.getFs({ wsPath });
-    this.noteSelfWrite(wsPath);
     try {
       await fs.deleteFile(this.toRelativePath(wsPath));
     } catch (error) {
@@ -461,7 +430,6 @@ export class FileStorageNativeFs
     await this.mountPromise;
     assertSameWorkspaceRename(wsPath, newWsPath);
     const fs = await this.getFs({ wsPath });
-    this.noteSelfWrite(wsPath, newWsPath);
     try {
       await fs.moveFile(
         this.toRelativePath(wsPath),
@@ -499,7 +467,6 @@ export class FileStorageNativeFs
   async writeFile(wsPath: string, file: File): Promise<void> {
     await this.mountPromise;
     const fs = await this.getFs({ wsPath });
-    this.noteSelfWrite(wsPath);
     try {
       await fs.writeFile(this.toRelativePath(wsPath), file, { create: false });
     } catch (error) {

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -23,6 +23,7 @@ import type {
   FileStorageExternalChangeEvent,
 } from '@bangle.io/types';
 import {
+  isIgnoredWorkspacePathSegment,
   isVisibleWorkspaceDirectoryName,
   isVisibleWorkspaceFilePath,
   WsPath,
@@ -227,6 +228,14 @@ export class FileStorageNativeFs
     wsName: string,
     relativePath: string,
   ): WatchPathClass {
+    // Locations the workspace listing never shows cannot change it, whatever
+    // shape their paths have. This runs before the file-shape parse because
+    // extensionless paths (`.git/HEAD`, `node_modules/.bin/tsc`) do not parse
+    // as files — without it, ordinary `git` and `npm` activity inside a
+    // workspace would each force a full re-list.
+    if (relativePath.split('/').some(isIgnoredWorkspacePathSegment)) {
+      return { kind: 'ignored' };
+    }
     const result = WsPath.safeFromParts(wsName, relativePath);
     const wsPath = result.ok && result.data ? result.data.wsPath : undefined;
     if (wsPath === undefined) {
@@ -246,24 +255,32 @@ export class FileStorageNativeFs
    * whole workspace has to be re-read.
    */
   private needsCoarseRefresh(wsName: string, change: NativeFsChange): boolean {
-    if (change.type === 'unknown' || change.kind === 'directory') {
+    if (change.type === 'unknown') {
       return true;
     }
-    if (change.type !== 'moved') {
-      return this.classifyWatchPath(wsName, change.path).kind === 'coarse';
+    if (change.type === 'moved') {
+      if (change.movedFromPath === undefined) {
+        // The origin is required to determine visibility.
+        return true;
+      }
+      const from = this.classifyWatchPath(wsName, change.movedFromPath);
+      const to = this.classifyWatchPath(wsName, change.path);
+      if (from.kind === 'ignored' && to.kind === 'ignored') {
+        return false;
+      }
+      return (
+        from.kind === 'coarse' ||
+        to.kind === 'coarse' ||
+        // Visible moves may be renames or atomic replacements.
+        (from.kind === 'file' && to.kind === 'file')
+      );
     }
-    if (change.movedFromPath === undefined) {
-      // The origin is required to determine visibility.
-      return true;
+    const classified = this.classifyWatchPath(wsName, change.path);
+    if (classified.kind === 'ignored') {
+      return false;
     }
-    const from = this.classifyWatchPath(wsName, change.movedFromPath);
-    const to = this.classifyWatchPath(wsName, change.path);
-    return (
-      from.kind === 'coarse' ||
-      to.kind === 'coarse' ||
-      // Visible moves may be renames or atomic replacements.
-      (from.kind === 'file' && to.kind === 'file')
-    );
+    // A visible directory appearing or vanishing changes the listing.
+    return change.kind === 'directory' || classified.kind === 'coarse';
   }
 
   /** Targeted events for a burst, deduplicated and in arrival order. */

--- a/packages/platform/service-platform/src/index.ts
+++ b/packages/platform/service-platform/src/index.ts
@@ -16,7 +16,9 @@ export { NodeErrorHandlerService } from './node-error-handler';
 export {
   BrowserRouterService,
   HashStrategy,
+  isPageReturnTransition,
   MemoryRouterService,
+  onPageReturn,
   PathBasedStrategy,
   QueryStringStrategy,
 } from './router';

--- a/packages/platform/service-platform/src/router/index.ts
+++ b/packages/platform/service-platform/src/router/index.ts
@@ -1,5 +1,6 @@
 export * from './browser-router';
 export * from './hash-strategy';
 export * from './memory-router';
+export * from './page-return';
 export * from './path-based-strategy';
 export * from './query-string-strategy';

--- a/packages/platform/service-platform/src/router/page-return.ts
+++ b/packages/platform/service-platform/src/router/page-return.ts
@@ -1,6 +1,28 @@
 import type { BaseRouter, PageLifeCycleState } from '@bangle.io/types';
 
 /**
+ * What a page-return listener learns about the return it is being told
+ * about. `returnedFromHidden` distinguishes "the tab was hidden or frozen
+ * and is visible again" (the browser may have starved observers and events
+ * while away) from a mere window refocus while the page stayed visible the
+ * whole time.
+ */
+export interface PageReturnInfo {
+  returnedFromHidden: boolean;
+}
+
+/**
+ * Window within which page-return transitions are treated as one return: a
+ * single return fires `visibilitychange` and `focus` back-to-back (e.g.
+ * hidden → passive → active), and only the first should notify. Kept short
+ * deliberately — consumers like the native FS revalidation may use the
+ * return as their only reconciliation signal, so a genuinely separate
+ * leave→edit→return cycle moments later must not be swallowed by a
+ * wall-clock throttle.
+ */
+const PAGE_RETURN_DEDUPE_MS = 1_000;
+
+/**
  * Whether a page-lifecycle transition means the user has come back to the
  * page after being away:
  *
@@ -35,21 +57,31 @@ export function isPageReturnTransition(
  * state that may have gone stale while the page was hidden, unfocused, or
  * frozen (e.g. files changed on disk by a sync tool).
  *
- * The listener can fire in quick succession around a single return (the
- * browser may emit `hidden → passive → active` as separate transitions);
- * callers that do non-trivial work must throttle.
+ * The browser reports a single return as several transitions (hidden →
+ * passive → active); this helper collapses them so the listener fires once
+ * per return, with `returnedFromHidden` taken from the transition that won
+ * the collapse.
  */
 export function onPageReturn(
   emitter: Pick<BaseRouter['emitter'], 'on'>,
-  listener: () => void,
+  listener: (info: PageReturnInfo) => void,
   signal: AbortSignal,
 ): void {
+  let lastNotified = 0;
   emitter.on(
     'event::router:page-lifecycle-state',
     ({ current, previous }) => {
-      if (isPageReturnTransition(current, previous)) {
-        listener();
+      if (!isPageReturnTransition(current, previous)) {
+        return;
       }
+      const now = Date.now();
+      if (now - lastNotified < PAGE_RETURN_DEDUPE_MS) {
+        return;
+      }
+      lastNotified = now;
+      listener({
+        returnedFromHidden: previous === 'hidden' || previous === 'frozen',
+      });
     },
     signal,
   );

--- a/packages/platform/service-platform/src/router/page-return.ts
+++ b/packages/platform/service-platform/src/router/page-return.ts
@@ -1,0 +1,56 @@
+import type { BaseRouter, PageLifeCycleState } from '@bangle.io/types';
+
+/**
+ * Whether a page-lifecycle transition means the user has come back to the
+ * page after being away:
+ *
+ * - the tab became visible again (`hidden`/`frozen` → `passive`/`active`), or
+ * - the window regained focus while already visible (`passive` → `active`) —
+ *   e.g. the user was editing files in another app window next to the
+ *   browser and clicked back.
+ *
+ * The initial page load (`undefined` → `active`) is intentionally NOT a
+ * return: everything is freshly read at that point.
+ *
+ * States come from the router's page-lifecycle stream, which normalizes the
+ * Page Visibility API (`visibilitychange`, window focus/blur, and the Page
+ * Lifecycle freeze/resume events) via GoogleChromeLabs' page-lifecycle.
+ */
+export function isPageReturnTransition(
+  current: PageLifeCycleState,
+  previous: PageLifeCycleState,
+): boolean {
+  if (current !== 'active' && current !== 'passive') {
+    return false;
+  }
+  if (previous === 'hidden' || previous === 'frozen') {
+    return true;
+  }
+  return current === 'active' && previous === 'passive';
+}
+
+/**
+ * Invokes `listener` whenever the user returns to the page, derived from the
+ * router-owned page-lifecycle event stream. Consumers use this to revalidate
+ * state that may have gone stale while the page was hidden, unfocused, or
+ * frozen (e.g. files changed on disk by a sync tool).
+ *
+ * The listener can fire in quick succession around a single return (the
+ * browser may emit `hidden → passive → active` as separate transitions);
+ * callers that do non-trivial work must throttle.
+ */
+export function onPageReturn(
+  emitter: Pick<BaseRouter['emitter'], 'on'>,
+  listener: () => void,
+  signal: AbortSignal,
+): void {
+  emitter.on(
+    'event::router:page-lifecycle-state',
+    ({ current, previous }) => {
+      if (isPageReturnTransition(current, previous)) {
+        listener();
+      }
+    },
+    signal,
+  );
+}

--- a/packages/platform/service-platform/src/router/page-return.ts
+++ b/packages/platform/service-platform/src/router/page-return.ts
@@ -72,6 +72,10 @@ export function onPageReturn(
     'event::router:page-lifecycle-state',
     ({ current, previous }) => {
       if (!isPageReturnTransition(current, previous)) {
+        // A real departure starts a new return cycle immediately. Keep the
+        // clock only for adjacent transitions within one browser-generated
+        // hidden → passive → active burst.
+        lastNotified = 0;
         return;
       }
       const now = Date.now();

--- a/packages/shared/base-utils/index.ts
+++ b/packages/shared/base-utils/index.ts
@@ -1,4 +1,5 @@
 import { BROWSING_CONTEXT_ID } from '@bangle.io/config';
+import { EXTERNAL_FILE_CHANGE_SENDER_TAG } from '@bangle.io/constants';
 import type { EventSenderMetadata } from '@bangle.io/types';
 
 export type { ErrorReporter } from '@bangle.io/logger';
@@ -74,4 +75,19 @@ export function getEventSenderMetadata({
     id: BROWSING_CONTEXT_ID,
     tag: tag,
   };
+}
+
+/**
+ * Where an app event came from, relative to the listening context. The two
+ * axes are independent: a storage watcher reports this tab's own writes
+ * (`watcher` without `foreignTab`), while another tab's watcher is both.
+ * `external` means "not caused by this context's own code path".
+ */
+export function classifyEventSender(
+  sender: EventSenderMetadata,
+  selfSenderId: string,
+): { external: boolean; foreignTab: boolean; watcher: boolean } {
+  const watcher = sender.tag === EXTERNAL_FILE_CHANGE_SENDER_TAG;
+  const foreignTab = sender.id !== selfSenderId;
+  return { external: watcher || foreignTab, foreignTab, watcher };
 }

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -150,6 +150,13 @@ export const APP_MAIN_CONTENT_PADDING = 'px-4 py-4 pt-0 md:px-6';
  */
 export const EDITOR_GUTTER_PADDING_LEFT = 'pl-10 md:pl-14';
 export type ServiceName = (typeof SERVICE_NAME)[keyof typeof SERVICE_NAME];
+/**
+ * Sender tag on `event::file:update` / `event::file:force-update` events that
+ * originated from a storage watcher observing changes made OUTSIDE this app
+ * (sync tools, other editors). Consumers use it to react to external edits
+ * without re-triggering on the app's own writes.
+ */
+export const EXTERNAL_FILE_CHANGE_SENDER_TAG = 'external-file-change';
 export { browserHistoryStateEvents } from './browser-history-events';
 export { commandExcludedServices, commandKeyToContext } from './command';
 export { THEME_MANAGER_CONFIG } from './theme';

--- a/packages/shared/root-emitter/src/index.ts
+++ b/packages/shared/root-emitter/src/index.ts
@@ -68,6 +68,12 @@ export type RootEvents =
   | {
       event: 'event::file:force-update';
       payload: {
+        /**
+         * When set, the refresh concerns a single workspace (e.g. a storage
+         * watcher's coarse "something changed here"); consumers doing
+         * per-workspace work can scope to it. Absent means app-wide.
+         */
+        wsName?: string;
         sender: EventSenderMetadata;
       };
     }

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -641,6 +641,8 @@ export const t = {
         `${fileName} changed on disk, but the change could not be applied safely. The editor kept the current version.`,
       externalDiskVersionUnavailable: ({ fileName }: { fileName: string }) =>
         `Could not read ${fileName} from disk. The editor kept the current version.`,
+      externalDiskVersionNotApplied: ({ fileName }: { fileName: string }) =>
+        `The disk version of ${fileName} was not loaded. The editor kept the current version.`,
       loadDiskVersion: 'Load disk version',
       fileCreated: ({ fileName }: { fileName: string }) =>
         `Created ${fileName}`,

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -639,6 +639,8 @@ export const t = {
       }) => `${fileName} is too large. Maximum file size is ${maxFileSize}.`,
       externalChangeNotApplied: ({ fileName }: { fileName: string }) =>
         `${fileName} changed on disk, but the change could not be applied safely. The editor kept the current version.`,
+      externalDiskVersionUnavailable: ({ fileName }: { fileName: string }) =>
+        `Could not read ${fileName} from disk. The editor kept the current version.`,
       loadDiskVersion: 'Load disk version',
       fileCreated: ({ fileName }: { fileName: string }) =>
         `Created ${fileName}`,

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -639,7 +639,7 @@ export const t = {
       }) => `${fileName} is too large. Maximum file size is ${maxFileSize}.`,
       externalChangeNotApplied: ({ fileName }: { fileName: string }) =>
         `${fileName} changed on disk, but the change could not be applied safely. The editor kept the current version.`,
-      reloadToApplyExternalChange: 'Reload',
+      loadDiskVersion: 'Load disk version',
       fileCreated: ({ fileName }: { fileName: string }) =>
         `Created ${fileName}`,
       fileCreateFailed: 'Could not create file',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -637,6 +637,9 @@ export const t = {
         fileName: string;
         maxFileSize: string;
       }) => `${fileName} is too large. Maximum file size is ${maxFileSize}.`,
+      externalChangeNotApplied: ({ fileName }: { fileName: string }) =>
+        `${fileName} changed on disk, but the change could not be applied safely. The editor kept the current version.`,
+      reloadToApplyExternalChange: 'Reload',
       fileCreated: ({ fileName }: { fileName: string }) =>
         `Created ${fileName}`,
       fileCreateFailed: 'Could not create file',

--- a/packages/shared/types/base-file-storage.ts
+++ b/packages/shared/types/base-file-storage.ts
@@ -35,19 +35,12 @@ export type FileStorageChangeEvent =
 /**
  * A change made to workspace files by something other than this app instance
  * (a sync tool, another editor, a shell command), detected by a storage
- * provider's watcher. `refresh` is the coarse fallback when the watcher only
- * knows "something under this workspace changed".
+ * provider's watcher. Per-path changes reuse the mutation event shape;
+ * `refresh` is the coarse fallback when the watcher only knows "something
+ * under this workspace changed".
  */
 export type FileStorageExternalChangeEvent =
-  | {
-      type: 'create' | 'update' | 'delete';
-      wsPath: string;
-    }
-  | {
-      type: 'rename';
-      oldWsPath: string;
-      newWsPath: string;
-    }
+  | FileStorageChangeEvent
   | {
       type: 'refresh';
       wsName: string;

--- a/packages/shared/types/base-file-storage.ts
+++ b/packages/shared/types/base-file-storage.ts
@@ -32,6 +32,27 @@ export type FileStorageChangeEvent =
       wsPath: string;
     };
 
+/**
+ * A change made to workspace files by something other than this app instance
+ * (a sync tool, another editor, a shell command), detected by a storage
+ * provider's watcher. `refresh` is the coarse fallback when the watcher only
+ * knows "something under this workspace changed".
+ */
+export type FileStorageExternalChangeEvent =
+  | {
+      type: 'create' | 'update' | 'delete';
+      wsPath: string;
+    }
+  | {
+      type: 'rename';
+      oldWsPath: string;
+      newWsPath: string;
+    }
+  | {
+      type: 'refresh';
+      wsName: string;
+    };
+
 type EmptyObject = Record<string, never>;
 
 export interface BaseFileStorageProvider {

--- a/packages/shared/types/base-file-storage.ts
+++ b/packages/shared/types/base-file-storage.ts
@@ -37,13 +37,14 @@ export type FileStorageChangeEvent =
  * (a sync tool, another editor, a shell command), detected by a storage
  * provider's watcher. Per-path changes reuse the mutation event shape;
  * `refresh` is the coarse fallback when the watcher only knows "something
- * under this workspace changed".
+ * changed". A workspace name scopes the refresh when known; absent means
+ * app-wide.
  */
 export type FileStorageExternalChangeEvent =
   | FileStorageChangeEvent
   | {
       type: 'refresh';
-      wsName: string;
+      wsName?: string;
     };
 
 type EmptyObject = Record<string, never>;

--- a/packages/shared/types/base-file-storage.ts
+++ b/packages/shared/types/base-file-storage.ts
@@ -41,7 +41,7 @@ export type FileStorageChangeEvent =
  * app-wide.
  */
 export type FileStorageExternalChangeEvent =
-  | FileStorageChangeEvent
+  | Exclude<FileStorageChangeEvent, { type: 'rename' }>
   | {
       type: 'refresh';
       wsName?: string;

--- a/packages/shared/ws-path/src/__tests__/workspace-file-policy.spec.ts
+++ b/packages/shared/ws-path/src/__tests__/workspace-file-policy.spec.ts
@@ -51,14 +51,22 @@ describe('workspace file visibility policy', () => {
   });
 });
 
-describe('transient swap/temp files', () => {
+describe('transient swap files', () => {
   it.each([
     'ws:note.md.crswap',
     'ws:docs/other.MD.CRSWAP',
-    'ws:draft.tmp',
-    'ws:notes/file.swp',
-  ])('hides %s from workspace listings and watchers', (wsPath) => {
+  ])('hides Chromium swap file %s from workspace listings and watchers', (wsPath) => {
     expect(isVisibleWorkspaceFilePath(wsPath)).toBe(false);
+  });
+
+  it.each([
+    'ws:export.tmp',
+    'ws:notes/recovered.swp',
+  ])('keeps possibly-legitimate temp-suffixed user file %s visible', (wsPath) => {
+    // .tmp/.swp can be real pre-existing user files (and the asset
+    // pipeline accepts them); only the native FS watcher suppresses them
+    // as change noise, listings must not hide them.
+    expect(isVisibleWorkspaceFilePath(wsPath)).toBe(true);
   });
 
   it('still shows regular notes and assets', () => {

--- a/packages/shared/ws-path/src/__tests__/workspace-file-policy.spec.ts
+++ b/packages/shared/ws-path/src/__tests__/workspace-file-policy.spec.ts
@@ -50,3 +50,19 @@ describe('workspace file visibility policy', () => {
     expect(isVisibleWorkspaceFilePath('garden:assets/THUMBS.DB')).toBe(false);
   });
 });
+
+describe('transient swap/temp files', () => {
+  it.each([
+    'ws:note.md.crswap',
+    'ws:docs/other.MD.CRSWAP',
+    'ws:draft.tmp',
+    'ws:notes/file.swp',
+  ])('hides %s from workspace listings and watchers', (wsPath) => {
+    expect(isVisibleWorkspaceFilePath(wsPath)).toBe(false);
+  });
+
+  it('still shows regular notes and assets', () => {
+    expect(isVisibleWorkspaceFilePath('ws:note.md')).toBe(true);
+    expect(isVisibleWorkspaceFilePath('ws:image.png')).toBe(true);
+  });
+});

--- a/packages/shared/ws-path/src/__tests__/workspace-file-policy.spec.ts
+++ b/packages/shared/ws-path/src/__tests__/workspace-file-policy.spec.ts
@@ -64,8 +64,8 @@ describe('transient swap files', () => {
     'ws:notes/recovered.swp',
   ])('keeps possibly-legitimate temp-suffixed user file %s visible', (wsPath) => {
     // .tmp/.swp can be real pre-existing user files (and the asset
-    // pipeline accepts them); only the native FS watcher suppresses them
-    // as change noise, listings must not hide them.
+    // pipeline accepts them), so listings and the native FS watcher both
+    // keep them visible; only `.crswap` above is hidden.
     expect(isVisibleWorkspaceFilePath(wsPath)).toBe(true);
   });
 

--- a/packages/shared/ws-path/src/workspace-file-policy.ts
+++ b/packages/shared/ws-path/src/workspace-file-policy.ts
@@ -24,10 +24,8 @@ const IGNORED_FILE_NAMES = new Set(['desktop.ini', 'thumbs.db']);
  * as workspace content.
  *
  * Deliberately narrow: broader temp suffixes like `.tmp`/`.swp` can be
- * legitimate pre-existing user files (and the asset pipeline accepts them),
- * so hiding them here would silently remove them from every listing.
- * Watcher-only noise suppression for such suffixes belongs in the watcher
- * (see `TRANSIENT_WATCH_SUFFIXES` in the native FS storage provider).
+ * legitimate user files (and the asset pipeline accepts them), so hiding or
+ * suppressing their changes would leave visible workspace content stale.
  */
 const IGNORED_FILE_SUFFIXES = ['.crswap'];
 

--- a/packages/shared/ws-path/src/workspace-file-policy.ts
+++ b/packages/shared/ws-path/src/workspace-file-policy.ts
@@ -17,6 +17,14 @@ const IGNORED_DIRECTORY_NAMES = new Set([
 
 const IGNORED_FILE_NAMES = new Set(['desktop.ini', 'thumbs.db']);
 
+/**
+ * Transient files other software writes next to real content: Chromium's
+ * File System Access swap files and common editor temp suffixes. They can
+ * surface through directory listings and file watchers mid-write and must
+ * never be treated as workspace content.
+ */
+const IGNORED_FILE_SUFFIXES = ['.crswap', '.tmp', '.swp'];
+
 function pathSegments(filePath: WsFilePath): readonly string[] {
   return filePath.path.split('/').filter(Boolean);
 }
@@ -50,6 +58,11 @@ export function isVisibleWorkspaceFilePath(
   if (
     parentSegments.some((segment) => isIgnoredWorkspacePathSegment(segment))
   ) {
+    return false;
+  }
+
+  const lowerFileName = fileName.toLowerCase();
+  if (IGNORED_FILE_SUFFIXES.some((suffix) => lowerFileName.endsWith(suffix))) {
     return false;
   }
 

--- a/packages/shared/ws-path/src/workspace-file-policy.ts
+++ b/packages/shared/ws-path/src/workspace-file-policy.ts
@@ -18,12 +18,18 @@ const IGNORED_DIRECTORY_NAMES = new Set([
 const IGNORED_FILE_NAMES = new Set(['desktop.ini', 'thumbs.db']);
 
 /**
- * Transient files other software writes next to real content: Chromium's
- * File System Access swap files and common editor temp suffixes. They can
- * surface through directory listings and file watchers mid-write and must
- * never be treated as workspace content.
+ * Chromium's File System Access API writes `<name>.crswap` swap files next
+ * to real content while a writable stream is open. They can surface through
+ * directory listings and file watchers mid-write and must never be treated
+ * as workspace content.
+ *
+ * Deliberately narrow: broader temp suffixes like `.tmp`/`.swp` can be
+ * legitimate pre-existing user files (and the asset pipeline accepts them),
+ * so hiding them here would silently remove them from every listing.
+ * Watcher-only noise suppression for such suffixes belongs in the watcher
+ * (see `TRANSIENT_WATCH_SUFFIXES` in the native FS storage provider).
  */
-const IGNORED_FILE_SUFFIXES = ['.crswap', '.tmp', '.swp'];
+const IGNORED_FILE_SUFFIXES = ['.crswap'];
 
 function pathSegments(filePath: WsFilePath): readonly string[] {
   return filePath.path.split('/').filter(Boolean);

--- a/packages/shared/ws-path/src/workspace-file-policy.ts
+++ b/packages/shared/ws-path/src/workspace-file-policy.ts
@@ -27,7 +27,7 @@ const IGNORED_FILE_NAMES = new Set(['desktop.ini', 'thumbs.db']);
  * legitimate user files (and the asset pipeline accepts them), so hiding or
  * suppressing their changes would leave visible workspace content stale.
  */
-const IGNORED_FILE_SUFFIXES = ['.crswap'];
+const CHROMIUM_SWAP_FILE_SUFFIX = '.crswap';
 
 function pathSegments(filePath: WsFilePath): readonly string[] {
   return filePath.path.split('/').filter(Boolean);
@@ -65,8 +65,7 @@ export function isVisibleWorkspaceFilePath(
     return false;
   }
 
-  const lowerFileName = fileName.toLowerCase();
-  if (IGNORED_FILE_SUFFIXES.some((suffix) => lowerFileName.endsWith(suffix))) {
+  if (fileName.toLowerCase().endsWith(CHROMIUM_SWAP_FILE_SUFFIX)) {
     return false;
   }
 

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -250,11 +250,8 @@ test('page-return revalidation refreshes external changes when FileSystemObserve
     'external-note.md',
     '# External Note\n\nedited again while away\n',
   );
-  // Page-return notifications collapse a single return's transition burst
-  // within a 1s window; a genuinely separate leave→edit→return cycle must
-  // sit outside it (not a sleep-for-sync — the window is the semantics
-  // under test).
-  await page.waitForTimeout(1_100);
+  // A real departure starts a new return cycle immediately, even when it
+  // follows the prior return by less than the burst-dedupe window.
   await simulateLeaveAndReturn(page);
   await expect(getEditorLocator(page, {})).toContainText(
     'edited again while away',

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -292,13 +292,14 @@ test('a refused external change surfaces a toast whose action loads the disk ver
     })
     .toContain('local wording of the note');
 
-  // Reference-style links do not round-trip through the editor schema, so
-  // the sync refuses to auto-apply them — the user must learn the editor is
-  // now showing older content than disk.
+  // The parser consumes an unresolved link reference definition and emits
+  // nothing, so auto-applying this would arm the next keystroke to delete a
+  // line that is still on disk. The user must learn the editor is now showing
+  // older content than disk.
   await externallyWriteFile(
     page,
     'conflict-note.md',
-    'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+    'see the spec\n\n[unused]: https://example.com/spec\n',
   );
 
   const conflictToast = page.getByText(/conflict-note\.md changed on disk/);
@@ -309,9 +310,51 @@ test('a refused external change surfaces a toast whose action loads the disk ver
   // The offered recovery replaces only this note's content in place — no
   // app reload that could disturb another editor's unsaved work.
   await page.getByRole('button', { name: 'Load disk version' }).click();
-  await expect(editor).toContainText('the spec');
+  await expect(editor).toContainText('see the spec');
   await expect(editor).not.toContainText('local wording of the note');
   await expect(conflictToast).not.toBeVisible();
+});
+
+test('external content that only reformats on save is applied, not refused', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== 'chromium',
+    'NativeFS workspaces are Chromium-only',
+  );
+
+  await createNativeFsWorkspace(page);
+  const observerSupported = await page.evaluate(
+    () =>
+      typeof (globalThis as { FileSystemObserver?: unknown })
+        .FileSystemObserver === 'function',
+  );
+  test.skip(
+    !observerSupported,
+    'FileSystemObserver is unavailable in this Chromium build',
+  );
+
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill('reflow-note');
+  await page.getByRole('button', { name: 'Create' }).click();
+  const editor = getEditorLocator(page, {});
+  await expect(editor).toBeVisible();
+
+  // Hand-wrapped list items are extremely common in real Markdown. They never
+  // round-trip byte-for-byte, but parsing keeps every word, so the editor must
+  // follow disk instead of going stale behind a conflict notice.
+  await externallyWriteFile(
+    page,
+    'reflow-note.md',
+    '- Standup notes:\n  https://example.com/standup\n- second item\n',
+  );
+
+  await expect(editor).toContainText('Standup notes');
+  await expect(editor).toContainText('second item');
+  await expect(
+    page.getByText(/reflow-note\.md changed on disk/),
+  ).not.toBeVisible();
 });
 
 test('an externally deleted note stays mounted while its local save is failed', async ({

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -54,6 +54,49 @@ async function externallyWriteFile(
   );
 }
 
+async function externallyDeleteFile(page: Page, relativePath: string) {
+  await page.evaluate(
+    async ({ workspaceDir, relativePath }) => {
+      const root = await navigator.storage.getDirectory();
+      let dir = await root.getDirectoryHandle(workspaceDir);
+      const segments = relativePath.split('/');
+      for (const segment of segments.slice(0, -1)) {
+        dir = await dir.getDirectoryHandle(segment);
+      }
+      const fileName = segments.at(-1);
+      if (!fileName) {
+        throw new Error(`Invalid path: ${relativePath}`);
+      }
+      await dir.removeEntry(fileName);
+    },
+    { workspaceDir: WORKSPACE_DIR, relativePath },
+  );
+}
+
+async function rejectAppWritesToFile(page: Page, fileName: string) {
+  await page.evaluate(
+    async ({ workspaceDir, fileName }) => {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle(workspaceDir);
+      const handle = await dir.getFileHandle(fileName);
+      const prototype = Object.getPrototypeOf(handle) as {
+        createWritable: FileSystemFileHandle['createWritable'];
+      };
+      const originalCreateWritable = prototype.createWritable;
+      prototype.createWritable = async function createWritable(
+        this: FileSystemFileHandle,
+        options?: FileSystemCreateWritableOptions,
+      ) {
+        if (this.name === fileName) {
+          throw new DOMException('Forced save failure', 'NotAllowedError');
+        }
+        return originalCreateWritable.call(this, options);
+      };
+    },
+    { workspaceDir: WORKSPACE_DIR, fileName },
+  );
+}
+
 async function createNativeFsWorkspace(page: Page) {
   await page.goto('/');
   if (await page.getByRole('dialog').isVisible()) {
@@ -218,7 +261,7 @@ test('page-return revalidation refreshes external changes when FileSystemObserve
   );
 });
 
-test('a refused external change surfaces a toast whose Reload action loads the disk version', async ({
+test('a refused external change surfaces a toast whose action loads the disk version in place', async ({
   page,
   browserName,
 }) => {
@@ -266,8 +309,54 @@ test('a refused external change surfaces a toast whose Reload action loads the d
   // The editor deliberately kept the current version.
   await expect(editor).toContainText('local wording of the note');
 
-  // The offered recovery reloads the app; the note then goes through the
-  // load path, which shows the disk content.
-  await page.getByRole('button', { name: 'Reload' }).click();
-  await expect(getEditorLocator(page, {})).toContainText('the spec');
+  // The offered recovery replaces only this note's content in place — no
+  // app reload that could disturb another editor's unsaved work.
+  await page.getByRole('button', { name: 'Load disk version' }).click();
+  await expect(editor).toContainText('the spec');
+  await expect(editor).not.toContainText('local wording of the note');
+  await expect(conflictToast).not.toBeVisible();
+});
+
+test('an externally deleted note stays mounted while its local save is failed', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== 'chromium',
+    'NativeFS workspaces are Chromium-only',
+  );
+
+  await createNativeFsWorkspace(page);
+  const observerSupported = await page.evaluate(
+    () =>
+      typeof (globalThis as { FileSystemObserver?: unknown })
+        .FileSystemObserver === 'function',
+  );
+  test.skip(
+    !observerSupported,
+    'FileSystemObserver is unavailable in this Chromium build',
+  );
+
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill('dirty-note');
+  await page.getByRole('button', { name: 'Create' }).click();
+  const editor = getEditorLocator(page, {});
+  await expect(editor).toBeVisible();
+
+  await rejectAppWritesToFile(page, 'dirty-note.md');
+  await editor.click();
+  await page.keyboard.type('local content that has not been saved');
+  await expect(page.getByText(/Changes could not be saved/)).toBeVisible();
+
+  await externallyDeleteFile(page, 'dirty-note.md');
+  await expect(
+    page
+      .getByTestId('bangle-file-explorer')
+      .getByRole('treeitem', { name: /dirty-note/ }),
+  ).not.toBeVisible();
+
+  // The route is now missing from the file tree, but the failed editor is
+  // still the only recoverable copy and must remain available to the user.
+  await expect(editor).toBeVisible();
+  await expect(editor).toContainText('local content that has not been saved');
 });

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -92,9 +92,27 @@ async function rejectAppWritesToFile(page: Page, fileName: string) {
         }
         return originalCreateWritable.call(this, options);
       };
+      (
+        window as Window & { __restoreAppWrites?: () => void }
+      ).__restoreAppWrites = () => {
+        prototype.createWritable = originalCreateWritable;
+      };
     },
     { workspaceDir: WORKSPACE_DIR, fileName },
   );
+}
+
+/**
+ * Undoes {@link rejectAppWritesToFile}. A save that already failed stays
+ * failed until the user retries it, so the editor remains dirty afterwards —
+ * this only reopens the disk for the test's own external writes.
+ */
+async function restoreAppWrites(page: Page) {
+  await page.evaluate(() => {
+    (
+      window as Window & { __restoreAppWrites?: () => void }
+    ).__restoreAppWrites?.();
+  });
 }
 
 async function createNativeFsWorkspace(page: Page) {
@@ -355,6 +373,79 @@ test('external content that only reformats on save is applied, not refused', asy
   await expect(
     page.getByText(/reflow-note\.md changed on disk/),
   ).not.toBeVisible();
+});
+
+test('an external write never clobbers unsaved local edits in the open editor', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== 'chromium',
+    'NativeFS workspaces are Chromium-only',
+  );
+
+  await createNativeFsWorkspace(page);
+  const observerSupported = await page.evaluate(
+    () =>
+      typeof (globalThis as { FileSystemObserver?: unknown })
+        .FileSystemObserver === 'function',
+  );
+  test.skip(
+    !observerSupported,
+    'FileSystemObserver is unavailable in this Chromium build',
+  );
+
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill('conflict-dirty');
+  await page.getByRole('button', { name: 'Create' }).click();
+  const editor = getEditorLocator(page, {});
+  await expect(editor).toBeVisible();
+
+  // Break saves first so the local edit stays pending: the editor then holds
+  // the only copy of the user's wording when the external write arrives.
+  await rejectAppWritesToFile(page, 'conflict-dirty.md');
+  await editor.click();
+  await page.keyboard.type('local wording that exists nowhere else');
+  await expect(page.getByText(/Changes could not be saved/)).toBeVisible();
+  // The failed save keeps the editor dirty until the user retries; restoring
+  // writes only reopens the disk for the sync tool simulated below.
+  await restoreAppWrites(page);
+
+  // A sync tool overwrites the dirty note, then creates a sentinel file. The
+  // sentinel's appearance in the tree proves the watcher pipeline processed
+  // the burst, so "the editor did not change" below is a real refusal rather
+  // than the sync simply not having run yet.
+  await externallyWriteFile(
+    page,
+    'conflict-dirty.md',
+    '# External\n\noverwritten by the sync tool\n',
+  );
+  await externallyWriteFile(page, 'sentinel.md', 'marker\n');
+  await expect(
+    page
+      .getByTestId('bangle-file-explorer')
+      .getByRole('treeitem', { name: /sentinel/ }),
+  ).toBeVisible();
+
+  // Unsaved edits always win over the external copy...
+  await expect(editor).toContainText('local wording that exists nowhere else');
+  await expect(editor).not.toContainText('overwritten by the sync tool');
+  // ...and refusing must not auto-save the editor over disk either: the
+  // sync tool's copy survives until the user resolves the conflict.
+  await expect
+    .poll(async () => {
+      return page.evaluate(
+        async ({ workspaceDir }) => {
+          const root = await navigator.storage.getDirectory();
+          const dir = await root.getDirectoryHandle(workspaceDir);
+          const handle = await dir.getFileHandle('conflict-dirty.md');
+          const file = await handle.getFile();
+          return file.text();
+        },
+        { workspaceDir: WORKSPACE_DIR },
+      );
+    })
+    .toContain('overwritten by the sync tool');
 });
 
 test('an externally deleted note stays mounted while its local save is failed', async ({

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -74,6 +74,28 @@ async function createNativeFsWorkspace(page: Page) {
   ).toBeVisible();
 }
 
+/**
+ * Simulates the user leaving the tab and coming back: the page-lifecycle
+ * stream sees hidden → visible, which the app treats as a page return and
+ * uses to revalidate Native FS workspaces.
+ */
+async function simulateLeaveAndReturn(page: Page) {
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
 test('externally created and edited files refresh the tree and the open note', async ({
   page,
   browserName,
@@ -134,4 +156,118 @@ test('externally created and edited files refresh the tree and the open note', a
   // The refresh pipeline must not have clobbered the other note.
   await explorer.getByRole('treeitem', { name: /local-note/ }).click();
   await expect(getEditorLocator(page, {})).toBeVisible();
+});
+
+test('page-return revalidation refreshes external changes when FileSystemObserver is unavailable', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== 'chromium',
+    'NativeFS workspaces are Chromium-only',
+  );
+
+  // Remove the observer API before the app boots: this is the fallback
+  // world (non-Chromium engines, older Chrome) where returning to the page
+  // is the ONLY reconciliation with external edits.
+  await page.addInitScript(() => {
+    delete (globalThis as { FileSystemObserver?: unknown }).FileSystemObserver;
+  });
+
+  await createNativeFsWorkspace(page);
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill('watched-note');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(getEditorLocator(page, {})).toBeVisible();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+
+  // With no observer, an external creation does NOT appear on its own...
+  await externallyWriteFile(
+    page,
+    'external-note.md',
+    '# External Note\n\nwritten while the user was away\n',
+  );
+
+  // ...but coming back to the tab revalidates the workspace: the tree picks
+  // up the new file.
+  await simulateLeaveAndReturn(page);
+  await expect(
+    explorer.getByRole('treeitem', { name: /external-note/ }),
+  ).toBeVisible();
+
+  // Same for an open, unmodified note: edit it externally while away, and
+  // the return refreshes its content.
+  await explorer.getByRole('treeitem', { name: /external-note/ }).click();
+  await expect(getEditorLocator(page, {})).toContainText(
+    'written while the user was away',
+  );
+  await externallyWriteFile(
+    page,
+    'external-note.md',
+    '# External Note\n\nedited again while away\n',
+  );
+  // Page-return notifications collapse a single return's transition burst
+  // within a 1s window; a genuinely separate leave→edit→return cycle must
+  // sit outside it (not a sleep-for-sync — the window is the semantics
+  // under test).
+  await page.waitForTimeout(1_100);
+  await simulateLeaveAndReturn(page);
+  await expect(getEditorLocator(page, {})).toContainText(
+    'edited again while away',
+  );
+});
+
+test('a refused external change surfaces a toast whose Reload action loads the disk version', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== 'chromium',
+    'NativeFS workspaces are Chromium-only',
+  );
+
+  await createNativeFsWorkspace(page);
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill('conflict-note');
+  await page.getByRole('button', { name: 'Create' }).click();
+  const editor = getEditorLocator(page, {});
+  await expect(editor).toBeVisible();
+  await editor.click();
+  await page.keyboard.type('local wording of the note');
+  // Wait until the edit is durably saved so the external write below is a
+  // clean conflict, not a dirty-guard skip.
+  await expect
+    .poll(async () => {
+      return page.evaluate(
+        async ({ workspaceDir }) => {
+          const root = await navigator.storage.getDirectory();
+          const dir = await root.getDirectoryHandle(workspaceDir);
+          const handle = await dir.getFileHandle('conflict-note.md');
+          const file = await handle.getFile();
+          return file.text();
+        },
+        { workspaceDir: WORKSPACE_DIR },
+      );
+    })
+    .toContain('local wording of the note');
+
+  // Reference-style links do not round-trip through the editor schema, so
+  // the sync refuses to auto-apply them — the user must learn the editor is
+  // now showing older content than disk.
+  await externallyWriteFile(
+    page,
+    'conflict-note.md',
+    'see [the spec][1]\n\n[1]: https://example.com/spec\n',
+  );
+
+  const conflictToast = page.getByText(/conflict-note\.md changed on disk/);
+  await expect(conflictToast).toBeVisible();
+  // The editor deliberately kept the current version.
+  await expect(editor).toContainText('local wording of the note');
+
+  // The offered recovery reloads the app; the note then goes through the
+  // load path, which shows the disk content.
+  await page.getByRole('button', { name: 'Reload' }).click();
+  await expect(getEditorLocator(page, {})).toContainText('the spec');
 });

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -1,0 +1,137 @@
+import { expect, type Page, test } from '@playwright/test';
+import { getEditorLocator } from './common';
+
+/**
+ * Exercises the NativeFS external-change refresh pipeline end to end:
+ * FileSystemObserver → storage watcher → typed file events → file tree and
+ * open-editor refresh.
+ *
+ * The directory picker is stubbed to return an OPFS-backed directory, which
+ * behaves like a picked local directory (granted permissions, observer
+ * support) but works headless. "External" edits are writes made directly
+ * through OPFS handles, bypassing the app's storage layer exactly like a sync
+ * tool writing to disk would.
+ */
+
+const WORKSPACE_DIR = 'sync-notes';
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((workspaceDir) => {
+    (
+      window as Window & {
+        showDirectoryPicker?: () => Promise<FileSystemDirectoryHandle>;
+      }
+    ).showDirectoryPicker = async () => {
+      const root = await navigator.storage.getDirectory();
+      return root.getDirectoryHandle(workspaceDir, { create: true });
+    };
+  }, WORKSPACE_DIR);
+});
+
+async function externallyWriteFile(
+  page: Page,
+  relativePath: string,
+  content: string,
+) {
+  await page.evaluate(
+    async ({ workspaceDir, relativePath, content }) => {
+      const root = await navigator.storage.getDirectory();
+      let dir = await root.getDirectoryHandle(workspaceDir, { create: true });
+      const segments = relativePath.split('/');
+      for (const segment of segments.slice(0, -1)) {
+        dir = await dir.getDirectoryHandle(segment, { create: true });
+      }
+      const fileName = segments[segments.length - 1];
+      if (!fileName) {
+        throw new Error(`Invalid path: ${relativePath}`);
+      }
+      const fileHandle = await dir.getFileHandle(fileName, { create: true });
+      const writable = await fileHandle.createWritable();
+      await writable.write(content);
+      await writable.close();
+    },
+    { workspaceDir: WORKSPACE_DIR, relativePath, content },
+  );
+}
+
+async function createNativeFsWorkspace(page: Page) {
+  await page.goto('/');
+  if (await page.getByRole('dialog').isVisible()) {
+    await page.keyboard.press('Escape');
+  }
+  await page.getByRole('button', { name: 'Create Workspace' }).click();
+  await page
+    .getByRole('radio', {
+      name: 'Native File System Save workspace data in native file system',
+    })
+    .click();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await page.getByRole('button', { name: 'Pick Directory' }).click();
+  await expect(page.getByText(WORKSPACE_DIR)).toBeVisible();
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(
+    page.getByRole('heading', { name: WORKSPACE_DIR }),
+  ).toBeVisible();
+}
+
+test('externally created and edited files refresh the tree and the open note', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== 'chromium',
+    'NativeFS workspaces are Chromium-only',
+  );
+
+  await createNativeFsWorkspace(page);
+
+  const observerSupported = await page.evaluate(
+    () =>
+      typeof (globalThis as { FileSystemObserver?: unknown })
+        .FileSystemObserver === 'function',
+  );
+  test.skip(
+    !observerSupported,
+    'FileSystemObserver is unavailable in this Chromium build',
+  );
+
+  // Sanity: the normal app flow works against the OPFS-backed directory.
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill('local-note');
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(getEditorLocator(page, {})).toBeVisible();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+
+  // A file created outside the app appears in the file tree without any
+  // manual reload.
+  await externallyWriteFile(
+    page,
+    'external-note.md',
+    '# External Note\n\nsynced from another device\n',
+  );
+  await expect(
+    explorer.getByRole('treeitem', { name: /external-note/ }),
+  ).toBeVisible();
+
+  // Open the externally created note...
+  await explorer.getByRole('treeitem', { name: /external-note/ }).click();
+  await expect(getEditorLocator(page, {})).toContainText(
+    'synced from another device',
+  );
+
+  // ...and edit it externally again: the open, unmodified editor refreshes
+  // to the new disk content instead of showing a stale note.
+  await externallyWriteFile(
+    page,
+    'external-note.md',
+    '# External Note\n\nupdated by the sync tool\n',
+  );
+  await expect(getEditorLocator(page, {})).toContainText(
+    'updated by the sync tool',
+  );
+
+  // The refresh pipeline must not have clobbered the other note.
+  await explorer.getByRole('treeitem', { name: /local-note/ }).click();
+  await expect(getEditorLocator(page, {})).toBeVisible();
+});

--- a/plans/004-vite-plus-migration.md
+++ b/plans/004-vite-plus-migration.md
@@ -4,7 +4,7 @@ status: planned
 type: plan
 archived: false
 created: 2026-06-14
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs: []
 related_issues: []
@@ -32,19 +32,6 @@ de-risk versus the alpha this plan was written against — but still pre-1.0.
 The Known Risks below stand, in particular Oxlint/Oxfmt-versus-Biome rule
 parity, which decides whether this is a net win. Re-evaluate at 1.0; no
 forcing function today.
-
-- [ ] Create a dedicated migration branch.
-- [ ] Capture baseline results for the current toolchain.
-- [ ] Install and inspect `vp` locally.
-- [ ] Run `vp migrate --no-interactive` from the repository root.
-- [ ] Review and normalize generated changes against Bangle workspace rules.
-- [ ] Consolidate tool config into root `vite.config.ts`.
-- [ ] Replace old package scripts with the Vite+ command surface.
-- [ ] Migrate Vitest imports to `vite-plus/test`.
-- [ ] Remove obsolete direct tooling dependencies and configs.
-- [ ] Update CI to use `voidzero-dev/setup-vp`.
-- [ ] Update developer and deployment docs.
-- [ ] Complete local and CI verification.
 
 ## Scope
 
@@ -83,113 +70,6 @@ Keep unless a Vite+ replacement is proven stable:
 - Bangle custom maintenance scripts that validate workspace rules beyond
   generic lint/format/type checks.
 
-## Migration Plan
-
-### Phase 0: Baseline
-
-- Create a branch such as `chore/adopt-vite-plus`.
-- Record current dirty state before tool-generated edits.
-- Run:
-  - `pnpm install`
-  - `pnpm run typecheck`
-  - `pnpm run lint:ci`
-  - `pnpm build`
-  - `pnpm run test:ci`
-  - `pnpm run e2e:ci`
-- Record any pre-existing failures, warnings, or local-only console noise.
-
-### Phase 1: Official Migration
-
-- Install `vp` for the local environment.
-- Run:
-  - `vp help`
-  - `vp help migrate`
-  - `vp help check`
-  - `vp help run`
-  - `vp help build`
-- Run `vp migrate --no-interactive` from the repository root.
-- Review all generated changes manually before continuing.
-- Keep the migration constrained to tooling; do not mix in app feature work.
-
-### Phase 2: Root Config Consolidation
-
-- Add or convert root `vite.config.ts` to import `defineConfig` from
-  `vite-plus`.
-- Move the root Vitest config into the Vite+ `test` block.
-- Move Biome formatting intent into the Vite+ `fmt` block.
-- Move Biome linting intent into the Vite+ `lint` block with package/test/story
-  overrides.
-- Add Vite Task entries under `run` for repo-specific commands that remain
-  outside built-in Vite+ commands.
-- Preserve workspace hierarchy rules and package import conventions.
-
-### Phase 3: Browser Entry
-
-- Convert `packages/tooling/browser-entry/vite.config.ts` to use Vite+
-  `defineConfig`.
-- Keep app-specific Vite plugins for React, Tailwind, Sentry, and HTML/env
-  injection as needed.
-- Replace `vite-plugin-html` with a local transform only if behavior is
-  equivalent for translation, theme, and env-var injection.
-- Remove unsafe serializer typing while touching the config.
-- Replace browser-entry scripts with `vp dev`, `vp build`, and `vp preview`.
-
-### Phase 4: Tests
-
-- Rewrite imports from `vitest` to `vite-plus/test`.
-- Rewrite `@vitest/browser` references to Vite+ browser test paths where
-  applicable.
-- Update `vitest-global-setup.js`.
-- Delete root `vitest.config.ts` after parity is verified.
-- Make `vp test` the canonical unit test command.
-
-### Phase 5: Scripts And Dependencies
-
-- Replace root scripts with Vite+ commands.
-- Remove direct Biome usage after Vite+ lint/format parity is acceptable.
-- Keep custom validation scripts only for Bangle-specific workspace checks.
-- Remove obsolete dependencies after imports and scripts are migrated.
-- Run `vp install` to refresh the lockfile.
-- Audit the lockfile for stale direct references to removed tools.
-
-### Phase 6: CI And Docs
-
-- Replace GitHub Actions Node/pnpm/Biome setup with `voidzero-dev/setup-vp`.
-- Use:
-  - `vp install`
-  - `vp check`
-  - `vp test`
-  - `vp build`
-  - `vp run e2e:ci`
-- Keep Playwright browser install/cache behavior as needed.
-- Update `AGENTS.md`, deployment notes, and any contributor docs to use Vite+
-  commands.
-- Update plop/test templates that import from `vitest`.
-
-## Verification
-
-Run after the migration:
-
-- [ ] `vp install`
-- [ ] `vp check`
-- [ ] `vp test`
-- [ ] `vp build`
-- [ ] `vp run e2e:ci`
-- [ ] `pnpm audit --audit-level low` or Vite+ equivalent if available.
-
-Run browser smoke against a local production preview:
-
-- [ ] Start preview with Vite+.
-- [ ] Verify page title is `Bangle App`.
-- [ ] Verify welcome screen renders `Create Workspace`.
-- [ ] Create a Browser workspace.
-- [ ] Create a note.
-- [ ] Type editor content.
-- [ ] Reload and confirm workspace, note, and content persist.
-- [ ] Open search or command UI and confirm it is usable.
-- [ ] Record console errors and separate known local-only Sentry noise from app
-  regressions.
-
 ## Known Risks
 
 - Vite+ is still early tooling, so Oxlint/Oxfmt behavior may not fully match
@@ -201,8 +81,6 @@ Run browser smoke against a local production preview:
 - Vite+ migration may upgrade the Vite major line, which can interact with the
   existing Playwright CT Vite override documented in
   `plans/archived/003-upgrade-wrap-up.md`.
-- The repo already has local uncommitted toolchain changes, so generated edits
-  must be reviewed carefully before cleanup.
 
 ## Out of Scope
 
@@ -211,11 +89,3 @@ Run browser smoke against a local production preview:
 - Production deploy unless explicitly requested after local and CI validation.
 - Replacing Playwright or Storybook unless Vite+ ships a stable direct
   replacement.
-
-## Next Steps
-
-- Review the archived Playwright CT Vite override note in
-  `plans/archived/003-upgrade-wrap-up.md`.
-- Run the Phase 0 baseline and record results in this plan.
-- Install `vp`, run the official migration, and review the diff before making
-  manual cleanup changes.

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-15
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
@@ -66,172 +66,41 @@ workflows, recovery gaps, and the open package-boundary items below.
   error instead of leaving the mount promise silently pending. Failed load
   status and a same-node retry API are now exposed. Parse-failure isolation and
   the user-facing recovery view remain.
-- 2026-07-07 re-audit and cleanup pass:
-  - P0.3 verified complete on main: ws command handlers await storage
-    mutations before navigating, keep routes stable on failure, and
-    `ws-command-handlers.spec.ts` covers the ordering.
-  - P0.4 safe ordering landed: baby-fs rename now verifies the destination
-    bytes before deleting the source and throws
-    `RENAME_VERIFICATION_FAILED_ERROR` with cause; failure-point tests cover
-    both backends. Journaled pending-move records and startup recovery remain
-    follow-up.
-  - P0.5 done for file-tree listing: `WorkspaceStateService` preserves the last
-    known file tree on same-workspace list failures, exposes
-    `$fileTreeListState`, and the sidebar shows a retry notice backed by
-    `command::ws:refresh-file-tree`. This does not cover `$workspaces` metadata
-    refresh failures; that remains C1 in the 2026-07-12 matrix.
-  - P1.1 partially superseded: the shared golden corpus
-    (`test-utils/markdown-corpus.ts`) plus a load-time round-trip fidelity
-    gate in `PmEditorService` (warns when a note cannot round-trip; opening
-    never writes back) landed. Per-construct parity decisions live in plan
-    012.
-  - P2.1 and P2.2 verified already resolved on main: `@bangle.io/types` no
-    longer imports core services and no package-private `src` imports remain.
-  - P2.3 improved mechanically: storage services now reach
-    `FileSystemService` via a config thunk resolved inside `instantiate()` and
-    asserted before use. The 2026-07-12 re-audit reopens the Native FS half as
-    A3 because its platform root-handle provider still calls upward into
-    `WorkspaceOpsService` through a late-bound closure.
-  - P3.1 verified already resolved: no duplicate component trees remain.
-  - P3.2 done for render paths: remaining render-time `resolveAtoms()` reads
-    replaced with `useAtomValue` subscriptions.
-  - P3.5 done for app-level decomposition: sidebar file-tree actions moved to
-    `useSidebarFileActions`, the footer menu moved to `SidebarFooterMenu`, and
-    core `AppSidebar` is a thin composition layer. Moving the one-caller,
-    Bangle-specific 582-line UI composition out of `ui-components` remains A6.
-  - P4.1 done: GitHub Actions runs `pnpm run build`.
-  - P4.5 partially done: `noFloatingPromises` is now a Biome error repo-wide;
-    `noExplicitAny` (163 sites) and `noUnusedVariables` remain warnings.
-- 2026-07-12 high-ROI cleanup batch:
-  - A10 done: production editor setup no longer enables global debug mode,
-    installs the schema/editor view on `window`, or ships the console-only
-    document inspection helpers. E2E assertions now observe DOM selection and
-    navigation rather than the private editor global.
-  - P4.2 done: the external Playwright sample was deleted, E2E and component
-    reports/results use separate package-local directories, and CI uploads
-    those actual artifact paths.
-  - A4 improved: `WorkbenchStateService` no longer declares or receives its
-    unused database dependency.
-  - P3.3 improved: `StarButton` now follows the application convention of using
-    the global `t` object instead of importing translations directly. The
-    broader literal-string sweep remains open.
-- 2026-07-12 obsolete service API cleanup (PR #636):
-  - A4 improved: removed the zero-consumer command object-to-key cache/getter,
-    core navigation `fromUri` pass-through, workspace misc-data methods, and
-    their unreachable app-error variant. The generic database misc table stays
-    intact so this cleanup does not alter persisted storage schemas.
-- 2026-07-12 workspace dialog correctness and accessibility cleanup:
-  - C5 done: workspace creation now awaits the durable callback, blocks repeat
-    submission and dismissal while pending, keeps the dialog open on failure,
-    and restores an in-dialog retry path. Component coverage proves a
-    double-click starts one attempt, while app E2E covers a real duplicate
-    workspace rejection.
-  - P3.4 improved: the sidebar search affordance is now a semantic button with
-    native Enter/Space behavior instead of a `div role="button"` wrapped around
-    a read-only input. App E2E exercises the Space-key path.
-- 2026-07-12 IndexedDB error and type hygiene cleanup:
-  - P5.3 done: the remaining IndexedDB adapter now retains the original
-    rejection as `Error.cause` for both generic upstream errors and translated
-    constraint failures. The replacement Native FS library already preserves
-    causes when it normalizes browser errors; the legacy Native Browser FS
-    evidence was removed with that adapter.
-  - P5.1 improved: foundational `BaseError` stack capture no longer relies on
-    `any` or the obsolete `__proto__` fallback, and the touched IndexedDB slice
-    no longer carries an unsafe array guard, a parameter-assignment lint
-    suppression, or dead untyped test helpers.
-- 2026-07-13 workspace refresh continuity cleanup:
-  - C1 done: `WorkspaceStateService` now exposes an explicit
-    `$workspaceListState` resource with `loading`, `ready`, and `error` states.
-    Every state carries the last successful workspace data, so a failed
-    metadata refresh no longer hides the active workspace or clears
-    workspace-driven UI.
-  - Focused real-service coverage forces a database failure after a successful
-    load, verifies the prior array and current workspace remain available, and
-    proves a later refresh returns the resource to `ready`.
-- 2026-07-13 cross-context lifecycle and type-hygiene cleanup:
-  - P5.4 done: `TypedBroadcastBus` now closes immediately for an already-aborted
-    owner, ignores already-aborted subscriptions, and makes sends after disposal
-    a consistent no-op across native and memory channels.
-  - The in-memory channel now structured-clones a payload independently for
-    each recipient, matching the isolation of the browser channel instead of
-    sharing mutable references between services and tests. Its public type now
-    describes the small channel contract it actually implements rather than
-    carrying throwing `BroadcastChannel` stubs.
-  - P5.1 improved: `Logger` now accepts the four-method console surface it uses,
-    and its message boundary uses `unknown[]` instead of five `any[]`
-    signatures. Browser-bus tests no longer need an unsafe logger cast.
-- 2026-07-13 foundational utility type and lifecycle cleanup (PR #646):
-  - P5.1 improved: mini validators now accept `unknown` at their public
-    boundary, weak caches require object keys, and command validator inspection
-    uses `Validator<unknown>`.
-  - P5.4 improved: generic emitter subscriptions now ignore already-aborted
-    signals, detach their abort listeners during cleanup, and make destruction
-    idempotent. The two-key weak cache now retains cached `undefined` results
-    instead of recomputing them.
-  - P4.5 re-audit: a package-wide `noExplicitAny` ratchet was trialled but not
-    kept because removing type-level wildcards from the generic emitter
-    required conditional types and a double assertion without rejecting more
-    invalid caller behavior. The stale browser-entry `eslint` script and the
-    original command-dialog/radio-control accessibility findings were verified
-    already resolved on `main` and are reconciled below.
-- 2026-07-14 storage-contract and translation hygiene cleanup (batch 3, PR
-  #647):
-  - P3.3 done: every Omni Search heading, action, empty state, placeholder, and
-    accessible dialog title now uses the global translation object. English
-    and German carry the complete eight-message surface, and locale E2E opens
-    the German command bar and verifies translated user-visible behavior.
-  - P5.1 improved: `BaseFileStorageProvider` no longer advertises six
-    zero-consumer metadata, capability, and search members. The three concrete
-    storage providers no longer carry the corresponding dead labels or
-    support-probe methods. The follow-up removes the unused `sha` create/write
-    option path and narrows provider workspace types to the existing typed
-    storage union.
-  - P4.2 improved: the shared create-workspace/note E2E helper now waits for
-    the exact new editor identity instead of any visible editor, preventing
-    follow-up typing and shortcuts from racing a stale view. The date picker
-    also makes its initial single-day selection required so selecting today
-    commits instead of toggling to an empty selection in UTC CI.
-  - The full open-item re-audit kept C3/C4, P0.4, and Native FS work out of this
-  batch because PR #640 owns relocation/save-queue changes, PR #644 owns the
-    Native FS settings command, PR #626 owns external sync, and the existing
-    service-architecture and Knip worktrees cover broader boundary/dead-code
-    changes. C6, C8, P1.3, P4.4, and P5.2 are narrowed below to match current
-    code instead of retaining stale claims.
-- 2026-07-15 relocation safety cleanup (PR #640):
-  - P0.4 substantially complete for ordinary file and directory relocation:
-    pending source saves drain before the durable mutation, queued and mounted
-    writes retarget afterward, IndexedDB rename/update paths are atomic, active
-    routes follow durable rename events, and starred paths migrate in one
-    lifecycle. Unit, race, command-handler, and Playwright coverage includes
-    reload persistence. Cross-workspace moves, empty-folder persistence,
-    journaled startup recovery, and link rewriting remain outside this slice.
-  - The matching project task for preserving stars across rename/move is now
-    complete. Issue #563 remains open because its cross-workspace move UX is
-    explicitly outside PR #640.
-- 2026-07-18 editor save-coordinator lifetime cleanup (PR #649):
-  - C4 resolved: the browser composition root now owns an explicit
-    `EditorSaveCoordinator` and injects it into every replacement UI service
-    graph. Queued and failed tasks retain document state only; execution and
-    error reporting resolve through the newest graph's writer and error
-    boundary instead of callbacks captured from a disposed service.
-  - Focused queue coverage retries a retained failure through the old graph's
-    facade and proves the current graph performs the write. Browser E2E forces
-    a save failure, emits the real `event::app:reload-ui`, retries through the
-    disposed graph, and verifies the edit is durable after a full page reload.
-- 2026-07-19 list-fidelity cleanup (PR #658):
-  - The merged implementation preserves tight/loose list semantics, ordered
-    task-list container kind, and structural nested-list indentation across
-    both editor engines.
-  - P1.3 is complete. Shared corpus, command, codec, DOM, persistence, and
-    reload coverage protect the cross-engine behavior.
-- 2026-07-21 broad cleanup continuation (PR #667, open):
-  - The review-ready sweep removes dead code and obsolete tooling, consolidates
-    repeated editor/router/service/script behavior behind existing owners, and
-    hardens Native FS rename, sync-value, malformed-state, and mobile-origin
-    boundaries.
-  - The plan remains active after this sweep because the command-completion,
-    asset-recovery, package-boundary, and workspace-index items below are still
-    separate follow-ups.
+- Landed-batch history (full detail lives in the per-item records below and
+  the 2026-07-12 matrix):
+  - 2026-07-07: re-audit and cleanup pass — verified P0.3/P2.1/P2.2/P3.1
+    resolved on main; landed P0.4 rename destination verification, P0.5
+    file-tree retention, the P1.1 golden corpus and load-time round-trip
+    gate, P2.3 config-thunk wiring, P3.2 render subscriptions, P3.5 sidebar
+    decomposition, P4.1 CI build, and the P4.5 `noFloatingPromises` error.
+  - 2026-07-12: high-ROI batch — A10 production debug surface removed, P4.2
+    Playwright hygiene, A4 unused database dependency dropped, P3.3
+    StarButton translation.
+  - 2026-07-12 (PR #636): zero-consumer service APIs removed (A4).
+  - 2026-07-12: C5 durable workspace-creation dialog and P3.4 sidebar search
+    accessibility.
+  - 2026-07-12: P5.3 IndexedDB error causes and a P5.1 type-hygiene slice.
+  - 2026-07-13: C1 `$workspaceListState` refresh continuity with real-service
+    failure/recovery coverage.
+  - 2026-07-13: P5.4 broadcast-bus lifetimes and payload isolation plus P5.1
+    logger typing.
+  - 2026-07-13 (PR #646): foundational validator/cache/emitter typing and
+    lifecycle (P5.1, P5.4) plus the P4.5 ratchet re-audit.
+  - 2026-07-14 (PR #647): storage-contract and translation hygiene — P3.3
+    completed, P5.1 provider-surface pruning, P4.2 E2E helper waits; the
+    batch deferred to PR #640 (relocation), PR #644 (Native FS settings
+    command), and PR #626 (external sync) ownership.
+  - 2026-07-15 (PR #640): P0.4 relocation-safety slice for ordinary file and
+    directory rename/move, with reload coverage and star migration.
+  - 2026-07-18 (PR #649): C4 browser-root `EditorSaveCoordinator` owning save
+    continuity across UI service-graph replacement.
+  - 2026-07-19 (PR #658): P1.3 list fidelity across both editor engines.
+  - 2026-07-21 (PR #667, merged 2026-07-22): broad sweep removing dead code
+    and obsolete tooling, consolidating repeated editor/router/service/script
+    behavior behind existing owners, and hardening Native FS rename,
+    sync-value, malformed-state, and mobile-origin boundaries. The
+    command-completion, asset-recovery, package-boundary, and workspace-index
+    items below remain separate follow-ups.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -254,49 +123,17 @@ workflows, recovery gaps, and the open package-boundary items below.
 
 ### P0.1 Add Reliable Editor Save Pipeline
 
-Problem:
-
-- Editor writes are started from `PmEditorService` without awaiting, catching,
-  retrying, or surfacing errors.
-- `createEditor` serializes Markdown on every document change, so rapid edits
-  can start overlapping storage writes.
-- A slower earlier write can finish after a newer write and overwrite the latest
-  content.
-
-Evidence:
-
-- `packages/core/editor/src/pm-editor-service.ts`
-- `packages/core/editor/src/pm-setup.ts`
-
-Plan:
-
-- [x] Introduce a per-`wsPath` save queue owned by editor or service-core.
-- [x] Debounce or coalesce rapid document changes before writing.
-- Track monotonically increasing save revisions and ignore stale completions.
-- [x] Surface save states: clean, pending, failed.
-- [x] Retain the latest failed save body for explicit retry.
-- Surface retrying save state if/when automatic retry is added.
-- [x] Route failures through the app error system and keep a persistent unsaved
-  state until the write succeeds or the user chooses a recovery action.
-- [x] Expose a service API that navigation/reload protection can query for
-  pending or failed writes.
-- [x] Add navigation/reload protection UI wiring when a note has pending or
-  failed writes.
-- [x] Show a persistent translated failed-save recovery action that retries the
-  retained latest body.
-
-Verification:
-
-- [x] Unit test ordered save completion with intentionally delayed writes.
-- [x] Unit test rejected writes produce an app error and do not clear dirty
-  state.
-- [x] Unit test latest failed save retry writes the retained unsaved body.
-- [x] Unit/integration test save-status subscriptions activate protection once
-  and clear it after save or successful retry.
-- [x] Playwright CLI verified successful edit navigation/reload persistence,
-  forced-write-failure dirty state and retry UI, protected reload and full-page
-  navigation, retained-body persistence after retry, and protection clearing
-  after retry.
+Done. The editor owns a per-`wsPath` save queue that serializes writes and
+coalesces rapid edits to the latest pending document, so an older completion
+cannot overwrite a newer edit. Save state (clean/pending/failed) is exposed
+with change subscriptions, failed latest saves retain the unsaved body for an
+explicit translated retry action, failures route through the app error system,
+and pending or failed saves activate browser navigation/reload protection.
+PR #649 (C4) moved queue lifetime to an explicit browser-root
+`EditorSaveCoordinator` that survives UI service-graph replacement. Unit,
+integration, and Playwright coverage exercise delayed writes, rejected writes,
+retained-body retry, and protection clearing. A separate `retrying` state is
+only needed if automatic retry is ever added.
 
 ### P0.2 Handle Editor Load And Parse Failures
 
@@ -332,30 +169,12 @@ Verification:
 
 ### P0.3 Await Command Storage Mutations Before Navigation
 
-Problem:
-
-- Some command handlers navigate before storage mutations complete.
-- Several command paths drop asynchronous failures with unawaited promises.
-- Failed create/delete/rename operations can leave navigation pointing at the
-  wrong route or hide a failure from the user.
-
-Evidence:
-
-- `packages/core/command-handlers/src/ws-command-handlers.ts`
-
-Plan:
-
-- Convert create/delete/rename/move command handlers to `async`.
-- Await storage mutations before navigating.
-- Route rejected mutations through command failure handling.
-- Keep the current route stable when a destructive operation fails.
-- Add tests for failure ordering: navigation should only happen after durable
-  success.
-
-Verification:
-
-- Unit tests in `packages/core/command-handlers/src/__tests__`.
-- E2E smoke for create, rename, move, delete, and reload.
+Done; verified resolved on main during the 2026-07-07 re-audit. Workspace
+command handlers await storage mutations before navigating, route rejected
+mutations through command failure handling, and keep the current route stable
+when a destructive operation fails. `ws-command-handlers.spec.ts` covers the
+failure ordering. Do not reintroduce fire-and-forget mutations followed by
+navigation.
 
 ### P0.4 Make Rename/Move Recoverable
 
@@ -365,10 +184,27 @@ Problem:
 - A crash, permission loss, quota failure, or partial write can leave duplicate
   files or incomplete moves.
 
+Current status:
+
+- 2026-07-07: baby-fs rename verifies destination bytes before deleting the
+  source and throws `RENAME_VERIFICATION_FAILED_ERROR` with cause;
+  failure-point tests cover both backends.
+- PR #640 landed the relocation-safety slice for ordinary file and directory
+  rename/move: pending source saves drain before the durable mutation, queued
+  and mounted writes retarget afterward, IndexedDB rename/update paths are
+  atomic, active routes follow durable rename events, and starred paths
+  migrate in one lifecycle, with unit, race, command-handler, and Playwright
+  coverage including reload persistence.
+- Remaining: journaled pending-move records, startup recovery for incomplete
+  moves, cross-workspace moves (issue #563 UX), empty-folder persistence, and
+  link rewriting.
+
 Evidence:
 
 - `packages/js-lib/baby-fs/indexed-db-fs.ts`
-- `packages/js-lib/baby-fs/native-browser-fs.ts`
+- `packages/js-lib/native-fs` and
+  `packages/platform/service-platform/src/file-storage-nativefs.ts` (the
+  Native FS side; the legacy baby-fs native adapter no longer exists)
 
 Plan:
 
@@ -387,27 +223,12 @@ Verification:
 
 ### P0.5 Preserve File Tree On Transient List Failures
 
-Problem:
-
-- Workspace file tree refresh falls back to an empty path list when list fails.
-- A transient storage or permission failure can make notes appear missing.
-
-Evidence:
-
-- `packages/core/service-core/src/workspace-state-service.ts`
-
-Plan:
-
-- Preserve the last known file tree on list failures.
-- Add a separate file-tree error atom/state.
-- Render a recoverable error state instead of empty workspace state.
-- Keep `Note Not Found` reserved for confirmed absence, not load failure.
-
-Verification:
-
-- Unit test list failure preserves previous paths.
-- E2E test reload during transient storage failure does not show destructive or
-  misleading empty state.
+Done. `WorkspaceStateService` preserves the last known file tree on
+same-workspace list failures, exposes `$fileTreeListState`, and the sidebar
+shows a recoverable retry notice backed by `command::ws:refresh-file-tree`.
+The parallel `$workspaces` metadata-refresh gap was tracked as C1 and resolved
+by `$workspaceListState` on 2026-07-13. Keep `Note Not Found` reserved for
+confirmed absence, never for load failure.
 
 ## Priority 1: Markdown Fidelity
 
@@ -418,6 +239,13 @@ Problem:
 - Markdown is parsed into ProseMirror and serialized back after edits.
 - There is no clear raw-preservation layer for frontmatter, raw HTML, tables,
   unknown directives, or unsupported constructs.
+
+Current status:
+
+- The shared golden corpus (`test-utils/markdown-corpus.ts`) and a load-time
+  round-trip fidelity gate in `PmEditorService` (warns when a note cannot
+  round-trip; opening never writes back) landed 2026-07-07. Per-construct
+  parity decisions live in plan 012.
 
 Evidence:
 
@@ -470,93 +298,31 @@ Verification:
 
 ### P1.3 Harden List And Task-List Parsing
 
-Current status:
-
-- The shared golden corpus now covers unchecked, checked, uppercase, nested,
-  mixed, linked, marked-up, and empty task items for both editor engines.
-- ProseMirror explicitly ignores wrapper `bullet_list`/`ordered_list` tokens
-  and derives flat list items from the configured kind/checked attributes.
-- The original general task-list coverage gap is resolved.
-- PR #658 merged with the remaining implementation: tight/loose list semantics,
-  ordered task-list containers, and structural marker widths for stable nested
-  indentation across both editor engines.
-
-Evidence:
-
-- `packages/js-lib/banger-editor/src/list.ts`
-
-Plan:
-
-- [x] Add tests for `- [ ]`, `- [x]`, nested task/bullet lists, and mixed
-  task/plain lists.
-- [x] Derive task-list state from standard Markdown tokens or configure the parser
-  explicitly to emit the required attrs.
-- [x] Document task-list normalization rules in tests.
-- [x] Merge PR #658, including nested ordered-list indentation in the golden
-  corpus and fixed-point coverage.
-
-Verification:
-
-- Golden Markdown list fixtures pass parse/serialize round trips.
+Done in PR #658. The shared golden corpus covers unchecked, checked,
+uppercase, nested, mixed, linked, marked-up, and empty task items for both
+editor engines, and the merged implementation preserves tight/loose list
+semantics, ordered task-list container kind, and structural marker widths for
+stable nested indentation. ProseMirror derives flat list items from configured
+kind/checked attributes rather than wrapper list tokens. Shared corpus,
+command, codec, DOM, persistence, and reload coverage protect the
+cross-engine behavior.
 
 ## Priority 2: Architecture And Package Boundaries
 
 ### P2.1 Split Shared Types Away From Core Implementations
 
-Problem:
-
-- `@bangle.io/types` is in the shared layer but imports concrete core/editor
-  services.
-- The validator has a broad exemption allowing shared types to import anything.
-
-Evidence:
-
-- `packages/shared/types/src/services.ts`
-- `packages/shared/types/src/services-setup.ts`
-- `packages/tooling/custom-scripts/scripts/validate-all.ts`
-
-Plan:
-
-- Move core-specific service aggregation types to a core package.
-- Keep `@bangle.io/types` limited to stable cross-layer contracts.
-- Replace the broad validator exemption with a narrow allowlist for true
-  type-only exceptions.
-- Add a validation check that fails if shared imports core/platform/ui.
-
-Verification:
-
-- `pnpm run custom-validation`
-- Typecheck across packages.
+Done; verified resolved on main during the 2026-07-07 re-audit.
+`@bangle.io/types` no longer imports concrete core/editor services and stays
+limited to cross-layer contracts. The intentional validator exception for
+`@bangle.io/types` remains type-only; do not use it to move runtime logic
+across layers.
 
 ### P2.2 Ban Package-Private `src` Imports Across Package Boundaries
 
-Problem:
-
-- Several packages import `@bangle.io/*/src/...`, bypassing public APIs.
-- This weakens package ownership and makes refactors harder.
-
-Evidence:
-
-- `packages/tooling/test-utils/test-service-setup.ts`
-- `packages/js-lib/prosemirror-plugins/src/index.ts`
-- `packages/core/app/src/layout/app-sidebar.tsx`
-- `packages/core/app/src/components/*`
-- `packages/tooling/e2e-tests/src/component-tests/*`
-
-Plan:
-
-- Add public exports or explicit subpath exports for required APIs and assets.
-- Export the Bangle icon through `@bangle.io/ui-components` or wrap it in a UI
-  component.
-- Split `@bangle.io/service-platform` public entrypoints for browser, memory,
-  test, and router implementations if a single barrel pulls browser-only deps.
-- Add custom validation that rejects `@bangle.io/*/src` imports outside the
-  package itself.
-
-Verification:
-
-- `pnpm run custom-validation`
-- `rg -n "from ['\"]@bangle\\.io/.*/src" packages`
+Done; verified resolved on main during the 2026-07-07 re-audit. No
+`@bangle.io/*/src` imports cross package boundaries, and custom validation
+rejects package-private `src` imports outside the owning package (see the
+P4.4 checkbox). Import other workspaces only through package roots.
 
 ### P2.3 Remove Post-Construction Service Wiring
 
@@ -564,6 +330,13 @@ Problem:
 
 - `FileSystemService` declares no DI deps, then receives storage services and
   workspace lookup through mutable properties.
+
+Current status:
+
+- Storage services now reach `FileSystemService` via a config thunk resolved
+  inside `instantiate()` and asserted before use (2026-07-07). The Native FS
+  half is reopened as A3: the platform root-handle provider still calls
+  upward into core through a late-bound closure.
 
 Evidence:
 
@@ -588,33 +361,10 @@ Verification:
 
 ### P3.1 Consolidate Duplicate App Components
 
-Problem:
-
-- Old and new component trees coexist with near-duplicate implementations.
-- Breadcrumb logic and sibling-file helpers are duplicated.
-
-Evidence:
-
-- `packages/core/app/src/components/note-breadcrumb.tsx`
-- `packages/core/app/src/components/navigation/note-breadcrumb.tsx`
-- `packages/core/app/src/components/navigation/utils.ts`
-- `packages/core/app/src/components/page-header.tsx`
-- `packages/core/app/src/components/common/page-header.tsx`
-- `packages/core/app/src/components/notice-view.tsx`
-- `packages/core/app/src/components/feedback/notice-view.tsx`
-- `packages/core/app/src/components/app-toolbar.tsx`
-
-Plan:
-
-- Confirm unused top-level duplicates with `rg`.
-- Keep `common`, `feedback`, and `navigation` variants as the canonical tree.
-- Move tests to utility modules where possible.
-- Delete stale duplicates and update imports.
-
-Verification:
-
-- App unit tests.
-- `rg` confirms stale component names are gone.
+Done; verified resolved on main during the 2026-07-07 re-audit. The duplicate
+top-level component tree is gone; the `common`, `feedback`, and `navigation`
+variants are canonical. Do not reintroduce parallel component trees for the
+same surface.
 
 ### P3.2 Make React State Subscription-Safe
 
@@ -644,144 +394,51 @@ Verification:
 
 ### P3.3 Translate Remaining User-Visible Strings
 
-Problem:
-
-- Production user-visible strings bypass the global `t` object.
-- One UI component imports `t` directly despite the project convention.
-
-Evidence:
-
-- `packages/core/omni-search/src/index.tsx`
-
-Plan:
-
-- [x] Add the complete Omni Search surface to the English and German bundles.
-- [x] Replace the remaining Omni Search group headings, empty state, accessible
-  dialog name, and input placeholder with global `t` references.
-- [x] Verify the audited app-sidebar, slash-command, link-menu, and star-button
-  strings use the global `t` object.
-- [x] Remove direct `t` imports from the audited production UI components.
-- [x] Replace the placeholder translation test with bundle parity coverage and
-  add German-locale browser coverage for the Omni Search surface.
-
-Verification:
-
-- [x] `packages/core/app/src/__tests__/translation.spec.ts`
-- [x] `packages/shared/translations/src/__tests__/translations.spec.ts`
-- [x] `packages/tooling/e2e-tests/src/translations-locale.e2e.ts`
+Done in the 2026-07-14 batch (PR #647), after the StarButton fix in the
+2026-07-12 batch. Every Omni Search heading, action, empty state, placeholder,
+and accessible dialog title uses the global `t` object; English and German
+carry the complete surface; direct `t` imports were removed from the audited
+production UI components. Bundle parity is covered by
+`packages/shared/translations/src/__tests__/translations.spec.ts`, and
+`packages/tooling/e2e-tests/src/translations-locale.e2e.ts` opens the German
+command bar and verifies translated user-visible behavior.
 
 ### P3.4 Fix Dialog And Custom Control Accessibility
 
-Problem:
-
-- The original command-dialog, sidebar search, and workspace-storage selector
-  accessibility findings have been resolved on `main`.
-
-Evidence:
-
-- `packages/ui/shadcn/src/command.tsx`
-- `packages/ui/ui-components/src/app-sidebar.tsx`
-- `packages/ui/ui-components/src/workspace-dialog.tsx`
-
-Plan:
-
-- [x] Keep command-dialog title and description elements inside
-  `DialogContent` where the dialog primitive expects them.
-- [x] Give every command dialog an accessible description.
-- [x] Replace the sidebar pseudo-button with a real button or fully implement
-  Space, Enter, focus, and label semantics.
-- [x] Use native radio inputs in a labeled radiogroup for workspace type
-  selection.
-
-Verification:
-
-- [x] Component tests select workspace storage choices by radio role and
-  accessible name.
-- [x] App E2E opens the workspace dialog by its accessible name and completes
-  the Browser workspace flow.
+Done; resolved on main plus the 2026-07-12 batch. Command dialogs keep title
+and description elements inside `DialogContent` with accessible descriptions,
+the sidebar search affordance is a semantic button with native Enter/Space
+behavior, and workspace type selection uses native radio inputs in a labeled
+radiogroup. Component tests select storage choices by radio role and
+accessible name; app E2E covers the Space-key search path and the Browser
+workspace flow.
 
 ### P3.5 Split Overloaded Sidebar Composition
 
-Problem:
-
-- Core `AppSidebar` handles command wiring, footer menu composition, workspace
-  mapping, truncation policy, file actions, and drag/drop behavior together.
-
-Evidence:
-
-- `packages/core/app/src/layout/app-sidebar.tsx`
-
-Plan:
-
-- Extract a `useSidebarModel` hook for derived workspace/path data.
-- Extract sidebar action handlers into small functions or a command adapter.
-- Keep presentational sidebar pieces in `ui-components`.
-- Preserve existing drag/drop behavior during the split.
-
-Verification:
-
-- Unit tests for derived model output.
-- Existing E2E workspace navigation and drag/drop smoke.
+Done for app-level decomposition (2026-07-07 pass): sidebar file-tree actions
+moved to `useSidebarFileActions`, the footer menu moved to
+`SidebarFooterMenu`, and core `AppSidebar` is a thin composition layer with
+drag/drop behavior preserved. The remaining work — moving the one-caller,
+Bangle-specific `ui-components/AppSidebar` composition into
+`core/app/features/sidebar` — is tracked as A6 in the 2026-07-12 matrix.
 
 ## Priority 4: Tooling, CI, And Validation Hardening
 
 ### P4.1 Run Production Build In CI And Local CI
 
-Problem:
-
-- GitHub Actions run lint, unit tests, and E2E, but not the production build.
-- `local-ci-check.sh` only runs root scripts ending in `:ci`, so it skips
-  `build`.
-
-Evidence:
-
-- `.github/workflows/node.js.yml`
-- `local-ci-check.sh`
-- `package.json`
-
-Plan:
-
-- Add a CI build job that runs `pnpm run build`.
-- Add `build:ci` or explicitly include `pnpm run build` in
-  `local-ci-check.sh`.
-- Keep build after lint/test unless build catches type or bundling issues that
-  should fail earlier.
-
-Verification:
-
-- GitHub Actions build job passes.
-- `pnpm local-ci-check` includes build.
+Done (2026-07-07 pass): GitHub Actions runs `pnpm run build`, so production
+build breakage fails CI.
 
 ### P4.2 Fix Playwright CI Hygiene
 
-Problem:
-
-- A sample Playwright test hits `https://playwright.dev/`, making CI depend on
-  external network and not the app.
-- Playwright artifact upload path points at repo-root `playwright-report/`, but
-  package reports are under `packages/tooling/e2e-tests`.
-- One `.e2e.tsx` file imports component-test APIs.
-
-Evidence:
-
-- `packages/tooling/e2e-tests/src/sample.e2e.ts`
-- `packages/tooling/e2e-tests/src/workspace-dialog.e2e.tsx`
-- `packages/tooling/e2e-tests/playwright.config.ts`
-- `.github/workflows/node.js.yml`
-
-Plan:
-
-- [x] Delete or replace the external sample with a local app smoke test.
-- [x] Upload `packages/tooling/e2e-tests/playwright-report/` and relevant
-  `test-results/` paths.
-- [x] Move component-style tests to CT or import from `@playwright/test`.
-- [x] Wait for the exact newly created note editor before follow-up E2E input,
-  and cover selecting an already-selected current day in the slash date picker.
-
-Verification:
-
-- `pnpm e2e:ci`
-- CI artifact contains the expected report.
+Done in the 2026-07-12 batch. The external `playwright.dev` sample was
+deleted, E2E and component reports/results use separate package-local
+directories, CI uploads those actual artifact paths, and component-style
+tests were moved off the `.e2e.tsx` import mix. PR #647 additionally made the
+shared create-workspace/note E2E helper wait for the exact new editor
+identity before follow-up input, and made the slash date picker's initial
+single-day selection required so UTC CI cannot toggle to an empty selection.
+Do not reintroduce network-dependent sample tests.
 
 ### P4.3 Add Coverage Paths For Data-Safety Packages
 
@@ -847,6 +504,14 @@ Problem:
 - Tooling disables `noExplicitAny`.
 - CSS and HTML are excluded from Biome file includes, while Tailwind/CSS are
   part of the shipped app.
+
+Current status:
+
+- `noFloatingPromises` is a Biome error repo-wide (2026-07-07);
+  `noExplicitAny` (163 sites at that count) and `noUnusedVariables` remain
+  warnings. A package-wide `noExplicitAny` ratchet was trialled alongside PR
+  #646 but dropped: de-wildcarding the generic emitter needed conditional
+  types and a double assertion without rejecting more invalid callers.
 
 Evidence:
 
@@ -920,9 +585,10 @@ Current status:
 
 Evidence:
 
-- `packages/platform/service-platform/src/file-storage-nativefs.ts`
+- `packages/platform/service-platform/src/file-storage-nativefs.ts` and
+  `packages/js-lib/native-fs` (the Native FS side; the legacy baby-fs native
+  adapter no longer exists)
 - `packages/js-lib/baby-fs/indexed-db-fs.ts`
-- `packages/js-lib/baby-fs/native-browser-fs.ts`
 - `packages/core/service-core/src/file-system-service.ts`
 
 Plan:
@@ -940,71 +606,25 @@ Verification:
 
 ### P5.3 Preserve Error Cause Details Across Storage Boundaries
 
-Problem:
-
-- The IndexedDB adapter converted upstream failures to broad storage errors
-  without preserving original cause details.
-
-Evidence:
-
-- `packages/js-lib/baby-fs/indexed-db-fs.ts`
-- `packages/js-lib/native-fs/src/errors.ts`
-
-Plan:
-
-- [x] Preserve original error cause for generic IndexedDB failures and mapped
-  constraint failures.
-- [x] Verify the replacement Native FS error normalization preserves causes.
-- [x] Keep user-facing messages safe and readable while retaining structured
-  diagnostic details on the error object.
-
-Verification:
-
-- [x] Unit tests assert error code and cause shape.
+Done. The IndexedDB adapter (`packages/js-lib/baby-fs/indexed-db-fs.ts`)
+retains the original rejection as `Error.cause` for generic upstream errors
+and translated constraint failures, and the replacement Native FS library
+(`packages/js-lib/native-fs/src/errors.ts`) preserves causes when normalizing
+browser errors. Unit tests assert error code and cause shape. The legacy
+Native Browser FS evidence was removed together with that adapter.
 
 ### P5.4 Align Cross-Context Messaging Lifetimes And Payload Isolation
 
-Problem:
-
-- A bus created with an already-aborted owner remained connected because an
-  abort listener added after abort never runs.
-- An already-aborted subscription was still registered and could continue
-  receiving messages indefinitely.
-- Sending after disposal was a silent no-op for the memory channel but could
-  throw through a closed native channel.
-- The memory fallback shared the same mutable payload object with every
-  recipient, unlike native `BroadcastChannel` structured-clone isolation.
-- `MemoryBroadcastChannel` claimed the full browser interface while three
-  inherited event methods only threw `Method not implemented`.
-
-Evidence:
-
-- `packages/js-lib/browser-utils/src/broadcast-channel.ts`
-- `packages/js-lib/browser-utils/__tests__/broadcast-channel.spec.ts`
-
-Plan:
-
-- [x] Close immediately when the owner signal is already aborted.
-- [x] Ignore subscriptions whose signal is already aborted.
-- [x] Make post-disposal sends consistently inert.
-- [x] Structured-clone payloads independently for memory-channel recipients.
-- [x] Type the fallback against the minimal channel contract it supports.
-- [x] Apply the same already-aborted subscription and idempotent-disposal
-  semantics to the generic emitter used by root events.
-
-Verification:
-
-- [x] Focused tests cover already-aborted owners and subscriptions.
-- [x] Focused tests prove independent mutable payloads for memory recipients.
-- [x] Focused emitter tests cover already-aborted subscriptions and repeated
-  destruction.
-- [x] Browser-utils and logger unit suites pass.
-- [x] Repository project-reference typecheck passes.
-- [x] `pnpm lint:ci`, `pnpm test:ci`, `pnpm build`, and `pnpm e2e:ci`
-  pass. The E2E run had one unrelated cursor-restoration retry.
-- [x] `pnpm local-ci-check` passes every root CI script, including E2E,
-  component tests, desktop builds/tests, and the Electron persistence smoke.
-  Its E2E run had one unrelated file-explorer retry.
+Done (2026-07-13 batches; PR #646 for the emitter slice). `TypedBroadcastBus`
+closes immediately for an already-aborted owner, ignores already-aborted
+subscriptions, and makes post-disposal sends a consistent no-op across native
+and memory channels. The in-memory channel structured-clones payloads
+independently per recipient and is typed against the minimal channel contract
+it implements instead of the full throwing `BroadcastChannel` interface. The
+generic emitter used by root events applies the same already-aborted and
+idempotent-destruction semantics, and the two-key weak cache retains cached
+`undefined` results. Focused suites cover all of the above, and the batch
+passed `pnpm local-ci-check` end to end.
 
 ## 2026-07-12 Core/App Containment Re-audit
 
@@ -1032,10 +652,10 @@ listed so future agents do not rediscover it or accidentally restore it.
 | --- | --- | --- | --- |
 | A1 | Open; extends P3.2 | Move dialog intents and transient feature state out of `WorkbenchStateService`. It still imports UI prop types and stores callbacks/icons/full dialog props, plus Omni and All Files state, inside `service-core`. Put feature-owned state and callback execution beside the owning app feature; keep durable preferences in the service. | 250-500 LOC; removes core-to-UI coupling |
 | A2 | Open | Replace the global `commandKeyToContext` WeakMap and string-selected service-locator kernel with direct typed handler context. Colocate command metadata and handlers by feature; keep only serializable cross-context command contracts in shared. | 100-200 LOC; explicit dependencies |
-| A3 | Open; reopens P2.3 | Remove the hidden Native FS upward dependency. `initialize-services` currently gives the platform storage adapter a late-bound closure that calls core `WorkspaceOpsService`. Introduce a core-owned workspace storage-session/root-handle registry with explicit invalidation and a downward platform contract. | Removes reload/recovery glue and runtime cycle |
+| A3 | Open; reopens P2.3 | Remove the hidden Native FS upward dependency. `initialize-services` currently gives the platform storage adapter a late-bound closure that calls core `WorkspaceOpsService`. Introduce a core-owned workspace storage-session/root-handle registry with explicit invalidation and a downward platform contract. Plan 019 M4 owns the router late-bound closure; A3's remaining half is the workspaceOps/root-handle capability injection. | Removes reload/recovery glue and runtime cycle |
 | A4 | Partial | PR #631 deleted `WorkspaceService` and pass-through `WorkbenchService` and strengthened graph validation. The 2026-07-12 cleanup batches removed the unused `WorkbenchStateService` database dependency plus the zero-consumer command-key cache/getter, navigation `fromUri` pass-through, and workspace misc-data methods/error variant. The core aggregate is still repeated in `coreServiceClasses`, `coreServiceSlots`, `getCoreInstances`, `toCoreServices`, and public service types; derive those views from one descriptor in a separate slice. | 150-250 LOC originally; remaining benefit is one derived service graph |
 | A5 | Open | Fold All Files into Omni Search as a file-only scope. Both surfaces independently map workspace files, fuzzy-search, virtualize results, dispatch navigation, and maintain separate open/input state. | 184-230 LOC |
-| A6 | Open; remainder of P3.5 | Move the one-caller Bangle-specific `ui-components/AppSidebar` composition into `core/app/features/sidebar`. Keep reusable sidebar and file-tree primitives in UI, but remove the roughly 30-prop adapter boundary split across a 582-line UI component and its sole app caller. | About 100-200 LOC and one feature boundary |
+| A6 | Open; remainder of P3.5 | Move the one-caller Bangle-specific `ui-components/AppSidebar` composition into `core/app/features/sidebar`. Keep reusable sidebar and file-tree primitives in UI, but remove the roughly 30-prop adapter boundary split across a 631-line UI component and its sole app caller. | About 100-200 LOC and one feature boundary |
 | A7 | Resolved in PR #632 | Delete the five zero-producer fatal/auth/missing routes, their pages/types/decoder branches/translations, and unused `ROUTES`; stale IDs decode through normal `not-found`. | 205 net code LOC before review hardening |
 | A8 | Open; tracked by plan 007 | Extract backlink indexing from `WorkspaceStateService`. Current content-update signals trigger a debounced serial full-workspace reread, and a failed rebuild returns an empty map. A dedicated index service should update per source from typed file events, use bounded concurrency, ignore stale generations, and retain last-good data. | Performance, failure semantics, ownership |
 | A9 | Partial | PR #631 stopped the switch-workspace dialog from mutating the atom array with `.sort()`. Welcome, switcher, and settings still need one immutable workspace-summary model and one sorting policy; cached workspace objects/arrays should not be exposed as mutable shared state. | 80-150 LOC and consistent ordering |
@@ -1079,18 +699,6 @@ listed so future agents do not rediscover it or accidentally restore it.
    coverage where navigation or interaction changes.
 5. A8 through plan 007, after correcting the temporary index's failure and
    concurrency assumptions.
-
-## Original 2026-06-15 Suggested Execution Order
-
-1. Editor save queue, error surfacing, and pending-save state.
-2. Await command storage mutations and add failure-ordering tests.
-3. File tree failure behavior and recoverable rename design.
-4. Markdown golden fixture suite.
-5. Shared types/package boundary refactor and `src` import validation.
-6. CI build and Playwright hygiene.
-7. Duplicate component deletion and translation sweep.
-8. Accessibility fixes for dialogs and sidebar controls.
-9. Lint ratchet and unsafe TypeScript cleanup.
 
 ## Verification Matrix
 

--- a/plans/006-image-embeds-and-paste-assets.md
+++ b/plans/006-image-embeds-and-paste-assets.md
@@ -4,7 +4,7 @@ status: active
 type: plan
 archived: false
 created: 2026-06-30
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/587
@@ -53,44 +53,10 @@ The target behavior is:
 - Failure and recovery coverage should still be expanded for permission loss,
   quota failures, and missing assets without document mutation.
 
-## Legacy Findings
-
-Legacy commit `ec3fd897` (`Feat/images (#62)`) is the useful first pass:
-
-- `extensions/image-extension/parse-local-path.js` resolved Markdown image
-  sources relative to the current note path.
-- The image React node view left `http:`, `https:`, and `data:image/` sources
-  alone.
-- Local image sources were read through workspace storage, converted to object
-  URLs with `URL.createObjectURL(file)`, and revoked during cleanup.
-- Missing local files were silently tolerated in rendering; source Markdown was
-  not rewritten.
-
-Legacy commit `483aea18` (`Feat/image (#77)`) added the pasted-file flow:
-
-- `create-image-nodes.js` accepted pasted/dropped image files, calculated image
-  dimensions, created a workspace image path, saved the original file, and then
-  returned image nodes.
-- `image-writing.js` placed files under a configured image save directory and
-  returned both a storage `wsPath` and a Markdown `srcUrl`.
-- `image-file-helpers.js` added filename helpers for dimensions, timestamps,
-  and scale metadata.
-- `ImageEditorReactComponent.jsx` showed a selected-image floating menu with
-  scale controls.
-
-Do not copy this implementation directly. Reuse the product ideas, but adapt
-them to the current package boundaries, TypeScript code, service wiring, and
-data-safety rules.
-
 ## ProseKit Findings
 
-ProseKit's current image design is a useful reference:
-
-- Image file ingestion is handled through an uploader callback rather than
-  hardcoded inside the base image extension.
-- The editor can show upload/progress/error state through image-specific views.
-- Image attrs support `src`, `alt`, `title`, `width`, and `height`.
-- Resizing is represented in node attrs instead of encoding sizing in `alt`.
+- ProseKit represents image sizing as `width`/`height` node attrs (never
+  encoded in `alt`), the model to follow for any sizing controls here.
 
 Reference docs:
 
@@ -99,18 +65,20 @@ Reference docs:
 
 ## Scope
 
-- Render existing Markdown images in the editor for:
-  - relative paths such as `assets/pic.png` and `./assets/pic.png`;
-  - parent-relative paths such as `../assets/pic.png`;
-  - root-relative workspace paths such as `/assets/pic.png`;
-  - `http:` and `https:` URLs;
-  - `data:image/...` URLs.
-- Persist pasted and dropped image files into the active workspace before
+Shipped (PRs #587, #610, #661):
+
+- Rendering existing Markdown images: relative, parent-relative,
+  root-relative, `http:`/`https:`, and `data:image/...` sources.
+- Persisting pasted and dropped image files into the active workspace before
   inserting editor content.
-- Generate stable, safe Markdown image targets from stored file paths.
-- Preserve `src`, `alt`, and `title` through parse/serialize round trips.
+- Stable, safe Markdown image targets generated from stored file paths.
+- `src`, `alt`, and `title` preserved through parse/serialize round trips.
+
+Remaining:
+
 - Add selected-image UI for editing image metadata and supported sizing.
-- Add unit and Playwright coverage for visible behavior and persistence.
+- Expand unit and Playwright coverage for visible behavior and persistence,
+  especially failure and recovery paths.
 
 ## Out Of Scope
 
@@ -128,18 +96,20 @@ Reference docs:
 
 ### Package Ownership
 
-Keep `packages/js-lib/banger-editor` generic. It may expose better extension
-hooks, attrs, commands, and error callbacks, but it must not import Bangle
-workspace services.
+Keep `packages/js-lib/banger-editor` generic (schema, attrs, commands, error
+callbacks); it must not import Bangle workspace services. Bangle-specific
+storage behavior lives in `packages/core/editor` under `PmEditorService`,
+which already knows the mounted editor views, the current note `wsPath`,
+`FileSystemService`, app error reporting, and the editor save lifecycle.
 
-Put Bangle-specific storage behavior in `packages/core/editor`, owned by
-`PmEditorService`, because that service already knows:
+### Shipped Rendering And Persistence
 
-- the mounted editor views;
-- the current note `wsPath`;
-- `FileSystemService`;
-- app error reporting;
-- editor save lifecycle.
+Rendering, paste/drop persistence, and asset path generation shipped via
+`packages/core/editor/src/asset-file-plugin.ts`,
+`packages/core/editor/src/local-image-node-view.ts`, and
+`packages/core/service-core/src/workspace-asset-storage.ts`. The shipped
+paste/drop mechanism is that asset-file-plugin pipeline — `extensions.ts`
+calls plain `setupImage()`; there is no `createImageNodes` callback.
 
 ### Image Node Schema
 
@@ -163,81 +133,6 @@ release should either:
 
 Do not encode scale in `alt` like legacy did. That mixes display metadata with
 accessibility text.
-
-### Reading Existing Markdown Images
-
-Add an image node view in `core/editor` that receives the current note `wsPath`
-through service configuration or view metadata.
-
-Rendering rules:
-
-- If `src` starts with `http://`, `https://`, or `data:image/`, render it
-  directly.
-- If `src` has another explicit URL scheme, render a blocked/broken state.
-- If `src` is relative or root-relative, resolve it against the current note.
-- Reject paths that escape the workspace root or contain unsafe encoded
-  separators.
-- Read the target file with `fileSystem.readFile(imageWsPath)`.
-- Create an object URL for the returned `File`.
-- Revoke the previous object URL when attrs change, the node view updates, or
-  the node view is destroyed.
-- If the file is missing or unreadable, show a visible broken-image state with
-  useful alt text but never dispatch a document change.
-
-Path resolution should live in the lowest valid shared layer if it is reused by
-links or other asset types. `@bangle.io/ws-path` is the likely home for a typed
-helper such as `resolveWorkspaceAssetPath(currentWsPath, markdownTarget)`.
-
-### Pasting And Dropping Images
-
-Configure `setupImage({ createImageNodes })` from `PmEditorService`.
-
-The custom `createImageNodes` must:
-
-- accept a list of image `File` objects;
-- identify the current note path from the editor view;
-- sanitize the original file name;
-- preserve the original extension when safe and known;
-- derive an image directory;
-- generate a unique target `wsPath`;
-- optionally calculate dimensions using a temporary object URL;
-- await `fileSystem.createFile(targetWsPath, file)`;
-- only create and return the image node after the file write succeeds;
-- emit an app error and return no node on failure.
-
-Do not insert a Markdown image reference before persistence succeeds. A failed
-write must not leave the note pointing at an image file that does not exist.
-
-### Asset Location And Naming
-
-Recommended initial location:
-
-```text
-assets/<note-stem>/<sanitized-original-name>-<timestamp>-<width>x<height>.<ext>
-```
-
-Example:
-
-```text
-assets/research-note/screenshot-20260630142530123-1280x720.png
-```
-
-For notes inside folders, keep asset paths workspace-rooted under `assets/`
-rather than beside the note unless the product wants Obsidian-style colocated
-assets. Rooted `assets/` has simpler sidebar filtering and fewer rename/move
-implications.
-
-Collision policy:
-
-- Check `fileSystem.exists(targetWsPath)`.
-- If occupied, append `-2`, `-3`, etc. before the extension.
-- Keep the original source file bytes unchanged.
-
-Markdown insertion policy:
-
-- Insert a relative Markdown URL from the current note to the asset path.
-- URL-encode path segments for Markdown.
-- Keep the stored filesystem `wsPath` decoded.
 
 ### Selected Image Menu
 
@@ -264,38 +159,8 @@ an image node.
 
 ## Implementation Plan
 
-### Phase 1: Markdown And Path Fidelity
-
-- Add focused round-trip tests for image Markdown:
-  - `![alt](assets/pic.png)`;
-  - `![alt](assets/pic.png "title")`;
-  - paths with spaces and parentheses;
-  - data image source;
-  - image beside wiki links and normal links.
-- Add or reuse a typed resolver for Markdown asset targets.
-- Cover relative, root-relative, encoded space, `..`, and workspace-escape
-  cases.
-
-### Phase 2: Local Image Rendering
-
-- Add a Bangle image node view that resolves and reads local image files.
-- Ensure object URL lifecycle is tested.
-- Add broken-image UI state without document mutation.
-- Add Playwright coverage for loading an existing local image from a fixture
-  workspace.
-- Add Playwright coverage that missing images do not erase the Markdown source
-  after edit/reload.
-
-### Phase 3: Paste And Drop Persistence
-
-- Add Bangle-specific `createImageNodes` wiring in `PmEditorService`.
-- Add filename sanitization and collision-resistant path generation.
-- Add dimension calculation if it is reliable and does not block too long.
-- Await `fileSystem.createFile` before returning nodes.
-- Route failures through `emitAppError`.
-- Add tests for success, collision, invalid image names, and write failure.
-- Add Playwright coverage that paste creates an image file, inserts Markdown,
-  reloads, and still renders.
+Phases 1-3 (Markdown/path fidelity, local image rendering, and paste/drop
+persistence) shipped in PRs #587, #610, and #661.
 
 ### Phase 4: Image Menu
 
@@ -354,15 +219,12 @@ Manual smoke for release candidate:
   is easy.
 - Markdown image syntax does not support width/height. Avoid inventing hidden
   serialization that harms interoperability.
-- Renaming or moving notes will not automatically move assets in the initial
-  design. Root-level `assets/<note-stem>/` reduces ambiguity but does not solve
-  lifecycle cleanup.
+- Renaming or moving notes will not automatically move assets. Tracked as
+  https://github.com/bangle-io/bangle-io/issues/679. Root-level
+  `assets/<note-stem>/` reduces ambiguity but does not solve lifecycle
+  cleanup.
 
 ## Next Steps
 
-- Confirm the asset directory convention: root `assets/<note-stem>/` versus
-  colocated `./assets/<note-stem>/`.
-- Implement Phase 1 path/Markdown tests first.
-- Implement local image node view before paste persistence so existing
-  Markdown fixtures drive the rendering behavior.
-- Implement pasted-image persistence with failure-first tests before UI polish.
+- Implement the selected-image menu (Phase 4).
+- Add recovery and permission-failure coverage (Phase 5).

--- a/plans/007-workspace-index-cache.md
+++ b/plans/007-workspace-index-cache.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-30
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs: []
 related_issues: []
@@ -33,7 +33,9 @@ clearing, and eventual persisted snapshots.
 ## Current Status
 
 Verified against `main` 2026-07-24. No `WorkspaceIndexService` exists; Phase 1
-has not started.
+has not started. Plan 005 item A8 tracks this same service extraction, and
+plan 015 (file-change eventing consolidation) owns the typed-event-vs-counter
+groundwork that the incremental updates below depend on.
 
 - `WorkspaceStateService.$backlinkIndex` builds an in-memory reverse link map
   for the active workspace. A content-update counter triggers a debounced full
@@ -208,76 +210,21 @@ same note should result in one latest reindex task when practical.
 
 ### Persistence
 
-Persisted snapshots should be a second phase after the in-memory service is
-stable.
-
-Potential provider interface:
-
-```ts
-type WorkspaceIndexSnapshot = {
-  schemaVersion: number;
-  wsName: string;
-  generatedAt: number;
-  fileVersions: Record<string, { mtime?: number }>;
-  linkGraph: {
-    outgoingBySource: Record<string, string[]>;
-  };
-};
-
-interface WorkspaceIndexCacheProvider {
-  readSnapshot(wsName: string): Promise<WorkspaceIndexSnapshot | undefined>;
-  writeSnapshot(wsName: string, snapshot: WorkspaceIndexSnapshot): Promise<void>;
-  clearWorkspace(wsName: string): Promise<void>;
-  clearAll(): Promise<void>;
-}
-```
-
-Initial validity can compare known paths and `mtime` where available. If
-metadata is missing or unreliable, load the snapshot as stale and rebuild in
-the background.
+Persisted snapshots are a second phase, after the in-memory service is stable:
+a platform-owned `WorkspaceIndexCacheProvider` storing schema-versioned
+snapshots, loaded stale-while-revalidate by default when file metadata is
+missing or unreliable.
 
 ### Future Indexes
 
-Do not start with a generic plugin framework. Begin with typed fields on one
-service:
-
-- `linkGraph`
-- `search`
-- `noteMetadata`
-
-Extract a generic indexer interface only after the second real index lands and
-the shared lifecycle is proven.
-
-Possible future interface:
-
-```ts
-interface WorkspaceIndexer<TSnapshot> {
-  id: string;
-  build(ctx: WorkspaceIndexBuildContext): Promise<TSnapshot>;
-  update(
-    ctx: WorkspaceIndexUpdateContext,
-    change: WorkspaceFileChange,
-    previous: TSnapshot,
-  ): Promise<TSnapshot>;
-}
-```
+Do not build a generic indexer/plugin framework until the second real index
+(search or note metadata) lands and the shared lifecycle is proven.
 
 ## Migration Plan
 
 ### Phase 0: Lightweight Backlink Index
 
-Completed in the release branch as a scoped cleanup:
-
-- `WorkspaceStateService.$backlinkIndex` builds an in-memory reverse backlink
-  map for the active workspace.
-- `LinkedMentions` renders the service state and no longer reads files from
-  React.
-- Failed rebuilds expose an error state, but do **not** retain last-good data.
-- Extensionless Markdown backlink extraction now resolves through the known
-  note index instead of guessing `.md` before `.markdown`.
-
-This phase deliberately does not introduce the full `WorkspaceIndexService`,
-incremental graph updates, persisted snapshots, or reusable index lifecycle.
+Completed; see Current Status for what shipped and its limitations.
 
 ### Phase 1: Dedicated Workspace Index Service
 

--- a/plans/009-mobile-ios-expo-shell.md
+++ b/plans/009-mobile-ios-expo-shell.md
@@ -1,11 +1,11 @@
 ---
 title: iOS mobile app via Expo shell + WebView
-status: active
+status: blocked
 type: plan
 archived: false
 archived_on:
 created: 2026-07-02
-updated: 2026-07-12
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/567
@@ -38,25 +38,21 @@ Decisions made (2026-07-02, with Kushan):
 
 ## Why this shape
 
-- The web app already runs at 390x844; ProseMirror cannot run in React
-  Native, so any "native" rewrite still ends with the editor in a WebView.
-- Platform coupling is already behind DI seams
-  (`packages/core/initialize-services`): file storage is a registry keyed by
-  workspace type, cross-tab events degrade to an in-memory channel, and the
-  router/error services work in WKWebView.
-- The only hard WKWebView blocker is the File System Access API
-  (`showDirectoryPicker`), which only affects the NativeFS workspace type.
-- A maintainer-provided reference app (private) already proves the EAS +
-  pnpm-monorepo + GitHub Actions pipeline; we reuse its variant scheme
-  (dev/preview/prod bundle IDs, EAS profiles, fingerprint PR builds)
-  without its full-native UI architecture.
+The web app already runs at mobile viewport, ProseMirror ends up in a WebView
+under any architecture, platform coupling already sits behind DI seams, the
+only hard WKWebView blocker (File System Access API) affects only the NativeFS
+workspace type, and a maintainer-provided private reference app proves the
+EAS + pnpm-monorepo + GitHub Actions pipeline.
 
 ## Milestones
 
-PR #567 merged the M0 repository scaffolding: the Expo/WebView package, app
-variants, EAS profiles, and manual GitHub workflow. M0 is not complete until the
-human-owned account/provisioning steps below put the app on a physical phone.
-M1-M3 remain unstarted.
+Current status (2026-08-01): the repo-side M0 scaffolding (Expo/WebView
+package, app variants, EAS profiles, manual GitHub workflow) merged in PR #567
+on 2026-07-02; there has been no repository activity since beyond mechanical
+maintenance. The plan is blocked on the human-owned steps: Apple Developer
+enrollment, Expo account + `eas init` (no `EAS_PROJECT_ID` committed), and the
+`EXPO_TOKEN` secret. M0's exit criterion — the app running on a physical
+phone — is unmet; M1-M3 remain unstarted.
 
 ### M0 — pipeline end-to-end (this plan's exit criterion: app on a phone)
 

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-05
-updated: 2026-07-21
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/609
@@ -53,248 +53,37 @@ Key upstream facts (as of 2026-07-05):
 
 ## Current status
 
-2026-07-21 update:
+All groundwork PRs are merged (2026-08-01 summary):
 
-- PR #655 fixed nested multiline code serialization inside block delimiters in
-  the Wordgard Markdown codec.
-- PR #658 merged with shared list-syntax and codec work that preserves list
-  kind, task state, tightness, and structural indentation across both editor
-  engines. The migration remains active; M2 real-editor wiring is the next
-  documented milestone.
+- **M0 seam** (PR #609): `EditorEngineContract` / `editorEngine` slot,
+  `data-editor-engine` on the mount, the single documented `EditorSurface`
+  app-layer leak point.
+- **markdown-syntax extraction** (PR #613): `@bangle.io/markdown-syntax`
+  owns the engine-neutral markdown-it base tokenizer + wiki-link syntax;
+  the PM loader and the backlink extractor consume it, with no editor
+  dependency.
+- **M1 codec + packages + golden corpus** (PR #616, hardened in
+  #655/#658): `@bangle.io/wordgard-utils` (single wordgard chokepoint +
+  custom schema elements) and `@bangle.io/wordgard-markdown` (headless
+  codec) pass the shared golden corpus in `@bangle.io/test-utils`
+  byte-identically on both engines. The mark-spec registration order in
+  `defaultMarkdownSpecs` is load-bearing (outermost first, `Code` last).
+  Tables stay PM-only (`engines: ['prosemirror']` fixtures) until the M3
+  Wordgard table specs.
+- **M0b engine switch + read-only stub** (PR #620): `@bangle.io/editor-w`
+  renders raw markdown read-only; URL selection, composition-root wiring,
+  `command::ui:switch-editor-engine`, and e2e switch coverage landed.
+- **M4-P0 wordgard-plus bridge** (PR #623): `createEditorAtoms`,
+  `createMenuAtoms`/`useResolvedMenu`, and the `<TooltipHost>` portal
+  glue, verified live via a Storybook toolbar demo.
 
-Active. Landed so far (PR #609):
+M2 (writable Wordgard editor + `editor-common` extraction + live
+round-trip gate) has not started; editor-w is still the read-only stub.
 
-- The plan, vendored Wordgard docs, and the `wordgard` skill.
-- **M0 seam hardening**: `PmEditorServiceContract` → `EditorEngineContract`
-  (with documented engine semantics and an `engineId` field), the
-  `pmEditorService` slot → `editorEngine` across commands, handlers, app,
-  context, and the composition root; `PmEditorService` now formally
-  `implements EditorEngineContract`; the mounted editor carries
-  `data-editor-engine`; the app layer's only engine-package import is the
-  documented `EditorSurface` leak point
-  (`packages/core/app/src/components/editor-surface.tsx`).
-
-Deliberate M0 exceptions (KISS — no dead switches before a second engine
-exists):
-
-- Engine selection stays a one-line assignment in
-  `initialize-services/src/service-setup.ts` (`editorEngine: PmEditorService`)
-  rather than a parameterized option; it becomes conditional when editor-w
-  scaffolds.
-- The URL engine selection and the omni-search switch command are
-  deferred to the editor-w stub (start of M1/M2) — a switch with one engine
-  is untestable dead code.
-- `service-core/backlink-markdown-extractor.ts` still imports
-  `@bangle.io/prosemirror-plugins` for the markdown tokenizer + wiki-link
-  syntax; that moves to the shared markdown-syntax layer in M1 as planned.
-- The engine's own React overlays (slash/link/table/selection menus) remain
-  package-private to `core/editor`, consumed via the concrete service — this
-  is engine-internal by design, not a seam violation.
-
-### M1 in progress — shared markdown-syntax layer landed
-
-- **`@bangle.io/markdown-syntax`** (js-lib, universal) now owns the
-  engine-neutral markdown-it configuration: the base tokenizer (CommonMark +
-  GFM strikethrough + task lists via `listMarkdownPlugin`) and the
-  `[[wiki link]]` inline syntax plugin with its `parseWikiLinkContent` /
-  `serializeWikiLinkAttrs` helpers and `WikiLinkAttrs` type. It carries no
-  editor dependency (banger-editor now depends on it, not the reverse).
-- Both the ProseMirror markdown loader
-  (`prosemirror-plugins/markdown-loader.ts`) and the headless backlink
-  indexer (`service-core/backlink-markdown-extractor.ts`) consume the shared
-  base. As a result `service-core` and the neutral tokenizer no longer depend
-  on the PM editor package `@bangle.io/prosemirror-plugins` at all — closing
-  the altitude smell M1 called out. `prosemirror-plugins` drops its direct
-  `markdown-it` dependency (it now sources the base from markdown-syntax).
-- Behavior is unchanged: the PM wiki-link markdown round-trip suite stays
-  green, and the new package ships headless tokenizer + wiki-link syntax
-  tests. Verified with `lint:ci`, `typecheck`, `knip:ci`, and `test:ci`
-  (1416 passed).
-### M1 essentially complete — codec, packages, and golden corpus landed
-
-- **`@bangle.io/wordgard-utils`** (js-lib, universal) scaffolded with
-  `wordgard` exact-pinned at `0.1.1`: the single `wordgard/*` import
-  chokepoint (currently re-exporting `wordgard/doc` + `wordgard/types`;
-  grows per milestone), plus the first custom schema elements — `TaskItem`
-  (`Plot.Type<boolean>`, param = checked, with a `Schema.Override` slotting
-  it into the built-in `BulletList`), `WikiLink` (`Leaf.Type<string>`,
-  param = target) + `WikiLinkLabel` mark, and `LinkTitle`/`ImageTitle` marks
-  preserving Markdown title fidelity.
-- **`@bangle.io/wordgard-markdown`** (js-lib, universal) — the headless
-  codec. `MarkdownSpec`s keyed by node/mark type objects; parser and
-  serializer state are faithful ports of prosemirror-markdown's
-  `MarkdownParseState`/`MarkdownSerializerState` (MIT, attributed) onto
-  Wordgard's plot/leaf/mark model, consuming the shared
-  `@bangle.io/markdown-syntax` tokenizer. `createNoteMarkdownCodec()` is the
-  batteries-included bangle-note assembly. Byte-parity subtleties ported
-  deliberately: loose (blank-line-separated) list items, fixed `1.` ordered
-  markers, 2-space nesting indent, banger's heading start-of-line escaping,
-  autolink heuristic, adaptive code fences/backticks, hard-break lookahead.
-- **Golden corpus** in `@bangle.io/test-utils` (`markdown-corpus.ts`,
-  ~140 fixtures) with both-engine contract tests:
-  `core/editor/src/__tests__/markdown-golden-corpus.spec.ts` (ProseMirror)
-  and `wordgard-markdown/src/__tests__/markdown-golden-corpus.spec.ts`
-  (Wordgard). Table fixtures are `engines: ['prosemirror']` until M3.
-  Fixtures come in two contract shapes: canonical-form fixed points, and
-  `canonical`-carrying normalization fixtures (`*em*` -> `_em_`, setext ->
-  ATX, indented -> fenced code, reference -> inline links, ...) asserting
-  both engines normalize legal-but-non-canonical Markdown to the same bytes
-  AND that the canonical form is itself stable. Constructs with no shared
-  fixed point stay out, each documented in the corpus file (lists nested
-  under ordered items, task-item continuation paragraphs, code spans inside
-  other marks, link text carrying nested mark runs, empty-label links).
-- **M1 review hardening (post-scaffold):** empirical A/B probing of both
-  engines surfaced and fixed real divergences —
-  - Wordgard serializer now sorts spanning marks by mark-spec registration
-    order (`MarkdownSerializerState.serializationMarks`), because Wordgard's
-    built-in mark ranks (`Link 20 < Strike 42 < Em 50 < Strong 60 < Code
-    80`) are nearly the reverse of the PM schema's and produced broken
-    output for overlapping marks (`**[link](x) is bold**` serialized as
-    `[**link**](x)** is bold**`). The mark-spec order in
-    `defaultMarkdownSpecs` is therefore load-bearing (outermost first,
-    `Code` last since a non-escaping mark must be innermost).
-  - The PM corpus test's extension registration order now mirrors the app's
-    `setupExtensions` (bold, strike, code, italic, link) — PM mark rank
-    follows schema insertion order and decides delimiter nesting, so the
-    old test order blessed canonical forms the real app never emits.
-  - Autolink URL corruption fixed in BOTH engines (`<https://x/_f>` used to
-    serialize as `<https://x/\_f>`): banger-editor's link/text serializers
-    now implement prosemirror-markdown's `inAutolink` protocol, and the
-    Wordgard codec does the same.
-  - Image alt-text truncation fixed in BOTH engines (`![a\]b](x)` lost
-    everything after the escape): alt is now joined across all markdown-it
-    children instead of `children[0].content`.
-  - Deliberate divergences from the PM engine, kept because they preserve
-    data: the Wordgard link mark is `mixable` (PM's splits
-    `[link _foo **bar**_](x)` into three links, output that fails even PM's
-    own round trip), and Wordgard does not copy the PM `code` mark's
-    exclude-all-marks rule (PM silently unbolts `**bold `code`**`).
-- **M1 exit met for the non-table schema:** the corpus (round-trip +
-  normalization contracts) passes byte-identically through both engines
-  headlessly, plus serialize-only constructed-doc tests ported from
-  prosemirror-markdown's suite for shapes parsing cannot produce.
-- **List/task syntax now lives in the shared layer:** the markdown-it list
-  plugin (kind stamping + GFM task detection) is vendored into
-  `@bangle.io/markdown-syntax` (`list-syntax.ts`, replacing the
-  `@bangle.dev/pm-markdown/list-markdown` import), with exported
-  `LIST_KIND_ATTR`/`TASK_CHECKED_ATTR` constants both codecs now use. The
-  rewrite dropped dead behavior no consumer read (a `tight` attr that was
-  always `"false"`, an ordered `order` attr both engines ignore, an HTML
-  renderer override) and fixed real gaps, each pinned by tokenizer tests
-  and corpus fixtures:
-  - Empty tasks (`- [ ]` / `- [x]`) are now recognized, matching GitHub;
-    canonical form `- [ ] `.
-  - `1. [ ] x` (task inside an ordered list — GFM-legal) used to CRASH the
-    Wordgard codec (`OrderedList cannot contain child TaskItem`), i.e. a
-    legal note would fail to load. `taskListContentOverrides` now admits
-    the transient shape and serialization normalizes to `- [ ] x`,
-    byte-identical with the PM engine.
-  - The inline token's own `content` is kept in sync when the marker is
-    sliced off (it used to go stale), and the emptied text child is
-    removed.
-- **Table syntax now lives in the shared layer too:** the GFM table
-  markdown-it plugin (enable `table` + the `<br>`-in-cell → hardbreak
-  rule) moved from `banger-editor/table/table-markdown.ts` into
-  `@bangle.io/markdown-syntax` as the opt-in `tableTokenizer` (same
-  posture as `wikiLinkTokenizer` — deliberately NOT part of the base
-  tokenizer, because an engine without table handling must not receive
-  table tokens or table notes would fail to parse; a tokenizer test pins
-  that invariant). The PM table extension consumes it; the Wordgard codec
-  adopts it with table specs in M3. That closes M1 entirely except for
-  the M3-scheduled Wordgard table specs themselves.
-- **Frontmatter parity (integrated after PR #615 landed on main):** the
-  Wordgard codec now supports YAML frontmatter — `Frontmatter` plot in
-  wordgard-utils (inline text content, `Node.Role.Code`, admitted into
-  `Doc` via `frontmatterDocContentOverride`; the shared tokenizer only
-  produces the token at line 0, so position/single-instance invariants
-  are editor-milestone corrections, not schema rules), a `MarkdownSpec`
-  byte-matching the PM serializer, and `frontmatterTokenizer` wired into
-  `createNoteMarkdownCodec`. The PM engine's new doc-leading
-  thematic-break rule (`---` at document start serializes as `***` so it
-  cannot re-parse as a frontmatter fence) is mirrored in the Wordgard hr
-  spec. Corpus: frontmatter fixtures (with body, alone, empty, `...`
-  closing-fence normalization, unclosed-fence stays a thematic break,
-  mid-document `---` untouched) plus the reworked thematic-break
-  fixtures are all BOTH_ENGINES.
-### M0b complete — the engine switch is live
-
-- **`@bangle.io/editor-w` stub** (`packages/core/editor-w`): `EditorWService`
-  implements `EditorEngineContract` with `engineId: 'wordgard'` and renders
-  the note's Markdown source **read-only** (no Wordgard code yet). The save
-  contract reports a permanently clean state, a missing note renders empty
-  without writing (mirrors PM), and a failed read shows an error state and
-  never writes. Its React surface carries a persistent "experimental
-  preview" notice with a one-click switch back.
-- **URL selection**: the composition root reads `?editorEngine=` before the
-  container exists. Unknown or missing values select ProseMirror. The hash
-  router preserves the query string during normal navigation, with no stored
-  preference or storage migration.
-- **Composition-root selection**: `createServiceSetup` takes the selected
-  `EditorEngineId` and directly registers `PmEditorService` or
-  `EditorWService`. `EditorSurface` directly renders the matching component.
-  Both packages ship together; the simpler composition is preferred while
-  there are only two engines.
-- **Switch command**: `command::ui:switch-editor-engine` (omni-search)
-  opens the standard single-select dialog ("ProseMirror (stable)" /
-  "Wordgard (experimental)"), waits for the save queue to drain
-  (`waitForSaveQueueToDrain`, 5s bound — a still-dirty queue means a failed
-  save), refuses with a toast in that case, else updates the current tab's URL
-  and reloads that page. Other tabs keep their own URL and current editor,
-  so their saves are never interrupted by a switch elsewhere.
-- **Coverage**: unit specs for the stub service (read-only, load-failure,
-  idempotent mount), URL selection, and the drain helper;
-  `editor-engine-switch.e2e.ts` covers the full loop —
-  switch → wordgard renders raw markdown read-only → survives browser
-  reload → typing does nothing → switch back → note editable with no data
-  loss. It also proves that switching one tab does not reload another. The e2e
-  keys on `data-editor-engine`.
-- Deferred (deliberately): migrating shared e2e helpers off `.ProseMirror`
-  onto a neutral hook (revisit when editor-w is writable in M2); a gate for
-  editor-mount-time crashes (a React-render crash lands in the app error
-  boundary as before).
-
-### M4-P0 complete — wordgard-plus scaffold + bridge
-
-- **`@bangle.io/wordgard-plus`** (js-lib, browser, bangle-free) scaffolded
-  with the bridge foundation, holding the "complement, never wrap"
-  invariants: every export is an extension for the consumer's own
-  `Wordgard.create` config or a React component for the consumer's tree;
-  wordgard is consumed only via the `wordgard-utils` chokepoint (which grew
-  `editor`/`state`/`command`/`history`/schema-bundle re-exports).
-- **API adaptation discovered against the real 0.1.1 surface** (the plan
-  sketched `createEditorAtoms(wg)` / `useResolvedMenu(wg)` before the API
-  was checked): update hooks are config-time facets/plugins, not post-hoc
-  subscriptions on a live instance, so both bridges return
-  `{ atoms, extension }` and are fed by a `Wordgard.Plugin` (create seeds,
-  `update` syncs, `disconnect` clears focus). This is the Wordgard-idiomatic
-  shape and keeps the no-wrapping invariant by construction.
-- `createEditorAtoms({store, queries?})`: per-editor Jotai read atoms
-  (focused, selection summary, canUndo/canRedo via history depths —
-  gracefully false without the history extension — plus arbitrary
-  `(state) => boolean` queries for `listIsActive`-style predicates), every
-  write equality-guarded.
-- `createMenuAtoms({store, template?})` + `useResolvedMenu`: `Menu.resolve`
-  over the editor's own `Menu.Item.source` facet, projected to plain data
-  (label/icon/description with PhraseSet refs resolved, active/enabled,
-  `run()` dispatching through `Command.dispatch`), re-projected on
-  doc/selection changes plus item `updateFor` transactions, with deep
-  equality so the atom only notifies on visible change. No parallel menu
-  registry — 1p items from feature bundles render in React.
-- `reactTooltip` + `createTooltipHost` + `<TooltipHost>`: `Tooltip.View`s
-  whose DOM hosts a React subtree portaled from the consumer's tree
-  (context keeps flowing), mounted on `connect`, released on `disconnect`;
-  Wordgard owns geometry, React owns content, `@floating-ui/dom` stays out.
-- **Exit criterion met and verified live**: a Storybook story
-  (`tooling/storybook`, so wordgard-plus itself carries no storybook deps)
-  renders a React toolbar of resolved 1p menu items on a plain Wordgard
-  editor — exercised via playwright-cli: typing enables undo, toolbar
-  toggles strong (active state + bold output), block-style submenu shows
-  its active child as label, and a selection bubble demos the tooltip glue.
-- Unit specs (12, vitest + happy-dom — Wordgard runs headless there) cover
-  atom seeding/updates, equality guards, per-editor isolation, menu
-  projection + `run()` dispatch + notification suppression, and the tooltip
-  portal lifecycle including a real editor rendering a `Tooltip.show`
-  tooltip.
+Math (plan 012 M4, PR #637) is PM-only: wordgard-markdown has no math
+`MarkdownSpec` and the golden corpus has zero math fixtures — not even as
+`engines: ['prosemirror']`. A math row is added to the feature parity
+matrix below so the parity worklist stays honest.
 
 - **Coordination rule with plan 012 (markdown feature parity):** every
   012 construct changes what a note's bytes mean, so each 012 milestone
@@ -484,88 +273,13 @@ at M2 — not before)
 
 ### Designing for a raw (source) editor (and other future surfaces)
 
-A near-certain future surface is an **Obsidian-style raw Markdown editor**
-powered by **CodeMirror 6**: a toggle that switches a note from the WYSIWYG
-view to editing its Markdown source directly. It is **not built in this plan** —
-the goal here is only to keep the seam and kernel flexible enough that it (and
-surfaces like it) slot in without a redesign. Placed right, that flexibility is
-nearly free, and it sharpens the Wordgard work rather than competing with it.
-
-Implementation is now specified separately in
-`plans/013-live-markdown-source-editor.md`. That plan makes Live Markdown a
-surface mode above the selected rich engine and pulls the `editor-common`
-extraction forward as shared foundation. This section remains the architectural
-constraint for Wordgard work; plan 013 owns the source-editor product and
-delivery milestones.
-
-**The realization:** the `editorEngine` slot is not "which WYSIWYG library" — it
-is *whatever powers the editing surface* (as the name already intends). Editing
-surfaces span a spectrum:
-
-- **Rich / WYSIWYG surfaces** (ProseMirror, Wordgard) parse Markdown ⇄ a rich
-  document model. They own schema, decorations, and the round-trip gate.
-- **Raw / source surfaces** (CodeMirror) edit the Markdown text directly. There
-  is no document model to parse into and no serialization step, so a raw editor
-  is *inherently lossless* — the trivial implementation of
-  `EditorEngineContract`. That it fits so cleanly is the strongest evidence the
-  seam sits at the right altitude.
-
-Because the contract is **markdown-in / markdown-out**, the Markdown *is* the
-interchange format between surfaces. Switching surfaces — even instantly — is
-"serialize from the outgoing surface, mount the incoming surface with that
-string." No shared rich-document representation is ever needed.
-
-**Where the flexibility must live (the right places):**
-
-- **`EditorEngineContract`** — keep it free of WYSIWYG-only assumptions. Litmus
-  test for every method: *could a source editor implement this sensibly?*
-  Selection, `getSelectionMarkdown`, `insertMarkdownAtSelection`, save status,
-  and `hasPendingOrFailedSave` all pass. Anything that cannot belongs off the
-  shared contract or must be expressed generically — e.g. "heading collapse" is
-  document folding for a rich engine and code folding for a source editor, so
-  model it as a capability, not a PM/Wordgard detail.
-- **`engineId`** — already anticipates enumeration; the mental model is
-  `'prosemirror' | 'wordgard' | 'codemirror-source'`, so the contract admits
-  more than two WYSIWYG engines from the start, and `data-editor-engine` carries
-  the source id too.
-- **`editor-common` (M2 kernel)** — the save queue, load-status machine, and
-  `<Editor>` shell must be **surface-category-agnostic**: they may know only the
-  contract, never a rich document. Use the raw editor as the check when
-  extracting it — *would a CodeMirror surface fit through this shell unchanged?*
-  If a piece cannot, it belongs in the engine, not the kernel.
-- **`EditorSurface`** (`core/app/.../editor-surface.tsx`, the one documented
-  app-layer leak point) — already the per-engine component switch; it
-  generalizes to a per-**surface** switch (WYSIWYG engines + the source editor)
-  with no new seam.
-
-**Two levels of switching.** The engine-switch design below (URL-selected,
-reload-based) is right for *heavy* WYSIWYG engines — it avoids
-double-mounted editors and stale plugin state. A raw source editor is
-lightweight and stateless enough that a **per-note rich ⇄ raw toggle** can be an
-*instant* swap rather than a reload, feasible precisely because of the
-markdown-as-interchange property above. Shape the switch command/dialog and the
-engine selection so that adding a third option, or a per-note mode toggle,
-is *additive* — do not hardcode "exactly one engine per tab, changeable only by
-reload" so deeply that an in-place surface swap becomes impossible.
-
-**The gate and the fallback fit together.** The round-trip gate is a
-**rich-engine** concern (raw editing has nothing to round-trip). A raw editor is
-also the natural *editable* fallback when a WYSIWYG engine's gate fails: instead
-of only opening read-only, a note the rich engine cannot preserve can open in
-source mode — fully editable and inherently safe. The gate additionally guards
-the rich → raw handoff: if a note's parse→serialize is proven lossless, the
-rich ⇄ raw toggle is lossless too.
-
-**Cost noted, not paid here.** CodeMirror is a real future dependency (bundle
-weight; load it only when source mode is used). Convenient coincidence:
-Wordgard's extension architecture is modeled on CodeMirror 6, so the mental
-models (facets, state fields, extensions) transfer — the Wordgard stack warms us
-up for the source editor.
-
-**Directive for the Wordgard milestones (M1–M6):** never bake WYSIWYG-only
-assumptions into `EditorEngineContract` or `editor-common`. Each time the
-contract or kernel grows, ask the source-editor litmus question. Nothing else
-about the raw editor is in scope for this plan.
+Litmus rule for the Wordgard milestones: never bake WYSIWYG-only
+assumptions into `EditorEngineContract` or `editor-common` — each time the
+contract or kernel grows, ask whether a CodeMirror source surface could
+implement it sensibly. The source editor's product design and delivery
+(per-note rich ⇄ raw toggle, gate fallback, CodeMirror loading) now live
+in `plans/013-live-markdown-source-editor.md`; this rule is all that
+remains in scope here.
 
 ### Engine selection and switching
 
@@ -646,6 +360,7 @@ From the current extension inventory (`core/editor/src/extensions.ts`).
 | task lists (flat-list `kind: task`, checked; toggle/collapsed dropped) | `TaskItem` plot landed in M1; commands/input rule/checkbox are M3-T1..T3 (see Lists section) | M3 |
 | wiki link node + `[[` suggestions | Build in wordgard-utils (syntax + node) / editor-w (target resolution) | M3 |
 | markdown parse/serialize (pm-markdown) | **Build: `wordgard-markdown`** — the critical path | M1 |
+| math (inline `$x$` / block `$$…$$`; PM side landed via plan 012 M4, PR #637) | Build: math `MarkdownSpec` in `wordgard-markdown` + corpus fixtures | M3 or M5 |
 | slash commands, date picker suggestions | wordgard-plus `suggest` UI over a thin trigger seam (upstream #13); consumers in editor-w (M4-P3) | M4 |
 | selection menu (floating toolbar) | wordgard-plus `selection-toolbar`: Tooltip facet + resolved 1p menu items in React (M4-P1) | M4 |
 | placeholder, trailing node | Build (small decorations/corrections) | M4 |
@@ -908,34 +623,15 @@ Milestones can overlap where dependencies allow; the ordering below is the
 dependency spine, not a calendar.
 
 **M0 — Seam hardening (no Wordgard code) — DONE**
-Rename contract/slot (`EditorEngineContract` / `editorEngine`), move any
-stragglers onto the contract, `implements` check on `PmEditorService`,
-`data-editor-engine` on the mount, and the single `EditorSurface` leak point
-in the app layer. Exit (met): everything outside `core/editor` compiles
-against the contract only; zero behavior change for PM users.
+DONE — see Current status.
 
 **M0b — Switch plumbing (lands with the editor-w stub) — DONE**
-The URL engine selection, the omni-search switch command,
-and composition-root selection — landed
-together with a stub editor-w package whose "editor" renders the note
-read-only (no Wordgard yet), so the switch is real and e2e-testable the day
-it exists. Exit (met): switching engines round-trips through reload on a
-real workspace; e2e covers the switch + fallback (see "M0b complete"
-above).
+DONE — see Current status.
 
 **M1 — `wordgard-markdown` + shared syntax + golden corpus**
-The shared markdown-it syntax layer is **done** — extracted as
-`@bangle.io/markdown-syntax`, with the ProseMirror loader and the backlink
-extractor moved onto it (see "M1 in progress" above). Remaining: the codec
-for the full current schema (CommonMark + GFM tables/strikethrough/task lists
-+ wiki links) and the **golden corpus**: a fixture set of
-markdown documents (whitespace edge cases, nested/task lists, links, images,
-code, tables, wiki links, raw/unsupported constructs) with two contract
-tests — PM stack round-trips corpus unchanged; Wordgard stack round-trips
-corpus unchanged. The corpus lives in `@bangle.io/test-utils` so both
-engines consume it as a dev dependency. Exit: corpus green on both engines
-headlessly. This milestone is the schwerpunkt; nothing writable ships
-before it.
+DONE except the Wordgard table specs (scheduled M3) — see Current status.
+This milestone was the schwerpunkt; nothing writable ships before it. Exit
+(met for the non-table schema): corpus green on both engines headlessly.
 
 **M2 — Writable core editing**
 Wordgard editor wired in editor-w: schema assembly from wordgard-utils
@@ -1024,20 +720,8 @@ outlive the flip as a safety valve.
 
 ## The `wordgard` skill
 
-Because Wordgard is brand-new (released this week), no model knows it from
-training. `.claude/skills/wordgard/` ships in this PR:
-
-- `SKILL.md` — how to write idiomatic Wordgard in this repo: the concept
-  model (plot/leaf/tag/mark/param), the facet/state-field/correction/command
-  decision tree, repo-specific recipes (adding a feature = extension bundle
-  + markdown spec + corpus fixtures + tests), and explicit anti-patterns
-  (don't port PM idioms).
-- `references/` — verbatim vendored upstream docs (system guide,
-  ProseMirror-migration doc, FAQ, examples, README, CHANGELOG; MIT, with
-  attribution file). Refresh these on every `wordgard` version bump, and
-  read the vendored CHANGELOG diff as part of the upgrade ritual. The full
-  API surface is always available in `node_modules/wordgard/dist/*.d.ts`
-  once the dependency lands.
+The skill lives at `.claude/skills/wordgard/` (SKILL.md + vendored upstream
+docs). Refresh the vendored docs on every `wordgard` version bump.
 
 ## Risks
 
@@ -1092,20 +776,10 @@ None. M0 can start immediately.
 
 ## Next steps
 
-1. Shared syntax layer: **done** (`@bangle.io/markdown-syntax`).
-2. Scaffold `wordgard-utils` + `wordgard-markdown`, build the codec, add the
-   golden corpus with both-engine contract tests: **done** (see "M1
-   essentially complete" above).
-3. M0b: **done** — stub `@bangle.io/editor-w`, URL selection,
-   omni-search switch command, static composition-root selection, and e2e
-   switch coverage (see "M0b complete" above).
-4. M2 next: wire a real Wordgard editor into editor-w (schema assembly from
+1. M2: wire a real Wordgard editor into editor-w (schema assembly from
    wordgard-utils bundles, history, keymaps, styles, `t`→PhraseSet bridge),
    extract `editor-common` (save queue, load-status, `<Editor>` shell) when
    editor-w first needs it, and bring the round-trip gate live (including
-   the strict-vs-normalizing policy decision). M4-P0 (wordgard-plus
-   scaffold + bridge) can proceed in parallel — it needs no editor-w
-   service.
-5. Table parity (M3): move `banger-editor/table/table-markdown.ts` into the
-   shared layer, add Wordgard table specs, and flip the corpus table
-   fixtures to both engines.
+   the strict-vs-normalizing policy decision).
+2. Table parity (M3): add Wordgard table specs over the shared
+   `tableTokenizer` and flip the corpus table fixtures to both engines.

--- a/plans/012-markdown-feature-parity.md
+++ b/plans/012-markdown-feature-parity.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-07
-updated: 2026-07-21
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/615
@@ -51,6 +51,9 @@ Active and partially implemented:
   tokenization, editable inline/display nodes, KaTeX rendering, exact-source
   safeguards, and Playwright persistence coverage. That PR also added a
   separate Plan 016 for lazy-loading the renderer after the first release.
+- M4 shipped without golden-corpus math fixtures (neither BOTH_ENGINES nor
+  `engines: ['prosemirror']`); adding PM-only fixtures is owed under
+  architecture rule 6 / the plan 011 coordination rule.
 - PR #658 merged with a cross-engine list-fidelity slice: tight/loose list
   semantics, ordered task-list kind, split/input-rule transitions, and stable
   structural indentation. It strengthens the parity baseline but does not
@@ -68,16 +71,15 @@ Mutating on save today:
 | Reference links | `[foo][ref]` + `[ref]: url "T"` → inlined `[foo](url "T")`; definition destroyed |
 | Single-tilde strike (GFM) | `~x~` → `\~x\~` |
 | HTML entities | `&amp;` `&copy;` → literal `&` `©` |
-| Math block | `$$\nx^2\n$$` → `$$ x^2 $$` (soft break collapsed) |
 | Definition lists | `term\n: def` → `term : def` |
 
 Round-tripping safely as plain text (unrendered): raw HTML (tokenizer runs
-`html: false`), bare URLs, `==highlight==`, `$inline math$`, `:emoji:`,
-`> [!note]` callouts (render as plain blockquotes).
+`html: false`), bare URLs, `==highlight==`, `:emoji:`, `> [!note]` callouts
+(render as plain blockquotes).
 
 Already supported and verified: tables with alignment, task lists, `~~strike~~`,
 setext→ATX normalization, both hard-break forms, angle autolinks, link titles,
-indented + fenced code, frontmatter.
+indented + fenced code, frontmatter, inline + block math.
 
 ## Reference implementations studied
 
@@ -198,16 +200,8 @@ notes. Follow the GitLab/Milkdown two-node shape:
 
 ### M4 — Math (inline `$x$`, block `$$…$$`) — completed in PR #637
 
-- Two atom nodes with a `latex`/text content, per tiptap
-  `extension-mathematics`; block math is its own node, not a code-block
-  hijack (Milkdown's hijack couples two unrelated features).
-- Tokenizer: strict inline `$…$` rule (decline `$ 5 and $6`-style false
-  positives: no leading/trailing space inside delimiters, no digits abutting
-  outside — follow Pandoc's rules) and block `$$` fence rule.
-- Render with KaTeX behind a lazy dynamic import, mirroring the
-  `code-highlight-shiki` lazy-parser pattern already in `core/editor`.
-- Serialization must preserve interior newlines in block math (fixes the
-  probe's `$$ x^2 $$` collapse).
+Completed in PR #637 — atom nodes + strict tokenizer in `markdown-syntax`,
+interior newlines preserved; renderer lazy-loading tracked in plan 016.
 
 ### M5 — Reference links (decision milestone)
 

--- a/plans/013-live-markdown-source-editor.md
+++ b/plans/013-live-markdown-source-editor.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-12
-updated: 2026-07-19
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/630
@@ -431,14 +431,6 @@ Therefore:
 - use `atomicRanges` only for collapsed replacement ranges, and remove them as
   soon as selection/composition intersects the construct.
 
-Official CodeMirror support for mark/widget/replacement/line decorations,
-atomic ranges, viewport rendering, parser extensions, and explicit line
-separators is documented in the
-[decoration example](https://codemirror.net/examples/decoration/) and
-[reference manual](https://codemirror.net/docs/ref/). The current Markdown
-package exposes GFM language support, Markdown parser extensions, and fenced
-code language hooks.
-
 ### Link, wiki-link, and asset behavior
 
 Live Markdown keeps editing mechanics local to CodeMirror:
@@ -777,10 +769,9 @@ reasons to delay the earlier experimental milestones.
 
 ## Next steps
 
-1. Land this plan and add a short pointer from plan 011's raw-editor section.
-2. Build the M0 CodeMirror proof with heading/emphasis reveal, composition,
+1. Build the M0 CodeMirror proof with heading/emphasis reveal, composition,
    mixed line endings, dynamic loading, and a large-note fixture.
-3. Review the proof results and freeze the internal adapter contracts.
-4. Implement M1 as a behavior-preserving `editor-common` extraction.
-5. Land the M2 exact source editor behind `editorMode=live-markdown` with the
+2. Review the proof results and freeze the internal adapter contracts.
+3. Implement M1 as a behavior-preserving `editor-common` extraction.
+4. Land the M2 exact source editor behind `editorMode=live-markdown` with the
    full persistence/switching E2E before adding visual compaction.

--- a/plans/014-block-handle-slash-menu-hardening.md
+++ b/plans/014-block-handle-slash-menu-hardening.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-12
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/633
@@ -36,7 +36,7 @@ Large / Editor).
 Partially complete. Item 6 shipped in PR #656; items 1-5 and 7-8 remain, and
 none block release of the merged PR #633 behavior.
 
-Verified against `main` 2026-07-24: items 1-5, 7, and 8 all still open as
+Verified against `main` 2026-08-01: items 1-5, 7, and 8 all still open as
 described. Nothing has touched `banger-editor/src/drag/` since PR #633.
 Item 4 now goes first — see below.
 

--- a/plans/015-file-change-eventing-consolidation.md
+++ b/plans/015-file-change-eventing-consolidation.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-18
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/652
@@ -34,9 +34,14 @@ the actual design should be decided when the work is picked up.
 Documented during the notes-table work (PR #652), which added two more
 consumers (note file stats scan + targeted patch) and hit one of the implicit
 contracts described below as a real bug during review (force-update did not
-refresh stats). PR #626 is still open and activates Native FS external-change
-observation, making this consolidation more important, but the consolidation
-itself has not started.
+refresh stats). The Native FS external-change observation this plan was
+waiting on has now landed (PR #626): the provider seam is live, external disk
+changes flow through the existing typed events with a sender tag, and
+`ExternalContentSync` joined as another emitter-direct consumer. The
+"consolidate immediately before it lands" window has therefore passed; the
+consumer-side consolidation itself has still not started. The write-provenance
+primitive that would remove the sender-tag discrimination is recorded as plan
+019 M1.
 
 Inventory verified against `main` 2026-07-24; the ten atoms, the force-update
 side-channel, and the dead `onChange` seam are unchanged. `NoteSnapshotService`
@@ -195,7 +200,8 @@ producer contracts, not spaghetti.
 
 ## Next steps
 
-- Schedule alongside (immediately before) the FileSystemObserver integration
-  from issue #521.
+- The FileSystemObserver integration (issue #521, PR #626) has landed, so the
+  preferred scheduling window is gone; pick this up on its own merits, ideally
+  with plan 019 M1 so sender discrimination and dedup land as one design.
 - Re-read the consumer inventory above at pickup time; PR #652 and later work
   may have added consumers.

--- a/plans/015-heading-toc-rail.md
+++ b/plans/015-heading-toc-rail.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-13
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/642
@@ -33,7 +33,7 @@ editor engine is ProseMirror (`packages/core/editor` /
 heading APIs are stubs, so this plan targets the ProseMirror stack with a
 seam that wordgard can adopt later.
 
-Verified against `main` 2026-07-24.
+Verified against `main` 2026-08-01.
 
 ## UX behavior
 

--- a/plans/016-editor-math-lazy-loading.md
+++ b/plans/016-editor-math-lazy-loading.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-18
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/637
@@ -25,7 +25,10 @@ success to parse, edit, save, or recover.
 
 ## Current status
 
-Blocked on upstream, verified 2026-07-24.
+Blocked on upstream, verified 2026-08-01: `@benrbray/prosemirror-math` remains
+at 1.0.0 with no newer release, and no upstream issue requesting the
+renderer-free entry split has been filed yet — filing that request (next step
+2) is the actionable move, not waiting.
 
 - Math support is complete in PR #637 and deliberately loads KaTeX eagerly.
 - The recorded main JavaScript bundle grew from 564.01 kB gzip before the

--- a/plans/018-note-snapshot-native-fs-backend.md
+++ b/plans/018-note-snapshot-native-fs-backend.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-24
-updated: 2026-07-24
+updated: 2026-08-01
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/669
@@ -68,16 +68,17 @@ a real one rather than theoretical.
 These need answers before implementation, and none should be guessed:
 
 - Directory name and layout, and whether it must be hidden from the file tree,
-  search, backlinks, and the notes table.
+  search, backlinks, and the notes table. The external-change watcher (PR
+  #626) applies the listing's visibility policy before classifying records,
+  so a dot-prefixed directory such as `.bangle/backups/` is ignored by
+  observation for free once #626 merges — the decision reduces to name and
+  layout.
 - Whether a write failure to the snapshot directory (permission loss, quota,
   read-only volume) may ever fail or delay the user's own note write. It must
   not — but the pre-write hook currently sits on the write path, so this needs
   a deliberate answer.
 - Behavior when the user deletes or edits files inside the snapshot directory
   by hand, which they can and eventually will.
-- Whether snapshots should be excluded from the Native FS external-change
-  observation work (PR #626 / issue #521) to avoid a feedback loop where
-  writing a snapshot triggers a change event that triggers another snapshot.
 
 ## Verification
 
@@ -90,8 +91,9 @@ These need answers before implementation, and none should be guessed:
 
 ## Known blockers
 
-Depends on the open questions above, particularly the interaction with
-FileSystemObserver in PR #626.
+Depends on the open questions above, and on PR #626 landing (its watcher-side
+hidden-path exclusion is what keeps a dot-prefixed snapshot directory out of
+external-change observation).
 
 ## Next steps
 

--- a/plans/019-architecture-primitives.md
+++ b/plans/019-architecture-primitives.md
@@ -1,0 +1,77 @@
+---
+title: Architecture primitives — versioned storage, loss-aware codec, container lifetimes
+status: planned
+type: plan
+archived: false
+archived_on:
+created: 2026-08-01
+updated: 2026-08-01
+owner: mixed
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/626
+related_issues:
+  - https://github.com/bangle-io/bangle-io/issues/521
+---
+
+# Architecture Primitives
+
+## Summary
+
+The external-change auto-refresh work (PR #626) shipped correct behavior by
+compensating for primitives the lower layers do not provide: echo detection,
+conflict detection, and Markdown loss detection are heuristics at the top of
+the stack, and cross-lifetime objects are hand-threaded through the
+composition root. The compensations are fenced and test-collateralized; this
+plan records the primitives that would replace them, each with an explicit
+trigger. None of this is scheduled — pick up a milestone when its trigger
+fires, not before.
+
+## Scope
+
+- **M1 — Versioned storage contract.** Reads on `BaseFileStorageProvider`
+  return an opaque version token; writes accept an expected token (CAS) and
+  record the token they produce. Echo detection becomes a token comparison in
+  the adapter; overwrite races become a typed refusal. Exit criteria:
+  `external-content-sync.ts` drops the double stable read and the
+  serializer-equality echo branch. *Trigger: the next feature needing echo or
+  conflict detection (snapshot backends, sync, desktop), or the first
+  echo-heuristic bug in the wild.*
+- **M2 — Loss-aware Markdown codec.** Parsing returns the document plus a
+  structured loss report, owned by the codec; `round-trip-check.ts` shrinks
+  to a consumer and the byte-diff remains only as the normalization signal.
+  Design the report shape together with the wordgard-markdown corpus work
+  (plans 011/012) so both engines share it. *Trigger: the next silent-loss
+  hole in the regex gate, or whenever wordgard-markdown builds its
+  loss/parity reporting.*
+- **M3 — Container lifetimes.** `poor-mans-di` grows a browser-root scope
+  (save coordinator, root emitter stop being hand-threaded) and a
+  workspace-session scope that owns watchers, `fsCache` entries, and
+  per-workspace invalidation — disposal on workspace close is the eviction
+  story. *Trigger: the next browser-root object, or watcher/cache growth
+  showing up in practice.*
+- **M4 — Platform `pageLifecycle` slot.** A small platform capability that
+  the router and `FileStorageNativeFs` both depend on via `static deps`,
+  deleting the late-bound `getRouter` closure. Independent and cheap; can
+  land any time.
+
+## Out of scope
+
+- Rewriting `external-content-sync.ts` for its own sake — it shrinks as a
+  consequence of M1/M2, and its interleaving spec bank is the collateral
+  that must stay green throughout.
+- Consumer-side event mechanics (sequence dedup, counter vocabulary) — plan
+  015 owns that record.
+- Any user-visible behavior change.
+
+## Verification
+
+Contract tests for M1 shared across all three adapters; the existing
+external-sync specs and NativeFS Playwright suite pass unchanged at every
+milestone; M2 asserts loss reports against the golden corpus for both
+serializers. Standard `AGENTS.md` gates apply.
+
+## Next steps
+
+None scheduled. First mover when picked up: M4, then a spike on M1 token
+semantics (can NativeFS `lastModified` + size be trusted across external
+writers?).


### PR DESCRIPTION
## Summary

- Watch Native FS workspaces for external file changes and revalidate them when the user returns to the page.
- Route external changes through the existing typed file-event pipeline so file trees, indexes, and open notes refresh consistently across tabs.
- Reconcile clean open editors only after stable reads; apply anything whose parse keeps the user's content, and refuse only what it would drop.
- Preserve editor content in Recover snapshots before applying a genuinely different external disk version.
- Docs riding along: every active plan re-verified against the tree and trimmed of finished-work restatement (net -1,300 lines), plus a new plan 019 recording the architecture primitives this work surfaced (storage version tokens, loss-aware codec, container lifetimes).

## Reviewer callouts

**The apply gate asks whether parsing loses content, not whether saving would reformat.** Those differ constantly: hand-wrapped Markdown never round-trips byte-for-byte, yet every word survives the parse. Measured against a real 703-file Markdown repository, a byte comparison refuses 159 files — 23% — each one then permanently unable to receive an external change. The gate is the OR of `isMarkdownRoundTripPreserved` and `isMarkdownContentPreserved` (the predicate already written for the paste gate), which takes that 159 to 1. The one that remains is the destructive class: a link reference definition nothing resolves against is consumed by the parser and emitted nowhere, so applying it would arm the next keystroke to delete a line still on disk. The two tests are not nested — a fenced code block that merely contains a definition-shaped line is byte-identical yet fails the content test — so either passing is enough.

The fidelity notice keeps the stricter byte test: "saving will rewrite this" is true for all 159, which is exactly what it says. It now also refreshes on automatic applies, which it did not before.

**Watcher scope follows the listing policy.** A workspace pointed at a code repo sees constant `git` and `npm` activity. Records from locations the listing never shows are ignored before their path shape is parsed — extensionless paths like `.git/HEAD` and `node_modules/.bin/tsc` do not parse as files, so without that ordering each one forced a full workspace re-list.

**Watcher echoes.** The app's own writes come back through the observer. Those echoes are intentionally not time-suppressed — that can hide a real external overwrite — so serializer comparison coalesces them instead. The echo does *not* lift the note-snapshot capture throttle on its own; it earns a provisional bypass honoured only once the disk copy turns out not to be what this tab just wrote. Lifting it eagerly silently disabled local snapshot history on every watched workspace.

**Content that cannot be preserved.** A note too large to snapshot is reported `unpreservable`, and the sync refuses to replace the editor rather than destroying the last copy.

**Dirty editors survive external rename/delete.** They stay mounted as a recovery surface, subscribing to save status rather than reading it during render. `LinkedMentions` is guarded for this case — the editor can outlive its file-tree entry.

**Refusals are actionable.** A per-note notice offers "Load disk version". Every way that action can fail to apply — unreadable file, note went dirty, note closed, read/parse threw — reports back instead of silently dismissing the notice.

**Observer lifetime.** `NativeFs.watch` returns a `stop` handle; re-arming after an `errored` record disconnects the broken observer instead of stacking a second one.

## Known tradeoffs

- `acceptDiskVersion` reads once rather than requiring two agreeing reads — consenting mid-write can load a truncated file, but the editor's copy is snapshotted first, and making the user wait out a stability protocol for an explicit action is worse than the rare bad read.
- Watcher events travel on cross-tab events, so N tabs on one workspace each run a reconcile pass per external change. Bounded and coalesced downstream. Separate browsing contexts (e.g. incognito) do not share the channel and rely on their own observer.
- A burst the OS reports as `unknown` still forces a coarse refresh; that is the observer saying it lost track, so it is honoured rather than second-guessed.
- Page visibility is used as a staleness *repair* trigger only, never as a gate on reconciliation. Keying apply decisions on focus was considered and rejected: `visibilitychange` does not fire for a visible-but-unfocused window, which is precisely the side-by-side-with-another-editor setup this feature targets, and the real guards (pending saves, IME composition, document identity) are direct measurements that focus cannot replace.
- A not-byte-preserved file whose only definition-shaped line sits inside a code fence is still refused — the deliberate cost of not letting prose vouch for a definition, shared with the paste gate.

## Verification

Beyond unit/e2e coverage, this was exercised manually through a production build against a real ~700-file git repository as the workspace folder, with a live `FileSystemObserver`: external create/edit/rename/delete, an external write racing unsaved typing (local edit wins, displaced content recoverable), lossy-content refusal and in-place recovery, tab hide/return revalidation, and reload with a persisted directory grant. The hidden-location ignore fix and the apply-gate change both came out of that run.

Closes #521.

