### PR TITLE
fix: harden workspace creation dialog

### DIFF
--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -361,6 +361,7 @@ export const t = {
         directoryPickingUnsupported: 'Directory picking is not supported.',
         pickDirectoryButton: 'Pick Directory',
         invalidDirectoryDefault: 'Invalid directory selection',
+        createFailed: 'Could not create the workspace. Please try again.',
       },
       allFiles: {
         title: 'All Files',

--- a/packages/tooling/e2e-tests/src/component-tests/workspace-dialog.ct.tsx
+++ b/packages/tooling/e2e-tests/src/component-tests/workspace-dialog.ct.tsx
@@ -99,3 +99,23 @@ test('Shows error for invalid workspace name', async ({ mount, page }) => {
   await expect(page.getByText(/contains invalid characters/i)).toBeVisible();
   await expect(page.getByRole('button', { name: 'Create' })).toBeDisabled();
 });
+
+test('keeps the dialog open and allows retry after creation fails', async ({
+  mount,
+  page,
+}) => {
+  await mount(<stories.CreateFailure />);
+
+  await page.getByRole('radio', { name: /Browser Storage/i }).click();
+  await page.getByRole('button', { name: /next/i }).click();
+  await page.getByLabel('Workspace Name', { exact: true }).fill('my_workspace');
+  await page.getByRole('button', { name: 'Create' }).dblclick();
+
+  await expect(page.getByRole('button', { name: 'Create' })).toBeDisabled();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByRole('alert')).toHaveText(
+    'Workspace storage is unavailable.',
+  );
+  await expect(page.getByLabel('Creation attempts')).toHaveText('1');
+  await expect(page.getByRole('button', { name: 'Create' })).toBeEnabled();
+});

