### PR TITLE
feat(editor): quiet Markdown fidelity notice in the title bar

### DIFF
--- a/packages/core/app/src/components/navigation/markdown-fidelity-notice.tsx
+++ b/packages/core/app/src/components/navigation/markdown-fidelity-notice.tsx
@@ -1,0 +1,67 @@
+import { useCoreServices } from '@bangle.io/context';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@bangle.io/ui-components';
+import { useAtomValue } from 'jotai';
+import { Info } from 'lucide-react';
+import React from 'react';
+
+interface MarkdownFidelityNoticeProps {
+  wsPath: string;
+}
+
+/**
+ * A quiet info affordance shown next to the note name when the open note's
+ * stored Markdown does not survive the editor's parse/serialize round trip.
+ * Clicking it opens a calm explanation that editing may reformat those parts
+ * without losing any content.
+ *
+ * The active engine reports which notes are affected through
+ * `$roundTripWarnings` (`EditorEngineContract`); an engine that always
+ * preserves Markdown lists none, so this renders nothing.
+ */
+export function MarkdownFidelityNotice({
+  wsPath,
+}: MarkdownFidelityNoticeProps) {
+  const { editorEngine } = useCoreServices();
+  const roundTripWarnings = useAtomValue(editorEngine.$roundTripWarnings);
+
+  if (!roundTripWarnings.has(wsPath)) {
+    return null;
+  }
+
+  return (
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-muted-foreground"
+            title={t.app.editor.fidelityNotice.label}
+            data-testid="markdown-fidelity-notice"
+          >
+            <Info size={16} />
+            <span className="sr-only">{t.app.editor.fidelityNotice.label}</span>
+          </Button>
+        }
+      />
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t.app.editor.fidelityNotice.title}</DialogTitle>
+          <DialogDescription>
+            {t.app.editor.fidelityNotice.description}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter showCloseButton />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/core/app/src/layout/app-header.tsx
+++ b/packages/core/app/src/layout/app-header.tsx
@@ -13,6 +13,7 @@ import { WsPath } from '@bangle.io/ws-path';
 import { useAtom, useAtomValue } from 'jotai';
 import { ChevronsRightLeft, Home, MoveHorizontal } from 'lucide-react';
 import React from 'react';
+import { MarkdownFidelityNotice } from '../components/navigation/markdown-fidelity-notice';
 import { NoteBreadcrumb } from '../components/navigation/note-breadcrumb';
 import { WsNameBreadcrumb } from '../components/navigation/ws-name-breadcrumb'; // Import WsNameBreadcrumb
 
