### PR TITLE
feat: workspace "Locate folder" action for Native FS workspaces

### DIFF
--- a/packages/core/app/src/__tests__/app-error-handler.spec.ts
+++ b/packages/core/app/src/__tests__/app-error-handler.spec.ts
@@ -48,6 +48,13 @@ describe('shouldReportAppError', () => {
     },
     {
       appError: {
+        name: 'error::workspace:native-fs-locate-failed',
+        payload: { wsName: 'notes' },
+      } satisfies AppError,
+      expected: false,
+    },
+    {
+      appError: {
         name: 'error::file:already-existing',
         payload: { wsPath: 'notes:existing.md' },
       } satisfies AppError,

--- a/packages/core/app/src/app-error-handler.tsx
+++ b/packages/core/app/src/app-error-handler.tsx
@@ -11,6 +11,7 @@ export function shouldReportAppError(appError: AppError): boolean {
     case 'error::file:size-too-large':
     case 'error::file-storage:file-does-not-exist':
     case 'error::workspace:native-fs-auth-needed':
+    case 'error::workspace:native-fs-locate-failed':
     case 'error::workspace:native-fs-reconnect-failed':
     case 'error::workspace:no-note-opened':
     case 'error::workspace:no-notes-found':
@@ -103,7 +104,9 @@ export function AppErrorHandler({ rootEmitter }: { rootEmitter: RootEmitter }) {
             return;
           }
 
+          case 'error::workspace:native-fs-locate-failed':
           case 'error::workspace:native-fs-reconnect-failed': {
+            // Expected user-facing outcomes, not app defects: no Report action.
             toast.error(error.message, {
               duration: 5000,
               cancel: {

--- a/packages/core/app/src/pages/page-settings-workspaces.tsx
+++ b/packages/core/app/src/pages/page-settings-workspaces.tsx
@@ -1,8 +1,16 @@
+import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
 import { useCoreServices } from '@bangle.io/context';
+import { supportsNativeFs } from '@bangle.io/native-fs';
 import { Button, DropdownMenu } from '@bangle.io/ui-components';
 import { WsPath } from '@bangle.io/ws-path';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { ExternalLink, MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import {
+  ExternalLink,
+  FolderSearch,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from 'lucide-react';
 import React from 'react';
 import { getRelativeTimeOrNull } from '../common/get-relative-time';
 
@@ -75,6 +83,18 @@ export function WorkspacesSettingsPage() {
     commandDispatcher.dispatch(
       'command::ui:create-workspace-dialog',
       null,
+      'ui',
+    );
+  };
+
+  // The picker API existing is what makes a reveal possible at all; on
+  // browsers without it the action is hidden rather than shown-and-failing.
+  const canLocateNativeFs = supportsNativeFs();
+
+  const locateWorkspaceFolder = (wsName: string) => {
+    commandDispatcher.dispatch(
+      'command::ui:locate-native-fs-workspace',
+      { wsName },
       'ui',
     );
   };
@@ -171,6 +191,12 @@ export function WorkspacesSettingsPage() {
 
                 <WorkspaceActionsMenu
                   onDelete={() => requestDeleteWorkspace(workspace.name)}
+                  onLocate={
+                    canLocateNativeFs &&
+                    workspace.type === WORKSPACE_STORAGE_TYPE.NativeFS
+                      ? () => locateWorkspaceFolder(workspace.name)
+                      : undefined
+                  }
                   openHref={workspaceHref}
                   wsName={workspace.name}
                 />
@@ -187,10 +213,13 @@ function WorkspaceActionsMenu({
   wsName,
   openHref,
   onDelete,
+  onLocate,
 }: {
   wsName: string;
   openHref: string;
   onDelete: () => void;
+  /** Present only for Native FS workspaces on browsers with the picker API. */
+  onLocate?: () => void;
 }) {
   return (
     <DropdownMenu.DropdownMenu>
@@ -211,6 +240,12 @@ function WorkspaceActionsMenu({
           <ExternalLink className="mr-2 h-4 w-4" />
           <span>{t.app.settings.workspaces.openWorkspace}</span>
         </DropdownMenu.DropdownMenuItem>
+        {onLocate ? (
+          <DropdownMenu.DropdownMenuItem onClick={onLocate}>
+            <FolderSearch className="mr-2 h-4 w-4" />
+            <span>{t.app.settings.workspaces.locateFolder}</span>
+          </DropdownMenu.DropdownMenuItem>
+        ) : null}
         <DropdownMenu.DropdownMenuSeparator />
         <DropdownMenu.DropdownMenuItem
           className="text-destructive focus:text-destructive"

--- a/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
+import { getAppErrorCause } from '@bangle.io/base-utils';
 import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import type { BaseError } from '@bangle.io/mini-js-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setupTest } from './test-utils';
 
@@ -73,18 +75,38 @@ describe('command::ui:reconnect-native-fs-workspace', () => {
 describe('command::ui:locate-native-fs-workspace', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    permissionRequests.length = 0;
   });
+
+  const permissionRequests: string[] = [];
 
   // Passes the isFileSystemDirectoryHandle guard the handler applies to
-  // metadata restored from untyped storage.
-  const makeStoredHandle = (name: string) => ({
-    name,
-    kind: 'directory',
-    requestPermission: vi.fn().mockResolvedValue('granted'),
-  });
+  // metadata restored from untyped storage, while staying structured-clone
+  // safe: workspace writes broadcast their change events via structuredClone,
+  // which rejects own function properties (so no vi.fn()/spyOn on instances).
+  // Class methods live on the prototype and survive; calls are tracked in
+  // `permissionRequests` instead.
+  class StoredDirHandle {
+    readonly kind = 'directory';
+    constructor(readonly name: string) {}
+    async requestPermission(): Promise<PermissionState> {
+      permissionRequests.push(this.name);
+      return 'granted';
+    }
+  }
+  const makeStoredHandle = (name: string) => new StoredDirHandle(name);
+
+  // The exact app-error name matters: locate-failed is classified as handled
+  // (non-reportable) by shouldReportAppError, unlike a generic failure.
+  const emittedAppErrorNames = (testEnv: {
+    commonOpts: { emitAppError: (error: BaseError) => void };
+  }) =>
+    vi
+      .mocked(testEnv.commonOpts.emitAppError)
+      .mock.calls.map(([error]) => getAppErrorCause(error)?.name);
 
   it('anchors the picker at the stored handle and leaves everything unchanged', async () => {
-    const { dispatch, services, getCommandResults } = await setupTest({
+    const { dispatch, services, getCommandResults, testEnv } = await setupTest({
       targetId: 'command::ui:locate-native-fs-workspace',
       autoNavigate: false,
     });
@@ -106,17 +128,17 @@ describe('command::ui:locate-native-fs-workspace', () => {
     expect(picker).toHaveBeenCalledWith(
       expect.objectContaining({ mode: 'read', startIn: storedHandle }),
     );
-    // Reveal-only: the selection is discarded, no permission prompt fires,
-    // and the stored metadata is untouched.
-    expect(storedHandle.requestPermission).not.toHaveBeenCalled();
-    expect(pickedHandle.requestPermission).not.toHaveBeenCalled();
+    // Reveal-only: the selection is discarded, requestPermission is never
+    // invoked on either handle, and the stored metadata is untouched.
+    expect(permissionRequests).toEqual([]);
     expect(await services.workspaceOps.getWorkspaceMetadata('test-ws')).toEqual(
       { rootDirHandle: storedHandle },
     );
+    expect(emittedAppErrorNames(testEnv)).toEqual([]);
   });
 
   it('treats cancelling the dialog as a successful reveal', async () => {
-    const { dispatch, services, getCommandResults } = await setupTest({
+    const { dispatch, services, getCommandResults, testEnv } = await setupTest({
       targetId: 'command::ui:locate-native-fs-workspace',
       autoNavigate: false,
     });
@@ -143,10 +165,12 @@ describe('command::ui:locate-native-fs-workspace', () => {
     expect(await services.workspaceOps.getWorkspaceMetadata('test-ws')).toEqual(
       { rootDirHandle: storedHandle },
     );
+    // Cancelling is the expected way to close the reveal: no error surfaces.
+    expect(emittedAppErrorNames(testEnv)).toEqual([]);
   });
 
   it('fails without opening a picker when the workspace does not exist', async () => {
-    const { dispatch, getCommandResults } = await setupTest({
+    const { dispatch, getCommandResults, testEnv } = await setupTest({
       targetId: 'command::ui:locate-native-fs-workspace',
       autoNavigate: false,
     });
@@ -159,10 +183,13 @@ describe('command::ui:locate-native-fs-workspace', () => {
       expect(getCommandResults().at(-1)?.type).toBe('failure');
     });
     expect(picker).not.toHaveBeenCalled();
+    expect(emittedAppErrorNames(testEnv)).toEqual([
+      'error::workspace:not-found',
+    ]);
   });
 
   it('fails without opening a picker for a non-nativefs workspace', async () => {
-    const { dispatch, services, getCommandResults } = await setupTest({
+    const { dispatch, services, getCommandResults, testEnv } = await setupTest({
       targetId: 'command::ui:locate-native-fs-workspace',
       autoNavigate: false,
     });
@@ -182,10 +209,13 @@ describe('command::ui:locate-native-fs-workspace', () => {
       expect(getCommandResults().at(-1)?.type).toBe('failure');
     });
     expect(picker).not.toHaveBeenCalled();
+    expect(emittedAppErrorNames(testEnv)).toEqual([
+      'error::workspace:not-found',
+    ]);
   });
 
   it('fails without opening a picker when the stored handle is missing', async () => {
-    const { dispatch, services, getCommandResults } = await setupTest({
+    const { dispatch, services, getCommandResults, testEnv } = await setupTest({
       targetId: 'command::ui:locate-native-fs-workspace',
       autoNavigate: false,
     });
@@ -206,5 +236,10 @@ describe('command::ui:locate-native-fs-workspace', () => {
     expect(
       await services.workspaceOps.getWorkspaceMetadata('broken-ws'),
     ).toEqual({});
+    // A broken handle is an expected degraded state, surfaced as the handled
+    // locate-failed error rather than a reportable defect.
+    expect(emittedAppErrorNames(testEnv)).toEqual([
+      'error::workspace:native-fs-locate-failed',
+    ]);
   });
 });

--- a/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
@@ -69,3 +69,142 @@ describe('command::ui:reconnect-native-fs-workspace', () => {
     expect(reloadSpy).not.toHaveBeenCalled();
   });
 });
+
+describe('command::ui:locate-native-fs-workspace', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Passes the isFileSystemDirectoryHandle guard the handler applies to
+  // metadata restored from untyped storage.
+  const makeStoredHandle = (name: string) => ({
+    name,
+    kind: 'directory',
+    requestPermission: vi.fn().mockResolvedValue('granted'),
+  });
+
+  it('anchors the picker at the stored handle and leaves everything unchanged', async () => {
+    const { dispatch, services, getCommandResults } = await setupTest({
+      targetId: 'command::ui:locate-native-fs-workspace',
+      autoNavigate: false,
+    });
+    const storedHandle = makeStoredHandle('test-ws');
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'test-ws',
+      type: WORKSPACE_STORAGE_TYPE.NativeFS,
+      metadata: { rootDirHandle: storedHandle },
+    });
+    const pickedHandle = makeStoredHandle('whatever-was-selected');
+    const picker = vi.fn().mockResolvedValue(pickedHandle);
+    vi.stubGlobal('showDirectoryPicker', picker);
+
+    dispatch('command::ui:locate-native-fs-workspace', { wsName: 'test-ws' });
+
+    await vi.waitFor(() => {
+      expect(getCommandResults().at(-1)?.type).toBe('success');
+    });
+    expect(picker).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'read', startIn: storedHandle }),
+    );
+    // Reveal-only: the selection is discarded, no permission prompt fires,
+    // and the stored metadata is untouched.
+    expect(storedHandle.requestPermission).not.toHaveBeenCalled();
+    expect(pickedHandle.requestPermission).not.toHaveBeenCalled();
+    expect(await services.workspaceOps.getWorkspaceMetadata('test-ws')).toEqual(
+      { rootDirHandle: storedHandle },
+    );
+  });
+
+  it('treats cancelling the dialog as a successful reveal', async () => {
+    const { dispatch, services, getCommandResults } = await setupTest({
+      targetId: 'command::ui:locate-native-fs-workspace',
+      autoNavigate: false,
+    });
+    const storedHandle = makeStoredHandle('test-ws');
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'test-ws',
+      type: WORKSPACE_STORAGE_TYPE.NativeFS,
+      metadata: { rootDirHandle: storedHandle },
+    });
+    vi.stubGlobal(
+      'showDirectoryPicker',
+      vi
+        .fn()
+        .mockRejectedValue(
+          new DOMException('The user aborted a request.', 'AbortError'),
+        ),
+    );
+
+    dispatch('command::ui:locate-native-fs-workspace', { wsName: 'test-ws' });
+
+    await vi.waitFor(() => {
+      expect(getCommandResults().at(-1)?.type).toBe('success');
+    });
+    expect(await services.workspaceOps.getWorkspaceMetadata('test-ws')).toEqual(
+      { rootDirHandle: storedHandle },
+    );
+  });
+
+  it('fails without opening a picker when the workspace does not exist', async () => {
+    const { dispatch, getCommandResults } = await setupTest({
+      targetId: 'command::ui:locate-native-fs-workspace',
+      autoNavigate: false,
+    });
+    const picker = vi.fn();
+    vi.stubGlobal('showDirectoryPicker', picker);
+
+    dispatch('command::ui:locate-native-fs-workspace', { wsName: 'missing' });
+
+    await vi.waitFor(() => {
+      expect(getCommandResults().at(-1)?.type).toBe('failure');
+    });
+    expect(picker).not.toHaveBeenCalled();
+  });
+
+  it('fails without opening a picker for a non-nativefs workspace', async () => {
+    const { dispatch, services, getCommandResults } = await setupTest({
+      targetId: 'command::ui:locate-native-fs-workspace',
+      autoNavigate: false,
+    });
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'browser-ws',
+      type: WORKSPACE_STORAGE_TYPE.Browser,
+      metadata: {},
+    });
+    const picker = vi.fn();
+    vi.stubGlobal('showDirectoryPicker', picker);
+
+    dispatch('command::ui:locate-native-fs-workspace', {
+      wsName: 'browser-ws',
+    });
+
+    await vi.waitFor(() => {
+      expect(getCommandResults().at(-1)?.type).toBe('failure');
+    });
+    expect(picker).not.toHaveBeenCalled();
+  });
+
+  it('fails without opening a picker when the stored handle is missing', async () => {
+    const { dispatch, services, getCommandResults } = await setupTest({
+      targetId: 'command::ui:locate-native-fs-workspace',
+      autoNavigate: false,
+    });
+    await services.workspaceOps.createWorkspaceInfo({
+      name: 'broken-ws',
+      type: WORKSPACE_STORAGE_TYPE.NativeFS,
+      metadata: {},
+    });
+    const picker = vi.fn();
+    vi.stubGlobal('showDirectoryPicker', picker);
+
+    dispatch('command::ui:locate-native-fs-workspace', { wsName: 'broken-ws' });
+
+    await vi.waitFor(() => {
+      expect(getCommandResults().at(-1)?.type).toBe('failure');
+    });
+    expect(picker).not.toHaveBeenCalled();
+    expect(
+      await services.workspaceOps.getWorkspaceMetadata('broken-ws'),
+    ).toEqual({});
+  });
+});

--- a/packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts
+++ b/packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts
@@ -1,9 +1,11 @@
 import { throwAppError } from '@bangle.io/base-utils';
 import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
 import {
+  isFileSystemDirectoryHandle,
   isNativeFsError,
   NATIVE_FS_ERROR_CODE,
   pickDirectory,
+  revealDirectoryLocation,
 } from '@bangle.io/native-fs';
 import { c } from '../helper';
 
@@ -59,6 +61,51 @@ export const nativeFsRecoveryHandlers = [
       // Recreate the service graph so every Native FS handle cache observes
       // the newly stored directory before any reads or writes resume.
       workbenchState.reloadUi();
+    },
+  ),
+  c(
+    'command::ui:locate-native-fs-workspace',
+    async ({ workspaceOps }, { wsName }) => {
+      const workspace = await workspaceOps.getWorkspaceInfo(wsName, {
+        type: WORKSPACE_STORAGE_TYPE.NativeFS,
+      });
+      if (!workspace) {
+        throwAppError(
+          'error::workspace:not-found',
+          t.app.errors.workspace.locateNotFound({ wsName }),
+          { wsName },
+        );
+      }
+
+      const rootDirHandle = workspace.metadata.rootDirHandle;
+      if (!isFileSystemDirectoryHandle(rootDirHandle)) {
+        // A broken entry has nothing to anchor the dialog at; pointing the
+        // user at the reconnect flow beats opening a picker somewhere random.
+        throwAppError(
+          'error::workspace:invalid-metadata',
+          t.app.errors.workspace.locateMissingHandle({ wsName }),
+          { wsName },
+        );
+      }
+
+      // Reveal-only: the OS dialog shows the folder's path, the selection is
+      // discarded, and cancelling resolves silently. No metadata is written.
+      try {
+        await revealDirectoryLocation(rootDirHandle);
+      } catch (error) {
+        if (isNativeFsError(error, NATIVE_FS_ERROR_CODE.unsupported)) {
+          throwAppError(
+            'error::workspace:native-fs-locate-failed',
+            t.app.errors.workspace.locateUnsupported,
+            { wsName },
+          );
+        }
+        throwAppError(
+          'error::workspace:native-fs-locate-failed',
+          t.app.errors.workspace.locateFailed,
+          { wsName },
+        );
+      }
     },
   ),
 ];

--- a/packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts
+++ b/packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts
@@ -81,14 +81,17 @@ export const nativeFsRecoveryHandlers = [
       if (!isFileSystemDirectoryHandle(rootDirHandle)) {
         // A broken entry has nothing to anchor the dialog at; pointing the
         // user at the reconnect flow beats opening a picker somewhere random.
+        // This is an expected degraded state, so it uses the locate-failed
+        // error (handled, non-reportable) rather than invalid-metadata.
         throwAppError(
-          'error::workspace:invalid-metadata',
+          'error::workspace:native-fs-locate-failed',
           t.app.errors.workspace.locateMissingHandle({ wsName }),
           { wsName },
         );
       }
 
-      // Reveal-only: the OS dialog shows the folder's path, the selection is
+      // Reveal-only and best-effort: the OS dialog shows the folder's path
+      // (when the browser honors the startIn suggestion), the selection is
       // discarded, and cancelling resolves silently. No metadata is written.
       try {
         await revealDirectoryLocation(rootDirHandle);

--- a/packages/js-lib/native-fs/src/__tests__/picker-and-permissions.spec.ts
+++ b/packages/js-lib/native-fs/src/__tests__/picker-and-permissions.spec.ts
@@ -10,7 +10,7 @@ import {
   queryPermission,
   requestPermission,
 } from '../permissions';
-import { pickDirectory } from '../picker';
+import { pickDirectory, revealDirectoryLocation } from '../picker';
 import {
   isFileSystemDirectoryHandle,
   supportsFileSystemObserver,
@@ -169,5 +169,54 @@ describe('pickDirectory', () => {
       true,
     );
     expect((error as { cause?: unknown }).cause).toBeInstanceOf(DOMException);
+  });
+});
+
+describe('revealDirectoryLocation', () => {
+  it('throws unsupported when the picker API is missing', async () => {
+    const anchor = asRootHandle(new FakeDirectoryHandle('notes'));
+    const error = await revealDirectoryLocation(anchor).catch((e) => e);
+    expect(isNativeFsError(error, NATIVE_FS_ERROR_CODE.unsupported)).toBe(true);
+  });
+
+  it('anchors the picker at the handle and discards the selection', async () => {
+    const anchor = asRootHandle(new FakeDirectoryHandle('notes'));
+    const picked = new FakeDirectoryHandle('somewhere-else');
+    const requestPermission = vi.spyOn(picked, 'requestPermission');
+    const picker = vi.fn(async () => asRootHandle(picked));
+    vi.stubGlobal('showDirectoryPicker', picker);
+
+    await expect(revealDirectoryLocation(anchor)).resolves.toBeUndefined();
+    expect(picker).toHaveBeenCalledWith({
+      id: 'bangle-locate-workspace',
+      mode: 'read',
+      startIn: anchor,
+    });
+    // A reveal never asks for permission on whatever the user happened to pick.
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+
+  it('resolves silently when the user cancels the dialog', async () => {
+    const anchor = asRootHandle(new FakeDirectoryHandle('notes'));
+    vi.stubGlobal('showDirectoryPicker', async () => {
+      throw new DOMException('The user aborted a request.', 'AbortError');
+    });
+
+    await expect(revealDirectoryLocation(anchor)).resolves.toBeUndefined();
+  });
+
+  it('maps missing user activation to activationRequired', async () => {
+    const anchor = asRootHandle(new FakeDirectoryHandle('notes'));
+    vi.stubGlobal('showDirectoryPicker', async () => {
+      throw new DOMException(
+        'Must be handling a user gesture to show a file picker.',
+        'SecurityError',
+      );
+    });
+
+    const error = await revealDirectoryLocation(anchor).catch((e) => e);
+    expect(
+      isNativeFsError(error, NATIVE_FS_ERROR_CODE.activationRequired),
+    ).toBe(true);
   });
 });

--- a/packages/js-lib/native-fs/src/index.ts
+++ b/packages/js-lib/native-fs/src/index.ts
@@ -20,7 +20,7 @@ export {
   queryPermission,
   requestPermission,
 } from './permissions';
-export { pickDirectory } from './picker';
+export { pickDirectory, revealDirectoryLocation } from './picker';
 export {
   isFileSystemDirectoryHandle,
   supportsFileSystemObserver,

--- a/packages/js-lib/native-fs/src/picker.ts
+++ b/packages/js-lib/native-fs/src/picker.ts
@@ -1,6 +1,6 @@
 import { isAbortError } from '@bangle.io/mini-js-utils';
 
-import { NATIVE_FS_ERROR_CODE, NativeFsError } from './errors';
+import { isNativeFsError, NATIVE_FS_ERROR_CODE, NativeFsError } from './errors';
 import { requestPermission } from './permissions';
 import { getShowDirectoryPicker } from './support';
 import type { DirectoryPickerOpts } from './types';
@@ -18,47 +18,16 @@ import type { DirectoryPickerOpts } from './types';
 export async function pickDirectory(
   opts: DirectoryPickerOpts = {},
 ): Promise<FileSystemDirectoryHandle> {
-  const showDirectoryPicker = getShowDirectoryPicker();
-  if (!showDirectoryPicker) {
-    throw new NativeFsError({
-      message: 'This browser does not support picking a directory',
-      code: NATIVE_FS_ERROR_CODE.unsupported,
-    });
-  }
-
   const { mode = 'readwrite', ...rest } = opts;
 
-  let handle: FileSystemDirectoryHandle;
-  try {
-    // `mode` is deliberately NOT forwarded to the picker. A picker-time
-    // readwrite grant makes the explicit `requestPermission` below a no-op,
-    // and Chrome has not reliably recorded picker-mode grants as persisted
-    // grants — losing the "Allow on every visit" restore prompt on the next
-    // visit, so users were re-prompted on every return. Picking read-only and
-    // then explicitly requesting `mode` keeps the upfront prompt on the
-    // requestPermission path, which Chrome persists across sessions.
-    handle = await showDirectoryPicker({ ...rest });
-  } catch (error) {
-    if (isAbortError(error)) {
-      throw new NativeFsError({
-        message: 'The user dismissed the directory picker',
-        code: NATIVE_FS_ERROR_CODE.userAborted,
-        cause: error,
-      });
-    }
-    if (isActivationError(error)) {
-      throw new NativeFsError({
-        message: 'Opening the directory picker requires a user gesture',
-        code: NATIVE_FS_ERROR_CODE.activationRequired,
-        cause: error,
-      });
-    }
-    throw new NativeFsError({
-      message: 'Unable to open the directory picker',
-      code: NATIVE_FS_ERROR_CODE.unknown,
-      cause: error,
-    });
-  }
+  // `mode` is deliberately NOT forwarded to the picker. A picker-time
+  // readwrite grant makes the explicit `requestPermission` below a no-op,
+  // and Chrome has not reliably recorded picker-mode grants as persisted
+  // grants — losing the "Allow on every visit" restore prompt on the next
+  // visit, so users were re-prompted on every return. Picking read-only and
+  // then explicitly requesting `mode` keeps the upfront prompt on the
+  // requestPermission path, which Chrome persists across sessions.
+  const handle = await invokeDirectoryPicker(rest);
 
   // The explicit permission prompt for `mode`; see the note above on why this
   // must stay the prompting step rather than the picker's `mode` option.
@@ -97,8 +66,14 @@ export async function pickDirectory(
  * dialog reveals where that folder lives on disk — the web platform never
  * exposes a handle's absolute path, but the OS dialog's own breadcrumb does.
  *
- * This is a reveal, not a pick: whatever the user selects is discarded, no
- * permission is requested, and cancelling the dialog is the normal way to
+ * This is a best-effort picker workaround, not a guaranteed reveal: the spec
+ * treats `startIn` as a suggestion applied "when possible", so a stale or
+ * ignored anchor can leave the dialog at an unrelated default location.
+ *
+ * This function never calls `requestPermission` and discards whatever the
+ * dialog resolves with. Note the pick itself is not permission-free: if the
+ * user does select a folder, the browser grants (or prompts for) read access
+ * to it as part of the pick. Cancelling the dialog is the expected way to
  * close it once the path has been read, so `userAborted` resolves silently.
  *
  * Must be called from a user gesture. Failures are typed:
@@ -108,26 +83,48 @@ export async function pickDirectory(
 export async function revealDirectoryLocation(
   anchor: FileSystemHandle,
 ): Promise<void> {
-  const showDirectoryPicker = getShowDirectoryPicker();
-  if (!showDirectoryPicker) {
-    throw new NativeFsError({
-      message: 'This browser does not support revealing a directory',
-      code: NATIVE_FS_ERROR_CODE.unsupported,
-    });
-  }
-
   try {
-    // A handle-form `startIn` takes precedence over the picker's per-`id`
-    // memory, so the dialog always opens at the anchor; the stable id only
-    // keeps this reveal from clobbering the default picker bucket.
-    await showDirectoryPicker({
+    // The stable id keeps this reveal from clobbering the default picker
+    // bucket that workspace creation uses.
+    await invokeDirectoryPicker({
       id: 'bangle-locate-workspace',
       mode: 'read',
       startIn: anchor,
     });
   } catch (error) {
-    if (isAbortError(error)) {
+    if (isNativeFsError(error, NATIVE_FS_ERROR_CODE.userAborted)) {
       return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Feature-detects and invokes `showDirectoryPicker`, normalizing every
+ * rejection into the typed taxonomy. Callers layer their own semantics on
+ * top: `pickDirectory` enforces the requested permission on the result,
+ * `revealDirectoryLocation` discards it and treats cancellation as success.
+ */
+async function invokeDirectoryPicker(
+  opts: DirectoryPickerOpts,
+): Promise<FileSystemDirectoryHandle> {
+  const showDirectoryPicker = getShowDirectoryPicker();
+  if (!showDirectoryPicker) {
+    throw new NativeFsError({
+      message: 'This browser does not support picking a directory',
+      code: NATIVE_FS_ERROR_CODE.unsupported,
+    });
+  }
+
+  try {
+    return await showDirectoryPicker(opts);
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new NativeFsError({
+        message: 'The user dismissed the directory picker',
+        code: NATIVE_FS_ERROR_CODE.userAborted,
+        cause: error,
+      });
     }
     if (isActivationError(error)) {
       throw new NativeFsError({

--- a/packages/js-lib/native-fs/src/picker.ts
+++ b/packages/js-lib/native-fs/src/picker.ts
@@ -46,11 +46,7 @@ export async function pickDirectory(
         cause: error,
       });
     }
-    if (
-      error instanceof DOMException &&
-      (error.name === 'SecurityError' ||
-        error.message.toLowerCase().includes('user activation'))
-    ) {
+    if (isActivationError(error)) {
       throw new NativeFsError({
         message: 'Opening the directory picker requires a user gesture',
         code: NATIVE_FS_ERROR_CODE.activationRequired,
@@ -73,11 +69,7 @@ export async function pickDirectory(
     // requestPermission can itself reject (e.g. the user gesture expired by
     // the time the explicit prompt runs); keep the typed taxonomy instead of
     // leaking a raw DOMException to the UI.
-    if (
-      error instanceof DOMException &&
-      (error.name === 'SecurityError' ||
-        error.message.toLowerCase().includes('user activation'))
-    ) {
+    if (isActivationError(error)) {
       throw new NativeFsError({
         message: `Requesting ${mode} permission for "${handle.name}" requires a user gesture`,
         code: NATIVE_FS_ERROR_CODE.activationRequired,
@@ -98,4 +90,65 @@ export async function pickDirectory(
   }
 
   return handle;
+}
+
+/**
+ * Opens the directory picker anchored at `anchor` purely so the native OS
+ * dialog reveals where that folder lives on disk — the web platform never
+ * exposes a handle's absolute path, but the OS dialog's own breadcrumb does.
+ *
+ * This is a reveal, not a pick: whatever the user selects is discarded, no
+ * permission is requested, and cancelling the dialog is the normal way to
+ * close it once the path has been read, so `userAborted` resolves silently.
+ *
+ * Must be called from a user gesture. Failures are typed:
+ * - `unsupported` — the environment has no `showDirectoryPicker`
+ * - `activationRequired` — called without a (fresh enough) user gesture
+ */
+export async function revealDirectoryLocation(
+  anchor: FileSystemHandle,
+): Promise<void> {
+  const showDirectoryPicker = getShowDirectoryPicker();
+  if (!showDirectoryPicker) {
+    throw new NativeFsError({
+      message: 'This browser does not support revealing a directory',
+      code: NATIVE_FS_ERROR_CODE.unsupported,
+    });
+  }
+
+  try {
+    // A handle-form `startIn` takes precedence over the picker's per-`id`
+    // memory, so the dialog always opens at the anchor; the stable id only
+    // keeps this reveal from clobbering the default picker bucket.
+    await showDirectoryPicker({
+      id: 'bangle-locate-workspace',
+      mode: 'read',
+      startIn: anchor,
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      return;
+    }
+    if (isActivationError(error)) {
+      throw new NativeFsError({
+        message: 'Opening the directory picker requires a user gesture',
+        code: NATIVE_FS_ERROR_CODE.activationRequired,
+        cause: error,
+      });
+    }
+    throw new NativeFsError({
+      message: 'Unable to open the directory picker',
+      code: NATIVE_FS_ERROR_CODE.unknown,
+      cause: error,
+    });
+  }
+}
+
+/** A picker/permission call rejected because transient user activation was missing. */
+function isActivationError(error: unknown): error is DOMException {
+  return (
+    error instanceof DOMException &&
+    (error.name === 'SecurityError' ||
+      error.message.toLowerCase().includes('user activation'))
+  );
 }

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -343,6 +343,20 @@ export const uiCommands = narrow([
     omniSearch: false,
   },
   {
+    // Reveal-only: anchors the OS directory picker at the workspace's stored
+    // handle so the dialog shows its on-disk path. Unlike the reconnect
+    // command above it never rebinds the handle or mutates metadata.
+    id: 'command::ui:locate-native-fs-workspace',
+    dependencies: {
+      services: ['workspaceOps'],
+    },
+    autoFocusEditor: false,
+    args: {
+      wsName: T.String,
+    },
+    omniSearch: false,
+  },
+  {
     id: 'command::ui:toggle-all-files',
     title: 'View All Files',
     keywords: ['files', 'list', 'browse', 'all'],

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -247,6 +247,7 @@ export const t = {
         actionsLabel: ({ wsName }: { wsName: string }) =>
           `Workspace actions for ${wsName}`,
         openWorkspace: 'Open workspace',
+        locateFolder: 'Locate folder',
         deleteWorkspace: 'Delete workspace',
       },
       nav: {

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -458,6 +458,13 @@ export const t = {
           selectedName: string;
         }) =>
           `Choose the folder named "${expectedName}", not "${selectedName}". Your workspace was not changed.`,
+        locateNotFound: ({ wsName }: { wsName: string }) =>
+          `The workspace "${wsName}" is no longer available.`,
+        locateUnsupported:
+          'This browser cannot show where a workspace folder lives on disk.',
+        locateMissingHandle: ({ wsName }: { wsName: string }) =>
+          `Bangle has lost the link to the folder for "${wsName}". Open the workspace to reconnect it.`,
+        locateFailed: 'Bangle could not open the folder location dialog.',
       },
       file: {
         invalidNotePath: 'Invalid note path provided',

--- a/packages/shared/types/app-errors.ts
+++ b/packages/shared/types/app-errors.ts
@@ -71,6 +71,12 @@ export type AppError =
       };
     }
   | {
+      name: `error::workspace:native-fs-locate-failed`;
+      payload: {
+        wsName: string;
+      };
+    }
+  | {
       name: 'error::workspace:no-notes-found';
       payload: {
         wsName?: string;

--- a/packages/tooling/e2e-tests/src/settings-workspaces.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-workspaces.e2e.ts
@@ -143,3 +143,195 @@ test('workspaces settings deletes a workspace from the row actions', async ({
   );
   await expect(page.getByRole('link', { name: keptWorkspace })).toBeVisible();
 });
+
+// Locate folder delegates the reveal to the native OS dialog, whose path bar
+// is browser chrome that a page-level test cannot read. These assertions
+// therefore cover the mechanism — the picker opens anchored (`startIn`) at the
+// workspace's stored handle and the outcome is discarded — not the
+// human-visible path itself.
+test('locate folder anchors the OS picker at a nativefs workspace without side effects', async ({
+  page,
+}) => {
+  const nativeWorkspace = 'locate-native-ws';
+  const browserWorkspace = 'locate-browser-ws';
+  const parentDir = 'locate-native-parent';
+
+  type PickerCall = {
+    id?: string;
+    mode?: string;
+    startInName?: string;
+    startInKind?: string;
+  };
+  type PickerTestWindow = {
+    __locatePickerCalls?: PickerCall[];
+    __locatePickerBehavior?: 'select' | 'cancel';
+  };
+
+  await page.addInitScript(() => {
+    const win = window as unknown as PickerTestWindow & typeof window;
+    win.__locatePickerCalls = [];
+    win.__locatePickerBehavior = 'select';
+    win.showDirectoryPicker = async (options?: {
+      id?: string;
+      mode?: string;
+      startIn?: FileSystemHandle;
+    }) => {
+      win.__locatePickerCalls?.push({
+        id: options?.id,
+        mode: options?.mode,
+        startInName: options?.startIn?.name,
+        startInKind: options?.startIn?.kind,
+      });
+      if (win.__locatePickerBehavior === 'cancel') {
+        throw new DOMException('The user aborted a request.', 'AbortError');
+      }
+      // Selecting some unrelated folder must be a no-op for the app.
+      return navigator.storage.getDirectory();
+    };
+  });
+
+  await createBrowserWorkspace(page, { workspaceName: browserWorkspace });
+
+  // Seed a nativefs workspace the same way native-fs-recovery.e2e.ts does:
+  // an OPFS-backed directory handle stored in the WorkspaceInfo table.
+  await page.evaluate(
+    async ({ parentName, workspaceName }) => {
+      const root = await navigator.storage.getDirectory();
+      await root.removeEntry(parentName, { recursive: true }).catch(() => {});
+      const parent = await root.getDirectoryHandle(parentName, {
+        create: true,
+      });
+      const workspaceHandle = await parent.getDirectoryHandle(workspaceName, {
+        create: true,
+      });
+      const noteHandle = await workspaceHandle.getFileHandle('welcome.md', {
+        create: true,
+      });
+      const writable = await noteHandle.createWritable();
+      await writable.write('# Locate me\n');
+      await writable.close();
+
+      const request = indexedDB.open('bangle-io-db');
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      await new Promise<void>((resolve, reject) => {
+        const transaction = database.transaction('WorkspaceInfo', 'readwrite');
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error);
+        transaction.objectStore('WorkspaceInfo').put({
+          key: workspaceName,
+          lastModified: Date.now(),
+          value: {
+            name: workspaceName,
+            type: 'nativefs',
+            deleted: false,
+            lastModified: Date.now(),
+            metadata: { rootDirHandle: workspaceHandle },
+          },
+        });
+      });
+      database.close();
+    },
+    { parentName: parentDir, workspaceName: nativeWorkspace },
+  );
+
+  // Reboot the app so the injected workspace entry is part of the list.
+  await page.goto('/');
+  await openWorkspacesSettings(page);
+  await expect(page.getByRole('link', { name: nativeWorkspace })).toBeVisible();
+  const urlBeforeLocate = page.url();
+
+  // No on-disk folder to reveal for a browser workspace: the action is absent.
+  await page
+    .getByRole('button', { name: `Workspace actions for ${browserWorkspace}` })
+    .click();
+  await expect(
+    page.getByRole('menuitem', { name: 'Open workspace' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('menuitem', { name: 'Locate folder' }),
+  ).toHaveCount(0);
+  await page.keyboard.press('Escape');
+
+  const clickLocate = async () => {
+    await page
+      .getByRole('button', { name: `Workspace actions for ${nativeWorkspace}` })
+      .click();
+    await page.getByRole('menuitem', { name: 'Locate folder' }).click();
+  };
+  const readPickerCalls = () =>
+    page.evaluate(
+      () => (window as unknown as PickerTestWindow).__locatePickerCalls ?? [],
+    );
+
+  // Selecting a folder in the dialog: the pick is discarded.
+  await clickLocate();
+  await expect.poll(async () => (await readPickerCalls()).length).toBe(1);
+  const [firstCall] = await readPickerCalls();
+  expect(firstCall).toMatchObject({
+    id: 'bangle-locate-workspace',
+    mode: 'read',
+    startInName: nativeWorkspace,
+    startInKind: 'directory',
+  });
+
+  // Cancelling the dialog: equally a no-op, with no error surfaced.
+  await page.evaluate(() => {
+    (window as unknown as PickerTestWindow).__locatePickerBehavior = 'cancel';
+  });
+  await clickLocate();
+  await expect.poll(async () => (await readPickerCalls()).length).toBe(2);
+  await expect(page.getByRole('alert')).toHaveCount(0);
+
+  // No rebind, no navigation, no list change — for either outcome.
+  expect(page.url()).toBe(urlBeforeLocate);
+  await expect(
+    page.getByRole('heading', { name: 'Workspaces' }).first(),
+  ).toBeVisible();
+  await expect(page.getByRole('link', { name: nativeWorkspace })).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: browserWorkspace }),
+  ).toBeVisible();
+  const metadataIntact = await page.evaluate(
+    async ({ parentName, workspaceName }) => {
+      const root = await navigator.storage.getDirectory();
+      const parent = await root.getDirectoryHandle(parentName);
+      const expectedHandle = await parent.getDirectoryHandle(workspaceName);
+
+      const request = indexedDB.open('bangle-io-db');
+      const database = await new Promise<IDBDatabase>((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      const entry = await new Promise<
+        | {
+            value?: {
+              type?: string;
+              metadata?: { rootDirHandle?: FileSystemDirectoryHandle };
+            };
+          }
+        | undefined
+      >((resolve, reject) => {
+        const transaction = database.transaction('WorkspaceInfo', 'readonly');
+        const getRequest = transaction
+          .objectStore('WorkspaceInfo')
+          .get(workspaceName);
+        getRequest.onsuccess = () => resolve(getRequest.result);
+        getRequest.onerror = () => reject(getRequest.error);
+      });
+      database.close();
+
+      const storedHandle = entry?.value?.metadata?.rootDirHandle;
+      return Boolean(
+        entry?.value?.type === 'nativefs' &&
+          storedHandle &&
+          (await expectedHandle.isSameEntry(storedHandle)),
+      );
+    },
+    { parentName: parentDir, workspaceName: nativeWorkspace },
+  );
+  expect(metadataIntact).toBe(true);
+});

--- a/plans/015-workspace-locate-feature.md
+++ b/plans/015-workspace-locate-feature.md
@@ -7,7 +7,8 @@ archived_on:
 created: 2026-07-13
 updated: 2026-07-13
 owner: mixed
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/644
 related_issues: []
 ---
 

--- a/plans/015-workspace-locate-feature.md
+++ b/plans/015-workspace-locate-feature.md
@@ -1,0 +1,193 @@
+---
+title: Workspace "Locate folder" action for Native FS workspaces
+status: planned
+type: plan
+archived: false
+archived_on:
+created: 2026-07-13
+updated: 2026-07-13
+owner: mixed
+related_prs: []
+related_issues: []
+---
+
+# Workspace "Locate folder" action for Native FS workspaces
+
+## Summary
+
+Add a per-workspace **Locate folder** action in the Workspaces settings page
+(`route=settings-workspaces`) that helps a user answer "where on disk is this
+workspace?" for Native File System workspaces.
+
+The File System Access API deliberately never exposes a directory handle's
+absolute path — `FileSystemDirectoryHandle` only carries `.name` (the leaf
+folder name). So the app genuinely cannot read or display the workspace's
+location, and a user with two folders both named `notes` cannot tell them
+apart.
+
+The creative workaround: the picker functions accept a
+`startIn?: FileSystemHandle` option that anchors the **native OS dialog** at a
+folder's real location. We open a directory picker anchored at the workspace's
+stored `rootDirHandle` purely so the OS dialog (Finder / Explorer) reveals the
+path in its breadcrumb — the human reads it there. Whatever the user then does
+in the dialog is **discarded**: selecting a folder does nothing, cancelling does
+nothing. The web app never learns the path (privacy preserved by the platform),
+but the human does, because the reveal is delegated to the OS chrome.
+
+This is intentionally distinct from the existing Native FS **recovery** flow
+([page-native-fs-recovery.tsx](../packages/core/app/src/pages/page-native-fs-recovery.tsx),
+`command::ui:reconnect-native-fs-workspace`), which *rebinds* a lost folder.
+Locate never rebinds, never mutates metadata, never navigates, never touches
+files.
+
+## Mechanism (already mostly plumbed)
+
+- `DirectoryPickerOpts` already declares `startIn?: FileSystemHandle | string`
+  ([native-fs/src/types.ts:17](../packages/js-lib/native-fs/src/types.ts)) and
+  `pickDirectory` already spreads unknown opts into `showDirectoryPicker`
+  ([native-fs/src/picker.ts:33](../packages/js-lib/native-fs/src/picker.ts)).
+- `WorkspaceInfo` carries `type: string` and `metadata: Record<string, unknown>`
+  ([shared/types/workspace.ts](../packages/shared/types/workspace.ts)); a
+  `nativefs` workspace stores its handle at `metadata.rootDirHandle`
+  (see the reconnect handler, which writes it back on recovery).
+- `WORKSPACE_STORAGE_TYPE.NativeFS === 'nativefs'`
+  ([shared/constants/index.ts:86](../packages/shared/constants/index.ts)).
+- The settings page's `$workspaces` atom resolves to `WorkspaceInfo[]`
+  (`workspaceOps.getAllWorkspaces()`), so the row already has `type` to gate on.
+
+Reuse of `pickDirectory` is **not** appropriate here: `pickDirectory` requests
+`readwrite` permission on the returned handle, which would fire an unwanted
+permission prompt for a mere reveal. Locate needs a thin, reveal-only helper.
+
+## Scope
+
+### 1. `@bangle.io/native-fs` — reveal-only helper (js-lib, lowest layer)
+
+Add an exported helper, e.g. `revealDirectoryLocation(anchor: FileSystemHandle)`:
+
+- Feature-detect via the existing `getShowDirectoryPicker()`
+  ([native-fs/src/support.ts](../packages/js-lib/native-fs/src/support.ts)); if
+  absent, throw the typed `NATIVE_FS_ERROR_CODE.unsupported` `NativeFsError`.
+- Call `showDirectoryPicker({ startIn: anchor, mode: 'read', id: '<stable>' })`.
+- **Discard** the resolved handle; do **not** call `requestPermission` and do
+  **not** return the handle.
+- Swallow `userAborted` (AbortError) silently — cancelling is the normal,
+  expected outcome once the user has read the path.
+- Surface only `unsupported` / `activationRequired` as typed errors.
+
+Rationale for layering: the reveal mechanism is a native-fs capability and
+belongs beside `pickDirectory`, not in a caller. Keep the typed error taxonomy.
+
+### 2. `@bangle.io/commands` — command definition (shared)
+
+Add `command::ui:locate-native-fs-workspace`, mirroring
+`command::ui:reconnect-native-fs-workspace`
+([shared/commands/src/ui-commands.ts:335](../packages/shared/commands/src/ui-commands.ts)):
+
+- `args: { wsName: T.String }`
+- `dependencies.services: ['workspaceOps']` (add `workbenchState` only if we
+  choose to surface a toast on unsupported)
+- `autoFocusEditor: false`, `omniSearch: false` (per-row action, not global
+  search; keep it out of omni-search).
+
+### 3. `@bangle.io/command-handlers` — handler (core)
+
+Add the handler next to `nativeFsRecoveryHandlers`
+([command-handlers/src/ui-handlers/native-fs-recovery.ts](../packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts)):
+
+- `getWorkspaceInfo(wsName, { type: NativeFS })`; if missing → typed
+  `error::workspace:not-found`.
+- Read `metadata.rootDirHandle`; validate it is a directory handle (has a
+  string `.name`). If absent/invalid (a broken entry) → typed info error that
+  points at the recovery flow; do not attempt a bare picker (revealing nothing
+  useful is worse than a clear message).
+- Call `revealDirectoryLocation(rootDirHandle)`.
+- Map `unsupported` to a typed app error → toast; never throw a raw
+  `DOMException` to the UI.
+- Must be dispatched from a user gesture (the menu click satisfies this).
+
+### 4. `packages/core/app` — settings UI
+
+In `WorkspaceActionsMenu`
+([page-settings-workspaces.tsx:186](../packages/core/app/src/pages/page-settings-workspaces.tsx)):
+
+- Thread the workspace `type` (or an `onLocate?`/`isNativeFs` prop) into the
+  menu.
+- Render a **Locate folder** `DropdownMenuItem` (icon `FolderSearch`, already
+  used by the recovery page) **only when** `type === 'nativefs'` **and** the
+  picker API is supported. Hide it for `browser`/IndexedDB workspaces (no disk
+  location) and on non-Chromium browsers.
+- On click: `commandDispatcher.dispatch('command::ui:locate-native-fs-workspace',
+  { wsName }, 'ui')`.
+
+### 5. `@bangle.io/translations` — strings (en.ts)
+
+- `t.app.settings.workspaces.locateFolder: 'Locate folder'` (menu item), matching
+  the recovery page's `pageNativeFsRecovery.locateFolderButton` tone.
+- Error strings under `t.app.errors.workspace.*` for the unsupported and
+  missing-handle cases.
+
+## Out of scope
+
+- Rebinding / reconnecting a moved or deleted folder — that is the existing
+  `command::ui:reconnect-native-fs-workspace` recovery flow; Locate must never
+  write metadata.
+- Displaying the path string inside the app — the platform forbids reading it;
+  we intentionally delegate the reveal to the OS dialog.
+- "Reveal in Finder/Explorer" as a one-click OS action — no web API exists; the
+  OS dialog's own breadcrumb / "reveal" affordances are the path.
+- Persisting, caching, or logging any resolved path.
+- Non-Native-FS workspaces (browser, help, memory, github) — no on-disk folder.
+
+## Verification
+
+- **Unit — native-fs** (`revealDirectoryLocation`): stub global
+  `showDirectoryPicker` (mirror
+  [picker-and-permissions.spec.ts](../packages/js-lib/native-fs/src/__tests__/picker-and-permissions.spec.ts)).
+  Assert it is called with `startIn` set to the anchor handle; assert the
+  resolved handle is discarded and `requestPermission` is never invoked; assert
+  a `userAborted`/AbortError resolves without throwing; assert `unsupported`
+  when the picker is absent.
+- **Unit — command-handlers**: real DI container (mirror
+  [native-fs-recovery.spec.ts](../packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts)).
+  With a `nativefs` `WorkspaceInfo` carrying a fake `rootDirHandle`, dispatch and
+  assert the reveal helper is called with that handle; assert typed errors for
+  missing workspace, non-nativefs type, and absent handle; assert no metadata
+  write and no navigation occur.
+- **E2E — settings-workspaces** (`*.e2e.ts`, required for release): seed one
+  `nativefs` and one `browser` workspace; stub `window.showDirectoryPicker` via
+  `addInitScript` (as
+  [native-fs-recovery.e2e.ts](../packages/tooling/e2e-tests/src/native-fs-recovery.e2e.ts)
+  does). Assert the **Locate folder** action shows only on the nativefs row;
+  clicking calls `showDirectoryPicker` with `startIn` set to a handle whose
+  `.name` equals the workspace name; and that both selecting a folder and
+  cancelling leave the workspace list, note counts, current route, and stored
+  metadata **unchanged** (no rebind, no navigation).
+- `pnpm lint:ci` and `pnpm test:ci` green; run the settings-workspaces E2E
+  filtered while iterating, full `pnpm e2e:ci` before the PR.
+- Manual `playwright-cli` smoke on a real Chromium build: create a Native FS
+  workspace, open it, then use Locate and confirm the OS dialog opens focused on
+  that folder.
+
+## Known blockers / limitations
+
+- **Testability boundary**: the OS dialog's path bar is native chrome outside
+  the page, so automated tests can only assert the *mechanism* (picker invoked
+  with the correct `startIn`, result discarded, no side effects) — not the
+  human-visible path. State this in the test file.
+- **`startIn` is best-effort**: if the stored handle's permission has lapsed or
+  the folder has moved/been deleted, Chromium may ignore `startIn` and open the
+  dialog at a default location. That is acceptable degradation; the remedy for a
+  genuinely missing folder is the existing recovery flow, not Locate.
+- **Chromium-only**: Native FS + `startIn` are unavailable on Firefox/Safari and
+  most mobile browsers. In practice a `nativefs` workspace can only exist where
+  the API exists, but feature-detect and hide the action regardless.
+
+## Next steps
+
+1. Land the `native-fs` reveal helper + unit tests.
+2. Add the command definition and core handler + unit tests.
+3. Wire the settings menu item (gated to nativefs + supported) and strings.
+4. Add the settings-workspaces E2E and run `pnpm local-ci-check`.
+5. Open the PR; link it and any tracking issue back into this plan's
+   frontmatter.

--- a/plans/archived/015-workspace-locate-feature.md
+++ b/plans/archived/015-workspace-locate-feature.md
@@ -1,9 +1,9 @@
 ---
 title: Workspace "Locate folder" action for Native FS workspaces
-status: planned
+status: completed
 type: plan
-archived: false
-archived_on:
+archived: true
+archived_on: 2026-07-13
 created: 2026-07-13
 updated: 2026-07-13
 owner: mixed
@@ -11,6 +11,14 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/644
 related_issues: []
 ---
+
+> DONE Completed on 2026-07-13 in PR #644, which carries both this plan and
+> the implementation: `revealDirectoryLocation` in `@bangle.io/native-fs`,
+> `command::ui:locate-native-fs-workspace` (definition + handler), the gated
+> settings-workspaces menu item, and unit + E2E coverage. Final verification
+> passed with `pnpm lint:ci`, `pnpm test:ci`, and `pnpm e2e:ci`. Known caveat
+> (by design): tests assert the picker mechanism, not the OS dialog's path bar,
+> and `startIn` is best-effort when the stored handle is stale.
 
 # Workspace "Locate folder" action for Native FS workspaces
 
@@ -36,7 +44,7 @@ nothing. The web app never learns the path (privacy preserved by the platform),
 but the human does, because the reveal is delegated to the OS chrome.
 
 This is intentionally distinct from the existing Native FS **recovery** flow
-([page-native-fs-recovery.tsx](../packages/core/app/src/pages/page-native-fs-recovery.tsx),
+([page-native-fs-recovery.tsx](../../packages/core/app/src/pages/page-native-fs-recovery.tsx),
 `command::ui:reconnect-native-fs-workspace`), which *rebinds* a lost folder.
 Locate never rebinds, never mutates metadata, never navigates, never touches
 files.
@@ -44,15 +52,15 @@ files.
 ## Mechanism (already mostly plumbed)
 
 - `DirectoryPickerOpts` already declares `startIn?: FileSystemHandle | string`
-  ([native-fs/src/types.ts:17](../packages/js-lib/native-fs/src/types.ts)) and
+  ([native-fs/src/types.ts:17](../../packages/js-lib/native-fs/src/types.ts)) and
   `pickDirectory` already spreads unknown opts into `showDirectoryPicker`
-  ([native-fs/src/picker.ts:33](../packages/js-lib/native-fs/src/picker.ts)).
+  ([native-fs/src/picker.ts:33](../../packages/js-lib/native-fs/src/picker.ts)).
 - `WorkspaceInfo` carries `type: string` and `metadata: Record<string, unknown>`
-  ([shared/types/workspace.ts](../packages/shared/types/workspace.ts)); a
+  ([shared/types/workspace.ts](../../packages/shared/types/workspace.ts)); a
   `nativefs` workspace stores its handle at `metadata.rootDirHandle`
   (see the reconnect handler, which writes it back on recovery).
 - `WORKSPACE_STORAGE_TYPE.NativeFS === 'nativefs'`
-  ([shared/constants/index.ts:86](../packages/shared/constants/index.ts)).
+  ([shared/constants/index.ts:86](../../packages/shared/constants/index.ts)).
 - The settings page's `$workspaces` atom resolves to `WorkspaceInfo[]`
   (`workspaceOps.getAllWorkspaces()`), so the row already has `type` to gate on.
 
@@ -67,7 +75,7 @@ permission prompt for a mere reveal. Locate needs a thin, reveal-only helper.
 Add an exported helper, e.g. `revealDirectoryLocation(anchor: FileSystemHandle)`:
 
 - Feature-detect via the existing `getShowDirectoryPicker()`
-  ([native-fs/src/support.ts](../packages/js-lib/native-fs/src/support.ts)); if
+  ([native-fs/src/support.ts](../../packages/js-lib/native-fs/src/support.ts)); if
   absent, throw the typed `NATIVE_FS_ERROR_CODE.unsupported` `NativeFsError`.
 - Call `showDirectoryPicker({ startIn: anchor, mode: 'read', id: '<stable>' })`.
 - **Discard** the resolved handle; do **not** call `requestPermission` and do
@@ -83,7 +91,7 @@ belongs beside `pickDirectory`, not in a caller. Keep the typed error taxonomy.
 
 Add `command::ui:locate-native-fs-workspace`, mirroring
 `command::ui:reconnect-native-fs-workspace`
-([shared/commands/src/ui-commands.ts:335](../packages/shared/commands/src/ui-commands.ts)):
+([shared/commands/src/ui-commands.ts:335](../../packages/shared/commands/src/ui-commands.ts)):
 
 - `args: { wsName: T.String }`
 - `dependencies.services: ['workspaceOps']` (add `workbenchState` only if we
@@ -94,7 +102,7 @@ Add `command::ui:locate-native-fs-workspace`, mirroring
 ### 3. `@bangle.io/command-handlers` — handler (core)
 
 Add the handler next to `nativeFsRecoveryHandlers`
-([command-handlers/src/ui-handlers/native-fs-recovery.ts](../packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts)):
+([command-handlers/src/ui-handlers/native-fs-recovery.ts](../../packages/core/command-handlers/src/ui-handlers/native-fs-recovery.ts)):
 
 - `getWorkspaceInfo(wsName, { type: NativeFS })`; if missing → typed
   `error::workspace:not-found`.
@@ -110,7 +118,7 @@ Add the handler next to `nativeFsRecoveryHandlers`
 ### 4. `packages/core/app` — settings UI
 
 In `WorkspaceActionsMenu`
-([page-settings-workspaces.tsx:186](../packages/core/app/src/pages/page-settings-workspaces.tsx)):
+([page-settings-workspaces.tsx:186](../../packages/core/app/src/pages/page-settings-workspaces.tsx)):
 
 - Thread the workspace `type` (or an `onLocate?`/`isNativeFs` prop) into the
   menu.
@@ -144,13 +152,13 @@ In `WorkspaceActionsMenu`
 
 - **Unit — native-fs** (`revealDirectoryLocation`): stub global
   `showDirectoryPicker` (mirror
-  [picker-and-permissions.spec.ts](../packages/js-lib/native-fs/src/__tests__/picker-and-permissions.spec.ts)).
+  [picker-and-permissions.spec.ts](../../packages/js-lib/native-fs/src/__tests__/picker-and-permissions.spec.ts)).
   Assert it is called with `startIn` set to the anchor handle; assert the
   resolved handle is discarded and `requestPermission` is never invoked; assert
   a `userAborted`/AbortError resolves without throwing; assert `unsupported`
   when the picker is absent.
 - **Unit — command-handlers**: real DI container (mirror
-  [native-fs-recovery.spec.ts](../packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts)).
+  [native-fs-recovery.spec.ts](../../packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts)).
   With a `nativefs` `WorkspaceInfo` carrying a fake `rootDirHandle`, dispatch and
   assert the reveal helper is called with that handle; assert typed errors for
   missing workspace, non-nativefs type, and absent handle; assert no metadata
@@ -158,7 +166,7 @@ In `WorkspaceActionsMenu`
 - **E2E — settings-workspaces** (`*.e2e.ts`, required for release): seed one
   `nativefs` and one `browser` workspace; stub `window.showDirectoryPicker` via
   `addInitScript` (as
-  [native-fs-recovery.e2e.ts](../packages/tooling/e2e-tests/src/native-fs-recovery.e2e.ts)
+  [native-fs-recovery.e2e.ts](../../packages/tooling/e2e-tests/src/native-fs-recovery.e2e.ts)
   does). Assert the **Locate folder** action shows only on the nativefs row;
   clicking calls `showDirectoryPicker` with `startIn` set to a handle whose
   `.name` equals the workspace name; and that both selecting a folder and


### PR DESCRIPTION
## Summary

Implements the per-workspace **Locate folder** action for Native FS workspaces, following the plan in [`plans/archived/015-workspace-locate-feature.md`](plans/archived/015-workspace-locate-feature.md) (added and now completed in this PR).

The File System Access API never exposes a directory handle's absolute path (`FileSystemDirectoryHandle` only carries `.name`), so the app cannot display where a workspace lives on disk. Instead, the new action opens the **native OS directory dialog** anchored (`startIn`) at the workspace's stored `rootDirHandle` so the OS breadcrumb can reveal the path to the user. Whatever happens in the dialog is **discarded** — no rebind, no metadata write, no navigation — which is what distinguishes it from the existing `command::ui:reconnect-native-fs-workspace` recovery flow.

**This is a best-effort picker workaround, not a guaranteed reveal.** Per the spec, `startIn` is a suggestion applied "when possible": a stale or ignored anchor can leave the dialog at a default location (the remedy for a genuinely missing folder remains the recovery flow). And while the app never calls `requestPermission`, the pick itself is not permission-free — if the user selects a folder in the dialog, the browser grants (or prompts for) read access to it as part of the pick; the handle is discarded and never used. Cancelling is the expected way to close the dialog.

## Changes (one commit per plan step)

- **`@bangle.io/native-fs`** — new reveal-only `revealDirectoryLocation(anchor)` helper beside `pickDirectory`: read-mode picker anchored at the handle, result discarded, cancel resolves silently, `unsupported`/`activationRequired` surface as typed `NativeFsError`s. Both picker workflows share one private `invokeDirectoryPicker` primitive for feature detection and error normalization.
- **`@bangle.io/commands` / `@bangle.io/command-handlers`** — `command::ui:locate-native-fs-workspace` (args `{ wsName }`, not in omni-search) with a handler that resolves the `nativefs` workspace, validates the stored handle, and calls the reveal helper. All expected failure paths (unsupported, broken/missing handle, picker failure) surface as the new `error::workspace:native-fs-locate-failed`, which is classified as **handled** in `shouldReportAppError` — dismiss-only toast, no "Report" action — matching the reconnect flow. A missing workspace stays `error::workspace:not-found`.
- **`packages/core/app`** — **Locate folder** item (`FolderSearch` icon) in the settings-workspaces row actions menu, rendered only for `nativefs` workspaces on browsers with the picker API.
- **Tests** — unit coverage for the helper (anchoring, discard, no `requestPermission` call, silent cancel, unsupported) and the handler (success, cancel, missing workspace, wrong type, broken handle — asserting exact emitted app-error names and no metadata writes); a `shouldReportAppError` classification case; an E2E test that seeds a real OPFS-backed `nativefs` workspace, stubs `showDirectoryPicker`, and asserts the menu gating, the `startIn` anchoring, and that select/cancel leave route, list, and stored metadata untouched. Handler fixtures are structured-clone-safe class instances (main's #645 broadcast hardening clones workspace change events, so `vi.fn()` own-properties would throw `DataCloneError`).

## Testability boundary

The OS dialog's path bar is native chrome outside the page, so automated tests assert the *mechanism* (picker invoked read-mode with the correct `startIn`, result discarded, no side effects), not the human-visible path. A manual smoke on a real Chromium build (create a Native FS workspace → Locate → confirm the dialog opens at that folder) is still required before treating the reveal as reliable in a release.

## Verification

- `pnpm lint:ci` ✅ (workspace validation, tsgo, Biome)
- `pnpm test:ci` ✅ (2110 passed, 1 skipped) — on the branch merged with current `main` (includes #645/#646)
- `pnpm e2e:ci` ✅ (full E2E + component suite)
- `pnpm knip:ci` ✅, `pnpm desktop:ci` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
