### PR TITLE
fix: preserve IndexedDB error causes

### DIFF
--- a/packages/js-lib/baby-fs/__tests__/indexed-db-fs.spec.ts
+++ b/packages/js-lib/baby-fs/__tests__/indexed-db-fs.spec.ts
@@ -1,17 +1,15 @@
 import { isAbortError } from '@bangle.io/mini-js-utils';
 import { expect, test, vi } from 'vitest';
-import { IndexedDBFileSystem } from '../indexed-db-fs';
+import { FILE_ALREADY_EXISTS_ERROR, UPSTREAM_ERROR } from '../error-codes';
+import {
+  IndexedDBFileSystem,
+  IndexedDBFileSystemError,
+} from '../indexed-db-fs';
 
-const toFile = (str: any) => {
+const toFile = (str: string) => {
   const file = new File([str], 'foo.txt', { type: 'text/plain' });
 
   return file;
-};
-
-const _serializeMap = (map: any) => {
-  return Promise.all(
-    [...map.entries()].map(async (r) => [r[0], await r[1]?.text()]),
-  );
 };
 
 test('writeFile', async () => {
@@ -31,9 +29,16 @@ test('createFile rejects existing files without overwriting', async () => {
   const fs = new IndexedDBFileSystem();
   await fs.createFile('hola/hi', toFile('original'));
 
-  await expect(
-    fs.createFile('hola/hi', toFile('replacement')),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(
+  const error = await fs
+    .createFile('hola/hi', toFile('replacement'))
+    .catch((cause: unknown) => cause);
+
+  expect(error).toBeInstanceOf(IndexedDBFileSystemError);
+  expect(error).toMatchObject({
+    code: FILE_ALREADY_EXISTS_ERROR,
+    cause: expect.objectContaining({ name: 'ConstraintError' }),
+  });
+  expect(error).toMatchInlineSnapshot(
     `[IndexedDBFileSystemError: File "hola/hi" already exists]`,
   );
 
@@ -48,6 +53,29 @@ test('readFile', async () => {
 
   const data = await fs.readFileAsText('hola/hi');
   expect(data).toMatchInlineSnapshot(`"my-data"`);
+});
+
+test('readFile preserves the upstream IndexedDB failure as its cause', async () => {
+  const fs = new IndexedDBFileSystem();
+  await fs.writeFile('hola/hi', toFile('my-data'));
+
+  const cause = new Error('forced IndexedDB failure');
+  const transactionSpy = vi
+    .spyOn(IDBDatabase.prototype, 'transaction')
+    .mockImplementationOnce(() => {
+      throw cause;
+    });
+
+  try {
+    const error = await fs
+      .readFile('hola/hi')
+      .catch((readError: unknown) => readError);
+
+    expect(error).toBeInstanceOf(IndexedDBFileSystemError);
+    expect(error).toMatchObject({ code: UPSTREAM_ERROR, cause });
+  } finally {
+    transactionSpy.mockRestore();
+  }
 });
 
 test('stat', async () => {

--- a/packages/js-lib/baby-fs/indexed-db-fs.ts
+++ b/packages/js-lib/baby-fs/indexed-db-fs.ts
@@ -15,13 +15,12 @@ import {
 import { readFileAsText as readFileAsTextHelper } from './read-file-as-text';
 
 function catchUpstream<T>(idbPromise: Promise<T>, errorMessage: string) {
-  return idbPromise.catch((_error) => {
-    return Promise.reject(
-      new IndexedDBFileSystemError({
-        message: errorMessage,
-        code: UPSTREAM_ERROR,
-      }),
-    );
+  return idbPromise.catch((cause: unknown) => {
+    throw new IndexedDBFileSystemError({
+      message: errorMessage,
+      code: UPSTREAM_ERROR,
+      cause,
+    });
   });
 }
 
@@ -157,12 +156,8 @@ export class IndexedDBFileSystem extends BaseFileSystem {
       throw new Error('Keys in opendirRecursive must be array');
     }
 
-    if (dirPath && !dirPath.endsWith('/')) {
-      // biome-ignore lint/style/noParameterAssign: <explanation>
-      dirPath += '/';
-    }
-
-    const result = dirPath ? keys.filter((k) => k.startsWith(dirPath)) : keys;
+    const dirPrefix = dirPath.endsWith('/') ? dirPath : `${dirPath}/`;
+    const result = keys.filter((key) => key.startsWith(dirPrefix));
 
     return result;
   }
@@ -270,11 +265,13 @@ export class IndexedDBFileSystem extends BaseFileSystem {
         throw new IndexedDBFileSystemError({
           message: `File "${filePath}" already exists`,
           code: FILE_ALREADY_EXISTS_ERROR,
+          cause: error,
         });
       }
       throw new IndexedDBFileSystemError({
         message: 'Error creating file',
         code: UPSTREAM_ERROR,
+        cause: error,
       });
     }
 
@@ -295,7 +292,7 @@ export class IndexedDBFileSystem extends BaseFileSystem {
 
 export class IndexedDBFileSystemError extends BaseFileSystemError {}
 
-function isArrayOfStrings(arr: any): arr is string[] {
+function isArrayOfStrings(arr: unknown): arr is string[] {
   if (!Array.isArray(arr)) {
     return false;
   }

--- a/packages/js-lib/mini-js-utils/__tests__/base-error.spec.ts
+++ b/packages/js-lib/mini-js-utils/__tests__/base-error.spec.ts
@@ -2,7 +2,9 @@ import { expect, test } from 'vitest';
 import { BaseError } from '../base-error';
 
 test('works', () => {
-  const error = new BaseError({ message: 'test' });
+  const cause = new Error('upstream failure');
+  const error = new BaseError({ message: 'test', cause });
 
   expect(error).toMatchInlineSnapshot('[BaseError: test]');
+  expect(error.cause).toBe(cause);
 });

--- a/packages/js-lib/mini-js-utils/base-error.ts
+++ b/packages/js-lib/mini-js-utils/base-error.ts
@@ -1,11 +1,5 @@
 export class BaseError extends Error {
   code?: string;
-  /**
-   *
-   * @param {*} message
-   * @param {*} code - error code
-   * @param {*} cause - the cause of the error
-   */
   constructor({
     message,
     code,
@@ -18,10 +12,13 @@ export class BaseError extends Error {
     // 'Error' breaks prototype chain here
     super(message, { cause });
 
-    // Error.captureStackTrace is a v8-specific method so not avilable on
+    // Error.captureStackTrace is a V8-specific method, so it is not available on
     // Firefox or Safari
-    if ((Error as any).captureStackTrace) {
-      (Error as any).captureStackTrace(this, BaseError);
+    const errorConstructor = Error as ErrorConstructor & {
+      captureStackTrace?: (target: object, constructorOption?: object) => void;
+    };
+    if (errorConstructor.captureStackTrace) {
+      errorConstructor.captureStackTrace(this, BaseError);
     } else {
       const stack = new Error().stack;
 
@@ -33,11 +30,7 @@ export class BaseError extends Error {
     // restore prototype chain
     const actualProto = new.target.prototype;
 
-    if (Object.setPrototypeOf) {
-      Object.setPrototypeOf(this, actualProto);
-    } else {
-      (this as any).__proto__ = actualProto;
-    }
+    Object.setPrototypeOf(this, actualProto);
 
     this.name = this.constructor.name;
 

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -118,6 +118,16 @@ before broader UI or tooling cleanup.
   - P3.4 improved: the sidebar search affordance is now a semantic button with
     native Enter/Space behavior instead of a `div role="button"` wrapped around
     a read-only input. App E2E exercises the Space-key path.
+- 2026-07-12 IndexedDB error and type hygiene cleanup:
+  - P5.3 done: the remaining IndexedDB adapter now retains the original
+    rejection as `Error.cause` for both generic upstream errors and translated
+    constraint failures. The replacement Native FS library already preserves
+    causes when it normalizes browser errors; the legacy Native Browser FS
+    evidence was removed with that adapter.
+  - P5.1 improved: foundational `BaseError` stack capture no longer relies on
+    `any` or the obsolete `__proto__` fallback, and the touched IndexedDB slice
+    no longer carries an unsafe array guard, a parameter-assignment lint
+    suppression, or dead untyped test helpers.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -765,6 +775,8 @@ Plan:
 - Separate public API `any` from internal implementation `any`.
 - Replace command arg `any` with inferred validator output where feasible.
 - Add typed wrappers around native browser APIs that currently require casts.
+- [x] Remove avoidable `any` and obsolete prototype fallback logic from the
+  foundational `BaseError` and IndexedDB adapter slice.
 - Keep intentional negative type tests using `@ts-expect-error`.
 
 Verification:
@@ -804,23 +816,25 @@ Verification:
 
 Problem:
 
-- Some storage wrappers convert upstream failures to broad app-specific errors
+- The IndexedDB adapter converted upstream failures to broad storage errors
   without preserving original cause details.
 
 Evidence:
 
 - `packages/js-lib/baby-fs/indexed-db-fs.ts`
-- `packages/js-lib/baby-fs/native-browser-fs.ts`
+- `packages/js-lib/native-fs/src/errors.ts`
 
 Plan:
 
-- Preserve original error cause where supported.
-- Keep user-facing messages safe and readable.
-- Log structured diagnostic details through the existing logger/error service.
+- [x] Preserve original error cause for generic IndexedDB failures and mapped
+  constraint failures.
+- [x] Verify the replacement Native FS error normalization preserves causes.
+- [x] Keep user-facing messages safe and readable while retaining structured
+  diagnostic details on the error object.
 
 Verification:
 
-- Unit tests assert error code and cause shape.
+- [x] Unit tests assert error code and cause shape.
 
 ## 2026-07-12 Core/App Containment Re-audit
 

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -13,6 +13,7 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/635
   - https://github.com/bangle-io/bangle-io/pull/636
   - https://github.com/bangle-io/bangle-io/pull/638
+  - https://github.com/bangle-io/bangle-io/pull/639
 related_issues: []
 ---
 


### PR DESCRIPTION
## Summary

- preserve original IndexedDB failures as Error.cause while keeping stable storage error codes and user-facing messages
- retain ConstraintError details when createFile reports an existing destination
- remove nearby unsafe any usage, obsolete __proto__ fallback logic, a lint suppression, and a dead untyped test helper
- update the durable tech-debt audit to mark P5.3 complete and record P5.1 progress

## Regression coverage

- generic IndexedDB transaction failure retains BABY_FS_UPSTREAM_ERROR and the exact cause
- createFile conflict retains BABY_FS_FILE_ALREADY_EXISTS and the underlying ConstraintError
- BaseError retains the supplied cause

## Validation

- pnpm lint:ci
- pnpm test:ci (149 files; 2,050 passed, 1 skipped)
- pnpm build
- pnpm local-ci-check (final exact-tree run: 137 browser E2E, 8 component, 28 desktop tests, Electron persistence smoke; all passed)
- focused Vitest: 19 passed
- isolated delete-note Playwright suite: 3 passed

The first full local-ci run had one unrelated delete-note command-menu timeout that passed on Playwright retry; it then passed 3/3 in isolation, and the final exact-tree local-ci run passed all 137 browser tests without a retry.