@@ -87,22 +88,25 @@ function ToolbarLeftSection({
       <Sidebar.SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="h-4" />
       {showEditorToolbar && currentWsPath ? (
-        <NoteBreadcrumb
-          wsPath={currentWsPath}
-          wsPaths={wsPaths}
-          onNewNote={({ wsPath }) => {
-            const parent = WsPath.fromString(wsPath).getParent();
-            const path = parent?.path;
+        <>
+          <NoteBreadcrumb
+            wsPath={currentWsPath}
+            wsPaths={wsPaths}
+            onNewNote={({ wsPath }) => {
+              const parent = WsPath.fromString(wsPath).getParent();
+              const path = parent?.path;
 
-            coreServices.commandDispatcher.dispatch(
-              'command::ui:create-note-dialog',
-              {
-                prefillName: path || '',
-              },
-              'AppHeader',
-            );
-          }}
-        />
+              coreServices.commandDispatcher.dispatch(
+                'command::ui:create-note-dialog',
+                {
+                  prefillName: path || '',
+                },
+                'AppHeader',
+              );
+            }}
+          />
+          <MarkdownFidelityNotice wsPath={currentWsPath} />
+        </>
       ) : currentWsName ? (
         <WsNameBreadcrumb wsName={currentWsName} />
       ) : (

--- a/packages/core/context/package.json
+++ b/packages/core/context/package.json
@@ -31,6 +31,7 @@
     "@bangle.io/base-utils": "workspace:*",
     "@bangle.io/service-core": "workspace:*",
     "@bangle.io/types": "workspace:*",
+    "jotai": "^2.20.1",
     "react": "19.2.7"
   },
   "devDependencies": {}

--- a/packages/core/context/src/service-types.ts
+++ b/packages/core/context/src/service-types.ts
@@ -12,6 +12,7 @@ import type {
   WorkspaceStateService,
 } from '@bangle.io/service-core';
 import type { CommandExcludedServiceSlotId } from '@bangle.io/types';
+import type { Atom } from 'jotai';
 
 /**
  * The engine-agnostic contract of the service powering the note editing
@@ -35,6 +36,13 @@ export type EditorEngineContract = BaseService & {
   /** Stable engine identifier (e.g. 'prosemirror'), exposed on the mounted
    * DOM as `data-editor-engine` for tests and diagnostics. */
   readonly engineId: string;
+  /**
+   * wsPaths whose stored Markdown does not survive this engine's
+   * parse/serialize round trip, so saving an edit reformats content the user
+   * never touched. The title bar surfaces a quiet fidelity notice for the open
+   * note. An engine that always preserves Markdown exposes an always-empty set.
+   */
+  readonly $roundTripWarnings: Atom<ReadonlySet<string>>;
   collapseAllHeadings: (level: number) => boolean;
   focusEditor: () => void;
   getSelectionMarkdown: () => string | null;

--- a/packages/core/editor-w/package.json
+++ b/packages/core/editor-w/package.json
@@ -35,6 +35,7 @@
     "@bangle.io/service-core": "workspace:*",
     "@bangle.io/ws-path": "workspace:*",
     "@types/react": "^19.2.17",
+    "jotai": "^2.20.1",
     "react": "19.2.7"
   },
   "devDependencies": {

--- a/packages/core/editor-w/src/editor-w-service.ts
+++ b/packages/core/editor-w/src/editor-w-service.ts
@@ -7,6 +7,7 @@ import { type EditorEngineId, SERVICE_NAME } from '@bangle.io/constants';
 import type { EditorEngineContract } from '@bangle.io/context';
 import type { FileSystemService } from '@bangle.io/service-core';
 import { WsPath } from '@bangle.io/ws-path';
+import { atom } from 'jotai';
 
 type EditorEntry = {
   name: string;
@@ -32,6 +33,15 @@ export class EditorWService
   static deps = ['fileSystem'] as const;
 
   public readonly engineId: EditorEngineId = 'wordgard';
+
+  /**
+   * Wordgard renders the note's Markdown source read-only and never rewrites
+   * it, so no note is ever at risk of round-trip reformatting: the fidelity
+   * set is permanently empty.
+   */
+  public readonly $roundTripWarnings = atom<ReadonlySet<string>>(
+    new Set<string>(),
+  );
 
   private editors = new Map<HTMLElement, EditorEntry>();
 

--- a/packages/core/editor/src/__tests__/round-trip-check.spec.ts
+++ b/packages/core/editor/src/__tests__/round-trip-check.spec.ts
@@ -105,4 +105,20 @@ describe('round-trip gate against the real serializer', () => {
   ])('flags %s as not preserved', (_label, source) => {
     expect(roundTrip(source)).toBe(false);
   });
+
+  // Not every mismatch is a benign reformat: an unused reference definition is
+  // dropped entirely on save (`Some text.\n\n[u]: https://x` -> `Some text.`),
+  // so the notice must never claim the user's content is safe. This locks in
+  // that the gate still fires for the genuine data-loss case.
+  it('flags an unused reference definition whose content is dropped', () => {
+    const source = 'Some paragraph.\n\n[unused]: https://example.com\n';
+    const markdown = createMarkdown();
+    const doc = markdown.parser.parse(source);
+    if (!doc) {
+      throw new Error('parse returned null');
+    }
+    const serialized = markdown.serializer.serialize(doc);
+    expect(serialized).not.toContain('https://example.com');
+    expect(isMarkdownRoundTripPreserved(source, serialized)).toBe(false);
+  });
 });

--- a/packages/core/editor/src/index.tsx
+++ b/packages/core/editor/src/index.tsx
@@ -2,8 +2,6 @@ import 'prosemirror-view/style/prosemirror.css';
 import './typography.css';
 
 import { cx } from '@bangle.io/base-utils';
-import { useAtomValue } from 'jotai';
-import { TriangleAlert } from 'lucide-react';
 import React, { useCallback } from 'react';
 import {
   DatePickerMenu,
@@ -27,21 +25,9 @@ export function Editor({
   name: string;
 }) {
   const { editorEngine } = useEditorCoreServices();
-  const roundTripWarnings = useAtomValue(editorEngine.$roundTripWarnings);
-  const showFidelityNotice = roundTripWarnings.has(wsPath);
 
   return (
     <div className="box-border flex h-full min-h-36 w-full min-w-0 flex-col">
-      {showFidelityNotice && (
-        <div
-          role="status"
-          data-testid="editor-fidelity-notice"
-          className="mx-4 mt-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-amber-700 text-sm dark:text-amber-400"
-        >
-          <TriangleAlert aria-hidden className="mt-0.5 h-4 w-4 shrink-0" />
-          <span>{t.app.editor.fidelityNotice}</span>
-        </div>
-      )}
       <div className="relative box-border w-full min-w-0 flex-1">
         <div
           // in react 19 callback change retriggers this callback

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -40,8 +40,12 @@ export const t = {
       toggleMaxWidth: 'Toggle Max Width',
     },
     editor: {
-      fidelityNotice:
-        'This note contains Markdown this editor cannot fully preserve. Saving an edit will reformat those parts.',
+      fidelityNotice: {
+        label: 'Formatting notice',
+        title: 'Some formatting may change',
+        description:
+          'This note contains Markdown this editor cannot fully preserve, so saving an edit will reformat those parts. Your content is safe — no text will be lost.',
+      },
       selectionMenu: {
         label: 'Text formatting',
         bold: 'Bold',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -41,10 +41,10 @@ export const t = {
     },
     editor: {
       fidelityNotice: {
-        label: 'Formatting notice',
-        title: 'Some formatting may change',
+        label: 'Markdown compatibility',
+        title: 'Some Markdown cannot be fully preserved',
         description:
-          'This note contains Markdown this editor cannot fully preserve, so saving an edit will reformat those parts. Your content is safe — no text will be lost.',
+          'This note contains Markdown this editor cannot fully preserve. Opening it is safe and changes nothing, but if you edit and save, the parts it cannot represent are rewritten — some formatting or content may change or be removed.',
       },
       selectionMenu: {
         label: 'Text formatting',

--- a/packages/tooling/e2e-tests/src/editor-fidelity-notice.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-fidelity-notice.e2e.ts
@@ -13,7 +13,8 @@ const LOSSY_SOURCE = ['A claim.[^1]', '', '[^1]: The source.'].join('\n');
 // Markdown that serializes back byte-identical.
 const CLEAN_SOURCE = ['# Title', '', 'Some plain text.'].join('\n');
 
-const NOTICE_TEST_ID = 'editor-fidelity-notice';
+// The quiet info button shown next to the note name in the title bar.
+const NOTICE_TEST_ID = 'markdown-fidelity-notice';
 
 async function seedNote(page: Page, noteName: string, source: string) {
   const workspaceName = 'fidelity-notice';
@@ -31,7 +32,16 @@ test('warns when a note contains Markdown the editor will reformat', async ({
 
   const editor = getEditorLocator(page, {});
   await expect(editor.getByText('A claim.')).toBeVisible();
-  await expect(page.getByTestId(NOTICE_TEST_ID)).toBeVisible();
+
+  // The notice is quiet: an info button in the title bar, not a loud banner.
+  const notice = page.getByTestId(NOTICE_TEST_ID);
+  await expect(notice).toBeVisible();
+
+  // Clicking it opens a calm dialog that reassures no content is lost.
+  await notice.click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('no text will be lost');
 
   // The gate only warns: merely opening the note must not rewrite storage.
   await expect

--- a/packages/tooling/e2e-tests/src/editor-fidelity-notice.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-fidelity-notice.e2e.ts
@@ -37,11 +37,12 @@ test('warns when a note contains Markdown the editor will reformat', async ({
   const notice = page.getByTestId(NOTICE_TEST_ID);
   await expect(notice).toBeVisible();
 
-  // Clicking it opens a calm dialog that reassures no content is lost.
+  // Clicking it opens a calm dialog that honestly warns a save may change or
+  // drop unsupported Markdown — it must not promise the content is safe.
   await notice.click();
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
-  await expect(dialog).toContainText('no text will be lost');
+  await expect(dialog).toContainText('may change or be removed');
 
   // The gate only warns: merely opening the note must not rewrite storage.
   await expect

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@bangle.io/types':
         specifier: workspace:*
         version: link:../../shared/types
+      jotai:
+        specifier: ^2.20.1
+        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -310,6 +313,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      jotai:
+        specifier: ^2.20.1
+        version: 2.20.1(@babel/core@7.29.7)(@babel/template@7.29.7)(@types/react@19.2.17)(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7


### PR DESCRIPTION
## What & why

The old fidelity warning — a loud amber banner inside the editor telling the user their note would be reformatted — read as scary for a benign-*looking* situation. This replaces it with a quiet, discoverable affordance while keeping the message honest.

- **Before:** an amber `TriangleAlert` banner at the top of the editor surface whenever a note's Markdown doesn't survive a parse/serialize round trip.
- **After:** a small, neutral `Info` (ⓘ) icon next to the note name in the title bar. Clicking it opens a calm dialog:
  - **Title:** "Some Markdown cannot be fully preserved"
  - **Body:** "This note contains Markdown this editor cannot fully preserve. Opening it is safe and changes nothing, but if you edit and save, the parts it cannot represent are rewritten — some formatting or content may change or be removed."

The gate itself is unchanged: opening such a note still never rewrites storage; it only informs.

### On the wording (important)

An earlier revision of this dialog reassured "no text will be lost." That promise is **false** for the cases the notice actually fires on. `$roundTripWarnings` only establishes that the serialized bytes differ from the stored source (and is also set on serializer errors); it does **not** establish that the difference is formatting-only. Verified counterexample with the app's real codec:

```
Some paragraph.

[unused]: https://example.com
```

serializes back to just `Some paragraph.` — the reference definition **and its URL are dropped entirely**. So the copy must not claim the content is safe. The dialog now scopes its reassurance correctly (opening is safe) and honestly warns that a save may change or remove content.

## Design / architecture

The round-trip fidelity set was a concrete `PmEditorService` detail. To let the engine-agnostic title bar (in `core/app`) read it without knowing the concrete engine, `$roundTripWarnings` is now part of `EditorEngineContract`. The read-only Wordgard stub implements it as a permanently empty set (it never rewrites a note).

- `packages/core/context` — add `$roundTripWarnings: Atom<ReadonlySet<string>>` to `EditorEngineContract`.
- `packages/core/editor-w` — implement the contract with an always-empty set.
- `packages/core/editor` — remove the in-editor banner.
- `packages/core/app` — new `MarkdownFidelityNotice` title-bar component + wiring in `app-header`.
- `packages/shared/translations` — restructure `editor.fidelityNotice` into `label` / `title` / `description`.

## Testing

- `pnpm lint:ci` ✅ (custom-validation, tsgo typecheck, Biome)
- `pnpm test:ci` ✅ (2091 passed, 1 skipped)
- `pnpm e2e:ci` ✅ (browser e2e + component tests)
- `round-trip-check.spec.ts` — added a regression proving the gate fires for the genuine content-drop case (unused reference definition), not just reformats.
- `editor-fidelity-notice.e2e.ts` — asserts the quiet title-bar icon appears for lossy notes, the dialog opens with the honest warning ("may change or be removed"), storage is not rewritten, and no icon appears for clean notes.
- Manual Playwright smoke: verified icon placement/color and dialog rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)