### PR TITLE
fix: preserve workspace list on refresh failures

### DIFF
--- a/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/workspace-state-service.spec.ts
@@ -102,6 +102,78 @@ describe('WorkspaceStateService $workspaces list', () => {
       expect(names).not.toContain('delete-ws');
     });
   });
+
+  it('preserves the last successful workspace list when a refresh fails', async () => {
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+    const store = testEnv.store;
+
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'keep-ws',
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    services.navigation.goWorkspace('keep-ws');
+
+    await vi.waitFor(() => {
+      expect(
+        store.get(services.workspaceState.$workspaceListState),
+      ).toMatchObject({
+        status: 'ready',
+        data: [expect.objectContaining({ name: 'keep-ws' })],
+      });
+      expect(services.workspaceState.resolveAtoms().currentWsName).toBe(
+        'keep-ws',
+      );
+    });
+
+    const lastSuccessfulList = store.get(services.workspaceState.$workspaces);
+    const databaseFailure = new Error('forced workspace refresh failure');
+    const getAllEntriesSpy = vi
+      .spyOn(services.database, 'getAllEntries')
+      .mockImplementation(async () => {
+        throwAppError(
+          'error::database:unknown-error',
+          'Failed to refresh workspace metadata',
+          {
+            error: databaseFailure,
+            databaseName: services.database.name,
+          },
+        );
+      });
+
+    store.set(services.workspaceOps.$workspaceInfoChange, (count) => count + 1);
+
+    await vi.waitFor(() => {
+      expect(store.get(services.workspaceState.$workspaceListState)).toEqual({
+        status: 'error',
+        data: lastSuccessfulList,
+        error: expect.any(Error),
+      });
+    });
+    expect(store.get(services.workspaceState.$workspaces)).toBe(
+      lastSuccessfulList,
+    );
+    expect(services.workspaceState.resolveAtoms().currentWsName).toBe(
+      'keep-ws',
+    );
+    expect(testEnv.commonOpts.emitAppError).toHaveBeenCalledWith(
+      store.get(services.workspaceState.$workspaceListState).error,
+    );
+
+    getAllEntriesSpy.mockRestore();
+    store.set(services.workspaceOps.$workspaceInfoChange, (count) => count + 1);
+
+    await vi.waitFor(() => {
+      expect(
+        store.get(services.workspaceState.$workspaceListState),
+      ).toMatchObject({
+        status: 'ready',
+        data: [expect.objectContaining({ name: 'keep-ws' })],
+      });
+    });
+  });
 });
 
 describe('WorkspaceStateService backlink index', () => {

--- a/packages/core/service-core/src/workspace-state-service.ts
+++ b/packages/core/service-core/src/workspace-state-service.ts
@@ -3,12 +3,12 @@ import {
   atomWithCompare,
   BaseService,
   type BaseServiceContext,
-  createAsyncAtom,
   getAppErrorCause,
   isAbortError,
   isAppError,
 } from '@bangle.io/base-utils';
 import { SERVICE_NAME } from '@bangle.io/constants';
+import type { WorkspaceInfo } from '@bangle.io/types';
 import {
   createWikiLinkIndex,
   isVisibleWorkspaceFilePath,
@@ -26,6 +26,7 @@ import type { WorkspaceOpsService } from './workspace-ops-service';
 
 const EMPTY_FILE_PATH_ARRAY: WsFilePath[] = [];
 const EMPTY_STRING_ARRAY: string[] = [];
+const EMPTY_WORKSPACE_ARRAY: WorkspaceInfo[] = [];
 const EMPTY_BACKLINKS = new Map<string, readonly WsFilePath[]>();
 const BACKLINK_INDEX_REBUILD_DELAY_MS = 250;
 const EMPTY_BACKLINK_INDEX_STATE: BacklinkIndexState = {
@@ -43,6 +44,18 @@ export type FileTreeListState =
       wsName: string;
     }
   | { status: 'error'; error: unknown };
+
+export type WorkspaceListState =
+  | {
+      status: 'loading' | 'ready';
+      data: WorkspaceInfo[];
+      error?: undefined;
+    }
+  | {
+      status: 'error';
+      data: WorkspaceInfo[];
+      error: unknown;
+    };
 
 export type BacklinkIndexState =
   | {
@@ -107,15 +120,18 @@ function appendSortedUniqueWsPath(paths: string[], wsPath: string): string[] {
 export class WorkspaceStateService extends BaseService {
   static deps = ['navigation', 'fileSystem', 'workspaceOps'] as const;
 
-  $workspaces = createAsyncAtom(
-    async (get) => {
-      get(this.workspaceOps.$workspaceInfoChange);
-      const workspaces = await this.workspaceOps.getAllWorkspaces();
-      return workspaces;
-    },
-    (prev) => prev || [],
-    this.emitAppError,
-  );
+  /**
+   * Tracks workspace metadata refreshes without discarding the last successful
+   * result when a later database read fails.
+   */
+  $workspaceListState = atom<WorkspaceListState>({
+    status: 'loading',
+    data: EMPTY_WORKSPACE_ARRAY,
+  });
+
+  $workspaces = atom<WorkspaceInfo[]>((get) => {
+    return get(this.$workspaceListState).data;
+  });
 
   private $rawWsPaths = atomWithCompare<string[]>(
     EMPTY_STRING_ARRAY,
@@ -246,9 +262,56 @@ export class WorkspaceStateService extends BaseService {
 
   private createdWsPathsBySequence = new Map<number, string>();
   private handledFileCreateSequence = 0;
+  private lastKnownWorkspaces = EMPTY_WORKSPACE_ARRAY;
   private lastListedWsName: string | undefined;
 
   async hookMount(): Promise<void> {
+    this.addCleanup(
+      this.store.sub(
+        atomEffect((get, set) => {
+          const abortController = new AbortController();
+          get(this.workspaceOps.$workspaceInfoChange);
+          set(this.$workspaceListState, {
+            status: 'loading',
+            data: this.lastKnownWorkspaces,
+          });
+
+          this.workspaceOps.getAllWorkspaces().then(
+            (workspaces) => {
+              if (abortController.signal.aborted) {
+                return;
+              }
+              this.lastKnownWorkspaces = workspaces;
+              set(this.$workspaceListState, {
+                status: 'ready',
+                data: workspaces,
+              });
+            },
+            (error: unknown) => {
+              if (abortController.signal.aborted) {
+                return;
+              }
+              set(this.$workspaceListState, {
+                status: 'error',
+                data: this.lastKnownWorkspaces,
+                error,
+              });
+              if (error instanceof Error && isAppError(error)) {
+                this.emitAppError(error);
+              } else {
+                this.logger.error('Failed to list workspaces', error);
+              }
+            },
+          );
+
+          return () => {
+            abortController.abort();
+          };
+        }),
+        () => {},
+      ),
+    );
+
     this.addCleanup(
       this.store.sub(
         atomEffect((get, set) => {

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-15
-updated: 2026-07-12
+updated: 2026-07-13
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
@@ -27,11 +27,11 @@ preserve Markdown fidelity, keep local-first behavior predictable, and maintain
 clear workspace boundaries.
 
 The most urgent remaining cleanup area is failure-state continuity across
-resource and service lifetimes. Save serialization/coalescing has landed, but
-workspace-list failures can still erase last-good UI state, the module-global
-save store can retain tasks from a disposed service graph, and command/dialog
-workflows can still detach asynchronous completion. Those items should land
-before broader UI or tooling cleanup.
+service lifetimes. Save serialization/coalescing and last-good workspace-list
+retention have landed, but the module-global save store can retain tasks from a
+disposed service graph, and command/dialog workflows can still detach
+asynchronous completion. Those items should land before broader UI or tooling
+cleanup.
 
 ## Current Status
 
@@ -129,6 +129,15 @@ before broader UI or tooling cleanup.
     `any` or the obsolete `__proto__` fallback, and the touched IndexedDB slice
     no longer carries an unsafe array guard, a parameter-assignment lint
     suppression, or dead untyped test helpers.
+- 2026-07-13 workspace refresh continuity cleanup:
+  - C1 done: `WorkspaceStateService` now exposes an explicit
+    `$workspaceListState` resource with `loading`, `ready`, and `error` states.
+    Every state carries the last successful workspace data, so a failed
+    metadata refresh no longer hides the active workspace or clears
+    workspace-driven UI.
+  - Focused real-service coverage forces a database failure after a successful
+    load, verifies the prior array and current workspace remain available, and
+    proves a later refresh returns the resource to `ready`.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -848,7 +857,7 @@ listed so future agents do not rediscover it or accidentally restore it.
 
 | ID | Status | Finding and required boundary | ROI |
 | --- | --- | --- | --- |
-| C1 | Open | `createAsyncAtom` still computes its handled-error fallback with `initialValue()` instead of the previous value. `WorkspaceStateService.$workspaces` therefore resolves a failed refresh to `[]`, which can hide an existing workspace and its tree. Replace fallback-only atoms with an explicit `{ status, data, error }` resource that retains last-good data; test a refresh failure after a successful load. | Critical / medium |
+| C1 | Resolved in 2026-07-13 workspace refresh continuity cleanup | `WorkspaceStateService` now derives `$workspaces` from an explicit `$workspaceListState` resource. Failed refreshes retain the last successful data and error, preserve `$currentWsName`, and can recover to `ready`; real-service coverage forces the full success-failure-recovery sequence. | Critical / medium |
 | C2 | Resolved in PR #631 | `PmEditorService` now caches `markdownLoader` instances per ProseMirror `Schema` in a `WeakMap`. A real two-editor regression proves paste uses the active editor schema. | High / small-medium |
 | C3 | Partial | PR #631 made the Native FS metadata lookup awaitable and report invalid metadata as command failure. `CommandDispatchService.dispatch()` still returns `void`, reports a missing handler as success, converts null args with `args || {}`, releases cycle/focus state before async completion, and detaches non-app async errors. Native FS permission work also occurs later in a dialog callback, outside command completion. Make command completion an awaitable typed result and move callback-owned workflows behind feature controllers. | Critical / medium |
 | C4 | Open | The editor save-queue store remains module-global while each queued task captures the writer and error emitter from the service instance that enqueued it. UI reload rebuilds the service graph, so retrying a retained failure can execute through a disposed graph. Move the store to an explicit root-lifetime coordinator and resolve the current writer at execution time; test a failed save across `event::app:reload-ui`. | Critical data safety / medium |
@@ -900,8 +909,8 @@ listed so future agents do not rediscover it or accidentally restore it.
 
 ### Recommended Next Batches
 
-1. C1 workspace resource state and C4 save-coordinator lifetime, because both
-   can hide or endanger existing user data.
+1. C4 save-coordinator lifetime, because a retained task can outlive its
+   service graph and endanger unsaved user data.
 2. C3 command completion, with real-service failure tests and no detached
    promises. C5 async workspace creation is complete.
 3. C6 asset read/recovery semantics, aligned with plan 006.


### PR DESCRIPTION
## Summary

- replace the fallback-only workspace atom with a typed `loading | ready | error` resource
- retain the last successful workspace data and active workspace when a metadata refresh fails, while preserving the existing `$workspaces` consumer API
- add a real-service success → failure → recovery regression and update the durable tech-debt plan

## Why

A handled database refresh failure previously resolved `$workspaces` to `[]`. That could hide an existing workspace and make its tree disappear even though the failure did not prove the workspace was gone. The new state keeps last-good data alongside the refresh error and recovers normally on the next successful refresh.

## Validation

- `pnpm vitest packages/core/service-core/src/__tests__/workspace-state-service.spec.ts` — 18 passed
- `pnpm lint:ci`
- `pnpm test:ci` — 2,091 passed, 1 skipped
- `pnpm build`
- full browser Playwright suite — 152 passed
- `pnpm local-ci-check`
  - 2,091 Vitest tests passed, 1 skipped
  - 152 browser E2E tests passed
  - 8 Playwright component tests passed
  - 28 desktop tests passed
  - browser and desktop production builds passed
  - Electron persistence smoke passed
  - Knip, workspace validation, TypeScript, and Biome passed

No deployment was performed.