### PR TITLE
feat: add file tree collapse-all action

### DIFF
--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -196,7 +196,8 @@ export const AppSidebar = ({ children }: SidebarProps) => {
         }
         activeFilePaths={activeWsPaths.map((wsPath) => wsPath.path)}
         expandedFileTreePaths={
-          activeWsName
+          activeWsName &&
+          Object.hasOwn(fileTreeExpandedPathsByWorkspace, activeWsName)
             ? fileTreeExpandedPathsByWorkspace[activeWsName]
             : undefined
         }

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -25,10 +25,9 @@ export const AppSidebar = ({ children }: SidebarProps) => {
   const [showNoteFilesOnly, setShowNoteFilesOnly] = useAtom(
     workbenchState.$showNoteFilesOnlyInSidebar,
   );
-  const [
-    fileTreeExpandedPathsByWorkspace,
-    setFileTreeExpandedPathsByWorkspace,
-  ] = useAtom(workbenchState.$fileTreeExpandedPathsByWorkspace);
+  const fileTreeExpandedPathsByWorkspace = useAtomValue(
+    workbenchState.$fileTreeExpandedPathsByWorkspace,
+  );
   const activeWsName = useAtomValue(navigation.$wsName);
   const activeWsPaths = useAtomValue(workspaceState.$activeWsPaths);
   const wsPaths = useAtomValue(workspaceState.$wsPaths);
@@ -61,6 +60,35 @@ export const AppSidebar = ({ children }: SidebarProps) => {
     activeWsName,
     commandDispatcher,
   });
+
+  const handleFileTreeDirectoryExpansionChange = React.useCallback(
+    (path: string, expanded: boolean) => {
+      if (activeWsName) {
+        workbenchState.setFileTreeDirectoryExpanded(
+          activeWsName,
+          path,
+          expanded,
+        );
+      }
+    },
+    [activeWsName, workbenchState],
+  );
+  const handleRevealFileTreePaths = React.useCallback(
+    (paths: readonly string[]) => {
+      if (activeWsName) {
+        workbenchState.revealFileTreePaths(activeWsName, paths);
+      }
+    },
+    [activeWsName, workbenchState],
+  );
+  const handleCollapseFileTree = React.useCallback(
+    (keepExpandedPaths: readonly string[]) => {
+      if (activeWsName) {
+        workbenchState.collapseFileTree(activeWsName, keepExpandedPaths);
+      }
+    },
+    [activeWsName, workbenchState],
+  );
 
   return (
     <Sidebar.SidebarProvider
@@ -172,16 +200,11 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             ? fileTreeExpandedPathsByWorkspace[activeWsName]
             : undefined
         }
-        onExpandedFileTreePathsChange={(expandedPaths) => {
-          if (!activeWsName) {
-            return;
-          }
-
-          setFileTreeExpandedPathsByWorkspace((current) => ({
-            ...current,
-            [activeWsName]: expandedPaths,
-          }));
-        }}
+        onFileTreeDirectoryExpansionChange={
+          handleFileTreeDirectoryExpansionChange
+        }
+        onRevealFileTreePaths={handleRevealFileTreePaths}
+        onCollapseFileTree={handleCollapseFileTree}
         commandButtonClassName="desktop-titlebar-no-drag"
         showNoteFilesOnly={showNoteFilesOnly}
         onShowNoteFilesOnlyChange={setShowNoteFilesOnly}

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -25,9 +25,10 @@ export const AppSidebar = ({ children }: SidebarProps) => {
   const [showNoteFilesOnly, setShowNoteFilesOnly] = useAtom(
     workbenchState.$showNoteFilesOnlyInSidebar,
   );
-  const [fileTreeExpanded, setFileTreeExpanded] = useAtom(
-    workbenchState.$fileTreeExpanded,
-  );
+  const [
+    fileTreeExpandedPathsByWorkspace,
+    setFileTreeExpandedPathsByWorkspace,
+  ] = useAtom(workbenchState.$fileTreeExpandedPathsByWorkspace);
   const activeWsName = useAtomValue(navigation.$wsName);
   const activeWsPaths = useAtomValue(workspaceState.$activeWsPaths);
   const wsPaths = useAtomValue(workspaceState.$wsPaths);
@@ -166,8 +167,21 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             : undefined
         }
         activeFilePaths={activeWsPaths.map((wsPath) => wsPath.path)}
-        fileTreeExpanded={fileTreeExpanded}
-        onFileTreeExpandedChange={setFileTreeExpanded}
+        expandedFileTreePaths={
+          activeWsName
+            ? fileTreeExpandedPathsByWorkspace[activeWsName]
+            : undefined
+        }
+        onExpandedFileTreePathsChange={(expandedPaths) => {
+          if (!activeWsName) {
+            return;
+          }
+
+          setFileTreeExpandedPathsByWorkspace((current) => ({
+            ...current,
+            [activeWsName]: expandedPaths,
+          }));
+        }}
         commandButtonClassName="desktop-titlebar-no-drag"
         showNoteFilesOnly={showNoteFilesOnly}
         onShowNoteFilesOnlyChange={setShowNoteFilesOnly}

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -25,6 +25,9 @@ export const AppSidebar = ({ children }: SidebarProps) => {
   const [showNoteFilesOnly, setShowNoteFilesOnly] = useAtom(
     workbenchState.$showNoteFilesOnlyInSidebar,
   );
+  const [fileTreeExpanded, setFileTreeExpanded] = useAtom(
+    workbenchState.$fileTreeExpanded,
+  );
   const activeWsName = useAtomValue(navigation.$wsName);
   const activeWsPaths = useAtomValue(workspaceState.$activeWsPaths);
   const wsPaths = useAtomValue(workspaceState.$wsPaths);
@@ -163,6 +166,8 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             : undefined
         }
         activeFilePaths={activeWsPaths.map((wsPath) => wsPath.path)}
+        fileTreeExpanded={fileTreeExpanded}
+        onFileTreeExpandedChange={setFileTreeExpanded}
         commandButtonClassName="desktop-titlebar-no-drag"
         showNoteFilesOnly={showNoteFilesOnly}
         onShowNoteFilesOnlyChange={setShowNoteFilesOnly}

--- a/packages/core/service-core/src/__tests__/file-tree-expansion-state.spec.ts
+++ b/packages/core/service-core/src/__tests__/file-tree-expansion-state.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { reduceFileTreeExpansion } from '../file-tree-expansion-state';
+
+describe('reduceFileTreeExpansion', () => {
+  it('records directory expansion without disturbing other workspaces', () => {
+    const state = { alpha: ['docs'], beta: ['archive'] };
+
+    expect(
+      reduceFileTreeExpansion(state, {
+        type: 'set-directory',
+        workspaceName: 'alpha',
+        path: 'src',
+        expanded: true,
+      }),
+    ).toEqual({ alpha: ['docs', 'src'], beta: ['archive'] });
+  });
+
+  it('removes the collapsed directory and its hidden expanded descendants', () => {
+    const state = { alpha: ['docs', 'docs/deep', 'src'] };
+
+    expect(
+      reduceFileTreeExpansion(state, {
+        type: 'set-directory',
+        workspaceName: 'alpha',
+        path: 'docs',
+        expanded: false,
+      }),
+    ).toEqual({ alpha: ['src'] });
+  });
+
+  it('reveals paths by union without collapsing user-expanded branches', () => {
+    const state = { alpha: ['muddied'] };
+
+    expect(
+      reduceFileTreeExpansion(state, {
+        type: 'reveal',
+        workspaceName: 'alpha',
+        paths: ['active', 'active/deep'],
+      }),
+    ).toEqual({ alpha: ['muddied', 'active', 'active/deep'] });
+  });
+
+  it('collapse-all replaces only the target workspace state', () => {
+    const state = { alpha: ['muddied'], beta: ['archive'] };
+
+    expect(
+      reduceFileTreeExpansion(state, {
+        type: 'collapse-all',
+        workspaceName: 'alpha',
+        keepExpandedPaths: ['active', 'active/deep'],
+      }),
+    ).toEqual({
+      alpha: ['active', 'active/deep'],
+      beta: ['archive'],
+    });
+  });
+
+  it('preserves identity for no-op transitions', () => {
+    const state = { alpha: ['docs'] };
+
+    expect(
+      reduceFileTreeExpansion(state, {
+        type: 'reveal',
+        workspaceName: 'alpha',
+        paths: ['docs'],
+      }),
+    ).toBe(state);
+  });
+});

--- a/packages/core/service-core/src/__tests__/file-tree-expansion-state.spec.ts
+++ b/packages/core/service-core/src/__tests__/file-tree-expansion-state.spec.ts
@@ -66,4 +66,22 @@ describe('reduceFileTreeExpansion', () => {
       }),
     ).toBe(state);
   });
+
+  it.each([
+    'constructor',
+    '__proto__',
+  ])('treats the prototype-key workspace %s as an independent entry', (workspaceName) => {
+    const result = reduceFileTreeExpansion(
+      {},
+      {
+        type: 'set-directory',
+        workspaceName,
+        path: 'docs',
+        expanded: true,
+      },
+    );
+
+    expect(Object.hasOwn(result, workspaceName)).toBe(true);
+    expect(result[workspaceName]).toEqual(['docs']);
+  });
 });

