### PR TITLE
refactor: trim storage, translation, and test debt

### DIFF
--- a/packages/core/editor/src/components/date-picker-menu.tsx
+++ b/packages/core/editor/src/components/date-picker-menu.tsx
@@ -131,6 +131,10 @@ export function DatePickerMenu({
     >
       <Calendar
         mode="single"
+        // The highlighted date starts at today. Without `required`, clicking
+        // that already-selected day toggles the selection to `undefined`, so
+        // the trigger is left behind instead of committing today's date.
+        required
         // Move focus to the selected day so arrow keys navigate the grid and
         // Enter commits, without any editor-side key forwarding.
         autoFocus

--- a/packages/core/omni-search/src/index.tsx
+++ b/packages/core/omni-search/src/index.tsx
@@ -123,7 +123,7 @@ function HomeRoute({
 
     const viewAllCommand: CommandItemProp = {
       id: 'view-all-commands',
-      title: 'View All Commands',
+      title: t.app.omniSearch.viewAllCommands,
       metadata: { type: 'command', cmd: { id: 'view-all-commands', args: {} } },
       onSelect: goToCommandRoute,
     };
@@ -161,13 +161,22 @@ function HomeRoute({
     <>
       {recentFiles.length > 0 && (
         <>
-          <CommandGroupSection heading="Recent Notes" items={recentFiles} />
+          <CommandGroupSection
+            heading={t.app.omniSearch.recentNotesHeading}
+            items={recentFiles}
+          />
           <CommandSeparator />
         </>
       )}
-      <CommandGroupSection heading="> Commands" items={allCommands} />
+      <CommandGroupSection
+        heading={t.app.omniSearch.commandsHeading}
+        items={allCommands}
+      />
       <CommandSeparator />
-      <CommandGroupSection heading="All Files" items={allFiles} />
+      <CommandGroupSection
+        heading={t.app.omniSearch.allFilesHeading}
+        items={allFiles}
+      />
     </>
   );
 }
@@ -206,7 +215,12 @@ function CommandRoute({
     return searchItems(items, search);
   }, [items, search]);
 
-  return <CommandGroupSection heading="> Commands" items={commands} />;
+  return (
+    <CommandGroupSection
+      heading={t.app.omniSearch.commandsHeading}
+      items={commands}
+    />
+  );
 }
 
 function FilteredRoute({
@@ -245,7 +259,7 @@ function FilteredRoute({
 
   return (
     <CommandGroup
-      heading={'Filtered'}
+      heading={t.app.omniSearch.filteredHeading}
       ref={parentRef}
       style={{ height: '428px', overflowY: 'auto' }}
     >
@@ -380,11 +394,11 @@ export function OmniSearch() {
         }
       }}
       shouldFilter={false}
-      screenReaderTitle="omni command bar"
+      screenReaderTitle={t.app.omniSearch.dialogTitle}
     >
       <CommandInput
         ref={commandInputRef}
-        placeholder="Type a command or search..."
+        placeholder={t.app.omniSearch.inputPlaceholder}
         value={search}
         onValueChange={(value) => {
           updateSearch(value);
@@ -412,7 +426,7 @@ export function OmniSearch() {
         )}
 
         <CommandEmpty>
-          <span>No results found.</span>
+          <span>{t.app.omniSearch.noResults}</span>
         </CommandEmpty>
       </CommandList>
     </CommandDialog>

--- a/packages/core/service-core/src/file-system-service.ts
+++ b/packages/core/service-core/src/file-system-service.ts
@@ -10,11 +10,7 @@ import {
   WORKSPACE_STORAGE_TYPE,
   type WorkspaceStorageType,
 } from '@bangle.io/constants';
-import type {
-  BaseFileStorageService,
-  ScopedEmitter,
-  WorkspaceInfo,
-} from '@bangle.io/types';
+import type { BaseFileStorageService, ScopedEmitter } from '@bangle.io/types';
 import { isVisibleWorkspaceFilePath, WsPath } from '@bangle.io/ws-path';
 import { atom } from 'jotai';
 import type { WorkspaceOpsService } from './workspace-ops-service';
@@ -305,11 +301,7 @@ export class FileSystemService extends BaseService {
     );
   }
 
-  public async createFile(
-    wsPath: string,
-    file: File,
-    _options: { sha?: string } = {},
-  ): Promise<void> {
+  public async createFile(wsPath: string, file: File): Promise<void> {
     await this.mountPromise;
     WsPath.assertFile(wsPath);
 
@@ -333,18 +325,12 @@ export class FileSystemService extends BaseService {
     );
   }
 
-  public async writeFile(
-    wsPath: string,
-    file: File,
-    options: { sha?: string } = {},
-  ): Promise<void> {
+  public async writeFile(wsPath: string, file: File): Promise<void> {
     await this.mountPromise;
     WsPath.assertFile(wsPath);
 
     const storageService = await this.getStorageService({ wsPath });
-    await storageService.writeFile(wsPath, file, {
-      sha: options.sha,
-    });
+    await storageService.writeFile(wsPath, file, {});
     this.onChange({
       type: 'file-content-update',
       payload: { wsPath },

--- a/packages/platform/service-platform/src/file-storage-indexeddb.ts
+++ b/packages/platform/service-platform/src/file-storage-indexeddb.ts
@@ -29,8 +29,6 @@ export class FileStorageIndexedDB
   implements BaseFileStorageProvider
 {
   public readonly workspaceType = WORKSPACE_STORAGE_TYPE.Browser;
-  public readonly displayName = 'Browser Storage';
-  public readonly description = "Saves data in your browser's local storage";
   public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.browser;
 
   private idb = new IndexedDBFileSystem();
@@ -107,10 +105,6 @@ export class FileStorageIndexedDB
       ctime: stat.mtimeMs,
       mtime: stat.mtimeMs,
     };
-  }
-
-  isSupported() {
-    return globalThis.indexedDB != null;
   }
 
   async listAllFiles(

--- a/packages/platform/service-platform/src/file-storage-memory.ts
+++ b/packages/platform/service-platform/src/file-storage-memory.ts
@@ -26,8 +26,6 @@ export class FileStorageMemory
   implements BaseFileStorageProvider
 {
   public readonly workspaceType = WORKSPACE_STORAGE_TYPE.Memory;
-  public readonly displayName = 'Memory Storage';
-  public readonly description = 'Temporarily saves data in memory';
   public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.memory;
 
   private fileEntries = new Map<string, FileEntry>();
@@ -115,10 +113,6 @@ export class FileStorageMemory
       ctime: entry.ctime,
       mtime: entry.mtime,
     };
-  }
-
-  isSupported() {
-    return true;
   }
 
   async listAllFiles(

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -2,7 +2,6 @@ import {
   assertIsDefined,
   BaseService,
   type BaseServiceContext,
-  isWorkerGlobalScope,
   throwAppError,
 } from '@bangle.io/base-utils';
 import {
@@ -15,7 +14,6 @@ import {
   isNativeFsError,
   NATIVE_FS_ERROR_CODE,
   NativeFs,
-  supportsNativeFs,
 } from '@bangle.io/native-fs';
 import type {
   BaseFileStorageProvider,
@@ -35,8 +33,6 @@ export class FileStorageNativeFs
   implements BaseFileStorageProvider
 {
   public readonly workspaceType = WORKSPACE_STORAGE_TYPE.NativeFS;
-  public readonly displayName = 'Native Storage';
-  public readonly description = 'Saves data on your hard drive';
   public readonly maxFileSizeBytes = FILE_STORAGE_MAX_FILE_SIZE_BYTES.nativeFs;
 
   private fsCache: Map<string, NativeFs> = new Map();
@@ -192,14 +188,6 @@ export class FileStorageNativeFs
       }
       throw error;
     }
-  }
-
-  isSupported() {
-    // TODO we donot have a great way to detect if supported in worker
-    if (isWorkerGlobalScope()) {
-      return true;
-    }
-    return supportsNativeFs();
   }
 
   async listAllFiles(

--- a/packages/shared/translations/src/__tests__/translations.spec.ts
+++ b/packages/shared/translations/src/__tests__/translations.spec.ts
@@ -1,5 +1,20 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
+import { t as german } from '../languages/de';
+import { t as english } from '../languages/en';
 
-test('works', () => {
-  expect(true).toBe(true);
+describe('omni search translations', () => {
+  test('German covers every English Omni Search message', () => {
+    expect(Object.keys(german.app?.omniSearch ?? {})).toEqual(
+      Object.keys(english.app.omniSearch),
+    );
+  });
+
+  test.each([
+    ['English', english.app.omniSearch],
+    ['German', german.app?.omniSearch],
+  ])('%s messages are non-empty strings', (_language, messages) => {
+    expect(messages).toBeDefined();
+    expect(Object.values(messages ?? {})).not.toContain('');
+    expect(Object.values(messages ?? {})).toHaveLength(8);
+  });
 });

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -142,6 +142,16 @@ export const t = {
         deleteTable: 'Tabelle löschen',
       },
     },
+    omniSearch: {
+      dialogTitle: 'Omni-Befehlsleiste',
+      inputPlaceholder: 'Befehl eingeben oder suchen...',
+      viewAllCommands: 'Alle Befehle anzeigen',
+      recentNotesHeading: 'Letzte Notizen',
+      commandsHeading: '> Befehle',
+      allFilesHeading: 'Alle Dateien',
+      filteredHeading: 'Gefiltert',
+      noResults: 'Keine Ergebnisse gefunden.',
+    },
     sidebar: {
       newLabel: 'Neu',
       appActionsLabel: 'App-Aktionen',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -174,6 +174,16 @@ export const t = {
       switchEditor: 'Switch editor',
       loadFailed: 'Unable to load this note.',
     },
+    omniSearch: {
+      dialogTitle: 'Omni command bar',
+      inputPlaceholder: 'Type a command or search...',
+      viewAllCommands: 'View All Commands',
+      recentNotesHeading: 'Recent Notes',
+      commandsHeading: '> Commands',
+      allFilesHeading: 'All Files',
+      filteredHeading: 'Filtered',
+      noResults: 'No results found.',
+    },
     sidebar: {
       newLabel: 'New',
       appActionsLabel: 'App Actions',

--- a/packages/shared/types/base-file-storage.ts
+++ b/packages/shared/types/base-file-storage.ts
@@ -1,3 +1,5 @@
+import type { WorkspaceStorageType } from '@bangle.io/constants';
+
 type WsPath = string;
 
 interface FileStat {
@@ -34,7 +36,7 @@ type EmptyObject = Record<string, never>;
 
 export interface BaseFileStorageProvider {
   readonly maxFileSizeBytes: number;
-  readonly workspaceType: string;
+  readonly workspaceType: WorkspaceStorageType;
 
   /**
    * Creates a new file. Implementations must reject with
@@ -74,8 +76,6 @@ export interface BaseFileStorageProvider {
   writeFile: (
     wsPath: WsPath,
     file: File,
-    options: {
-      sha?: string;
-    },
+    options: EmptyObject,
   ) => Promise<void>;
 }

--- a/packages/shared/types/base-file-storage.ts
+++ b/packages/shared/types/base-file-storage.ts
@@ -33,14 +33,8 @@ export type FileStorageChangeEvent =
 type EmptyObject = Record<string, never>;
 
 export interface BaseFileStorageProvider {
-  readonly description: string;
-  readonly displayName: string;
-  // hide creating a workspace of this type
-  readonly hidden?: boolean;
   readonly maxFileSizeBytes: number;
   readonly workspaceType: string;
-
-  isSupported: () => boolean | Promise<boolean>;
 
   /**
    * Creates a new file. Implementations must reject with
@@ -84,13 +78,4 @@ export interface BaseFileStorageProvider {
       sha?: string;
     },
   ) => Promise<void>;
-
-  searchFile?: (
-    abortSignal: AbortSignal,
-    options: {
-      query: { pattern: string };
-    },
-  ) => Promise<WsPath[]>;
-
-  searchText?: () => Promise<void>;
 }

--- a/packages/tooling/e2e-tests/src/common.ts
+++ b/packages/tooling/e2e-tests/src/common.ts
@@ -358,7 +358,15 @@ export async function createBrowserWorkspaceAndNote(
   await page.getByRole('button', { name: 'New Note' }).click();
   await page.getByLabel('Note name').fill(noteName);
   await page.getByRole('button', { name: 'Create' }).click();
-  await expect(getEditorLocator(page, {})).toBeVisible();
+  const editor = getEditorLocator(page, {});
+  const fileName = noteName.endsWith('.md') ? noteName : `${noteName}.md`;
+  await expect(editor).toBeVisible();
+  // A previous note editor can remain visible while navigation mounts the new
+  // one. Waiting for the exact editor identity prevents immediate follow-up
+  // typing or shortcuts from targeting a stale view that is about to unmount.
+  await expect
+    .poll(() => editor.getAttribute('data-editor-name'))
+    .toContain(`${workspaceName}:${fileName}`);
 }
 
 export async function createBrowserWorkspace(

--- a/packages/tooling/e2e-tests/src/tables.e2e.ts
+++ b/packages/tooling/e2e-tests/src/tables.e2e.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import {
+  collapseEditorSelectionAfterText,
   createBrowserWorkspaceAndNote,
   getEditorLocator,
   readStoredMarkdown,
@@ -277,13 +278,11 @@ test('arrow keys navigate cell edges and exit the table at its boundaries', asyn
   const editor = getEditorLocator(page, {});
   await expect(editor.locator('table')).toBeVisible();
 
-  // One initial click; everything after navigates by keyboard so the test
-  // exercises the caret behavior users actually rely on.
-  await editor.locator('table td', { hasText: 'c1' }).click();
-  await waitForEditorFocus(page, {});
+  // Place the initial caret deterministically; everything after navigates by
+  // keyboard so the test exercises the caret behavior users actually rely on.
+  await collapseEditorSelectionAfterText(page, 'c1');
 
   // ArrowRight at the end of a cell hops to the start of the next cell.
-  await page.keyboard.press('End');
   await page.keyboard.press('ArrowRight');
   await page.keyboard.insertText('X');
   await expect(editor.locator('table td').nth(1)).toHaveText('Xd1');

--- a/packages/tooling/e2e-tests/src/translations-locale.e2e.ts
+++ b/packages/tooling/e2e-tests/src/translations-locale.e2e.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
+import { pressAppShortcut } from './common';
 
 /** Locale bundle filenames (e.g. `['en.js', 'de.js']`) fetched so far, in order. */
 async function loadedLocaleFiles(page: Page): Promise<string[]> {
@@ -57,8 +58,25 @@ test.describe('translations delivery', () => {
       expect(await activeLanguage(page)).toBe('Deutsch');
 
       // English is always loaded first as the fallback base, then German is
-      // merged on top - never every language.
+      // merged on top - never every language. Check this before further UI
+      // activity so the assertion observes bootstrap request order directly.
       expect(await loadedLocaleFiles(page)).toEqual(['en.js', 'de.js']);
+
+      await pressAppShortcut(page, 'k');
+      const omniSearch = page.getByRole('dialog', {
+        name: 'Omni-Befehlsleiste',
+      });
+      const omniInput = omniSearch.getByPlaceholder(
+        'Befehl eingeben oder suchen...',
+      );
+      await expect(omniSearch).toBeVisible();
+      await expect(omniSearch.getByText('> Befehle')).toBeVisible();
+      await expect(omniSearch.getByText('Alle Dateien')).toBeVisible();
+      await expect(omniSearch.getByText('Alle Befehle anzeigen')).toBeVisible();
+      await omniInput.fill('definitely-no-result');
+      await expect(
+        omniSearch.getByText('Keine Ergebnisse gefunden.'),
+      ).toBeVisible();
     });
   });
 });

--- a/packages/ui/base-ui/src/__tests__/calendar.spec.tsx
+++ b/packages/ui/base-ui/src/__tests__/calendar.spec.tsx
@@ -45,6 +45,30 @@ describe('Calendar', () => {
     expect(selected.getDate()).toBe(24);
   });
 
+  it('keeps a required selected day when it is clicked again', () => {
+    const onSelect = vi.fn();
+    const selected = new Date(2025, 11, 24);
+    render(
+      <Calendar
+        mode="single"
+        required
+        defaultMonth={DECEMBER_2025}
+        selected={selected}
+        onSelect={onSelect}
+      />,
+    );
+
+    const dayButton = document.querySelector(
+      `[data-day="${selected.toLocaleDateString()}"]`,
+    );
+    expect(dayButton).not.toBeNull();
+
+    fireEvent.click(dayButton as Element);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]?.[0]).toEqual(selected);
+  });
+
   it('marks the selected day with the single-selection data attribute', () => {
     const selected = new Date(2025, 11, 24);
     render(

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-15
-updated: 2026-07-13
+updated: 2026-07-14
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
@@ -167,6 +167,21 @@ cleanup.
     invalid caller behavior. The stale browser-entry `eslint` script and the
     original command-dialog/radio-control accessibility findings were verified
     already resolved on `main` and are reconciled below.
+- 2026-07-14 storage-contract and translation hygiene cleanup (batch 3):
+  - P3.3 done: every Omni Search heading, action, empty state, placeholder, and
+    accessible dialog title now uses the global translation object. English
+    and German carry the complete eight-message surface, and locale E2E opens
+    the German command bar and verifies translated user-visible behavior.
+  - P5.1 improved: `BaseFileStorageProvider` no longer advertises six
+    zero-consumer metadata, capability, and search members. The three concrete
+    storage providers no longer carry the corresponding dead labels or
+    support-probe methods.
+  - The full open-item re-audit kept C3/C4, P0.4, and Native FS work out of this
+    batch because PR #640 owns relocation/save-queue changes, PR #644 owns the
+    Native FS settings command, PR #626 owns external sync, and the existing
+    service-architecture and Knip worktrees cover broader boundary/dead-code
+    changes. C6, C8, P1.3, P4.4, and P5.2 are narrowed below to match current
+    code instead of retaining stale claims.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -405,12 +420,16 @@ Verification:
 
 ### P1.3 Harden List And Task-List Parsing
 
-Problem:
+Current status:
 
-- List parsing ignores `bullet_list` and `ordered_list` tokens and depends on
-  custom token attributes for kind and checked state.
-- Standard task-list Markdown may not round-trip reliably without explicit
-  parser coverage.
+- The shared golden corpus now covers unchecked, checked, uppercase, nested,
+  mixed, linked, marked-up, and empty task items for both editor engines.
+- ProseMirror explicitly ignores wrapper `bullet_list`/`ordered_list` tokens
+  and derives flat list items from the configured kind/checked attributes.
+- Nested content under an ordered parent still has a documented indentation
+  fidelity gap and is deliberately excluded from the passing corpus. That is
+  the remaining correctness item; the original general task-list coverage gap
+  is resolved.
 
 Evidence:
 
@@ -418,10 +437,13 @@ Evidence:
 
 Plan:
 
-- Add tests for `- [ ]`, `- [x]`, nested ordered/bullet lists, and mixed lists.
-- Derive task-list state from standard Markdown tokens or configure the parser
+- [x] Add tests for `- [ ]`, `- [x]`, nested task/bullet lists, and mixed
+  task/plain lists.
+- [x] Derive task-list state from standard Markdown tokens or configure the parser
   explicitly to emit the required attrs.
-- Document list normalization rules in tests.
+- [x] Document task-list normalization rules in tests.
+- Fix or intentionally normalize nested list indentation under ordered parents,
+  then add that case to the golden corpus.
 
 Verification:
 
@@ -583,18 +605,20 @@ Evidence:
 
 Plan:
 
-- Add missing keys to `packages/shared/translations/src/languages/en.ts`.
-- Replace the remaining Omni Search group headings, empty state, accessible
+- [x] Add the complete Omni Search surface to the English and German bundles.
+- [x] Replace the remaining Omni Search group headings, empty state, accessible
   dialog name, and input placeholder with global `t` references.
 - [x] Verify the audited app-sidebar, slash-command, link-menu, and star-button
   strings use the global `t` object.
 - [x] Remove direct `t` imports from the audited production UI components.
-- Extend translation tests to catch imported `t` or common literal patterns.
+- [x] Replace the placeholder translation test with bundle parity coverage and
+  add German-locale browser coverage for the Omni Search surface.
 
 Verification:
 
-- `packages/core/app/src/__tests__/translation.spec.ts`
-- `packages/shared/translations/src/__tests__/translations.spec.ts`
+- [x] `packages/core/app/src/__tests__/translation.spec.ts`
+- [x] `packages/shared/translations/src/__tests__/translations.spec.ts`
+- [x] `packages/tooling/e2e-tests/src/translations-locale.e2e.ts`
 
 ### P3.4 Fix Dialog And Custom Control Accessibility
 
@@ -756,7 +780,7 @@ Plan:
 - Replace broad `skipValidation` with narrow exceptions.
 - Classify test, story, CT, E2E, and config files explicitly.
 - Fix or document import-parser limitations around comments.
-- Add a validation rule for package-private `src` imports.
+- [x] Add a validation rule for package-private `src` imports.
 
 Verification:
 
@@ -819,6 +843,9 @@ Plan:
   message boundary with `unknown[]`.
 - [x] Move mini validators, weak caches, and command validator inspection to
   `unknown`/object-constrained boundaries.
+- [x] Remove the zero-consumer storage-provider labels, hidden/support flags,
+  and optional search methods from the public provider contract and concrete
+  adapters.
 - Keep intentional negative type tests using `@ts-expect-error`.
 
 Verification:
@@ -828,12 +855,14 @@ Verification:
 
 ### P5.2 Standardize File Filtering Across Storage Backends
 
-Problem:
+Current status:
 
-- Native FS uses permissive `allowedFile: () => true` at the adapter boundary.
-- IndexedDB has a TODO for directory filtering.
-- Filtering currently happens later in `FileSystemService.listFiles`, which may
-  be too late for adapter-specific hazards.
+- Shared file and directory visibility policy now lives in `@bangle.io/ws-path`
+  with focused hidden/system-file coverage.
+- Native FS applies the shared directory policy while walking the tree.
+- IndexedDB and memory still return unfiltered adapter listings; the shared
+  file policy is applied later by `FileSystemService.listFiles`. Moving that
+  file filtering to every adapter, with contract coverage, remains open.
 
 Evidence:
 
@@ -844,9 +873,10 @@ Evidence:
 
 Plan:
 
-- Centralize supported file and ignored directory policy in a shared lower-layer
+- [x] Centralize supported file and ignored directory policy in a shared lower-layer
   helper that platform can import.
-- Apply filtering consistently in Native FS, IndexedDB, and memory adapters.
+- Apply file filtering consistently in Native FS, IndexedDB, and memory
+  adapters without changing direct-file access semantics.
 - Add tests for hidden/system/unsupported files.
 
 Verification:
@@ -936,11 +966,11 @@ listed so future agents do not rediscover it or accidentally restore it.
 | C1 | Resolved in 2026-07-13 workspace refresh continuity cleanup | `WorkspaceStateService` now derives `$workspaces` from an explicit `$workspaceListState` resource. Failed refreshes retain the last successful data and error, preserve `$currentWsName`, and can recover to `ready`; real-service coverage forces the full success-failure-recovery sequence. | Critical / medium |
 | C2 | Resolved in PR #631 | `PmEditorService` now caches `markdownLoader` instances per ProseMirror `Schema` in a `WeakMap`. A real two-editor regression proves paste uses the active editor schema. | High / small-medium |
 | C3 | Partial | PR #631 made the Native FS metadata lookup awaitable and report invalid metadata as command failure. `CommandDispatchService.dispatch()` still returns `void`, reports a missing handler as success, converts null args with `args || {}`, releases cycle/focus state before async completion, and detaches non-app async errors. Native FS permission work also occurs later in a dialog callback, outside command completion. Make command completion an awaitable typed result and move callback-owned workflows behind feature controllers. | Critical / medium |
-| C4 | Open | The editor save-queue store remains module-global while each queued task captures the writer and error emitter from the service instance that enqueued it. UI reload rebuilds the service graph, so retrying a retained failure can execute through a disposed graph. Move the store to an explicit root-lifetime coordinator and resolve the current writer at execution time; test a failed save across `event::app:reload-ui`. | Critical data safety / medium |
+| C4 | Open; coordinate after PR #640 | The editor save-queue store remains module-global while each queued task captures the writer and error emitter from the service instance that enqueued it. UI reload rebuilds the service graph, so retrying a retained failure can execute through a disposed graph. PR #640 is actively changing relocation and save-queue behavior but does not own this service-graph lifetime boundary. Move the store to an explicit root-lifetime coordinator and resolve the current writer at execution time; test a failed save across `event::app:reload-ui`. | Critical data safety / medium |
 | C5 | Resolved in 2026-07-12 workspace dialog cleanup | `CreateWorkspaceDialog` now accepts and awaits async durable creation, blocks duplicate submission and dismissal while pending, preserves the dialog with an alert on failure, and permits retry. Component coverage counts one callback for a double-click; app E2E exercises the real duplicate-workspace service rejection. | High / medium |
-| C6 | Open | `PageAsset` catches every storage, permission, decode, and object-URL failure, discards the cause, and renders the same generic copy as a missing file. Preserve missing vs failed states, emit/log the error, expose retry/recovery, and test Native FS permission loss. Plan 006 owns the broader unreadable-asset UX. | High / small-medium |
+| C6 | Partial; plan 006 owns the UX | `PageAsset` now has distinct internal `missing` and `error` states, but its catch still discards storage/permission/decode/object-URL causes and both states render the same generic unavailable copy. Emit/log the retained error, expose retry/recovery, and test Native FS permission loss after PR #626's external-sync work settles. | High / small-medium |
 | C7 | Resolved in PR #631 | Workspace info cache entries are keyed by workspace name and filtered after lookup. Memory storage now compares parsed workspace names exactly and rejects rename over an existing destination, with focused contract regressions. | Medium-high / small |
-| C8 | In PR #632 | Settings return-link validation now rejects both raw scheme-relative inputs and paths that normalize to `//host/...`; the latter previously passed the same-host check and became an external anchor when reserialized. Keep unit and browser E2E coverage for the normalized path. | Security blocker / small |
+| C8 | Resolved in PR #632 | Settings return-link validation rejects both raw scheme-relative inputs and paths that normalize to `//host/...`; unit and browser E2E coverage retain the normalized-path regression. | Security blocker / small |
 
 ### Architecture And Ownership Backlog
 

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -9,6 +9,7 @@ updated: 2026-07-14
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
+  - https://github.com/bangle-io/bangle-io/pull/647
   - https://github.com/bangle-io/bangle-io/pull/632
   - https://github.com/bangle-io/bangle-io/pull/635
   - https://github.com/bangle-io/bangle-io/pull/636
@@ -167,7 +168,8 @@ cleanup.
     invalid caller behavior. The stale browser-entry `eslint` script and the
     original command-dialog/radio-control accessibility findings were verified
     already resolved on `main` and are reconciled below.
-- 2026-07-14 storage-contract and translation hygiene cleanup (batch 3):
+- 2026-07-14 storage-contract and translation hygiene cleanup (batch 3, PR
+  #647):
   - P3.3 done: every Omni Search heading, action, empty state, placeholder, and
     accessible dialog title now uses the global translation object. English
     and German carry the complete eight-message surface, and locale E2E opens

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -177,7 +177,14 @@ cleanup.
   - P5.1 improved: `BaseFileStorageProvider` no longer advertises six
     zero-consumer metadata, capability, and search members. The three concrete
     storage providers no longer carry the corresponding dead labels or
-    support-probe methods.
+    support-probe methods. The follow-up removes the unused `sha` create/write
+    option path and narrows provider workspace types to the existing typed
+    storage union.
+  - P4.2 improved: the shared create-workspace/note E2E helper now waits for
+    the exact new editor identity instead of any visible editor, preventing
+    follow-up typing and shortcuts from racing a stale view. The date picker
+    also makes its initial single-day selection required so selecting today
+    commits instead of toggling to an empty selection in UTC CI.
   - The full open-item re-audit kept C3/C4, P0.4, and Native FS work out of this
     batch because PR #640 owns relocation/save-queue changes, PR #644 owns the
     Native FS settings command, PR #626 owns external sync, and the existing
@@ -727,6 +734,8 @@ Plan:
 - [x] Upload `packages/tooling/e2e-tests/playwright-report/` and relevant
   `test-results/` paths.
 - [x] Move component-style tests to CT or import from `@playwright/test`.
+- [x] Wait for the exact newly created note editor before follow-up E2E input,
+  and cover selecting an already-selected current day in the slash date picker.
 
 Verification:
 
@@ -848,6 +857,8 @@ Plan:
 - [x] Remove the zero-consumer storage-provider labels, hidden/support flags,
   and optional search methods from the public provider contract and concrete
   adapters.
+- [x] Remove the zero-consumer `sha` create/write options and constrain provider
+  workspace types to `WorkspaceStorageType`.
 - Keep intentional negative type tests using `@ts-expect-error`.
 
 Verification:


### PR DESCRIPTION
## Summary

- remove six zero-consumer metadata, capability, and search members from `BaseFileStorageProvider`, plus the dead implementations carried by Browser, memory, and Native FS adapters
- remove the unused file-write `sha` option path and narrow provider `workspaceType` from `string` to `WorkspaceStorageType`
- move all eight remaining Omni Search headings, actions, empty-state, placeholder, and accessible-name strings behind the global translation object, with complete English/German coverage
- require the date picker selection so choosing an already-selected current day still inserts the date, with a focused calendar regression test
- make the shared E2E workspace/note helper wait for the exact editor identity instead of accepting a stale visible editor
- replace a click-plus-`End` table test race with the repository's deterministic caret helper
- reconcile the active tech-debt audit with current code and live ownership, including narrowed C6/P1.3/P5.2 findings and resolved C8/P4.2/P4.4/P5.1 claims

## Why

This batch reduces misleading production API surface, closes a complete user-visible translation gap, fixes the UTC/current-day CI failure, and removes two broadly relevant Playwright races without widening architectural scope. It intentionally leaves relocation/save-queue work to #640, Native FS locate-folder work to #644, external-sync work to #626, and broader service/Knip cleanup to their existing worktrees.

The branch was created from and reverified against exact `origin/main` base `2e395a833b09d329cd228f98313114267645b78e` (`refactor: harden foundational utilities (#646)`). `origin/main` did not advance, so the requested rebase was a verified no-op.

## CI failure diagnosis

GitHub ran on July 15 UTC. Both failing date-command tests selected July 15, which was already the calendar's selected day; single-selection mode toggled it to `undefined`, so the handler correctly declined to insert a date. Making the selection required preserves the intended current-day action. The other three GitHub retries exposed a shared helper that could accept the previous visible editor before the newly created note mounted; it now waits for the expected `data-editor-name`.

## Validation

- `pnpm lint:ci`
- `pnpm test:ci` — 154 files, 2,103 passed, 1 skipped
- `pnpm build`
- focused translations/storage Vitest suites — 44 passed
- focused calendar Vitest suite — 5 passed
- UTC date-command regression, repeated 3 times each — 6 passed
- table keyboard-navigation regression, repeated 10 times — 10 passed
- standalone `pnpm e2e:ci` — 152 browser E2E and 8 component tests passed without retries
- final `BANGLE_PORT_SEED=batch3-followup-final-2 pnpm local-ci-check` on `a6d5df2f` — every root `*:ci` script passed without retries, including 152 browser E2E tests, 8 component tests, browser/desktop builds, and the Electron persistence smoke

An earlier aggregate run exposed one retry-only table navigation flake. It was traced to click-plus-visual-line-key caret setup, fixed with the existing deterministic selection helper, then verified 10 consecutive times and by the clean final aggregate run.

No deployment was performed.
