### PR TITLE
docs: groom plans and project backlog

### DIFF
--- a/plans/006-image-embeds-and-paste-assets.md
+++ b/plans/006-image-embeds-and-paste-assets.md
@@ -1,12 +1,14 @@
 ---
 title: Image Embeds And Paste Assets
-status: planned
+status: active
 type: plan
 archived: false
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-12
 owner: mixed
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/587
+  - https://github.com/bangle-io/bangle-io/pull/610
 related_issues: []
 ---
 
@@ -31,24 +33,19 @@ The target behavior is:
 
 ## Current Status
 
-- Current editor setup already registers `setupImage()` from
-  `@bangle.io/prosemirror-plugins` in
-  `packages/core/editor/src/extensions.ts`.
-- `packages/js-lib/banger-editor/src/image.ts` already defines an inline image
-  node with `src`, `alt`, and `title`, Markdown parse/serialize support, input
-  rules, paste handling, drop handling, and an `updateImageNodeAttribute`
-  command.
-- The default paste/drop behavior currently converts image files into `data:`
-  URLs. That is acceptable as a generic fallback, but not as Bangle's released
-  behavior because it bloats Markdown, bypasses workspace file persistence, and
-  gives no durable asset name.
-- `FileSystemService` can already create and read arbitrary workspace files by
-  `wsPath`, but `listFiles()` currently filters the workspace tree to note
-  extensions. Image assets should be stored and read without necessarily
-  becoming navigable notes.
-- Existing E2E fixtures include local missing images and data images in
-  `packages/tooling/e2e-tests/src/fixtures/workspaces/markdown-edge-cases/04-links-and-images.md`.
-  Preserve those cases.
+- PR #587 shipped workspace-backed asset paste/drop, relative Markdown paths,
+  local image rendering, asset routing, write-before-insert ordering, and
+  Playwright persistence coverage for images and PDFs.
+- PR #610 fixed duplicate image nodes when browsers surface the same clipboard
+  file through multiple transfer-list views.
+- `packages/js-lib/banger-editor/src/image.ts` owns the image schema and
+  Markdown parse/serialize behavior; `packages/core/editor/src/asset-file-plugin.ts`
+  and `local-image-node-view.ts` own Bangle's durable asset workflow.
+- The image-specific selected-node menu is not implemented. Editing `alt` and
+  `title`, replacing an image, and any Markdown-compatible sizing controls
+  remain the main unfinished scope in this plan.
+- Failure and recovery coverage should still be expanded for permission loss,
+  quota failures, and missing assets without document mutation.
 
 ## Legacy Findings
 

--- a/plans/009-mobile-ios-expo-shell.md
+++ b/plans/009-mobile-ios-expo-shell.md
@@ -5,9 +5,10 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-12
 owner: mixed
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/567
 related_issues: []
 ---
 
@@ -51,6 +52,11 @@ Decisions made (2026-07-02, with Kushan):
   without its full-native UI architecture.
 
 ## Milestones
+
+PR #567 merged the M0 repository scaffolding: the Expo/WebView package, app
+variants, EAS profiles, and manual GitHub workflow. M0 is not complete until the
+human-owned account/provisioning steps below put the app on a physical phone.
+M1-M3 remain unstarted.
 
 ### M0 — pipeline end-to-end (this plan's exit criterion: app on a phone)
 

--- a/plans/archived/003-upgrade-wrap-up.md
+++ b/plans/archived/003-upgrade-wrap-up.md
@@ -11,6 +11,11 @@ related_prs: []
 related_issues: []
 ---
 
+> DONE Completed on 2026-06-14 in commit `b7a8ee9e`. The toolchain compatibility
+> shims were either removed or explicitly retained with upstream exit criteria;
+> verification passed with install, lint, audit, build, unit, E2E, and
+> Playwright CLI production-preview smoke checks.
+
 # Upgrade Wrap-up
 
 ## Summary

--- a/plans/archived/008-markdown-table-support.md
+++ b/plans/archived/008-markdown-table-support.md
@@ -1,14 +1,22 @@
 ---
 title: Markdown Table Support
-status: active
+status: completed
 type: plan
-archived: false
+archived: true
+archived_on: 2026-07-12
 created: 2026-07-01
-updated: 2026-07-01
+updated: 2026-07-12
 owner: mixed
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/556
 related_issues: []
 ---
+
+> DONE Completed on 2026-07-02 in PR #556. V1 shipped editable Markdown pipe
+> tables, visible row/column/alignment controls, keyboard navigation, exact
+> round-trip coverage, and Playwright persistence coverage. The implementation
+> passed the repository checks recorded below; later table polish is separate
+> follow-up work rather than part of this completed V1 plan.
 
 # Markdown Table Support
 
@@ -33,7 +41,7 @@ inside a Markdown note, not a second product embedded in the editor.
 
 ## Current Status
 
-V1 is implemented on branch `worktree-markdown-table-support` (2026-07-01):
+V1 merged to `main` in PR #556 on 2026-07-02:
 
 - `packages/js-lib/banger-editor/src/table.ts` owns the schema
   (`prosemirror-tables` `tableNodes`, inline-only cells, `align` cell attr),
@@ -821,11 +829,5 @@ The first released version should satisfy all of these:
 
 ## Next Steps
 
-1. Re-read the files listed in "Current Status" and "Reference Projects".
-2. Confirm the current `prosemirror-tables` package version and API.
-3. Start with schema, parser, serializer, and round-trip tests.
-4. Register the extension only after the Markdown path is covered.
-5. Add command wrappers and keyboard behavior.
-6. Add slash command insertion.
-7. Add handle UI using ProseKit as the UX reference.
-8. Finish with E2E persistence coverage and the required repo checks.
+No remaining V1 work. Track optional table polish as separate project items so
+it can be prioritized independently from the shipped Markdown table workflow.

--- a/plans/archived/010-collapsible-headings.md
+++ b/plans/archived/010-collapsible-headings.md
@@ -2,14 +2,20 @@
 title: Collapsible Headings (fold / unfold sections)
 status: completed
 type: plan
-archived: false
-archived_on:
+archived: true
+archived_on: 2026-07-12
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-07-12
 owner: agent
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/597
 related_issues: []
 ---
+
+> DONE Completed on 2026-07-04 in PR #597. Collapsible headings shipped as
+> view-only editor state with Markdown round-trip safety, focused unit tests,
+> committed Playwright coverage, and the lint, test, E2E, build, and manual
+> Playwright smoke verification recorded below.
 
 # Collapsible Headings
 


### PR DESCRIPTION
## What changed

- archived the completed Markdown table and collapsible-heading plans with PR links, completion dates, and DONE notes
- updated the partially completed image and iOS plans to distinguish landed work from remaining work
- repaired the missing DONE note on the older upgrade wrap-up archive
- directly groomed Bangle 2 Project #5 with one linked draft item for each of the nine unfinished plans, including Status, Priority, Size, and Product area

## Why

The plans directory and project board had drifted: completed plans remained active, partial plans did not reflect merged work, and unfinished plans were absent from the prioritization board.

## Validation

Documentation-only change; code suites were not run under the documentation exception in `AGENTS.md`.

- verified all 9 unfinished plans have exactly one draft Project #5 item linking to the GitHub plan
- verified all 6 archived plans have completed/archived metadata, an archive date, and a DONE note
- verified partially completed plans distinguish landed and remaining work
- `git diff --check` passed