--- a/packages/tooling/e2e-tests/src/settings-workspaces.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-workspaces.e2e.ts
@@ -74,9 +74,22 @@ test('workspaces settings lists workspaces and exposes row actions', async ({
   await expect(
     page.getByRole('dialog', { name: 'Select a workspace type' }),
   ).toBeVisible();
+  await page.getByRole('radio', { name: /Browser/i }).click();
+  await page.getByRole('button', { name: 'Next' }).click();
+  await page
+    .getByLabel('Workspace Name', { exact: true })
+    .fill(workspaceWithNote);
+  await page.getByRole('button', { name: 'Create' }).dblclick();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByRole('alert')).toContainText(
+    'Cannot create workspace as it already exists',
+  );
+  await expect(page.getByRole('button', { name: 'Create' })).toBeEnabled();
   await page.getByRole('button', { name: 'Cancel' }).click();
 
-  await page.getByRole('button', { name: /Search/ }).click();
+  const searchButton = page.getByRole('button', { name: /Search/ });
+  await searchButton.focus();
+  await searchButton.press('Space');
   await page.getByRole('combobox').fill('settings');
   await expect(
     page.getByRole('option', { exact: true, name: '> Settings' }),

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -7,7 +7,6 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Label,
 } from '@bangle.io/base-ui';
 import { KEYBOARD_SHORTCUTS } from '@bangle.io/constants';
 import {
@@ -18,7 +17,7 @@ import {
   Settings,
   Star,
 } from 'lucide-react';
-import React, { useId } from 'react';
+import React from 'react';
 import bangleIcon from './bangle-transparent_x512.png';
 import {
   type FileTreeEntry,
@@ -34,7 +33,6 @@ import {
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarHeader,
-  SidebarInput,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -449,34 +447,25 @@ function CommandButton({
   className?: string;
   onClick: () => void;
 }) {
-  const commandButtonId = useId();
   return (
-    <div
-      // biome-ignore lint/a11y/useSemanticElements: requires div wrapper for proper component styling integration
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
+      aria-label={t.app.common.searchLabel}
       onClick={onClick}
-      onKeyUp={(e) => e.key === 'Enter' && onClick()}
-      className={cn('w-full cursor-pointer', className)}
+      className={cn('w-full cursor-pointer text-left', className)}
     >
       <SidebarGroup className="p-0">
         <SidebarGroupContent className="relative">
-          <Label htmlFor={commandButtonId} className="sr-only">
-            {t.app.common.searchLabel}
-          </Label>
-          <SidebarInput
-            id={commandButtonId}
-            placeholder={t.app.common.searchInputPlaceholder}
-            className="pointer-events-none h-8 rounded-md bg-background/70 pr-8 pl-8"
-            readOnly
-          />
+          <div className="flex h-8 w-full items-center rounded-md border border-input bg-background/70 pr-8 pl-8 text-muted-foreground text-sm shadow-none">
+            {t.app.common.searchInputPlaceholder}
+          </div>
           <Search className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 select-none opacity-50" />
           <div className="absolute top-1/2 right-2 -translate-y-1/2 rounded-sm opacity-70">
             <KbdShortcut keys={KEYBOARD_SHORTCUTS.toggleOmniSearch.keys} />
           </div>
         </SidebarGroupContent>
       </SidebarGroup>
-    </div>
+    </button>
   );
 }
 

--- a/packages/ui/ui-components/src/workspace-dialog.stories.portable.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.stories.portable.tsx
@@ -2,6 +2,7 @@ import { composeStory } from '@storybook/react';
 import type React from 'react';
 
 import meta, {
+  CreateFailure as CreateFailureStory,
   Default as DefaultStory,
   InvalidWsName as InvalidWsNameStory,
   NativeFsError as NativeFsErrorStory,
@@ -14,15 +15,17 @@ const Default: PortableStory = composeStory(DefaultStory, meta);
 const NativeFs: PortableStory = composeStory(NativeFsStory, meta);
 const NativeFsError: PortableStory = composeStory(NativeFsErrorStory, meta);
 const InvalidWsName: PortableStory = composeStory(InvalidWsNameStory, meta);
+const CreateFailure: PortableStory = composeStory(CreateFailureStory, meta);
 
 const composedStories: Record<
-  'Default' | 'NativeFs' | 'NativeFsError' | 'InvalidWsName',
+  'Default' | 'NativeFs' | 'NativeFsError' | 'InvalidWsName' | 'CreateFailure',
   PortableStory
 > = {
   Default,
   NativeFs,
   NativeFsError,
   InvalidWsName,
+  CreateFailure,
 };
 
 export default composedStories;

--- a/packages/ui/ui-components/src/workspace-dialog.stories.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import React, { useRef, useState } from 'react';
 import {
   CreateWorkspaceDialog,
   type CreateWorkspaceDialogProps,
@@ -109,3 +110,33 @@ export const InvalidWsName: Story = {
     validateWorkspace,
   },
 };
+
+export const CreateFailure: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+  },
+  render: (args: CreateWorkspaceDialogProps) => (
+    <CreateFailureHarness {...args} />
+  ),
+};
+
+function CreateFailureHarness(args: CreateWorkspaceDialogProps) {
+  const attemptCountRef = useRef(0);
+  const [attemptCount, setAttemptCount] = useState(0);
+
+  return (
+    <>
+      <CreateWorkspaceDialog
+        {...args}
+        onDone={async () => {
+          attemptCountRef.current += 1;
+          setAttemptCount(attemptCountRef.current);
+          await new Promise((resolve) => setTimeout(resolve, 100));
+          throw new Error('Workspace storage is unavailable.');
+        }}
+      />
+      <output aria-label="Creation attempts">{attemptCount}</output>
+    </>
+  );
+}

--- a/packages/ui/ui-components/src/workspace-dialog.tsx
+++ b/packages/ui/ui-components/src/workspace-dialog.tsx
@@ -48,7 +48,7 @@ export interface WorkspaceConfig {
 export interface CreateWorkspaceDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onDone: (config: WorkspaceConfig) => void;
+  onDone: (config: WorkspaceConfig) => void | Promise<void>;
   storageTypes: StorageTypeConfig[];
   onDirectoryPick?: () => Promise<DirectoryPickResult>;
   validateWorkspace: (config: WorkspaceConfig) => WorkspaceValidation;
@@ -56,6 +56,8 @@ export interface CreateWorkspaceDialogProps {
 
 type BaseState = {
   error?: ErrorInfo;
+  isSubmitting?: boolean;
+  submissionFailed?: boolean;
 };
 
 type SelectTypeState = BaseState & {
@@ -83,7 +85,9 @@ type Action =
   | { type: 'UPDATE_SELECTED_STORAGE'; storage: WorkspaceStorageType }
   | { type: 'UPDATE_WORKSPACE_NAME'; name: string }
   | { type: 'UPDATE_DIRECTORY_HANDLE'; dirHandle?: FileSystemDirectoryHandle }
-  | { type: 'UPDATE_ERROR'; error?: ErrorInfo };
+  | { type: 'UPDATE_ERROR'; error?: ErrorInfo }
+  | { type: 'START_SUBMIT' }
+  | { type: 'SUBMIT_FAILED'; error: ErrorInfo };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -113,7 +117,21 @@ function reducer(state: State, action: Action): State {
       }
       return state;
     case 'UPDATE_ERROR':
-      return { ...state, error: action.error };
+      return { ...state, error: action.error, submissionFailed: false };
+    case 'START_SUBMIT':
+      return {
+        ...state,
+        error: undefined,
+        isSubmitting: true,
+        submissionFailed: false,
+      };
+    case 'SUBMIT_FAILED':
+      return {
+        ...state,
+        error: action.error,
+        isSubmitting: false,
+        submissionFailed: true,
+      };
     case 'RESET_TO_TYPE_SELECT':
       return {
         stage: 'select-type',
@@ -143,6 +161,12 @@ export function CreateWorkspaceDialog({
     selected: defaultStorage,
   });
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!state.isSubmitting) {
+      onOpenChange(nextOpen);
+    }
+  };
+
   useEffect(() => {
     if (open) {
       dispatch({ type: 'RESET_TO_TYPE_SELECT', defaultStorage });
@@ -151,7 +175,7 @@ export function CreateWorkspaceDialog({
 
   if (storageTypes.length === 0) {
     return (
-      <Dialog open={open} onOpenChange={onOpenChange}>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
@@ -175,7 +199,7 @@ export function CreateWorkspaceDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-xl">
         {state.stage === 'select-type' && (
           <StageSelectStorage
@@ -322,10 +346,11 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
   onDone,
   onCancel,
 }) => {
-  const { name, error } = state;
+  const { name, error, isSubmitting, submissionFailed } = state;
 
   const ref = useRef<HTMLInputElement>(null);
   const workspaceNameId = useId();
+  const submitWorkspace = useWorkspaceSubmit(dispatch, onDone);
 
   useEffect(() => {
     ref.current?.focus();
@@ -337,11 +362,12 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
-      handleSubmit();
+      event.preventDefault();
+      void handleSubmit();
     }
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const config: WorkspaceConfig = {
       type: 'browser',
       name,
@@ -358,7 +384,7 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
       });
       return;
     }
-    onDone({ type: 'browser', name });
+    await submitWorkspace(config);
   };
 
   const handleBack = () => {
@@ -393,18 +419,24 @@ const StageEnterWorkspaceName: React.FC<StageEnterWorkspaceNameProps> = ({
       </div>
       <WorkspaceDialogFooter
         leadingAction={
-          <Button variant="outline" onClick={handleBack}>
+          <Button
+            variant="outline"
+            onClick={handleBack}
+            disabled={isSubmitting}
+          >
             {t.app.common.backButton}
           </Button>
         }
       >
-        <Button variant="outline" onClick={onCancel}>
+        <Button variant="outline" onClick={onCancel} disabled={isSubmitting}>
           {t.app.common.cancelButton}
         </Button>
         <Button
           type="submit"
-          onClick={handleSubmit}
-          disabled={Boolean(error) || !name}
+          onClick={() => void handleSubmit()}
+          disabled={
+            (Boolean(error) && !submissionFailed) || !name || isSubmitting
+          }
         >
           {t.app.common.createButton}
         </Button>
@@ -430,7 +462,8 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
   onDone,
   onCancel,
 }) => {
-  const { dirHandle, error } = state;
+  const { dirHandle, error, isSubmitting } = state;
+  const submitWorkspace = useWorkspaceSubmit(dispatch, onDone);
 
   const handlePickDirectory = async () => {
     if (!onDirectoryPick) {
@@ -461,7 +494,7 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
     dispatch({ type: 'NAVIGATE_TO_TYPE_SELECT' });
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const dirName = dirHandle?.name || '';
     const config: WorkspaceConfig = {
       type: 'nativefs',
@@ -480,7 +513,7 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
       });
       return;
     }
-    onDone({ type: 'nativefs', name: dirName, dirHandle });
+    await submitWorkspace(config);
   };
 
   return (
@@ -498,18 +531,25 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
 
       <div className="space-y-4 py-4">
         {!dirHandle ? (
-          <Button onClick={handlePickDirectory} disabled={!onDirectoryPick}>
+          <Button
+            onClick={handlePickDirectory}
+            disabled={!onDirectoryPick || isSubmitting}
+          >
             <FolderOpen />
             <span>{t.app.dialogs.createWorkspace.pickDirectoryButton}</span>
           </Button>
         ) : (
           <div className="flex items-center space-x-2">
-            <Button onClick={handlePickDirectory}>
+            <Button onClick={handlePickDirectory} disabled={isSubmitting}>
               <Check />
               <span>{dirHandle.name}</span>
             </Button>
 
-            <Button variant="outline" onClick={handleClearDirectory}>
+            <Button
+              variant="outline"
+              onClick={handleClearDirectory}
+              disabled={isSubmitting}
+            >
               {t.app.common.clearButton}
             </Button>
           </div>
@@ -519,15 +559,22 @@ const StagePickDirectory: React.FC<StagePickDirectoryProps> = ({
 
       <WorkspaceDialogFooter
         leadingAction={
-          <Button variant="outline" onClick={handleBack}>
+          <Button
+            variant="outline"
+            onClick={handleBack}
+            disabled={isSubmitting}
+          >
             {t.app.common.backButton}
           </Button>
         }
       >
-        <Button variant="outline" onClick={onCancel}>
+        <Button variant="outline" onClick={onCancel} disabled={isSubmitting}>
           {t.app.common.cancelButton}
         </Button>
-        <Button onClick={handleSubmit} disabled={!dirHandle}>
+        <Button
+          onClick={() => void handleSubmit()}
+          disabled={!dirHandle || isSubmitting}
+        >
           {t.app.common.createButton}
         </Button>
       </WorkspaceDialogFooter>
@@ -594,9 +641,46 @@ const ListItem: React.FC<ListItemProps> = ({
 const ErrorMessage: React.FC<{ error?: ErrorInfo }> = ({ error }) => {
   if (!error) return null;
   return (
-    <div className="rounded-sm bg-destructive p-2 text-destructive-foreground text-sm">
+    <div
+      className="rounded-sm bg-destructive p-2 text-destructive-foreground text-sm"
+      role="alert"
+    >
       {error.title && <strong>{error.title}: </strong>}
       {error.message}
     </div>
   );
 };
+
+function toSubmissionErrorInfo(error: unknown): ErrorInfo {
+  return {
+    message:
+      error instanceof Error && error.message
+        ? error.message
+        : t.app.dialogs.createWorkspace.createFailed,
+  };
+}
+
+function useWorkspaceSubmit(
+  dispatch: React.Dispatch<Action>,
+  onDone: CreateWorkspaceDialogProps['onDone'],
+) {
+  const submittingRef = useRef(false);
+
+  return async (config: WorkspaceConfig): Promise<void> => {
+    if (submittingRef.current) {
+      return;
+    }
+
+    submittingRef.current = true;
+    dispatch({ type: 'START_SUBMIT' });
+    try {
+      await onDone(config);
+    } catch (submissionError) {
+      submittingRef.current = false;
+      dispatch({
+        type: 'SUBMIT_FAILED',
+        error: toSubmissionErrorInfo(submissionError),
+      });
+    }
+  };
+}

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -108,6 +108,15 @@ before broader UI or tooling cleanup.
     core navigation `fromUri` pass-through, workspace misc-data methods, and
     their unreachable app-error variant. The generic database misc table stays
     intact so this cleanup does not alter persisted storage schemas.
+- 2026-07-12 workspace dialog correctness and accessibility cleanup:
+  - C5 done: workspace creation now awaits the durable callback, blocks repeat
+    submission and dismissal while pending, keeps the dialog open on failure,
+    and restores an in-dialog retry path. Component coverage proves a
+    double-click starts one attempt, while app E2E covers a real duplicate
+    workspace rejection.
+  - P3.4 improved: the sidebar search affordance is now a semantic button with
+    native Enter/Space behavior instead of a `div role="button"` wrapped around
+    a read-only input. App E2E exercises the Space-key path.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -557,8 +566,8 @@ Plan:
 
 - Move dialog title/description into `DialogContent` where Radix expects them.
 - Add optional `DialogDescription` support to command dialogs.
-- Replace the sidebar pseudo-button with a real button or fully implement Space,
-  Enter, focus, and label semantics.
+- [x] Replace the sidebar pseudo-button with a real button or fully implement
+  Space, Enter, focus, and label semantics.
 - Consider Radix RadioGroup for workspace type selection, or add stable
   `aria-labelledby` and `aria-describedby` wiring.
 
@@ -827,7 +836,7 @@ listed so future agents do not rediscover it or accidentally restore it.
 | C2 | Resolved in PR #631 | `PmEditorService` now caches `markdownLoader` instances per ProseMirror `Schema` in a `WeakMap`. A real two-editor regression proves paste uses the active editor schema. | High / small-medium |
 | C3 | Partial | PR #631 made the Native FS metadata lookup awaitable and report invalid metadata as command failure. `CommandDispatchService.dispatch()` still returns `void`, reports a missing handler as success, converts null args with `args || {}`, releases cycle/focus state before async completion, and detaches non-app async errors. Native FS permission work also occurs later in a dialog callback, outside command completion. Make command completion an awaitable typed result and move callback-owned workflows behind feature controllers. | Critical / medium |
 | C4 | Open | The editor save-queue store remains module-global while each queued task captures the writer and error emitter from the service instance that enqueued it. UI reload rebuilds the service graph, so retrying a retained failure can execute through a disposed graph. Move the store to an explicit root-lifetime coordinator and resolve the current writer at execution time; test a failed save across `event::app:reload-ui`. | Critical data safety / medium |
-| C5 | Open | `CreateWorkspaceDialog` types `onDone` as returning `void`, but production passes an async durable workspace create. Submit paths neither await nor catch it and have no busy/error state, allowing unhandled rejection and duplicate submission. Make submission awaitable, disable repeat submit, keep the dialog open on failure, and add a real-service rejection test. | High / medium |
+| C5 | Resolved in 2026-07-12 workspace dialog cleanup | `CreateWorkspaceDialog` now accepts and awaits async durable creation, blocks duplicate submission and dismissal while pending, preserves the dialog with an alert on failure, and permits retry. Component coverage counts one callback for a double-click; app E2E exercises the real duplicate-workspace service rejection. | High / medium |
 | C6 | Open | `PageAsset` catches every storage, permission, decode, and object-URL failure, discards the cause, and renders the same generic copy as a missing file. Preserve missing vs failed states, emit/log the error, expose retry/recovery, and test Native FS permission loss. Plan 006 owns the broader unreadable-asset UX. | High / small-medium |
 | C7 | Resolved in PR #631 | Workspace info cache entries are keyed by workspace name and filtered after lookup. Memory storage now compares parsed workspace names exactly and rejects rename over an existing destination, with focused contract regressions. | Medium-high / small |
 | C8 | In PR #632 | Settings return-link validation now rejects both raw scheme-relative inputs and paths that normalize to `//host/...`; the latter previously passed the same-host check and became an external anchor when reserialized. Keep unit and browser E2E coverage for the normalized path. | Security blocker / small |
@@ -877,8 +886,8 @@ listed so future agents do not rediscover it or accidentally restore it.
 
 1. C1 workspace resource state and C4 save-coordinator lifetime, because both
    can hide or endanger existing user data.
-2. C3 command completion plus C5 async workspace creation, with real-service
-   failure tests and no detached promises.
+2. C3 command completion, with real-service failure tests and no detached
+   promises. C5 async workspace creation is complete.
 3. C6 asset read/recovery semantics, aligned with plan 006.
 4. A1-A4 boundary work in independently reviewable slices; do not combine the
    command kernel, Native FS session provider, and service-graph derivation in

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -12,6 +12,7 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/632
   - https://github.com/bangle-io/bangle-io/pull/635
   - https://github.com/bangle-io/bangle-io/pull/636
+  - https://github.com/bangle-io/bangle-io/pull/638
 related_issues: []
 ---
 


### PR DESCRIPTION
## What changed

- await workspace creation and guard against duplicate submissions
- keep the dialog open with a retryable alert when durable creation fails
- block dismissal and conflicting controls while creation is pending
- replace the sidebar search pseudo-button with a semantic keyboard-operable button
- update the durable tech-debt audit to mark C5 complete and P3.4 improved

## Why

The production workspace callback performs an asynchronous durable database write, but the UI typed it as synchronous and detached completion. Rejected writes could become unhandled, and rapid submission could start duplicate work. The sidebar search affordance also implemented only partial custom button semantics.

## User impact

Workspace creation now has one in-flight operation at a time, visibly preserves failures in the dialog, and can be retried safely. Sidebar search responds to native Enter and Space activation.

## Validation

- `pnpm lint:ci`
- `pnpm test:ci` (2,049 passed; 1 existing skip)
- focused Playwright component suite (8 passed)
- full Playwright E2E suite (137 passed)
- `pnpm local-ci-check` (all root `*:ci` scripts, production browser/desktop builds, and Electron persistence smoke passed)

No deployment was performed.
