### PR TITLE
fix(e2e): deterministic editor caret placement + data-editor-chrome marker

### DIFF
--- a/packages/core/editor/src/block-action-button.ts
+++ b/packages/core/editor/src/block-action-button.ts
@@ -41,6 +41,19 @@ export function createBlockActionButton({
 }
 
 /**
+ * Marks a widget wrapper as editor chrome: interface elements (language
+ * badges, copy/delete buttons, ...) that render inside the editable content
+ * DOM but are not document content. Chrome must be non-editable so
+ * ProseMirror never places the cursor in it, and it carries
+ * `data-editor-chrome` so text extraction (tests, tooling) can exclude it —
+ * document text offsets must never depend on when chrome happens to render.
+ */
+export function markEditorChrome(element: HTMLElement): void {
+  element.contentEditable = 'false';
+  element.dataset.editorChrome = 'true';
+}
+
+/**
  * Events a block-action widget handles itself; ProseMirror must not treat
  * them as editor interactions. Used as the widget decoration's `stopEvent`.
  */

--- a/packages/core/editor/src/code-highlight.ts
+++ b/packages/core/editor/src/code-highlight.ts
@@ -12,6 +12,7 @@ import {
   createBlockActionButton,
   deleteBlockAt,
   isBlockActionEvent,
+  markEditorChrome,
 } from './block-action-button';
 import {
   DEFAULT_CODE_BLOCK_LANGUAGE,
@@ -231,7 +232,7 @@ function createCopyButtonWidget(
   const copyLabel = t.app.editor.codeBlock.copy;
   const wrapper = document.createElement('span');
   wrapper.className = 'prosemirror-code-copy-widget';
-  wrapper.contentEditable = 'false';
+  markEditorChrome(wrapper);
 
   const button = document.createElement('button');
   button.type = 'button';
@@ -347,7 +348,7 @@ function createLanguageBadgeWidget(
 ): HTMLElement {
   const wrapper = document.createElement('span');
   wrapper.className = 'prosemirror-code-language-widget';
-  wrapper.contentEditable = 'false';
+  markEditorChrome(wrapper);
   wrapper.append(
     createLanguageButton(wrapper, language, getCodeBlockPos, editorView),
   );

--- a/packages/core/editor/src/frontmatter-actions.ts
+++ b/packages/core/editor/src/frontmatter-actions.ts
@@ -11,6 +11,7 @@ import type { EditorView } from 'prosemirror-view';
 import {
   createBlockActionButton,
   isBlockActionEvent,
+  markEditorChrome,
 } from './block-action-button';
 
 const FRONTMATTER_ACTIONS_PLUGIN_KEY = new PluginKey('frontmatter-actions');
@@ -75,7 +76,7 @@ function createDeleteButtonWidget(
 ): HTMLElement {
   const wrapper = document.createElement('span');
   wrapper.className = 'prosemirror-frontmatter-actions-widget';
-  wrapper.contentEditable = 'false';
+  markEditorChrome(wrapper);
 
   wrapper.appendChild(
     createBlockActionButton({

--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -256,6 +256,10 @@ div.ProseMirror {
     display: flex;
     align-items: center;
     gap: 0.2rem;
+    /* Chrome is never document text (data-editor-chrome); also keep native
+       drag-selections from sweeping it up. */
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   & .prosemirror-code-language-widget {
@@ -263,6 +267,8 @@ div.ProseMirror {
     top: 0.42rem;
     left: 0.75rem;
     z-index: 1;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   & .prosemirror-code-language-button {

--- a/packages/tooling/browser-entry/src/__tests__/main.spec.tsx
+++ b/packages/tooling/browser-entry/src/__tests__/main.spec.tsx
@@ -39,7 +39,12 @@ describe('browser entry startup', () => {
     document.body.innerHTML = '';
   });
 
-  test('renders a user-visible startup error when service initialization fails', async () => {
+  // Importing `../main` pulls in the whole app graph; under a fully parallel
+  // vitest run that import alone can eat most of the default 5s test budget,
+  // so this test gets a wider one — it is import-bound, not logic-bound.
+  test('renders a user-visible startup error when service initialization fails', {
+    timeout: 30_000,
+  }, async () => {
     const error = new Error('database mount failed');
     let startupSignal: AbortSignal | undefined;
     mocks.initializeServices.mockImplementationOnce(
@@ -57,11 +62,14 @@ describe('browser entry startup', () => {
 
     await import('../main');
 
-    await vi.waitFor(() => {
-      expect(document.getElementById('root')?.textContent ?? '').toContain(
-        t.app.pageStartupError.title,
-      );
-    });
+    await vi.waitFor(
+      () => {
+        expect(document.getElementById('root')?.textContent ?? '').toContain(
+          t.app.pageStartupError.title,
+        );
+      },
+      { timeout: 10_000 },
+    );
 
     expect(document.getElementById('root')?.textContent ?? '').toContain(
       t.app.pageStartupError.description,

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -451,60 +451,131 @@ export async function loadBrowserWorkspaceFixture(
   return { workspaceName, files: files.map((file) => file.relativePath) };
 }
 
+/**
+ * Places a DOM selection over document text found inside the editor, retrying
+ * until the text exists (content and async decorations render over several
+ * frames — a one-shot walk is racy).
+ *
+ * Text offsets are computed over CONTENT text nodes only: widget chrome
+ * (language badges, copy/delete buttons) is marked `data-editor-chrome` and
+ * excluded, so offsets do not shift depending on whether async chrome has
+ * rendered yet. The filter deliberately does NOT key on
+ * `contenteditable="false"` — document atoms (e.g. wiki links) render
+ * non-editable too, and their text is real content.
+ */
+async function placeEditorTextSelection(
+  page: Page,
+  text: string,
+  mode: 'select' | 'collapse-after',
+) {
+  const editor = page.locator(EDITOR_SELECTOR);
+  await expect
+    .poll(
+      () =>
+        editor.evaluate(
+          (editorRoot, input) => {
+            const isChrome = (candidate: Text) => {
+              const chrome = candidate.parentElement?.closest(
+                '[data-editor-chrome]',
+              );
+              return Boolean(chrome && editorRoot.contains(chrome));
+            };
+            const walker = document.createTreeWalker(
+              editorRoot,
+              NodeFilter.SHOW_TEXT,
+            );
+            const textNodes: Text[] = [];
+            let node = walker.nextNode();
+            while (node) {
+              if (node instanceof Text && !isChrome(node)) {
+                textNodes.push(node);
+              }
+              node = walker.nextNode();
+            }
+
+            const fullText = textNodes
+              .map((textNode) => textNode.data)
+              .join('');
+            const start = fullText.indexOf(input.text);
+            if (start < 0) {
+              return false;
+            }
+            const end = start + input.text.length;
+
+            const resolveOffset = (offset: number) => {
+              let consumed = 0;
+              for (const textNode of textNodes) {
+                const next = consumed + textNode.length;
+                if (offset <= next) {
+                  return { node: textNode, offset: offset - consumed };
+                }
+                consumed = next;
+              }
+              throw new Error(`Unable to resolve editor offset: ${offset}`);
+            };
+
+            editorRoot.focus();
+            const range = document.createRange();
+            if (input.mode === 'collapse-after') {
+              const at = resolveOffset(end);
+              range.setStart(at.node, at.offset);
+              range.collapse(true);
+            } else {
+              const from = resolveOffset(start);
+              const to = resolveOffset(end);
+              range.setStart(from.node, from.offset);
+              range.setEnd(to.node, to.offset);
+            }
+            const selection = window.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+            document.dispatchEvent(
+              new Event('selectionchange', { bubbles: true }),
+            );
+            return true;
+          },
+          { text, mode },
+        ),
+      { message: `Unable to find editor text: ${text}` },
+    )
+    .toBe(true);
+}
+
 /** Selects the first exact text occurrence through a real browser Range. */
 export async function selectEditorText(page: Page, text: string) {
-  await page.locator(EDITOR_SELECTOR).evaluate((editor, selectedText) => {
-    editor.focus();
-    const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
-    const textNodes: Text[] = [];
-    let node = walker.nextNode();
-    while (node) {
-      textNodes.push(node as Text);
-      node = walker.nextNode();
-    }
+  await placeEditorTextSelection(page, text, 'select');
+}
 
-    const fullText = textNodes.map((textNode) => textNode.data).join('');
-    const start = fullText.indexOf(selectedText);
-    if (start < 0) {
-      throw new Error(`Unable to find editor text: ${selectedText}`);
-    }
-    const end = start + selectedText.length;
-
-    const resolveOffset = (offset: number) => {
-      let consumed = 0;
-      for (const textNode of textNodes) {
-        const next = consumed + textNode.length;
-        if (offset <= next) {
-          return { node: textNode, offset: offset - consumed };
-        }
-        consumed = next;
-      }
-      throw new Error(`Unable to resolve editor offset: ${offset}`);
-    };
-
-    const from = resolveOffset(start);
-    const to = resolveOffset(end);
-    const range = document.createRange();
-    range.setStart(from.node, from.offset);
-    range.setEnd(to.node, to.offset);
-    const selection = window.getSelection();
-    selection?.removeAllRanges();
-    selection?.addRange(range);
-    document.dispatchEvent(new Event('selectionchange', { bubbles: true }));
-  }, text);
+/**
+ * Places a collapsed caret immediately after the first exact occurrence of
+ * `text`. Prefer this over mouse coordinates + visual-line keys (`End`),
+ * which race async rendering (e.g. syntax highlighting swapping text nodes
+ * between the click and the keypress) and depend on line wrapping.
+ */
+export async function collapseEditorSelectionAfterText(
+  page: Page,
+  text: string,
+) {
+  await placeEditorTextSelection(page, text, 'collapse-after');
 }
 
 export async function collapseEditorSelection(page: Page, offset: number) {
   await page.locator(EDITOR_SELECTOR).evaluate((editor, cursorOffset) => {
+    const isChrome = (candidate: Text) => {
+      const chrome = candidate.parentElement?.closest('[data-editor-chrome]');
+      return Boolean(chrome && editor.contains(chrome));
+    };
     editor.focus();
     const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
     let textNode = walker.nextNode();
     let consumed = 0;
     while (textNode instanceof Text) {
-      if (cursorOffset <= consumed + textNode.length) {
-        break;
+      if (!isChrome(textNode)) {
+        if (cursorOffset <= consumed + textNode.length) {
+          break;
+        }
+        consumed += textNode.length;
       }
-      consumed += textNode.length;
       textNode = walker.nextNode();
     }
     if (!(textNode instanceof Text)) {

--- a/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-code-blocks.e2e.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
   clearEditor,
+  collapseEditorSelectionAfterText,
   createBrowserWorkspaceAndNote,
   ctrlKey,
   expectReadableContrast,
@@ -112,24 +113,17 @@ test('Shift-Enter adds persisted lines inside nested code blocks', async ({
   // Flat-list renders list items without a native <li>; the first fenced block
   // is the list-owned block and persisted Markdown below proves its ownership.
   const listedCode = editor.locator('pre code').first();
-  const listedBox = await listedCode.boundingBox();
-  expect(listedBox).not.toBeNull();
-  if (!listedBox) {
-    return;
-  }
-  await page.mouse.click(listedBox.x + 24, listedBox.y + listedBox.height - 8);
-  await page.keyboard.press(isDarwin ? 'Control+e' : 'End');
+  const quotedCode = editor.locator('blockquote pre code');
+
+  // Place the caret through a DOM Range instead of mouse coordinates +
+  // visual-line End: async syntax highlighting swaps the code text nodes
+  // shortly after load, which can void a coordinate-derived caret or a
+  // native End keypress between the click and the keystroke.
+  await collapseEditorSelectionAfterText(page, 'const listed = true;');
   await page.keyboard.press('Shift+Enter');
   await page.keyboard.insertText('return listed;');
 
-  const quotedCode = editor.locator('blockquote pre code');
-  const quotedBox = await quotedCode.boundingBox();
-  expect(quotedBox).not.toBeNull();
-  if (!quotedBox) {
-    return;
-  }
-  await page.mouse.click(quotedBox.x + 24, quotedBox.y + quotedBox.height - 8);
-  await page.keyboard.press(isDarwin ? 'Control+e' : 'End');
+  await collapseEditorSelectionAfterText(page, 'const quoted = true;');
   await page.keyboard.press('Shift+Enter');
   await page.keyboard.insertText('return quoted;');
 


### PR DESCRIPTION
## Problem

`editor-code-blocks.e2e.ts` › "Shift-Enter adds persisted lines inside nested code blocks" has failed on CI's slow single worker since it landed (red on main for `59d10fba` and `20f1929f`), while passing locally. The received text told the story:

```
JSCopyDeletecon
return listed;st listed = true;
```

Two distinct problems:

1. **Caret from coordinates + visual-line `End`.** The test clicked at `boundingBox().x + 24` (which lands the caret ~3 chars into `const`) and relied on a native `End` keypress to reach line end. On CI, the async shiki highlight re-render swaps the code-block text nodes between the click and the keystroke, so `End` no-ops against the stale DOM — the caret stays at `con|` and `Shift+Enter` + `insertText` splice into the middle of the word.
2. **Chrome text in offset math.** The code-block chrome (language badge, Copy/Delete buttons) renders *inside* the content DOM, so the shared `selectEditorText`/`collapseEditorSelection` helpers counted `JSCopyDelete` in their text walks — offsets depended on whether async chrome had rendered yet. The same one-shot, retry-less walk made `selection-menu.e2e.ts` › "creates and modifier-opens a relative Markdown note link" flake with "Unable to find editor text".

## Fix

**Editor (code side)** — a durable contract: *chrome never counts as document text*. New `markEditorChrome()` in `block-action-button.ts` stamps `contenteditable=false` + `data-editor-chrome` on the code-block language, copy/delete, and frontmatter-actions wrappers. The marker deliberately does **not** overload `contenteditable=false` alone for this meaning — document atoms (e.g. wiki links) render non-editable but *are* content (the first draft keyed on it and promptly broke wiki-link selection).

**E2E helpers (test side)** —
- `selectEditorText` now polls until the text exists (content and async decorations render over several frames; a one-shot walk is inherently racy) instead of throwing on first miss.
- Both it and `collapseEditorSelection` compute offsets over content text nodes only, skipping `data-editor-chrome` subtrees.
- New `collapseEditorSelectionAfterText(page, text)` places a collapsed caret through a real DOM Range — layout-, timing-, and platform-independent. The Shift-Enter test now uses it; no more `boundingBox` clicks or `isDarwin ? 'Control+e' : 'End'`.

**browser-entry unit test** — "renders a user-visible startup error…" is import-bound (it pulls the whole app graph) and starved its default 5s budget under fully parallel vitest runs (also seen red on CI-like local runs); it gets an explicit wider timeout with a comment saying why.

## Test plan

- `editor-code-blocks` ×3 repeats: 66/66 green; `selection-menu`, `selection-menu-touch`, `clipboard-markdown`, `editor-cursor-position`, `wiki-links` (every consumer of the touched helpers) green.
- `pnpm local-ci-check` green end to end on this branch (rebased on `4965b7b2`, post-#623).
- Pre-existing retry-flakes observed while verifying, **not** addressed here: `editor-cursor-position` restore (reproduces identically on unmodified main, self-heals on retry) and `file-explorer` drag-drop conflict under heavy parallel load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)