### PR TITLE
refactor: remove obsolete core service APIs

### DIFF
--- a/packages/core/service-core/src/command-registry-service.ts
+++ b/packages/core/service-core/src/command-registry-service.ts
@@ -4,7 +4,7 @@ import {
   type BaseServiceContext,
 } from '@bangle.io/base-utils';
 import { SERVICE_NAME } from '@bangle.io/constants';
-import type { Command, CommandHandler, CommandKey } from '@bangle.io/types';
+import type { Command, CommandHandler } from '@bangle.io/types';
 
 export type CommandHandlerConfig = { id: string; handler: CommandHandler };
 
@@ -16,7 +16,6 @@ export class CommandRegistryService extends BaseService {
 
   private commands: Map<string, Command> = new Map();
   private handlers: Map<string, CommandHandler> = new Map();
-  private commandKeyMap: WeakMap<Command, CommandKey<string>> = new WeakMap();
 
   constructor(
     context: BaseServiceContext,
@@ -52,25 +51,11 @@ export class CommandRegistryService extends BaseService {
     return Array.from(this.commands.values());
   }
 
-  public getCommandKey(command: Command): CommandKey<string> {
-    const key = this.commandKeyMap.get(command);
-    if (!key) {
-      throw new BaseError({
-        message: `Command "${command.id}" does not have a key.`,
-      });
-    }
-    return key;
-  }
-
   public register(command: Command) {
     if (this.commands.has(command.id)) {
       throw new BaseError({
         message: `Command "${command.id}" is already registered.`,
       });
-    }
-
-    if (!this.commandKeyMap.has(command)) {
-      this.commandKeyMap.set(command, { key: command.id });
     }
 
     this.commands.set(command.id, command);

--- a/packages/core/service-core/src/navigation-service.ts
+++ b/packages/core/service-core/src/navigation-service.ts
@@ -138,10 +138,6 @@ export class NavigationService extends BaseService {
     return this.routerService.toUri(routeInfo);
   }
 
-  public fromUri(uri: string): AppRouteInfo {
-    return this.routerService.fromUri(uri);
-  }
-
   public go(
     to: AppRouteInfo,
     options?: { replace?: boolean; state?: RouterState },

--- a/packages/core/service-core/src/workspace-ops-service.ts
+++ b/packages/core/service-core/src/workspace-ops-service.ts
@@ -249,57 +249,6 @@ export class WorkspaceOpsService extends BaseService {
     return true;
   }
 
-  public async getMiscData(key: string): Promise<{ data: string } | undefined> {
-    await this.mountPromise;
-    const data = await this.database.getEntry(key, {
-      tableName: DATABASE_TABLE_NAME.misc,
-    });
-
-    if (!data.found) {
-      return undefined;
-    }
-
-    if (typeof data.value !== 'string') {
-      throwAppError('error::workspace:invalid-misc-data', 'Invalid misc data', {
-        info: key,
-      });
-    }
-
-    return {
-      data: data.value,
-    };
-  }
-
-  public async setMiscData(key: string, data: string): Promise<void> {
-    await this.mountPromise;
-    if (typeof data !== 'string') {
-      throwAppError(
-        'error::workspace:invalid-misc-data',
-        `Invalid data for key ${key}`,
-        {
-          info: key,
-        },
-      );
-    }
-
-    await this.database.updateEntry(
-      key,
-      () => {
-        return {
-          value: data,
-        };
-      },
-      { tableName: DATABASE_TABLE_NAME.misc },
-    );
-  }
-
-  public async deleteMiscData(key: string): Promise<void> {
-    await this.mountPromise;
-    await this.database.deleteEntry(key, {
-      tableName: DATABASE_TABLE_NAME.misc,
-    });
-  }
-
   public invalidateCache(): void {
     this.workspaceInfoCache.clear();
   }

--- a/packages/shared/types/app-errors.ts
+++ b/packages/shared/types/app-errors.ts
@@ -46,12 +46,6 @@ export type AppError =
       };
     }
   | {
-      name: `error::workspace:invalid-misc-data`;
-      payload: {
-        info: string;
-      };
-    }
-  | {
       name: `error::workspace:not-allowed`;
       payload: {
         wsName?: string;

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -102,6 +102,11 @@ before broader UI or tooling cleanup.
   - P3.3 improved: `StarButton` now follows the application convention of using
     the global `t` object instead of importing translations directly. The
     broader literal-string sweep remains open.
+- 2026-07-12 obsolete service API cleanup:
+  - A4 improved: removed the zero-consumer command object-to-key cache/getter,
+    core navigation `fromUri` pass-through, workspace misc-data methods, and
+    their unreachable app-error variant. The generic database misc table stays
+    intact so this cleanup does not alter persisted storage schemas.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -833,7 +838,7 @@ listed so future agents do not rediscover it or accidentally restore it.
 | A1 | Open; extends P3.2 | Move dialog intents and transient feature state out of `WorkbenchStateService`. It still imports UI prop types and stores callbacks/icons/full dialog props, plus Omni and All Files state, inside `service-core`. Put feature-owned state and callback execution beside the owning app feature; keep durable preferences in the service. | 250-500 LOC; removes core-to-UI coupling |
 | A2 | Open | Replace the global `commandKeyToContext` WeakMap and string-selected service-locator kernel with direct typed handler context. Colocate command metadata and handlers by feature; keep only serializable cross-context command contracts in shared. | 100-200 LOC; explicit dependencies |
 | A3 | Open; reopens P2.3 | Remove the hidden Native FS upward dependency. `initialize-services` currently gives the platform storage adapter a late-bound closure that calls core `WorkspaceOpsService`. Introduce a core-owned workspace storage-session/root-handle registry with explicit invalidation and a downward platform contract. | Removes reload/recovery glue and runtime cycle |
-| A4 | Partial | PR #631 deleted `WorkspaceService` and pass-through `WorkbenchService` and strengthened graph validation. The unused `WorkbenchStateService` database dependency was removed in the 2026-07-12 high-ROI batch. The core aggregate is still repeated in `coreServiceClasses`, `coreServiceSlots`, `getCoreInstances`, `toCoreServices`, and public service types. Derive these views from one descriptor and delete unused command-key, navigation `fromUri`, and workspace misc-data APIs after focused verification. | 150-250 LOC |
+| A4 | Partial | PR #631 deleted `WorkspaceService` and pass-through `WorkbenchService` and strengthened graph validation. The 2026-07-12 cleanup batches removed the unused `WorkbenchStateService` database dependency plus the zero-consumer command-key cache/getter, navigation `fromUri` pass-through, and workspace misc-data methods/error variant. The core aggregate is still repeated in `coreServiceClasses`, `coreServiceSlots`, `getCoreInstances`, `toCoreServices`, and public service types; derive those views from one descriptor in a separate slice. | 150-250 LOC originally; remaining benefit is one derived service graph |
 | A5 | Open | Fold All Files into Omni Search as a file-only scope. Both surfaces independently map workspace files, fuzzy-search, virtualize results, dispatch navigation, and maintain separate open/input state. | 184-230 LOC |
 | A6 | Open; remainder of P3.5 | Move the one-caller Bangle-specific `ui-components/AppSidebar` composition into `core/app/features/sidebar`. Keep reusable sidebar and file-tree primitives in UI, but remove the roughly 30-prop adapter boundary split across a 582-line UI component and its sole app caller. | About 100-200 LOC and one feature boundary |
 | A7 | Resolved in PR #632 | Delete the five zero-producer fatal/auth/missing routes, their pages/types/decoder branches/translations, and unused `ROUTES`; stale IDs decode through normal `not-found`. | 205 net code LOC before review hardening |

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -11,6 +11,7 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
   - https://github.com/bangle-io/bangle-io/pull/632
   - https://github.com/bangle-io/bangle-io/pull/635
+  - https://github.com/bangle-io/bangle-io/pull/636
 related_issues: []
 ---
 
@@ -102,7 +103,7 @@ before broader UI or tooling cleanup.
   - P3.3 improved: `StarButton` now follows the application convention of using
     the global `t` object instead of importing translations directly. The
     broader literal-string sweep remains open.
-- 2026-07-12 obsolete service API cleanup:
+- 2026-07-12 obsolete service API cleanup (PR #636):
   - A4 improved: removed the zero-consumer command object-to-key cache/getter,
     core navigation `fromUri` pass-through, workspace misc-data methods, and
     their unreachable app-error variant. The generic database misc table stays


### PR DESCRIPTION
## What changed

- remove the unused command registry object-to-key cache and getter
- remove the unused core navigation `fromUri` pass-through
- remove unused workspace misc-data service methods and their unreachable app-error variant
- retain the generic database misc table so persisted storage schemas are unchanged
- update the durable tech-debt audit with the reduced A4 remainder

## Why

This is the next small, high-return cleanup slice after #635. It removes confirmed zero-consumer production APIs and state without overlapping the active service-architecture, Knip, editor, or Native FS branches.

## Validation

- focused Vitest: 20 passed across command registry, workspace operations, memory router, and memory database
- `pnpm lint:ci`
- `pnpm test:ci` — 2,049 passed, 1 skipped
- `pnpm local-ci-check` — all root `*:ci` scripts passed, including Knip, 137 E2E tests (135 direct + 2 flaky retries), 7 component tests, production/desktop builds, 28 desktop tests, and Electron persistence smoke

The two successful browser retries were existing timing flakes in editor cursor restoration and the file explorer workflow; neither surface is changed by this PR.