### PR TITLE
fix: harden cross-context messaging lifecycle

### DIFF
--- a/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts
@@ -14,10 +14,7 @@ describe('command::ui:reconnect-native-fs-workspace', () => {
       autoNavigate: false,
     });
     const originalHandle = { name: 'test-ws' };
-    const replacementHandle = {
-      name: 'test-ws',
-      requestPermission: vi.fn().mockResolvedValue('granted'),
-    };
+    const replacementHandle = { name: 'test-ws' };
     await services.workspaceOps.createWorkspaceInfo({
       name: 'test-ws',
       type: WORKSPACE_STORAGE_TYPE.NativeFS,
@@ -55,10 +52,7 @@ describe('command::ui:reconnect-native-fs-workspace', () => {
     });
     vi.stubGlobal(
       'showDirectoryPicker',
-      vi.fn().mockResolvedValue({
-        name: 'different-folder',
-        requestPermission: vi.fn().mockResolvedValue('granted'),
-      }),
+      vi.fn().mockResolvedValue({ name: 'different-folder' }),
     );
     const reloadSpy = vi.spyOn(services.workbenchState, 'reloadUi');
 

--- a/packages/js-lib/browser-utils/__tests__/broadcast-channel.spec.ts
+++ b/packages/js-lib/browser-utils/__tests__/broadcast-channel.spec.ts
@@ -1,13 +1,5 @@
 import { Logger } from '@bangle.io/logger';
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  type Mock,
-  vi,
-} from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type BroadcastMessage,
   MemoryBroadcastChannel,
@@ -24,14 +16,14 @@ function makeTestLogger() {
     error: vi.fn(),
   };
 
-  return { logger: new Logger('', 'debug', mockLog as any), mockLog: mockLog };
+  return { logger: new Logger('', 'debug', mockLog), mockLog };
 }
 
 describe('TypedBroadcastBus', () => {
   let busA: TypedBroadcastBus<string>;
   let busB: TypedBroadcastBus<string>;
-  let loggerA: { debug: Mock<any>; error: Mock<any> };
-  let loggerB: { debug: Mock<any>; error: Mock<any> };
+  let loggerA: ReturnType<typeof makeTestLogger>['mockLog'];
+  let loggerB: ReturnType<typeof makeTestLogger>['mockLog'];
   let controllerA: AbortController;
   let controllerB: AbortController;
 
@@ -148,6 +140,104 @@ describe('TypedBroadcastBus', () => {
     controllerB.abort(); // abort the bus B
     busA.send('Hello after abort');
     expect(handlerB).toHaveBeenCalledTimes(0);
+  });
+
+  it('should stay closed when constructed with an aborted lifetime', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const bus = new TypedBroadcastBus({
+      name: 'test-channel',
+      senderId: 'closed-sender',
+      signal: controller.signal,
+    });
+    const observer = vi.fn();
+    const closedHandler = vi.fn();
+    busB.subscribe(observer, new AbortController().signal);
+    bus.subscribe(closedHandler, new AbortController().signal);
+
+    bus.send('should not be delivered');
+    expect(observer).not.toHaveBeenCalled();
+
+    busB.send('should not reach the closed bus');
+    expect(closedHandler).not.toHaveBeenCalled();
+  });
+
+  it('should ignore subscriptions whose lifetime is already aborted', () => {
+    const controller = new AbortController();
+    controller.abort();
+    const handler = vi.fn();
+
+    busA.subscribe(handler, controller.signal);
+    busA.send('Hello');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('should isolate mutable payloads between memory-channel recipients', () => {
+    type Payload = { nested: { value: string } };
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+    const controllerC = new AbortController();
+    const payloadBusA = new TypedBroadcastBus<Payload>({
+      name: 'payload-channel',
+      senderId: 'payload-senderA',
+      useMemoryChannel: true,
+      signal: controllerA.signal,
+    });
+    const payloadBusB = new TypedBroadcastBus<Payload>({
+      name: 'payload-channel',
+      senderId: 'payload-senderB',
+      useMemoryChannel: true,
+      signal: controllerB.signal,
+    });
+    const busC = new TypedBroadcastBus<Payload>({
+      name: 'payload-channel',
+      senderId: 'payload-senderC',
+      useMemoryChannel: true,
+      signal: controllerC.signal,
+    });
+    const receivedByB: Payload[] = [];
+    const receivedByC: Payload[] = [];
+    payloadBusB.subscribe(
+      (message) => receivedByB.push(message.data),
+      new AbortController().signal,
+    );
+    busC.subscribe(
+      (message) => receivedByC.push(message.data),
+      new AbortController().signal,
+    );
+
+    const payload: Payload = { nested: { value: 'original' } };
+    payloadBusA.send(payload);
+    const firstB = receivedByB[0];
+    const firstC = receivedByC[0];
+
+    expect(firstB).toEqual(payload);
+    expect(firstC).toEqual(payload);
+    expect(firstB).not.toBe(firstC);
+    if (!firstB || !firstC) {
+      throw new Error('Expected both memory-channel recipients to run');
+    }
+    firstB.nested.value = 'mutated';
+    expect(firstC.nested.value).toBe('original');
+    controllerA.abort();
+    controllerB.abort();
+    controllerC.abort();
+  });
+
+  it('should reject non-cloneable memory-channel payloads', () => {
+    const controller = new AbortController();
+    const bus = new TypedBroadcastBus<() => void>({
+      name: 'non-cloneable-payload-channel',
+      senderId: 'sender',
+      useMemoryChannel: true,
+      signal: controller.signal,
+    });
+
+    expect(() => bus.send(() => undefined)).toThrowError(
+      expect.objectContaining({ name: 'DataCloneError' }),
+    );
+    controller.abort();
   });
 
   it('should receive messages from self with native BroadcastChannel', () => {

--- a/packages/js-lib/browser-utils/src/broadcast-channel.ts
+++ b/packages/js-lib/browser-utils/src/broadcast-channel.ts
@@ -33,11 +33,19 @@ export interface TypedBroadcastBusOptions {
   signal: AbortSignal;
 }
 
+interface BroadcastChannelLike {
+  readonly name: string;
+  onmessage: ((event: MessageEvent) => void) | null;
+  postMessage(message: unknown): void;
+  close(): void;
+}
+
 export class TypedBroadcastBus<T> {
-  _channel: BroadcastChannel;
+  _channel: BroadcastChannelLike;
   private handlers = new Set<MessageHandler<T>>();
   private readonly senderId: string;
   private readonly logger?: Logger;
+  private closed = false;
 
   constructor(options: TypedBroadcastBusOptions) {
     this.senderId = options.senderId;
@@ -60,16 +68,23 @@ export class TypedBroadcastBus<T> {
 
     this._channel.onmessage = this.handleMessage;
 
-    options.signal.addEventListener(
-      'abort',
-      () => {
-        this.handlers.clear();
-        this._channel.onmessage = null;
-        this._channel.close();
-      },
-      { once: true },
-    );
+    if (options.signal.aborted) {
+      this.close();
+    } else {
+      options.signal.addEventListener('abort', this.close, { once: true });
+    }
   }
+
+  private close = () => {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+    this.handlers.clear();
+    this._channel.onmessage = null;
+    this._channel.close();
+  };
 
   private handleMessage = (event: MessageEvent) => {
     const rawMessage = event.data as RawBroadcastMessage<T>;
@@ -104,6 +119,10 @@ export class TypedBroadcastBus<T> {
    * Send a message to all listeners on this channel including self.
    */
   send(data: T): void {
+    if (this.closed) {
+      return;
+    }
+
     const rawMessage: RawBroadcastMessage<T> = {
       senderId: this.senderId,
       data,
@@ -122,6 +141,10 @@ export class TypedBroadcastBus<T> {
   }
 
   subscribe(handler: MessageHandler<T>, signal: AbortSignal) {
+    if (this.closed || signal.aborted) {
+      return;
+    }
+
     this.handlers.add(handler);
 
     signal.addEventListener(
@@ -134,7 +157,7 @@ export class TypedBroadcastBus<T> {
   }
 }
 
-export class MemoryBroadcastChannel implements BroadcastChannel {
+export class MemoryBroadcastChannel {
   onmessage: ((event: MessageEvent) => void) | null = null;
   private static channels: Map<string, Set<MemoryBroadcastChannel>> = new Map();
   private closed = false;
@@ -151,13 +174,14 @@ export class MemoryBroadcastChannel implements BroadcastChannel {
   postMessage(data: unknown) {
     if (this.closed) return;
 
-    const event = new MessageEvent('message', { data });
     const channels = MemoryBroadcastChannel.channels.get(this.channelName);
 
     if (channels) {
       for (const channel of channels) {
         if (!channel.closed && channel.onmessage) {
-          channel.onmessage(event);
+          channel.onmessage(
+            new MessageEvent('message', { data: structuredClone(data) }),
+          );
         }
       }
     }
@@ -175,17 +199,4 @@ export class MemoryBroadcastChannel implements BroadcastChannel {
     }
     this.onmessage = null;
   }
-  onmessageerror: ((event: MessageEvent) => void) | null = null;
-
-  addEventListener() {
-    throw new Error('Method not implemented.');
-  }
-
-  removeEventListener() {
-    throw new Error('Method not implemented.');
-  }
-
-  dispatchEvent = () => {
-    throw new Error('Method not implemented.');
-  };
 }

--- a/packages/js-lib/logger/index.ts
+++ b/packages/js-lib/logger/index.ts
@@ -1,4 +1,5 @@
 type LogLevelName = 'debug' | 'info' | 'warn' | 'error';
+type LoggerConsole = Pick<Console, LogLevelName>;
 
 const LogLevelPriority: { [key in LogLevelName]: number } = {
   debug: 10,
@@ -26,7 +27,7 @@ export class Logger {
   constructor(
     private prefix = '',
     private localLogLevel: LogLevelName | null = null,
-    private loggerConsole = console,
+    private loggerConsole: LoggerConsole = console,
   ) {}
 
   /**
@@ -49,25 +50,25 @@ export class Logger {
     return LogLevelPriority[level] >= LogLevelPriority[this.effectiveLogLevel];
   }
 
-  private log(level: LogLevelName, ...message: any[]): void {
+  private log(level: LogLevelName, ...message: unknown[]): void {
     if (this.shouldLog(level)) {
       this.loggerConsole[level](`[${this.prefix}]`, ...message);
     }
   }
 
-  public debug(...message: any[]): void {
+  public debug(...message: unknown[]): void {
     this.log('debug', ...message);
   }
 
-  public info(...message: any[]): void {
+  public info(...message: unknown[]): void {
     this.log('info', ...message);
   }
 
-  public warn(...message: any[]): void {
+  public warn(...message: unknown[]): void {
     this.log('warn', ...message);
   }
 
-  public error(...message: any[]): void {
+  public error(...message: unknown[]): void {
     this.log('error', ...message);
 
     // If the first message is an Error instance, send it to the error reporter

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -14,6 +14,8 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/636
   - https://github.com/bangle-io/bangle-io/pull/638
   - https://github.com/bangle-io/bangle-io/pull/639
+  - https://github.com/bangle-io/bangle-io/pull/641
+  - https://github.com/bangle-io/bangle-io/pull/645
 related_issues: []
 ---
 
@@ -138,6 +140,18 @@ cleanup.
   - Focused real-service coverage forces a database failure after a successful
     load, verifies the prior array and current workspace remain available, and
     proves a later refresh returns the resource to `ready`.
+- 2026-07-13 cross-context lifecycle and type-hygiene cleanup:
+  - P5.4 done: `TypedBroadcastBus` now closes immediately for an already-aborted
+    owner, ignores already-aborted subscriptions, and makes sends after disposal
+    a consistent no-op across native and memory channels.
+  - The in-memory channel now structured-clones a payload independently for
+    each recipient, matching the isolation of the browser channel instead of
+    sharing mutable references between services and tests. Its public type now
+    describes the small channel contract it actually implements rather than
+    carrying throwing `BroadcastChannel` stubs.
+  - P5.1 improved: `Logger` now accepts the four-method console surface it uses,
+    and its message boundary uses `unknown[]` instead of five `any[]`
+    signatures. Browser-bus tests no longer need an unsafe logger cast.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -787,6 +801,8 @@ Plan:
 - Add typed wrappers around native browser APIs that currently require casts.
 - [x] Remove avoidable `any` and obsolete prototype fallback logic from the
   foundational `BaseError` and IndexedDB adapter slice.
+- [x] Narrow the logger console adapter and replace its avoidable `any[]`
+  message boundary with `unknown[]`.
 - Keep intentional negative type tests using `@ts-expect-error`.
 
 Verification:
@@ -845,6 +861,46 @@ Plan:
 Verification:
 
 - [x] Unit tests assert error code and cause shape.
+
+### P5.4 Align Cross-Context Messaging Lifetimes And Payload Isolation
+
+Problem:
+
+- A bus created with an already-aborted owner remained connected because an
+  abort listener added after abort never runs.
+- An already-aborted subscription was still registered and could continue
+  receiving messages indefinitely.
+- Sending after disposal was a silent no-op for the memory channel but could
+  throw through a closed native channel.
+- The memory fallback shared the same mutable payload object with every
+  recipient, unlike native `BroadcastChannel` structured-clone isolation.
+- `MemoryBroadcastChannel` claimed the full browser interface while three
+  inherited event methods only threw `Method not implemented`.
+
+Evidence:
+
+- `packages/js-lib/browser-utils/src/broadcast-channel.ts`
+- `packages/js-lib/browser-utils/__tests__/broadcast-channel.spec.ts`
+
+Plan:
+
+- [x] Close immediately when the owner signal is already aborted.
+- [x] Ignore subscriptions whose signal is already aborted.
+- [x] Make post-disposal sends consistently inert.
+- [x] Structured-clone payloads independently for memory-channel recipients.
+- [x] Type the fallback against the minimal channel contract it supports.
+
+Verification:
+
+- [x] Focused tests cover already-aborted owners and subscriptions.
+- [x] Focused tests prove independent mutable payloads for memory recipients.
+- [x] Browser-utils and logger unit suites pass.
+- [x] Repository project-reference typecheck passes.
+- [x] `pnpm lint:ci`, `pnpm test:ci`, `pnpm build`, and `pnpm e2e:ci`
+  pass. The E2E run had one unrelated cursor-restoration retry.
+- [x] `pnpm local-ci-check` passes every root CI script, including E2E,
+  component tests, desktop builds/tests, and the Electron persistence smoke.
+  Its E2E run had one unrelated file-explorer retry.
 
 ## 2026-07-12 Core/App Containment Re-audit
 


### PR DESCRIPTION
## Summary

- close cross-context buses immediately for already-aborted owners and ignore already-aborted subscriptions
- make post-disposal sends consistent across native and memory channels
- structured-clone memory-channel payloads per recipient and replace the incomplete full `BroadcastChannel` facade with the minimal supported contract
- narrow the logger console/message type boundary and remove the browser-bus test's unsafe casts
- update the durable tech-debt audit and keep the Native FS recovery fixture structured-cloneable

## Verification

- `pnpm vitest packages/js-lib/browser-utils/__tests__/broadcast-channel.spec.ts packages/js-lib/logger packages/core/command-handlers/src/__tests__/native-fs-recovery.spec.ts`
- `pnpm lint:ci`
- `pnpm test:ci`
- `pnpm build`
- `pnpm e2e:ci` (passed; one unrelated cursor-restoration retry)
- `pnpm local-ci-check` (passed every root CI script; one unrelated file-explorer retry)

No deployment performed.