--- a/packages/core/service-core/src/file-tree-expansion-state.ts
+++ b/packages/core/service-core/src/file-tree-expansion-state.ts
@@ -37,7 +37,9 @@ export function reduceFileTreeExpansion(
   current: FileTreeExpandedPathsByWorkspace,
   action: FileTreeExpansionAction,
 ): FileTreeExpandedPathsByWorkspace {
-  const currentPaths = current[action.workspaceName] ?? [];
+  const currentPaths = Object.hasOwn(current, action.workspaceName)
+    ? (current[action.workspaceName] ?? [])
+    : [];
   let nextPaths: readonly string[];
 
   switch (action.type) {

--- a/packages/core/service-core/src/file-tree-expansion-state.ts
+++ b/packages/core/service-core/src/file-tree-expansion-state.ts
@@ -1,0 +1,63 @@
+export type FileTreeExpandedPathsByWorkspace = Record<
+  string,
+  readonly string[]
+>;
+
+export type FileTreeExpansionAction =
+  | {
+      type: 'set-directory';
+      workspaceName: string;
+      path: string;
+      expanded: boolean;
+    }
+  | {
+      type: 'reveal';
+      workspaceName: string;
+      paths: readonly string[];
+    }
+  | {
+      type: 'collapse-all';
+      workspaceName: string;
+      keepExpandedPaths: readonly string[];
+    };
+
+function uniquePaths(paths: readonly string[]): readonly string[] {
+  return [...new Set(paths)];
+}
+
+function pathsEqual(left: readonly string[], right: readonly string[]) {
+  return (
+    left.length === right.length &&
+    left.every((path, index) => path === right[index])
+  );
+}
+
+/** Applies one semantic file-tree expansion transition. */
+export function reduceFileTreeExpansion(
+  current: FileTreeExpandedPathsByWorkspace,
+  action: FileTreeExpansionAction,
+): FileTreeExpandedPathsByWorkspace {
+  const currentPaths = current[action.workspaceName] ?? [];
+  let nextPaths: readonly string[];
+
+  switch (action.type) {
+    case 'set-directory':
+      nextPaths = action.expanded
+        ? uniquePaths([...currentPaths, action.path])
+        : currentPaths.filter(
+            (path) =>
+              path !== action.path && !path.startsWith(`${action.path}/`),
+          );
+      break;
+    case 'reveal':
+      nextPaths = uniquePaths([...currentPaths, ...action.paths]);
+      break;
+    case 'collapse-all':
+      nextPaths = uniquePaths(action.keepExpandedPaths);
+      break;
+  }
+
+  return pathsEqual(currentPaths, nextPaths)
+    ? current
+    : { ...current, [action.workspaceName]: nextPaths };
+}

--- a/packages/core/service-core/src/workbench-state-service.ts
+++ b/packages/core/service-core/src/workbench-state-service.ts
@@ -75,6 +75,7 @@ export class WorkbenchStateService extends BaseService {
   private $_sidebarWidth: PrimitiveAtom<number> | undefined;
   private $_linkedMentionsCollapsed: PrimitiveAtom<boolean> | undefined;
   private $_showNoteFilesOnlyInSidebar: PrimitiveAtom<boolean> | undefined;
+  private $_fileTreeExpanded: PrimitiveAtom<boolean> | undefined;
   private $_assetLocationPreference:
     | PrimitiveAtom<AssetLocationPreference>
     | undefined;
@@ -261,6 +262,20 @@ export class WorkbenchStateService extends BaseService {
       });
     }
     return this.$_showNoteFilesOnlyInSidebar;
+  }
+
+  get $fileTreeExpanded() {
+    if (!this.$_fileTreeExpanded) {
+      this.$_fileTreeExpanded = atomStorage({
+        serviceName: this.name,
+        key: 'file-tree-expanded',
+        initValue: false,
+        syncDb: this.dep.syncDatabase,
+        validator: T.Boolean,
+        logger: this.logger,
+      });
+    }
+    return this.$_fileTreeExpanded;
   }
 
   get $assetLocationPreference() {

--- a/packages/core/service-core/src/workbench-state-service.ts
+++ b/packages/core/service-core/src/workbench-state-service.ts
@@ -35,6 +35,20 @@ const AssetLocationPreferenceValidator = {
   typeName: 'asset-location-preference',
 };
 
+type FileTreeExpandedPathsByWorkspace = Record<string, readonly string[]>;
+
+const FileTreeExpandedPathsByWorkspaceValidator = {
+  validate: (value: unknown): value is FileTreeExpandedPathsByWorkspace =>
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every(
+      (paths) =>
+        Array.isArray(paths) && paths.every((path) => typeof path === 'string'),
+    ),
+  typeName: 'file-tree-expanded-paths-by-workspace',
+};
+
 function determineOmniSearchRoute(input: string, currentRoute: Route): Route {
   switch (currentRoute) {
     case 'omni-home': {
@@ -75,7 +89,9 @@ export class WorkbenchStateService extends BaseService {
   private $_sidebarWidth: PrimitiveAtom<number> | undefined;
   private $_linkedMentionsCollapsed: PrimitiveAtom<boolean> | undefined;
   private $_showNoteFilesOnlyInSidebar: PrimitiveAtom<boolean> | undefined;
-  private $_fileTreeExpanded: PrimitiveAtom<boolean> | undefined;
+  private $_fileTreeExpandedPathsByWorkspace:
+    | PrimitiveAtom<FileTreeExpandedPathsByWorkspace>
+    | undefined;
   private $_assetLocationPreference:
     | PrimitiveAtom<AssetLocationPreference>
     | undefined;
@@ -264,18 +280,18 @@ export class WorkbenchStateService extends BaseService {
     return this.$_showNoteFilesOnlyInSidebar;
   }
 
-  get $fileTreeExpanded() {
-    if (!this.$_fileTreeExpanded) {
-      this.$_fileTreeExpanded = atomStorage({
+  get $fileTreeExpandedPathsByWorkspace() {
+    if (!this.$_fileTreeExpandedPathsByWorkspace) {
+      this.$_fileTreeExpandedPathsByWorkspace = atomStorage({
         serviceName: this.name,
-        key: 'file-tree-expanded',
-        initValue: false,
+        key: 'file-tree-expanded-paths-by-workspace',
+        initValue: {},
         syncDb: this.dep.syncDatabase,
-        validator: T.Boolean,
+        validator: FileTreeExpandedPathsByWorkspaceValidator,
         logger: this.logger,
       });
     }
-    return this.$_fileTreeExpanded;
+    return this.$_fileTreeExpandedPathsByWorkspace;
   }
 
   get $assetLocationPreference() {

--- a/packages/core/service-core/src/workbench-state-service.ts
+++ b/packages/core/service-core/src/workbench-state-service.ts
@@ -27,6 +27,11 @@ import type {
 } from '@bangle.io/ui-components';
 import { atom, type PrimitiveAtom } from 'jotai';
 import { atomEffect } from 'jotai-effect';
+import {
+  type FileTreeExpandedPathsByWorkspace,
+  type FileTreeExpansionAction,
+  reduceFileTreeExpansion,
+} from './file-tree-expansion-state';
 
 type Route = 'omni-home' | 'omni-command' | 'omni-filtered';
 
@@ -34,8 +39,6 @@ const AssetLocationPreferenceValidator = {
   validate: isAssetLocationPreference,
   typeName: 'asset-location-preference',
 };
-
-type FileTreeExpandedPathsByWorkspace = Record<string, readonly string[]>;
 
 const FileTreeExpandedPathsByWorkspaceValidator = {
   validate: (value: unknown): value is FileTreeExpandedPathsByWorkspace =>
@@ -204,6 +207,40 @@ export class WorkbenchStateService extends BaseService {
     this.config.emitter.emit('event::app:reload-ui', {
       sender: getEventSenderMetadata({ tag: this.name }),
     });
+  }
+
+  public setFileTreeDirectoryExpanded(
+    workspaceName: string,
+    path: string,
+    expanded: boolean,
+  ) {
+    this.updateFileTreeExpansion({
+      type: 'set-directory',
+      workspaceName,
+      path,
+      expanded,
+    });
+  }
+
+  public revealFileTreePaths(workspaceName: string, paths: readonly string[]) {
+    this.updateFileTreeExpansion({ type: 'reveal', workspaceName, paths });
+  }
+
+  public collapseFileTree(
+    workspaceName: string,
+    keepExpandedPaths: readonly string[],
+  ) {
+    this.updateFileTreeExpansion({
+      type: 'collapse-all',
+      workspaceName,
+      keepExpandedPaths,
+    });
+  }
+
+  private updateFileTreeExpansion(action: FileTreeExpansionAction) {
+    this.store.set(this.$fileTreeExpandedPathsByWorkspace, (current) =>
+      reduceFileTreeExpansion(current, action),
+    );
   }
 
   get $wideEditor() {

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -563,6 +563,8 @@ export const t = {
         newFileActionTitle: 'Neue Datei',
         newFileActionSr: 'Datei erstellen',
         newFolderActionTitle: 'Neuer Ordner',
+        collapseAllFoldersActionTitle: 'Alle Ordner einklappen',
+        expandAllFoldersActionTitle: 'Alle Ordner ausklappen',
         showNoteFilesOnlyActionTitle: 'Nur Notizen anzeigen',
         newNoteHereActionTitle: 'Neue Notiz hier',
         newFolderHereActionTitle: 'Neuer Ordner hier',

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -564,7 +564,6 @@ export const t = {
         newFileActionSr: 'Datei erstellen',
         newFolderActionTitle: 'Neuer Ordner',
         collapseAllFoldersActionTitle: 'Alle Ordner einklappen',
-        expandAllFoldersActionTitle: 'Alle Ordner ausklappen',
         showNoteFilesOnlyActionTitle: 'Nur Notizen anzeigen',
         newNoteHereActionTitle: 'Neue Notiz hier',
         newFolderHereActionTitle: 'Neuer Ordner hier',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -621,7 +621,6 @@ export const t = {
         newFileActionSr: 'Create File',
         newFolderActionTitle: 'New Folder',
         collapseAllFoldersActionTitle: 'Collapse All Folders',
-        expandAllFoldersActionTitle: 'Expand All Folders',
         showNoteFilesOnlyActionTitle: 'Show Notes Only',
         newNoteHereActionTitle: 'New Note Here',
         newFolderHereActionTitle: 'New Folder Here',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -620,6 +620,8 @@ export const t = {
         newFileActionTitle: 'New File',
         newFileActionSr: 'Create File',
         newFolderActionTitle: 'New Folder',
+        collapseAllFoldersActionTitle: 'Collapse All Folders',
+        expandAllFoldersActionTitle: 'Expand All Folders',
         showNoteFilesOnlyActionTitle: 'Show Notes Only',
         newNoteHereActionTitle: 'New Note Here',
         newFolderHereActionTitle: 'New Folder Here',

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -3,7 +3,7 @@ import {
   createBrowserWorkspaceAndNote,
   ctrlKey,
   EDITOR_SELECTOR,
-  expandAllFileTreeFolders,
+  expandFileTreeFolder,
   getEditorLocator,
   readStoredMarkdown,
   selectEditorText,
@@ -403,7 +403,7 @@ test('copies workspace paths and smart-links pasted or dropped existing assets',
   await page.reload({ waitUntil: 'networkidle' });
 
   const explorer = page.getByTestId('bangle-file-explorer');
-  await expandAllFileTreeFolders(page);
+  await expandFileTreeFolder(page, /^assets$/);
   await expect(
     explorer.getByRole('treeitem', { name: /^assets$/ }),
   ).toBeVisible();
@@ -503,7 +503,7 @@ test('drags existing sidebar assets into the editor as smart Markdown links', as
   await page.reload({ waitUntil: 'networkidle' });
 
   const explorer = page.getByTestId('bangle-file-explorer');
-  await expandAllFileTreeFolders(page);
+  await expandFileTreeFolder(page, /^assets$/);
   const editor = getEditorLocator(page, {});
   await expect(editor).toBeVisible();
   const editorRoute = page.url();

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -3,6 +3,7 @@ import {
   createBrowserWorkspaceAndNote,
   ctrlKey,
   EDITOR_SELECTOR,
+  expandAllFileTreeFolders,
   getEditorLocator,
   readStoredMarkdown,
   selectEditorText,
@@ -402,6 +403,7 @@ test('copies workspace paths and smart-links pasted or dropped existing assets',
   await page.reload({ waitUntil: 'networkidle' });
 
   const explorer = page.getByTestId('bangle-file-explorer');
+  await expandAllFileTreeFolders(page);
   await expect(
     explorer.getByRole('treeitem', { name: /^assets$/ }),
   ).toBeVisible();
@@ -501,6 +503,7 @@ test('drags existing sidebar assets into the editor as smart Markdown links', as
   await page.reload({ waitUntil: 'networkidle' });
 
   const explorer = page.getByTestId('bangle-file-explorer');
+  await expandAllFileTreeFolders(page);
   const editor = getEditorLocator(page, {});
   await expect(editor).toBeVisible();
   const editorRoute = page.url();

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -9,17 +9,16 @@ export const EDITOR_SELECTOR = '.ProseMirror';
 export const EDITOR_FOCUSED_SELECTOR = `${EDITOR_SELECTOR}.ProseMirror-focused`;
 const DEFAULT_SLEEP_TIME = 20;
 
-export async function expandAllFileTreeFolders(page: Page) {
+export async function expandFileTreeFolder(page: Page, name: string | RegExp) {
   const explorer = page.getByTestId('bangle-file-explorer');
-  const expandButton = explorer.getByRole('button', {
-    name: 'Expand All Folders',
-  });
+  const folder = explorer.getByRole('treeitem', { name });
 
-  await expect(expandButton).toBeEnabled();
-  await expandButton.click();
-  await expect(
-    explorer.getByRole('button', { name: 'Collapse All Folders' }),
-  ).toBeVisible();
+  await expect(folder).toBeVisible();
+  if ((await folder.getAttribute('aria-expanded')) !== 'true') {
+    await folder.focus();
+    await page.keyboard.press('ArrowRight');
+  }
+  await expect(folder).toHaveAttribute('aria-expanded', 'true');
 }
 
 /**

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -9,6 +9,19 @@ export const EDITOR_SELECTOR = '.ProseMirror';
 export const EDITOR_FOCUSED_SELECTOR = `${EDITOR_SELECTOR}.ProseMirror-focused`;
 const DEFAULT_SLEEP_TIME = 20;
 
+export async function expandAllFileTreeFolders(page: Page) {
+  const explorer = page.getByTestId('bangle-file-explorer');
+  const expandButton = explorer.getByRole('button', {
+    name: 'Expand All Folders',
+  });
+
+  await expect(expandButton).toBeEnabled();
+  await expandButton.click();
+  await expect(
+    explorer.getByRole('button', { name: 'Collapse All Folders' }),
+  ).toBeVisible();
+}
+
 /**
  * Presses an *app-level* keyboard shortcut (e.g. Cmd/Ctrl+K for omni-search).
  *

--- a/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
@@ -1,8 +1,9 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 import {
   clearEditor,
   createBrowserWorkspace,
   dragTreeItemOnto,
+  expandAllFileTreeFolders,
   expectNoPageHorizontalOverflow,
   getEditorLocator,
   getEditorText,
@@ -86,6 +87,32 @@ async function setFileExplorerScrollTop(page: Page, scrollTop: number) {
 
       scroll.scrollTop = nextScrollTop;
     }, scrollTop);
+}
+
+async function expectFileTreeItemInViewport(item: Locator) {
+  await expect
+    .poll(() =>
+      item.evaluate((element) => {
+        const root = element.getRootNode();
+        if (!(root instanceof ShadowRoot)) {
+          return false;
+        }
+
+        const scroll = root.querySelector<HTMLElement>(
+          '[data-file-tree-virtualized-scroll="true"]',
+        );
+        if (!scroll) {
+          return false;
+        }
+
+        const itemRect = element.getBoundingClientRect();
+        const scrollRect = scroll.getBoundingClientRect();
+        return (
+          itemRect.top >= scrollRect.top && itemRect.bottom <= scrollRect.bottom
+        );
+      }),
+    )
+    .toBe(true);
 }
 
 async function readStoredFileText(
@@ -206,70 +233,105 @@ test('file explorer toggles between the active note path and all expanded folder
   await writeStoredMarkdown(
     page,
     workspaceName,
-    'active/branch/current',
+    'z-active/branch/current',
     'Current note',
   );
   await writeStoredMarkdown(
     page,
     workspaceName,
-    'active/sibling',
+    'z-active/sibling',
     'Active sibling',
   );
   await writeStoredMarkdown(
     page,
     workspaceName,
-    'other/deep/hidden',
+    'a-other/deep/hidden',
     'Other note',
   );
   await writeStoredMarkdown(
     page,
     workspaceName,
-    'other/root',
+    'a-other/root',
     'Other root note',
+  );
+  await writeStoredFiles(
+    page,
+    workspaceName,
+    Array.from({ length: 24 }, (_, index) => ({
+      content: `Bulk note ${index}`,
+      relativePath: `bulk-${String(index).padStart(2, '0')}/deep/note.md`,
+      type: 'text/markdown',
+    })),
   );
 
   await page.goto(
     `/ws#route=editor&wsPath=${encodeURIComponent(
-      `${workspaceName}:active/branch/current.md`,
+      `${workspaceName}:z-active/branch/current.md`,
     )}`,
   );
   await page.reload();
 
   const explorer = page.getByTestId('bangle-file-explorer');
-  const activeFolder = explorer.getByRole('treeitem', { name: /^active$/ });
+  const activeFolder = explorer.getByRole('treeitem', { name: /^z-active$/ });
   const branchFolder = explorer.getByRole('treeitem', { name: /^branch$/ });
-  const otherFolder = explorer.getByRole('treeitem', { name: /^other$/ });
+  const otherFolder = explorer.getByRole('treeitem', { name: /^a-other$/ });
+  const currentNote = explorer.getByRole('treeitem', {
+    name: /^current\.md$/,
+  });
 
-  await activeFolder.focus();
-  await page.keyboard.press('ArrowRight');
-  await branchFolder.focus();
-  await page.keyboard.press('ArrowRight');
-  await otherFolder.focus();
-  await page.keyboard.press('ArrowRight');
-  const deepFolder = explorer.getByRole('treeitem', { name: /^deep$/ });
-  await deepFolder.focus();
-  await page.keyboard.press('ArrowRight');
-  await expect(
-    explorer.getByRole('treeitem', { name: /^hidden\.md$/ }),
-  ).toBeVisible();
+  await test.step('starts collapsed while preserving and revealing the active note path', async () => {
+    await expect(
+      explorer.getByRole('button', { name: 'Expand All Folders' }),
+    ).toBeVisible();
+    await expect(activeFolder).toHaveAttribute('aria-expanded', 'true');
+    await expect(branchFolder).toHaveAttribute('aria-expanded', 'true');
+    await expect(currentNote).toBeVisible();
+    await expectFileTreeItemInViewport(currentNote);
 
-  await explorer.getByRole('button', { name: 'Collapse All Folders' }).click();
-
-  await expect(activeFolder).toHaveAttribute('aria-expanded', 'true');
-  await expect(branchFolder).toHaveAttribute('aria-expanded', 'true');
-  await expect(
-    explorer.getByRole('treeitem', { name: /^current\.md$/ }),
-  ).toBeVisible();
-  await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
-  await expect(deepFolder).toBeHidden();
+    await setFileExplorerScrollTop(page, 0);
+    await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
+  });
 
   await explorer.getByRole('button', { name: 'Expand All Folders' }).click();
 
+  await expectFileTreeItemInViewport(currentNote);
+  await setFileExplorerScrollTop(page, 0);
   await expect(otherFolder).toHaveAttribute('aria-expanded', 'true');
+  const deepFolder = explorer.getByRole('treeitem', { name: /^deep$/ });
   await expect(deepFolder).toHaveAttribute('aria-expanded', 'true');
   await expect(
     explorer.getByRole('treeitem', { name: /^hidden\.md$/ }),
   ).toBeVisible();
+
+  await test.step('persists expanded mode across reload', async () => {
+    await page.reload();
+    await expect(
+      explorer.getByRole('button', { name: 'Collapse All Folders' }),
+    ).toBeVisible();
+    await expectFileTreeItemInViewport(currentNote);
+    await setFileExplorerScrollTop(page, 0);
+    await expect(otherFolder).toHaveAttribute('aria-expanded', 'true');
+    await expect(deepFolder).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  await explorer.getByRole('button', { name: 'Collapse All Folders' }).click();
+
+  await expect(currentNote).toBeVisible();
+  await expectFileTreeItemInViewport(currentNote);
+  await setFileExplorerScrollTop(page, 0);
+  await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
+  await expect(deepFolder).toBeHidden();
+
+  await test.step('persists collapsed mode across reload', async () => {
+    await page.reload();
+    await expect(
+      explorer.getByRole('button', { name: 'Expand All Folders' }),
+    ).toBeVisible();
+    await expect(currentNote).toBeVisible();
+    await expectFileTreeItemInViewport(currentNote);
+    await setFileExplorerScrollTop(page, 0);
+    await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
+  });
 });
 
 test('file explorer creates folders, opens notes, and survives reload', async ({
@@ -361,6 +423,7 @@ test('file explorer creates folders, opens notes, and survives reload', async ({
   });
 
   await test.step('three-dot file menu is fully visible and hittable', async () => {
+    await expandAllFileTreeFolders(page);
     const alphaRow = explorer.getByRole('treeitem', { name: /alpha\.md/ });
 
     await alphaRow.hover();
@@ -561,6 +624,7 @@ test('file explorer keeps folders expanded when a note is moved', async ({
 
   const explorer = page.getByTestId('bangle-file-explorer');
   await expect(explorer).toBeVisible();
+  await expandAllFileTreeFolders(page);
 
   const keepFolder = explorer.getByRole('treeitem', { name: /^keep$/ });
   const nestedFolder = explorer.getByRole('treeitem', { name: /^nested$/ });
@@ -701,6 +765,7 @@ test('file explorer shows common workspace files and opens non-notes as assets',
 
   const explorer = page.getByTestId('bangle-file-explorer');
   await expect(explorer).toBeVisible();
+  await expandAllFileTreeFolders(page);
   const notesOnlyToggle = explorer.getByRole('button', {
     name: 'Show Notes Only',
   });

--- a/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
@@ -435,6 +435,35 @@ test('collapse-all persistence does not bounce between tabs', async ({
   await secondPage.close();
 });
 
+test('collapse-all supports a prototype-key workspace name', async ({
+  page,
+}) => {
+  const workspaceName = 'constructor';
+  await createBrowserWorkspace(page, { workspaceName });
+  await writeStoredMarkdown(page, workspaceName, 'active/current', 'Current');
+  await writeStoredMarkdown(page, workspaceName, 'other/note', 'Other');
+
+  await page.goto(
+    `/ws#route=editor&wsPath=${encodeURIComponent(
+      `${workspaceName}:active/current.md`,
+    )}`,
+  );
+  await page.reload();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+  const activeFolder = explorer.getByRole('treeitem', { name: /^active$/ });
+  const otherFolder = explorer.getByRole('treeitem', { name: /^other$/ });
+
+  await expect(activeFolder).toHaveAttribute('aria-expanded', 'true');
+  await otherFolder.press('ArrowRight');
+  await expect(otherFolder).toHaveAttribute('aria-expanded', 'true');
+
+  await explorer.getByRole('button', { name: 'Collapse All Folders' }).click();
+
+  await expect(activeFolder).toHaveAttribute('aria-expanded', 'true');
+  await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
+});
+
 test('file explorer creates folders, opens notes, and survives reload', async ({
   page,
 }) => {

--- a/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
@@ -198,6 +198,80 @@ async function writeStoredFiles(
   );
 }
 
+test('file explorer toggles between the active note path and all expanded folders', async ({
+  page,
+}) => {
+  const workspaceName = `explorer-collapse-all-${Date.now()}`;
+  await createBrowserWorkspace(page, { workspaceName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'active/branch/current',
+    'Current note',
+  );
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'active/sibling',
+    'Active sibling',
+  );
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'other/deep/hidden',
+    'Other note',
+  );
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'other/root',
+    'Other root note',
+  );
+
+  await page.goto(
+    `/ws#route=editor&wsPath=${encodeURIComponent(
+      `${workspaceName}:active/branch/current.md`,
+    )}`,
+  );
+  await page.reload();
+
+  const explorer = page.getByTestId('bangle-file-explorer');
+  const activeFolder = explorer.getByRole('treeitem', { name: /^active$/ });
+  const branchFolder = explorer.getByRole('treeitem', { name: /^branch$/ });
+  const otherFolder = explorer.getByRole('treeitem', { name: /^other$/ });
+
+  await activeFolder.focus();
+  await page.keyboard.press('ArrowRight');
+  await branchFolder.focus();
+  await page.keyboard.press('ArrowRight');
+  await otherFolder.focus();
+  await page.keyboard.press('ArrowRight');
+  const deepFolder = explorer.getByRole('treeitem', { name: /^deep$/ });
+  await deepFolder.focus();
+  await page.keyboard.press('ArrowRight');
+  await expect(
+    explorer.getByRole('treeitem', { name: /^hidden\.md$/ }),
+  ).toBeVisible();
+
+  await explorer.getByRole('button', { name: 'Collapse All Folders' }).click();
+
+  await expect(activeFolder).toHaveAttribute('aria-expanded', 'true');
+  await expect(branchFolder).toHaveAttribute('aria-expanded', 'true');
+  await expect(
+    explorer.getByRole('treeitem', { name: /^current\.md$/ }),
+  ).toBeVisible();
+  await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
+  await expect(deepFolder).toBeHidden();
+
+  await explorer.getByRole('button', { name: 'Expand All Folders' }).click();
+
+  await expect(otherFolder).toHaveAttribute('aria-expanded', 'true');
+  await expect(deepFolder).toHaveAttribute('aria-expanded', 'true');
+  await expect(
+    explorer.getByRole('treeitem', { name: /^hidden\.md$/ }),
+  ).toBeVisible();
+});
+
 test('file explorer creates folders, opens notes, and survives reload', async ({
   page,
 }) => {

--- a/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
@@ -3,7 +3,7 @@ import {
   clearEditor,
   createBrowserWorkspace,
   dragTreeItemOnto,
-  expandAllFileTreeFolders,
+  expandFileTreeFolder,
   expectNoPageHorizontalOverflow,
   getEditorLocator,
   getEditorText,
@@ -225,7 +225,7 @@ async function writeStoredFiles(
   );
 }
 
-test('file explorer toggles between the active note path and all expanded folders', async ({
+test('file explorer collapse-all preserves user expansion until invoked', async ({
   page,
 }) => {
   const workspaceName = `explorer-collapse-all-${Date.now()}`;
@@ -234,7 +234,7 @@ test('file explorer toggles between the active note path and all expanded folder
     page,
     workspaceName,
     'z-active/branch/current',
-    'Current note',
+    'Current note\n\n[[hidden]]',
   );
   await writeStoredMarkdown(
     page,
@@ -281,7 +281,7 @@ test('file explorer toggles between the active note path and all expanded folder
 
   await test.step('starts collapsed while preserving and revealing the active note path', async () => {
     await expect(
-      explorer.getByRole('button', { name: 'Expand All Folders' }),
+      explorer.getByRole('button', { name: 'Collapse All Folders' }),
     ).toBeVisible();
     await expect(activeFolder).toHaveAttribute('aria-expanded', 'true');
     await expect(branchFolder).toHaveAttribute('aria-expanded', 'true');
@@ -292,45 +292,62 @@ test('file explorer toggles between the active note path and all expanded folder
     await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
   });
 
-  await explorer.getByRole('button', { name: 'Expand All Folders' }).click();
+  const muddiedFolder = explorer.getByRole('treeitem', {
+    name: /^bulk-00 \/ deep$/,
+  });
+  await muddiedFolder.focus();
+  await page.keyboard.press('ArrowRight');
+  await expect(muddiedFolder).toHaveAttribute('aria-expanded', 'true');
 
-  await expectFileTreeItemInViewport(currentNote);
-  await setFileExplorerScrollTop(page, 0);
-  await expect(otherFolder).toHaveAttribute('aria-expanded', 'true');
-  const deepFolder = explorer.getByRole('treeitem', { name: /^deep$/ });
-  await expect(deepFolder).toHaveAttribute('aria-expanded', 'true');
-  await expect(
-    explorer.getByRole('treeitem', { name: /^hidden\.md$/ }),
-  ).toBeVisible();
+  await test.step('backlink navigation opens its ancestors without collapsing user-expanded folders', async () => {
+    await getEditorLocator(page, {})
+      .getByRole('link', { name: 'hidden', exact: true })
+      .click();
+    await expect(page).toHaveURL(
+      new RegExp(
+        `ws#route=editor&wsPath=${encodeURIComponent(
+          `${workspaceName}:a-other/deep/hidden.md`,
+        )}$`,
+      ),
+    );
 
-  await test.step('persists expanded mode across reload', async () => {
+    const hiddenNote = explorer.getByRole('treeitem', {
+      name: /^hidden\.md$/,
+    });
+    await expect(hiddenNote).toBeVisible();
+    await expectFileTreeItemInViewport(hiddenNote);
+    await expect(muddiedFolder).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  await test.step('persists manual expansion across reload', async () => {
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          window.localStorage.getItem(
+            'browser-local-storage-sync-database.sync:workbench-state:file-tree-expanded-paths-by-workspace',
+          ),
+        ),
+      )
+      .toContain('bulk-00/deep');
     await page.reload();
-    await expect(
-      explorer.getByRole('button', { name: 'Collapse All Folders' }),
-    ).toBeVisible();
-    await expectFileTreeItemInViewport(currentNote);
-    await setFileExplorerScrollTop(page, 0);
-    await expect(otherFolder).toHaveAttribute('aria-expanded', 'true');
-    await expect(deepFolder).toHaveAttribute('aria-expanded', 'true');
+    await expect(muddiedFolder).toHaveAttribute('aria-expanded', 'true');
   });
 
   await explorer.getByRole('button', { name: 'Collapse All Folders' }).click();
 
-  await expect(currentNote).toBeVisible();
-  await expectFileTreeItemInViewport(currentNote);
-  await setFileExplorerScrollTop(page, 0);
-  await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
-  await expect(deepFolder).toBeHidden();
+  const hiddenNote = explorer.getByRole('treeitem', { name: /^hidden\.md$/ });
+  await expect(hiddenNote).toBeVisible();
+  await expectFileTreeItemInViewport(hiddenNote);
+  await expect(muddiedFolder).toHaveAttribute('aria-expanded', 'false');
 
-  await test.step('persists collapsed mode across reload', async () => {
+  await test.step('persists the collapse-all result across reload', async () => {
     await page.reload();
     await expect(
-      explorer.getByRole('button', { name: 'Expand All Folders' }),
+      explorer.getByRole('button', { name: 'Collapse All Folders' }),
     ).toBeVisible();
-    await expect(currentNote).toBeVisible();
-    await expectFileTreeItemInViewport(currentNote);
-    await setFileExplorerScrollTop(page, 0);
-    await expect(otherFolder).toHaveAttribute('aria-expanded', 'false');
+    await expect(hiddenNote).toBeVisible();
+    await expectFileTreeItemInViewport(hiddenNote);
+    await expect(muddiedFolder).toHaveAttribute('aria-expanded', 'false');
   });
 });
 
@@ -423,7 +440,7 @@ test('file explorer creates folders, opens notes, and survives reload', async ({
   });
 
   await test.step('three-dot file menu is fully visible and hittable', async () => {
-    await expandAllFileTreeFolders(page);
+    await expandFileTreeFolder(page, /^docs$/);
     const alphaRow = explorer.getByRole('treeitem', { name: /alpha\.md/ });
 
     await alphaRow.hover();
@@ -531,6 +548,7 @@ test('file explorer creates folders, opens notes, and survives reload', async ({
     await expect(
       explorer.getByRole('treeitem', { name: /^docs$/ }),
     ).toBeVisible();
+    await expandFileTreeFolder(page, /^docs$/);
     await explorer.getByRole('treeitem', { name: /untitled-2\.md/ }).click();
 
     await expect(
@@ -624,8 +642,6 @@ test('file explorer keeps folders expanded when a note is moved', async ({
 
   const explorer = page.getByTestId('bangle-file-explorer');
   await expect(explorer).toBeVisible();
-  await expandAllFileTreeFolders(page);
-
   const keepFolder = explorer.getByRole('treeitem', { name: /^keep$/ });
   const nestedFolder = explorer.getByRole('treeitem', { name: /^nested$/ });
 
@@ -765,7 +781,9 @@ test('file explorer shows common workspace files and opens non-notes as assets',
 
   const explorer = page.getByTestId('bangle-file-explorer');
   await expect(explorer).toBeVisible();
-  await expandAllFileTreeFolders(page);
+  await expandFileTreeFolder(page, /^notes$/);
+  await expandFileTreeFolder(page, /^src$/);
+  await expandFileTreeFolder(page, /^assets$/);
   const notesOnlyToggle = explorer.getByRole('button', {
     name: 'Show Notes Only',
   });

--- a/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
+++ b/packages/tooling/e2e-tests/src/file-explorer.e2e.ts
@@ -115,6 +115,26 @@ async function expectFileTreeItemInViewport(item: Locator) {
     .toBe(true);
 }
 
+async function readPersistedExpandedPaths(
+  page: Page,
+  workspaceName: string,
+): Promise<readonly string[] | undefined> {
+  return page.evaluate((name) => {
+    const stored = window.localStorage.getItem(
+      'browser-local-storage-sync-database.sync:workbench-state:file-tree-expanded-paths-by-workspace',
+    );
+    if (!stored) {
+      return undefined;
+    }
+
+    const pathsByWorkspace = JSON.parse(stored) as Record<
+      string,
+      readonly string[]
+    >;
+    return pathsByWorkspace[name];
+  }, workspaceName);
+}
+
 async function readStoredFileText(
   page: Page,
   workspaceName: string,
@@ -298,6 +318,7 @@ test('file explorer collapse-all preserves user expansion until invoked', async 
   await muddiedFolder.focus();
   await page.keyboard.press('ArrowRight');
   await expect(muddiedFolder).toHaveAttribute('aria-expanded', 'true');
+  await expectFileTreeItemInViewport(muddiedFolder);
 
   await test.step('backlink navigation opens its ancestors without collapsing user-expanded folders', async () => {
     await getEditorLocator(page, {})
@@ -349,6 +370,69 @@ test('file explorer collapse-all preserves user expansion until invoked', async 
     await expectFileTreeItemInViewport(hiddenNote);
     await expect(muddiedFolder).toHaveAttribute('aria-expanded', 'false');
   });
+});
+
+test('collapse-all persistence does not bounce between tabs', async ({
+  page,
+}) => {
+  const workspaceName = `explorer-collapse-cross-tab-${Date.now()}`;
+  await createBrowserWorkspace(page, { workspaceName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'a-active/current',
+    'First active note',
+  );
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'b-active/current',
+    'Second active note',
+  );
+
+  await page.goto(
+    `/ws#route=editor&wsPath=${encodeURIComponent(
+      `${workspaceName}:a-active/current.md`,
+    )}`,
+  );
+  await page.reload();
+  const secondPage = await page.context().newPage();
+  await secondPage.goto(
+    `/ws#route=editor&wsPath=${encodeURIComponent(
+      `${workspaceName}:b-active/current.md`,
+    )}`,
+  );
+
+  const firstExplorer = page.getByTestId('bangle-file-explorer');
+  const secondExplorer = secondPage.getByTestId('bangle-file-explorer');
+  const firstPageOtherFolder = firstExplorer.getByRole('treeitem', {
+    name: /^b-active$/,
+  });
+  const secondPageOtherFolder = secondExplorer.getByRole('treeitem', {
+    name: /^a-active$/,
+  });
+
+  await expect(firstPageOtherFolder).toHaveAttribute('aria-expanded', 'true');
+  await secondExplorer
+    .getByRole('button', { name: 'Collapse All Folders' })
+    .click();
+  await expect(secondPageOtherFolder).toHaveAttribute('aria-expanded', 'false');
+
+  await firstExplorer
+    .getByRole('button', { name: 'Collapse All Folders' })
+    .click();
+  await expect(secondPageOtherFolder).toHaveAttribute('aria-expanded', 'true');
+  await expect
+    .poll(() => readPersistedExpandedPaths(page, workspaceName))
+    .toEqual(['a-active']);
+
+  await page.reload();
+  await expect(
+    firstExplorer.getByRole('treeitem', { name: /^a-active$/ }),
+  ).toHaveAttribute('aria-expanded', 'true');
+  await expect(firstPageOtherFolder).toHaveAttribute('aria-expanded', 'false');
+
+  await secondPage.close();
 });
 
 test('file explorer creates folders, opens notes, and survives reload', async ({

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -81,6 +81,8 @@ export type AppSidebarProps = {
   onOpenFile: (relativePath: string) => void;
   showNoteFilesOnly: boolean;
   onShowNoteFilesOnlyChange: (showNoteFilesOnly: boolean) => void;
+  fileTreeExpanded: boolean;
+  onFileTreeExpandedChange: (expanded: boolean) => void;
   /**
    * When set, renders a recoverable error notice above the file tree, e.g.
    * after a failed workspace file scan. The tree below keeps showing the last
@@ -210,6 +212,8 @@ export function AppSidebar({
   onCreateNote,
   onMoveFile,
   onOpenFile,
+  fileTreeExpanded,
+  onFileTreeExpandedChange,
   showNoteFilesOnly,
   onShowNoteFilesOnlyChange,
   fileTreeNotice,
@@ -280,6 +284,8 @@ export function AppSidebar({
               onCreateNote={onCreateNote}
               onMoveFile={onMoveFile}
               onOpenFile={onOpenFile}
+              fileTreeExpanded={fileTreeExpanded}
+              onFileTreeExpandedChange={onFileTreeExpandedChange}
               showNoteFilesOnly={showNoteFilesOnly}
               onShowNoteFilesOnlyChange={onShowNoteFilesOnlyChange}
             />

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -82,7 +82,9 @@ export type AppSidebarProps = {
   showNoteFilesOnly: boolean;
   onShowNoteFilesOnlyChange: (showNoteFilesOnly: boolean) => void;
   expandedFileTreePaths?: readonly string[];
-  onExpandedFileTreePathsChange: (expandedPaths: readonly string[]) => void;
+  onFileTreeDirectoryExpansionChange: (path: string, expanded: boolean) => void;
+  onRevealFileTreePaths: (paths: readonly string[]) => void;
+  onCollapseFileTree: (keepExpandedPaths: readonly string[]) => void;
   /**
    * When set, renders a recoverable error notice above the file tree, e.g.
    * after a failed workspace file scan. The tree below keeps showing the last
@@ -213,7 +215,9 @@ export function AppSidebar({
   onMoveFile,
   onOpenFile,
   expandedFileTreePaths,
-  onExpandedFileTreePathsChange,
+  onFileTreeDirectoryExpansionChange,
+  onRevealFileTreePaths,
+  onCollapseFileTree,
   showNoteFilesOnly,
   onShowNoteFilesOnlyChange,
   fileTreeNotice,
@@ -285,7 +289,9 @@ export function AppSidebar({
               onMoveFile={onMoveFile}
               onOpenFile={onOpenFile}
               expandedPaths={expandedFileTreePaths}
-              onExpandedPathsChange={onExpandedFileTreePathsChange}
+              onDirectoryExpansionChange={onFileTreeDirectoryExpansionChange}
+              onRevealPaths={onRevealFileTreePaths}
+              onCollapseAll={onCollapseFileTree}
               showNoteFilesOnly={showNoteFilesOnly}
               onShowNoteFilesOnlyChange={onShowNoteFilesOnlyChange}
             />

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -81,8 +81,8 @@ export type AppSidebarProps = {
   onOpenFile: (relativePath: string) => void;
   showNoteFilesOnly: boolean;
   onShowNoteFilesOnlyChange: (showNoteFilesOnly: boolean) => void;
-  fileTreeExpanded: boolean;
-  onFileTreeExpandedChange: (expanded: boolean) => void;
+  expandedFileTreePaths?: readonly string[];
+  onExpandedFileTreePathsChange: (expandedPaths: readonly string[]) => void;
   /**
    * When set, renders a recoverable error notice above the file tree, e.g.
    * after a failed workspace file scan. The tree below keeps showing the last
@@ -212,8 +212,8 @@ export function AppSidebar({
   onCreateNote,
   onMoveFile,
   onOpenFile,
-  fileTreeExpanded,
-  onFileTreeExpandedChange,
+  expandedFileTreePaths,
+  onExpandedFileTreePathsChange,
   showNoteFilesOnly,
   onShowNoteFilesOnlyChange,
   fileTreeNotice,
@@ -284,8 +284,8 @@ export function AppSidebar({
               onCreateNote={onCreateNote}
               onMoveFile={onMoveFile}
               onOpenFile={onOpenFile}
-              fileTreeExpanded={fileTreeExpanded}
-              onFileTreeExpandedChange={onFileTreeExpandedChange}
+              expandedPaths={expandedFileTreePaths}
+              onExpandedPathsChange={onExpandedFileTreePathsChange}
               showNoteFilesOnly={showNoteFilesOnly}
               onShowNoteFilesOnlyChange={onShowNoteFilesOnlyChange}
             />

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -14,13 +14,7 @@ import {
   FileText,
   FolderPlus,
 } from 'lucide-react';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { BANGLE_PIERRE_FILE_TREE_ICONS } from './pierre-file-tree-icons';
 import {
   type FileTreeEntry,
@@ -296,7 +290,9 @@ function getCurrentSelectedEntries(
 export interface PierreFileTreeProps {
   activePaths?: readonly string[];
   className?: string;
+  fileTreeExpanded: boolean;
   filePaths: readonly string[];
+  onFileTreeExpandedChange: (expanded: boolean) => void;
   onCreateDirectory: (pathPrefix: string | undefined) => void;
   onCreateNote: (pathPrefix: string | undefined) => void;
   onMoveFile: (
@@ -315,7 +311,9 @@ export interface PierreFileTreeProps {
 export function PierreFileTree({
   activePaths = [],
   className,
+  fileTreeExpanded,
   filePaths,
+  onFileTreeExpandedChange,
   onCreateDirectory,
   onCreateNote,
   onMoveFile,
@@ -360,7 +358,10 @@ export function PierreFileTree({
     () => collectAncestorDirectoryPaths(activeTreePath ? [activeTreePath] : []),
     [activeTreePath],
   );
-  const [expandAllOnNextClick, setExpandAllOnNextClick] = useState(false);
+  const lastCollapsedActivePathRef = useRef<{
+    model: PierreFileTreeModel;
+    path: string | null;
+  } | null>(null);
   const filePathSetRef = useRef<ReadonlySet<string>>(filePathSet);
   const modelRef = useRef<PierreFileTreeModel | null>(null);
   const contextMenuSelectedEntriesRef = useRef<readonly FileTreeEntry[]>([]);
@@ -516,7 +517,10 @@ export function PierreFileTree({
       },
     },
     flattenEmptyDirectories: true,
-    initialExpansion: 1,
+    initialExpandedPaths: fileTreeExpanded
+      ? directoryPaths
+      : activeAncestorPaths,
+    initialExpansion: 'closed',
     onSelectionChange: (selectedPaths) => {
       const selectedPath = selectedPaths.at(-1);
       const normalizedPath = selectedPath
@@ -565,12 +569,70 @@ export function PierreFileTree({
   }, [model, treePaths]);
 
   useEffect(() => {
-    if (!expandAllOnNextClick) {
+    if (fileTreeExpanded || treePaths.length === 0) {
       return;
     }
 
-    setExpandedDirectories(model, directoryPaths, new Set(activeAncestorPaths));
-  }, [activeAncestorPaths, directoryPaths, expandAllOnNextClick, model]);
+    const activePath = activeTreePath ?? null;
+    const lastApplied = lastCollapsedActivePathRef.current;
+    if (lastApplied?.model === model && lastApplied.path === activePath) {
+      return;
+    }
+    if (activeTreePath && !filePathSet.has(activeTreePath)) {
+      return;
+    }
+
+    setExpandedDirectories(
+      model,
+      directoryPaths,
+      new Set(
+        collectAncestorDirectoryPaths(activeTreePath ? [activeTreePath] : []),
+      ),
+    );
+    lastCollapsedActivePathRef.current = { model, path: activePath };
+
+    if (!activeTreePath) {
+      return;
+    }
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      model.scrollToPath(activeTreePath, {
+        focus: false,
+        offset: 'nearest',
+      });
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [
+    activeTreePath,
+    directoryPaths,
+    filePathSet,
+    fileTreeExpanded,
+    model,
+    treePaths.length,
+  ]);
+
+  useEffect(() => {
+    if (!fileTreeExpanded) {
+      return;
+    }
+
+    lastCollapsedActivePathRef.current = null;
+    setExpandedDirectories(model, directoryPaths, new Set(directoryPaths));
+
+    if (!activeTreePath) {
+      return;
+    }
+
+    const animationFrame = window.requestAnimationFrame(() => {
+      model.scrollToPath(activeTreePath, {
+        focus: false,
+        offset: 'nearest',
+      });
+    });
+
+    return () => window.cancelAnimationFrame(animationFrame);
+  }, [activeTreePath, directoryPaths, fileTreeExpanded, model]);
 
   useEffect(() => {
     const nextSelectedPath = activeTreePaths.at(-1) ?? null;
@@ -646,17 +708,18 @@ export function PierreFileTree({
   };
 
   const handleToggleAllDirectories = (): void => {
-    const nextExpandedPaths = expandAllOnNextClick
-      ? new Set(directoryPaths)
-      : new Set(activeAncestorPaths);
+    const nextFileTreeExpanded = !fileTreeExpanded;
+    const nextExpandedPaths = new Set(
+      nextFileTreeExpanded ? directoryPaths : activeAncestorPaths,
+    );
 
     setExpandedDirectories(model, directoryPaths, nextExpandedPaths);
-    setExpandAllOnNextClick(!expandAllOnNextClick);
+    onFileTreeExpandedChange(nextFileTreeExpanded);
   };
 
-  const toggleAllDirectoriesLabel = expandAllOnNextClick
-    ? t.app.components.appSidebar.expandAllFoldersActionTitle
-    : t.app.components.appSidebar.collapseAllFoldersActionTitle;
+  const toggleAllDirectoriesLabel = fileTreeExpanded
+    ? t.app.components.appSidebar.collapseAllFoldersActionTitle
+    : t.app.components.appSidebar.expandAllFoldersActionTitle;
 
   return (
     <div
@@ -680,10 +743,10 @@ export function PierreFileTree({
             disabled={directoryPaths.length === 0}
             onClick={handleToggleAllDirectories}
           >
-            {expandAllOnNextClick ? (
-              <ChevronsUpDown className="size-3.5" />
-            ) : (
+            {fileTreeExpanded ? (
               <ChevronsDownUp className="size-3.5" />
+            ) : (
+              <ChevronsUpDown className="size-3.5" />
             )}
           </button>
           <button

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -7,13 +7,7 @@ import type {
   FileTree as PierreFileTreeModel,
 } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
-import {
-  ChevronsDownUp,
-  ChevronsUpDown,
-  FilePlus2,
-  FileText,
-  FolderPlus,
-} from 'lucide-react';
+import { FilePlus2, FileText, FolderPlus, SquareMinus } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { BANGLE_PIERRE_FILE_TREE_ICONS } from './pierre-file-tree-icons';
 import {
@@ -157,22 +151,41 @@ function setExpandedDirectories(
   directoryPaths: readonly string[],
   expandedPaths: ReadonlySet<string>,
 ): void {
+  const pathsToExpand = new Set(expandedPaths);
+  for (const expandedPath of expandedPaths) {
+    let parentPath = getParentDirectory(expandedPath);
+    while (parentPath) {
+      pathsToExpand.add(parentPath);
+      parentPath = getParentDirectory(parentPath);
+    }
+  }
+
   // Collapse children before parents, then expand parents before children. This
   // keeps the operation deterministic even when the tree implementation skips
   // rendering descendants of a collapsed directory.
   for (const directoryPath of [...directoryPaths].reverse()) {
     const item = model.getItem(directoryPath);
-    if (item && 'collapse' in item && !expandedPaths.has(directoryPath)) {
+    if (item && 'collapse' in item && !pathsToExpand.has(directoryPath)) {
       item.collapse();
     }
   }
 
   for (const directoryPath of directoryPaths) {
     const item = model.getItem(directoryPath);
-    if (item && 'expand' in item && expandedPaths.has(directoryPath)) {
+    if (item && 'expand' in item && pathsToExpand.has(directoryPath)) {
       item.expand();
     }
   }
+}
+
+function getExpandedDirectoryPaths(
+  model: PierreFileTreeModel,
+  directoryPaths: readonly string[],
+): string[] {
+  return directoryPaths.filter((directoryPath) => {
+    const item = model.getItem(directoryPath);
+    return item !== null && 'isExpanded' in item && item.isExpanded();
+  });
 }
 
 // `resetPaths` re-seeds expansion from the tree's `initialExpansion` unless it
@@ -290,9 +303,9 @@ function getCurrentSelectedEntries(
 export interface PierreFileTreeProps {
   activePaths?: readonly string[];
   className?: string;
-  fileTreeExpanded: boolean;
+  expandedPaths?: readonly string[];
   filePaths: readonly string[];
-  onFileTreeExpandedChange: (expanded: boolean) => void;
+  onExpandedPathsChange: (expandedPaths: readonly string[]) => void;
   onCreateDirectory: (pathPrefix: string | undefined) => void;
   onCreateNote: (pathPrefix: string | undefined) => void;
   onMoveFile: (
@@ -311,9 +324,9 @@ export interface PierreFileTreeProps {
 export function PierreFileTree({
   activePaths = [],
   className,
-  fileTreeExpanded,
+  expandedPaths,
   filePaths,
-  onFileTreeExpandedChange,
+  onExpandedPathsChange,
   onCreateDirectory,
   onCreateNote,
   onMoveFile,
@@ -358,10 +371,11 @@ export function PierreFileTree({
     () => collectAncestorDirectoryPaths(activeTreePath ? [activeTreePath] : []),
     [activeTreePath],
   );
-  const lastCollapsedActivePathRef = useRef<{
-    model: PierreFileTreeModel;
-    path: string | null;
-  } | null>(null);
+  const directoryPathsRef = useRef(directoryPaths);
+  const expandedPathsRef = useRef(expandedPaths);
+  const onExpandedPathsChangeRef = useRef(onExpandedPathsChange);
+  const suppressExpansionPersistenceRef = useRef(false);
+  const lastReportedExpandedPathsSignatureRef = useRef<string | null>(null);
   const filePathSetRef = useRef<ReadonlySet<string>>(filePathSet);
   const modelRef = useRef<PierreFileTreeModel | null>(null);
   const contextMenuSelectedEntriesRef = useRef<readonly FileTreeEntry[]>([]);
@@ -379,10 +393,47 @@ export function PierreFileTree({
   onOpenFileRef.current = onOpenFile;
   onMoveFileRef.current = onMoveFile;
   treePathsRef.current = treePaths;
+  directoryPathsRef.current = directoryPaths;
+  expandedPathsRef.current = expandedPaths;
+  onExpandedPathsChangeRef.current = onExpandedPathsChange;
   // The file the active route points at. Kept current on every render so
   // `onSelectionChange` can tell a genuine user open from a route-driven
   // re-select (see `shouldOpenSelectedFile`).
   activeSelectedPathRef.current = activeTreePath ?? null;
+
+  const reportExpandedPaths = useCallback(
+    (
+      targetModel: PierreFileTreeModel,
+      preserveUnavailablePaths = true,
+    ): void => {
+      if (suppressExpansionPersistenceRef.current) {
+        return;
+      }
+
+      const currentDirectoryPaths = directoryPathsRef.current;
+      const availableExpandedPaths = getExpandedDirectoryPaths(
+        targetModel,
+        currentDirectoryPaths,
+      );
+      const unavailableExpandedPaths = preserveUnavailablePaths
+        ? (expandedPathsRef.current ?? []).filter(
+            (path) => !currentDirectoryPaths.includes(path),
+          )
+        : [];
+      const nextExpandedPaths = [
+        ...availableExpandedPaths,
+        ...unavailableExpandedPaths,
+      ];
+      const signature = nextExpandedPaths.join('\0');
+      if (lastReportedExpandedPathsSignatureRef.current === signature) {
+        return;
+      }
+
+      lastReportedExpandedPathsSignatureRef.current = signature;
+      onExpandedPathsChangeRef.current(nextExpandedPaths);
+    },
+    [],
+  );
 
   // Single source of truth for "is this drop a real move?": exactly one dragged
   // file we know about, landing in a directory other than its current parent.
@@ -517,9 +568,9 @@ export function PierreFileTree({
       },
     },
     flattenEmptyDirectories: true,
-    initialExpandedPaths: fileTreeExpanded
-      ? directoryPaths
-      : activeAncestorPaths,
+    initialExpandedPaths: [
+      ...new Set([...(expandedPaths ?? []), ...activeAncestorPaths]),
+    ],
     initialExpansion: 'closed',
     onSelectionChange: (selectedPaths) => {
       const selectedPath = selectedPaths.at(-1);
@@ -569,27 +620,25 @@ export function PierreFileTree({
   }, [model, treePaths]);
 
   useEffect(() => {
-    if (fileTreeExpanded || treePaths.length === 0) {
+    if (treePaths.length === 0) {
       return;
     }
 
-    const activePath = activeTreePath ?? null;
-    const lastApplied = lastCollapsedActivePathRef.current;
-    if (lastApplied?.model === model && lastApplied.path === activePath) {
-      return;
-    }
     if (activeTreePath && !filePathSet.has(activeTreePath)) {
       return;
     }
 
-    setExpandedDirectories(
-      model,
-      directoryPaths,
-      new Set(
-        collectAncestorDirectoryPaths(activeTreePath ? [activeTreePath] : []),
-      ),
-    );
-    lastCollapsedActivePathRef.current = { model, path: activePath };
+    const nextExpandedPaths = new Set([
+      ...(expandedPaths ?? []),
+      ...activeAncestorPaths,
+    ]);
+    suppressExpansionPersistenceRef.current = true;
+    try {
+      setExpandedDirectories(model, directoryPaths, nextExpandedPaths);
+    } finally {
+      suppressExpansionPersistenceRef.current = false;
+    }
+    reportExpandedPaths(model);
 
     if (!activeTreePath) {
       return;
@@ -604,35 +653,21 @@ export function PierreFileTree({
 
     return () => window.cancelAnimationFrame(animationFrame);
   }, [
+    activeAncestorPaths,
     activeTreePath,
     directoryPaths,
+    expandedPaths,
     filePathSet,
-    fileTreeExpanded,
     model,
+    reportExpandedPaths,
     treePaths.length,
   ]);
 
   useEffect(() => {
-    if (!fileTreeExpanded) {
-      return;
-    }
-
-    lastCollapsedActivePathRef.current = null;
-    setExpandedDirectories(model, directoryPaths, new Set(directoryPaths));
-
-    if (!activeTreePath) {
-      return;
-    }
-
-    const animationFrame = window.requestAnimationFrame(() => {
-      model.scrollToPath(activeTreePath, {
-        focus: false,
-        offset: 'nearest',
-      });
-    });
-
-    return () => window.cancelAnimationFrame(animationFrame);
-  }, [activeTreePath, directoryPaths, fileTreeExpanded, model]);
+    const unsubscribe = model.subscribe(() => reportExpandedPaths(model));
+    reportExpandedPaths(model);
+    return unsubscribe;
+  }, [model, reportExpandedPaths]);
 
   useEffect(() => {
     const nextSelectedPath = activeTreePaths.at(-1) ?? null;
@@ -707,19 +742,28 @@ export function PierreFileTree({
     }
   };
 
-  const handleToggleAllDirectories = (): void => {
-    const nextFileTreeExpanded = !fileTreeExpanded;
-    const nextExpandedPaths = new Set(
-      nextFileTreeExpanded ? directoryPaths : activeAncestorPaths,
-    );
+  const handleCollapseAllDirectories = (): void => {
+    suppressExpansionPersistenceRef.current = true;
+    try {
+      setExpandedDirectories(
+        model,
+        directoryPaths,
+        new Set(activeAncestorPaths),
+      );
+    } finally {
+      suppressExpansionPersistenceRef.current = false;
+    }
+    reportExpandedPaths(model, false);
 
-    setExpandedDirectories(model, directoryPaths, nextExpandedPaths);
-    onFileTreeExpandedChange(nextFileTreeExpanded);
+    if (activeTreePath) {
+      window.requestAnimationFrame(() => {
+        model.scrollToPath(activeTreePath, {
+          focus: false,
+          offset: 'nearest',
+        });
+      });
+    }
   };
-
-  const toggleAllDirectoriesLabel = fileTreeExpanded
-    ? t.app.components.appSidebar.collapseAllFoldersActionTitle
-    : t.app.components.appSidebar.expandAllFoldersActionTitle;
 
   return (
     <div
@@ -738,16 +782,14 @@ export function PierreFileTree({
           <button
             type="button"
             className="inline-flex size-6 items-center justify-center rounded-sm text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-40"
-            aria-label={toggleAllDirectoriesLabel}
-            title={toggleAllDirectoriesLabel}
+            aria-label={
+              t.app.components.appSidebar.collapseAllFoldersActionTitle
+            }
+            title={t.app.components.appSidebar.collapseAllFoldersActionTitle}
             disabled={directoryPaths.length === 0}
-            onClick={handleToggleAllDirectories}
+            onClick={handleCollapseAllDirectories}
           >
-            {fileTreeExpanded ? (
-              <ChevronsDownUp className="size-3.5" />
-            ) : (
-              <ChevronsUpDown className="size-3.5" />
-            )}
+            <SquareMinus className="size-3.5" />
           </button>
           <button
             type="button"
@@ -803,6 +845,12 @@ export function PierreFileTree({
           aria-label={t.app.components.appSidebar.fileTreeLabel}
           className="min-h-0 flex-1 overflow-hidden"
           model={model}
+          onClick={() => {
+            window.requestAnimationFrame(() => reportExpandedPaths(model));
+          }}
+          onKeyUp={() => {
+            window.requestAnimationFrame(() => reportExpandedPaths(model));
+          }}
           renderContextMenu={(item, context) => {
             const entry = toEntry(item);
             const selectedEntries =

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -17,6 +17,10 @@ import {
   normalizePierreFilePath,
   shouldOpenSelectedFile,
 } from './types';
+import {
+  collectPierreDirectoryPaths,
+  usePierreFileTreeExpansion,
+} from './use-pierre-file-tree-expansion';
 
 // Tune the Pierre tree to read like the rest of the sidebar (the previous file
 // tree): comfortable full-width rows with an icon + name, rounded hover/selected
@@ -63,6 +67,7 @@ const TREE_UNSAFE_CSS = `
 
 const CONTEXT_MENU_WIDTH = 176;
 const CONTEXT_MENU_VIEWPORT_MARGIN = 8;
+const EMPTY_PATHS: readonly string[] = [];
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
@@ -125,69 +130,6 @@ function getParentDirectory(path: string): string | undefined {
   return normalizePierreDirectoryPath(path.slice(0, slashIndex));
 }
 
-// Every ancestor directory id implied by a set of file paths. Directories are
-// implicit in Bangle (they exist only through contained notes), so the tree's
-// directory ids are the prefix paths of its files, e.g. `a/b/c.md` implies the
-// directories `a` and `a/b`.
-function collectAncestorDirectoryPaths(paths: readonly string[]): string[] {
-  const directories = new Set<string>();
-
-  for (const path of paths) {
-    const segments = normalizeInputPath(path).split('/');
-    segments.pop();
-
-    let accumulated = '';
-    for (const segment of segments) {
-      accumulated = accumulated ? `${accumulated}/${segment}` : segment;
-      directories.add(accumulated);
-    }
-  }
-
-  return [...directories];
-}
-
-function setExpandedDirectories(
-  model: PierreFileTreeModel,
-  directoryPaths: readonly string[],
-  expandedPaths: ReadonlySet<string>,
-): void {
-  const pathsToExpand = new Set(expandedPaths);
-  for (const expandedPath of expandedPaths) {
-    let parentPath = getParentDirectory(expandedPath);
-    while (parentPath) {
-      pathsToExpand.add(parentPath);
-      parentPath = getParentDirectory(parentPath);
-    }
-  }
-
-  // Collapse children before parents, then expand parents before children. This
-  // keeps the operation deterministic even when the tree implementation skips
-  // rendering descendants of a collapsed directory.
-  for (const directoryPath of [...directoryPaths].reverse()) {
-    const item = model.getItem(directoryPath);
-    if (item && 'collapse' in item && !pathsToExpand.has(directoryPath)) {
-      item.collapse();
-    }
-  }
-
-  for (const directoryPath of directoryPaths) {
-    const item = model.getItem(directoryPath);
-    if (item && 'expand' in item && pathsToExpand.has(directoryPath)) {
-      item.expand();
-    }
-  }
-}
-
-function getExpandedDirectoryPaths(
-  model: PierreFileTreeModel,
-  directoryPaths: readonly string[],
-): string[] {
-  return directoryPaths.filter((directoryPath) => {
-    const item = model.getItem(directoryPath);
-    return item !== null && 'isExpanded' in item && item.isExpanded();
-  });
-}
-
 // `resetPaths` re-seeds expansion from the tree's `initialExpansion` unless it
 // is told otherwise, so a bare reset collapses every folder the user opened.
 // Because Bangle drives the tree imperatively from Jotai state, any note
@@ -197,7 +139,7 @@ function resetModelPathsPreservingExpansion(
   model: PierreFileTreeModel,
   nextPaths: readonly string[],
 ): void {
-  const initialExpandedPaths = collectAncestorDirectoryPaths(nextPaths).filter(
+  const initialExpandedPaths = collectPierreDirectoryPaths(nextPaths).filter(
     (directoryPath) => {
       const item = model.getItem(directoryPath);
       return item !== null && 'isExpanded' in item && item.isExpanded();
@@ -305,7 +247,9 @@ export interface PierreFileTreeProps {
   className?: string;
   expandedPaths?: readonly string[];
   filePaths: readonly string[];
-  onExpandedPathsChange: (expandedPaths: readonly string[]) => void;
+  onDirectoryExpansionChange: (path: string, expanded: boolean) => void;
+  onRevealPaths: (paths: readonly string[]) => void;
+  onCollapseAll: (keepExpandedPaths: readonly string[]) => void;
   onCreateDirectory: (pathPrefix: string | undefined) => void;
   onCreateNote: (pathPrefix: string | undefined) => void;
   onMoveFile: (
@@ -322,11 +266,13 @@ export interface PierreFileTreeProps {
 }
 
 export function PierreFileTree({
-  activePaths = [],
+  activePaths = EMPTY_PATHS,
   className,
-  expandedPaths,
+  expandedPaths = EMPTY_PATHS,
   filePaths,
-  onExpandedPathsChange,
+  onDirectoryExpansionChange,
+  onRevealPaths,
+  onCollapseAll,
   onCreateDirectory,
   onCreateNote,
   onMoveFile,
@@ -367,20 +313,19 @@ export function PierreFileTree({
     activeTreePath && filePathSet.has(activeTreePath),
   );
   const directoryPaths = useMemo(
-    () => collectAncestorDirectoryPaths(treePaths),
+    () => collectPierreDirectoryPaths(treePaths),
     [treePaths],
   );
   const activeAncestorPaths = useMemo(
-    () => collectAncestorDirectoryPaths(activeTreePath ? [activeTreePath] : []),
-    [activeTreePath],
+    () =>
+      activeTreePathIsAvailable && activeTreePath
+        ? collectPierreDirectoryPaths([activeTreePath])
+        : [],
+    [activeTreePath, activeTreePathIsAvailable],
   );
-  const directoryPathsRef = useRef(directoryPaths);
-  const expandedPathsRef = useRef(expandedPaths);
-  const onExpandedPathsChangeRef = useRef(onExpandedPathsChange);
-  const suppressExpansionPersistenceRef = useRef(false);
-  const lastReportedExpandedPathsSignatureRef = useRef<string | null>(null);
-  const observedExpandedPathsSignatureRef = useRef(
-    (expandedPaths ?? []).join('\0'),
+  const initialExpandedPaths = useMemo(
+    () => [...new Set([...expandedPaths, ...activeAncestorPaths])],
+    [activeAncestorPaths, expandedPaths],
   );
   const filePathSetRef = useRef<ReadonlySet<string>>(filePathSet);
   const modelRef = useRef<PierreFileTreeModel | null>(null);
@@ -399,52 +344,10 @@ export function PierreFileTree({
   onOpenFileRef.current = onOpenFile;
   onMoveFileRef.current = onMoveFile;
   treePathsRef.current = treePaths;
-  directoryPathsRef.current = directoryPaths;
-  expandedPathsRef.current = expandedPaths;
-  onExpandedPathsChangeRef.current = onExpandedPathsChange;
-  const expandedPathsSignature = (expandedPaths ?? []).join('\0');
-  if (observedExpandedPathsSignatureRef.current !== expandedPathsSignature) {
-    observedExpandedPathsSignatureRef.current = expandedPathsSignature;
-    lastReportedExpandedPathsSignatureRef.current = expandedPathsSignature;
-  }
   // The file the active route points at. Kept current on every render so
   // `onSelectionChange` can tell a genuine user open from a route-driven
   // re-select (see `shouldOpenSelectedFile`).
   activeSelectedPathRef.current = activeTreePath ?? null;
-
-  const reportExpandedPaths = useCallback(
-    (
-      targetModel: PierreFileTreeModel,
-      preserveUnavailablePaths = true,
-    ): void => {
-      if (suppressExpansionPersistenceRef.current) {
-        return;
-      }
-
-      const currentDirectoryPaths = directoryPathsRef.current;
-      const availableExpandedPaths = getExpandedDirectoryPaths(
-        targetModel,
-        currentDirectoryPaths,
-      );
-      const unavailableExpandedPaths = preserveUnavailablePaths
-        ? (expandedPathsRef.current ?? []).filter(
-            (path) => !currentDirectoryPaths.includes(path),
-          )
-        : [];
-      const nextExpandedPaths = [
-        ...availableExpandedPaths,
-        ...unavailableExpandedPaths,
-      ];
-      const signature = nextExpandedPaths.join('\0');
-      if (lastReportedExpandedPathsSignatureRef.current === signature) {
-        return;
-      }
-
-      lastReportedExpandedPathsSignatureRef.current = signature;
-      onExpandedPathsChangeRef.current(nextExpandedPaths);
-    },
-    [],
-  );
 
   // Single source of truth for "is this drop a real move?": exactly one dragged
   // file we know about, landing in a directory other than its current parent.
@@ -579,9 +482,7 @@ export function PierreFileTree({
       },
     },
     flattenEmptyDirectories: true,
-    initialExpandedPaths: [
-      ...new Set([...(expandedPaths ?? []), ...activeAncestorPaths]),
-    ],
+    initialExpandedPaths,
     initialExpansion: 'closed',
     onSelectionChange: (selectedPaths) => {
       const selectedPath = selectedPaths.at(-1);
@@ -626,81 +527,32 @@ export function PierreFileTree({
   });
   modelRef.current = model;
 
-  useEffect(() => {
-    // A path reset temporarily drops directories that are filtered out and
-    // recreates newly visible directories in their default collapsed state.
-    // Let the controlled expansion effect below reconcile that intermediate
-    // model before any expansion state is persisted.
-    suppressExpansionPersistenceRef.current = true;
-    try {
-      resetModelPathsPreservingExpansion(model, treePaths);
-    } finally {
-      suppressExpansionPersistenceRef.current = false;
-    }
-  }, [model, treePaths]);
-
-  useEffect(() => {
-    if (treePaths.length === 0) {
-      return;
-    }
-
-    if (activeTreePath && !activeTreePathIsAvailable) {
-      return;
-    }
-
-    const nextExpandedPaths = new Set([
-      ...(expandedPaths ?? []),
-      ...activeAncestorPaths,
-    ]);
-    suppressExpansionPersistenceRef.current = true;
-    try {
-      setExpandedDirectories(model, directoryPaths, nextExpandedPaths);
-    } finally {
-      suppressExpansionPersistenceRef.current = false;
-    }
-  }, [
-    activeAncestorPaths,
-    activeTreePath,
+  const collapseAll = usePierreFileTreeExpansion({
+    model,
+    treePaths,
     directoryPaths,
     expandedPaths,
-    activeTreePathIsAvailable,
-    model,
-    treePaths.length,
-  ]);
+    activeAncestorPaths,
+    onDirectoryExpansionChange,
+    onRevealPaths,
+    onCollapseAll,
+  });
 
   useEffect(() => {
-    if (!activeTreePath || !activeTreePathIsAvailable) {
-      return;
-    }
-
-    // Active ancestors are forced open locally during controlled-state
-    // reconciliation. Persist them only when the active route (or available
-    // file set) changes, so an expansion update received from another tab is
-    // not immediately written back with this tab's active ancestors added.
-    reportExpandedPaths(model);
-
-    const animationFrame = window.requestAnimationFrame(() => {
-      model.scrollToPath(activeTreePath, {
-        focus: false,
-        offset: 'nearest',
-      });
-    });
-
-    return () => window.cancelAnimationFrame(animationFrame);
-  }, [activeTreePath, activeTreePathIsAvailable, model, reportExpandedPaths]);
-
-  useEffect(() => {
-    const unsubscribe = model.subscribe(() => reportExpandedPaths(model));
-    reportExpandedPaths(model);
-    return unsubscribe;
-  }, [model, reportExpandedPaths]);
-
-  useEffect(() => {
-    const nextSelectedPath = activeTreePaths.at(-1) ?? null;
+    const nextSelectedPath = activeTreePath ?? null;
     const shouldPreserveScroll =
       pendingUserOpenPathRef.current === nextSelectedPath;
 
     if (selectedPathRef.current === nextSelectedPath) {
+      if (nextSelectedPath && activeTreePathIsAvailable) {
+        model.getItem(nextSelectedPath)?.select();
+        if (!shouldPreserveScroll) {
+          model.scrollToPath(nextSelectedPath, {
+            focus: false,
+            offset: 'nearest',
+          });
+        }
+      }
       if (shouldPreserveScroll) {
         pendingUserOpenPathRef.current = null;
       }
@@ -714,7 +566,7 @@ export function PierreFileTree({
       model.getItem(previousSelectedPath)?.deselect();
     }
 
-    if (nextSelectedPath) {
+    if (nextSelectedPath && activeTreePathIsAvailable) {
       model.getItem(nextSelectedPath)?.select();
       if (shouldPreserveScroll) {
         pendingUserOpenPathRef.current = null;
@@ -725,7 +577,7 @@ export function PierreFileTree({
         });
       }
     }
-  }, [activeTreePaths, model]);
+  }, [activeTreePath, activeTreePathIsAvailable, model]);
 
   useEffect(
     () => () => {
@@ -769,17 +621,7 @@ export function PierreFileTree({
   };
 
   const handleCollapseAllDirectories = (): void => {
-    suppressExpansionPersistenceRef.current = true;
-    try {
-      setExpandedDirectories(
-        model,
-        directoryPaths,
-        new Set(activeAncestorPaths),
-      );
-    } finally {
-      suppressExpansionPersistenceRef.current = false;
-    }
-    reportExpandedPaths(model, false);
+    collapseAll();
 
     if (activeTreePath) {
       window.requestAnimationFrame(() => {
@@ -871,12 +713,6 @@ export function PierreFileTree({
           aria-label={t.app.components.appSidebar.fileTreeLabel}
           className="min-h-0 flex-1 overflow-hidden"
           model={model}
-          onClick={() => {
-            window.requestAnimationFrame(() => reportExpandedPaths(model));
-          }}
-          onKeyUp={() => {
-            window.requestAnimationFrame(() => reportExpandedPaths(model));
-          }}
           renderContextMenu={(item, context) => {
             const entry = toEntry(item);
             const selectedEntries =

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -363,6 +363,9 @@ export function PierreFileTree({
     [activePaths],
   );
   const activeTreePath = activeTreePaths.at(-1);
+  const activeTreePathIsAvailable = Boolean(
+    activeTreePath && filePathSet.has(activeTreePath),
+  );
   const directoryPaths = useMemo(
     () => collectAncestorDirectoryPaths(treePaths),
     [treePaths],
@@ -376,6 +379,9 @@ export function PierreFileTree({
   const onExpandedPathsChangeRef = useRef(onExpandedPathsChange);
   const suppressExpansionPersistenceRef = useRef(false);
   const lastReportedExpandedPathsSignatureRef = useRef<string | null>(null);
+  const observedExpandedPathsSignatureRef = useRef(
+    (expandedPaths ?? []).join('\0'),
+  );
   const filePathSetRef = useRef<ReadonlySet<string>>(filePathSet);
   const modelRef = useRef<PierreFileTreeModel | null>(null);
   const contextMenuSelectedEntriesRef = useRef<readonly FileTreeEntry[]>([]);
@@ -396,6 +402,11 @@ export function PierreFileTree({
   directoryPathsRef.current = directoryPaths;
   expandedPathsRef.current = expandedPaths;
   onExpandedPathsChangeRef.current = onExpandedPathsChange;
+  const expandedPathsSignature = (expandedPaths ?? []).join('\0');
+  if (observedExpandedPathsSignatureRef.current !== expandedPathsSignature) {
+    observedExpandedPathsSignatureRef.current = expandedPathsSignature;
+    lastReportedExpandedPathsSignatureRef.current = expandedPathsSignature;
+  }
   // The file the active route points at. Kept current on every render so
   // `onSelectionChange` can tell a genuine user open from a route-driven
   // re-select (see `shouldOpenSelectedFile`).
@@ -616,7 +627,16 @@ export function PierreFileTree({
   modelRef.current = model;
 
   useEffect(() => {
-    resetModelPathsPreservingExpansion(model, treePaths);
+    // A path reset temporarily drops directories that are filtered out and
+    // recreates newly visible directories in their default collapsed state.
+    // Let the controlled expansion effect below reconcile that intermediate
+    // model before any expansion state is persisted.
+    suppressExpansionPersistenceRef.current = true;
+    try {
+      resetModelPathsPreservingExpansion(model, treePaths);
+    } finally {
+      suppressExpansionPersistenceRef.current = false;
+    }
   }, [model, treePaths]);
 
   useEffect(() => {
@@ -624,7 +644,7 @@ export function PierreFileTree({
       return;
     }
 
-    if (activeTreePath && !filePathSet.has(activeTreePath)) {
+    if (activeTreePath && !activeTreePathIsAvailable) {
       return;
     }
 
@@ -638,11 +658,26 @@ export function PierreFileTree({
     } finally {
       suppressExpansionPersistenceRef.current = false;
     }
-    reportExpandedPaths(model);
+  }, [
+    activeAncestorPaths,
+    activeTreePath,
+    directoryPaths,
+    expandedPaths,
+    activeTreePathIsAvailable,
+    model,
+    treePaths.length,
+  ]);
 
-    if (!activeTreePath) {
+  useEffect(() => {
+    if (!activeTreePath || !activeTreePathIsAvailable) {
       return;
     }
+
+    // Active ancestors are forced open locally during controlled-state
+    // reconciliation. Persist them only when the active route (or available
+    // file set) changes, so an expansion update received from another tab is
+    // not immediately written back with this tab's active ancestors added.
+    reportExpandedPaths(model);
 
     const animationFrame = window.requestAnimationFrame(() => {
       model.scrollToPath(activeTreePath, {
@@ -652,16 +687,7 @@ export function PierreFileTree({
     });
 
     return () => window.cancelAnimationFrame(animationFrame);
-  }, [
-    activeAncestorPaths,
-    activeTreePath,
-    directoryPaths,
-    expandedPaths,
-    filePathSet,
-    model,
-    reportExpandedPaths,
-    treePaths.length,
-  ]);
+  }, [activeTreePath, activeTreePathIsAvailable, model, reportExpandedPaths]);
 
   useEffect(() => {
     const unsubscribe = model.subscribe(() => reportExpandedPaths(model));

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -7,8 +7,20 @@ import type {
   FileTree as PierreFileTreeModel,
 } from '@pierre/trees';
 import { FileTree, useFileTree } from '@pierre/trees/react';
-import { FilePlus2, FileText, FolderPlus } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  ChevronsDownUp,
+  ChevronsUpDown,
+  FilePlus2,
+  FileText,
+  FolderPlus,
+} from 'lucide-react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { BANGLE_PIERRE_FILE_TREE_ICONS } from './pierre-file-tree-icons';
 import {
   type FileTreeEntry,
@@ -144,6 +156,29 @@ function collectAncestorDirectoryPaths(paths: readonly string[]): string[] {
   }
 
   return [...directories];
+}
+
+function setExpandedDirectories(
+  model: PierreFileTreeModel,
+  directoryPaths: readonly string[],
+  expandedPaths: ReadonlySet<string>,
+): void {
+  // Collapse children before parents, then expand parents before children. This
+  // keeps the operation deterministic even when the tree implementation skips
+  // rendering descendants of a collapsed directory.
+  for (const directoryPath of [...directoryPaths].reverse()) {
+    const item = model.getItem(directoryPath);
+    if (item && 'collapse' in item && !expandedPaths.has(directoryPath)) {
+      item.collapse();
+    }
+  }
+
+  for (const directoryPath of directoryPaths) {
+    const item = model.getItem(directoryPath);
+    if (item && 'expand' in item && expandedPaths.has(directoryPath)) {
+      item.expand();
+    }
+  }
 }
 
 // `resetPaths` re-seeds expansion from the tree's `initialExpansion` unless it
@@ -316,6 +351,16 @@ export function PierreFileTree({
     () => activePaths.map((path) => normalizeInputPath(path)),
     [activePaths],
   );
+  const activeTreePath = activeTreePaths.at(-1);
+  const directoryPaths = useMemo(
+    () => collectAncestorDirectoryPaths(treePaths),
+    [treePaths],
+  );
+  const activeAncestorPaths = useMemo(
+    () => collectAncestorDirectoryPaths(activeTreePath ? [activeTreePath] : []),
+    [activeTreePath],
+  );
+  const [expandAllOnNextClick, setExpandAllOnNextClick] = useState(false);
   const filePathSetRef = useRef<ReadonlySet<string>>(filePathSet);
   const modelRef = useRef<PierreFileTreeModel | null>(null);
   const contextMenuSelectedEntriesRef = useRef<readonly FileTreeEntry[]>([]);
@@ -336,7 +381,7 @@ export function PierreFileTree({
   // The file the active route points at. Kept current on every render so
   // `onSelectionChange` can tell a genuine user open from a route-driven
   // re-select (see `shouldOpenSelectedFile`).
-  activeSelectedPathRef.current = activeTreePaths.at(-1) ?? null;
+  activeSelectedPathRef.current = activeTreePath ?? null;
 
   // Single source of truth for "is this drop a real move?": exactly one dragged
   // file we know about, landing in a directory other than its current parent.
@@ -520,6 +565,14 @@ export function PierreFileTree({
   }, [model, treePaths]);
 
   useEffect(() => {
+    if (!expandAllOnNextClick) {
+      return;
+    }
+
+    setExpandedDirectories(model, directoryPaths, new Set(activeAncestorPaths));
+  }, [activeAncestorPaths, directoryPaths, expandAllOnNextClick, model]);
+
+  useEffect(() => {
     const nextSelectedPath = activeTreePaths.at(-1) ?? null;
     const shouldPreserveScroll =
       pendingUserOpenPathRef.current === nextSelectedPath;
@@ -592,6 +645,19 @@ export function PierreFileTree({
     }
   };
 
+  const handleToggleAllDirectories = (): void => {
+    const nextExpandedPaths = expandAllOnNextClick
+      ? new Set(directoryPaths)
+      : new Set(activeAncestorPaths);
+
+    setExpandedDirectories(model, directoryPaths, nextExpandedPaths);
+    setExpandAllOnNextClick(!expandAllOnNextClick);
+  };
+
+  const toggleAllDirectoriesLabel = expandAllOnNextClick
+    ? t.app.components.appSidebar.expandAllFoldersActionTitle
+    : t.app.components.appSidebar.collapseAllFoldersActionTitle;
+
   return (
     <div
       ref={rootElementRef}
@@ -606,6 +672,20 @@ export function PierreFileTree({
           <span className="min-w-0 flex-1 truncate font-medium text-[11px] text-sidebar-foreground/55 uppercase tracking-wide">
             {t.app.components.appSidebar.filesLabel}
           </span>
+          <button
+            type="button"
+            className="inline-flex size-6 items-center justify-center rounded-sm text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-40"
+            aria-label={toggleAllDirectoriesLabel}
+            title={toggleAllDirectoriesLabel}
+            disabled={directoryPaths.length === 0}
+            onClick={handleToggleAllDirectories}
+          >
+            {expandAllOnNextClick ? (
+              <ChevronsUpDown className="size-3.5" />
+            ) : (
+              <ChevronsDownUp className="size-3.5" />
+            )}
+          </button>
           <button
             type="button"
             className={cn(

--- a/packages/ui/ui-components/src/file-tree/use-pierre-file-tree-expansion.ts
+++ b/packages/ui/ui-components/src/file-tree/use-pierre-file-tree-expansion.ts
@@ -136,11 +136,15 @@ export function usePierreFileTreeExpansion({
     previousExpandedPathsRef.current = readExpandedPaths(model, directoryPaths);
 
     return model.subscribe(() => {
+      if (isProjectingRef.current) {
+        return;
+      }
+
       const previous = previousExpandedPathsRef.current;
       const current = readExpandedPaths(model, directoryPaths);
       previousExpandedPathsRef.current = current;
 
-      if (isProjectingRef.current || setsEqual(previous, current)) {
+      if (setsEqual(previous, current)) {
         return;
       }
 

--- a/packages/ui/ui-components/src/file-tree/use-pierre-file-tree-expansion.ts
+++ b/packages/ui/ui-components/src/file-tree/use-pierre-file-tree-expansion.ts
@@ -1,0 +1,167 @@
+import type { FileTree as PierreFileTreeModel } from '@pierre/trees';
+import { useCallback, useEffect, useEffectEvent, useMemo, useRef } from 'react';
+
+function normalizePath(path: string): string {
+  return path.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+export function collectPierreDirectoryPaths(
+  paths: readonly string[],
+): string[] {
+  const directories = new Set<string>();
+
+  for (const path of paths) {
+    const segments = normalizePath(path).split('/');
+    segments.pop();
+
+    let accumulated = '';
+    for (const segment of segments) {
+      accumulated = accumulated ? `${accumulated}/${segment}` : segment;
+      directories.add(accumulated);
+    }
+  }
+
+  return [...directories];
+}
+
+function readExpandedPaths(
+  model: PierreFileTreeModel,
+  directoryPaths: readonly string[],
+): ReadonlySet<string> {
+  return new Set(
+    directoryPaths.filter((path) => {
+      const item = model.getItem(path);
+      return item !== null && 'isExpanded' in item && item.isExpanded();
+    }),
+  );
+}
+
+function setsEqual(left: ReadonlySet<string>, right: ReadonlySet<string>) {
+  return left.size === right.size && [...left].every((path) => right.has(path));
+}
+
+export function usePierreFileTreeExpansion({
+  model,
+  treePaths,
+  directoryPaths,
+  expandedPaths,
+  activeAncestorPaths,
+  onDirectoryExpansionChange,
+  onRevealPaths,
+  onCollapseAll,
+}: {
+  model: PierreFileTreeModel;
+  treePaths: readonly string[];
+  directoryPaths: readonly string[];
+  expandedPaths: readonly string[];
+  activeAncestorPaths: readonly string[];
+  onDirectoryExpansionChange: (path: string, expanded: boolean) => void;
+  onRevealPaths: (paths: readonly string[]) => void;
+  onCollapseAll: (keepExpandedPaths: readonly string[]) => void;
+}) {
+  const projectedExpandedPaths = useMemo(
+    () => [...new Set([...expandedPaths, ...activeAncestorPaths])],
+    [activeAncestorPaths, expandedPaths],
+  );
+  // Jotai owns durable expansion intent; Pierre is its imperative projection.
+  // Controlled projections must never return through the subscription as user
+  // expansion deltas.
+  const isProjectingRef = useRef(false);
+  const previousExpandedPathsRef = useRef<ReadonlySet<string>>(new Set());
+
+  const projectWithoutReporting = useCallback(
+    (apply: () => void) => {
+      isProjectingRef.current = true;
+      try {
+        apply();
+      } finally {
+        previousExpandedPathsRef.current = readExpandedPaths(
+          model,
+          directoryPaths,
+        );
+        isProjectingRef.current = false;
+      }
+    },
+    [directoryPaths, model],
+  );
+
+  const applyExpandedPaths = useCallback(
+    (paths: readonly string[]) => {
+      const nextExpandedPaths = new Set(paths);
+      projectWithoutReporting(() => {
+        for (const path of [...directoryPaths].reverse()) {
+          const item = model.getItem(path);
+          if (
+            item !== null &&
+            'isExpanded' in item &&
+            item.isExpanded() &&
+            !nextExpandedPaths.has(path)
+          ) {
+            item.collapse();
+          }
+        }
+        for (const path of directoryPaths) {
+          const item = model.getItem(path);
+          if (
+            item !== null &&
+            'isExpanded' in item &&
+            !item.isExpanded() &&
+            nextExpandedPaths.has(path)
+          ) {
+            item.expand();
+          }
+        }
+      });
+    },
+    [directoryPaths, model, projectWithoutReporting],
+  );
+
+  const resetModelPaths = useEffectEvent((nextTreePaths: readonly string[]) => {
+    projectWithoutReporting(() => {
+      model.resetPaths(nextTreePaths, {
+        initialExpandedPaths: projectedExpandedPaths,
+      });
+    });
+  });
+
+  useEffect(() => {
+    resetModelPaths(treePaths);
+  }, [treePaths]);
+
+  useEffect(() => {
+    applyExpandedPaths(projectedExpandedPaths);
+  }, [applyExpandedPaths, projectedExpandedPaths]);
+
+  useEffect(() => {
+    previousExpandedPathsRef.current = readExpandedPaths(model, directoryPaths);
+
+    return model.subscribe(() => {
+      const previous = previousExpandedPathsRef.current;
+      const current = readExpandedPaths(model, directoryPaths);
+      previousExpandedPathsRef.current = current;
+
+      if (isProjectingRef.current || setsEqual(previous, current)) {
+        return;
+      }
+
+      for (const path of new Set([...previous, ...current])) {
+        if (previous.has(path) !== current.has(path)) {
+          onDirectoryExpansionChange(path, current.has(path));
+        }
+      }
+    });
+  }, [directoryPaths, model, onDirectoryExpansionChange]);
+
+  useEffect(() => {
+    if (activeAncestorPaths.length > 0) {
+      onRevealPaths(activeAncestorPaths);
+    }
+  }, [activeAncestorPaths, onRevealPaths]);
+
+  const collapseAll = useCallback(() => {
+    applyExpandedPaths(activeAncestorPaths);
+    onCollapseAll(activeAncestorPaths);
+  }, [activeAncestorPaths, applyExpandedPaths, onCollapseAll]);
+
+  return collapseAll;
+}


### PR DESCRIPTION
## Summary
- add a VS Code-style one-shot Collapse All action that keeps the active note ancestor chain open
- make Jotai/workbench state the durable source of expanded paths per workspace
- model expansion changes as typed service-core transitions for directory toggles, active-path reveal, and Collapse All
- isolate the uncontrolled Pierre model behind a focused projection adapter using public model APIs
- prevent controlled and cross-tab projections from echoing back as local user changes
- preserve manually expanded branches through navigation, reload, notes-only filtering, and tree resets
- reveal the active note after navigation and Collapse All without changing scroll during ordinary folder browsing
- provide English and German accessible labels with the square-minus Collapse All icon

## Architecture
- service-core owns durable expansion state and semantic transitions
- core app binds transitions to the active workspace
- ui-components remains presentational and emits semantic expansion events
- Pierre owns rendering and interaction state; one guarded adapter projects Jotai state and reports genuine local deltas

## Testing
- pnpm local-ci-check
- pnpm lint:ci && pnpm test:ci after the final review-only rename/comment
- 1970 unit tests passed, 1 skipped
- 136 browser E2E tests passed
- 7 component tests passed
- 28 desktop unit tests passed
- browser and desktop builds passed
- Electron persistence smoke passed
- focused file-explorer Playwright suite: 9/9