### PR TITLE
fix(native-fs): request readwrite via explicit requestPermission so Chrome persists the grant

### DIFF
--- a/packages/js-lib/native-fs/src/__tests__/picker-and-permissions.spec.ts
+++ b/packages/js-lib/native-fs/src/__tests__/picker-and-permissions.spec.ts
@@ -101,7 +101,26 @@ describe('pickDirectory', () => {
 
     const handle = await pickDirectory({ id: 'bangle-ws' });
     expect(handle).toBe(asRootHandle(dir));
-    expect(picker).toHaveBeenCalledWith({ id: 'bangle-ws', mode: 'readwrite' });
+    expect(picker).toHaveBeenCalledWith({ id: 'bangle-ws' });
+  });
+
+  it('requests readwrite via requestPermission, not the picker mode option', async () => {
+    // Chrome persists explicit requestPermission grants across sessions
+    // (enabling the "Allow on every visit" restore prompt); picker-mode
+    // grants have not reliably been persisted. Keep the upfront prompt on
+    // the requestPermission path.
+    const dir = new FakeDirectoryHandle('picked');
+    dir.permissions = { read: 'granted', readwrite: 'prompt' };
+    const requestPermissionSpy = vi.spyOn(dir, 'requestPermission');
+    const picker = vi.fn(async () => asRootHandle(dir));
+    vi.stubGlobal('showDirectoryPicker', picker);
+
+    await pickDirectory({ id: 'bangle-ws' });
+    expect(picker).toHaveBeenCalledWith(
+      expect.not.objectContaining({ mode: expect.anything() }),
+    );
+    expect(requestPermissionSpy).toHaveBeenCalledWith({ mode: 'readwrite' });
+    expect(dir.permissions.readwrite).toBe('granted');
   });
 
   it('maps user cancellation to userAborted', async () => {

--- a/packages/js-lib/native-fs/src/picker.ts
+++ b/packages/js-lib/native-fs/src/picker.ts
@@ -30,7 +30,14 @@ export async function pickDirectory(
 
   let handle: FileSystemDirectoryHandle;
   try {
-    handle = await showDirectoryPicker({ mode, ...rest });
+    // `mode` is deliberately NOT forwarded to the picker. A picker-time
+    // readwrite grant makes the explicit `requestPermission` below a no-op,
+    // and Chrome has not reliably recorded picker-mode grants as persisted
+    // grants — losing the "Allow on every visit" restore prompt on the next
+    // visit, so users were re-prompted on every return. Picking read-only and
+    // then explicitly requesting `mode` keeps the upfront prompt on the
+    // requestPermission path, which Chrome persists across sessions.
+    handle = await showDirectoryPicker({ ...rest });
   } catch (error) {
     if (isAbortError(error)) {
       throw new NativeFsError({
@@ -57,9 +64,8 @@ export async function pickDirectory(
     });
   }
 
-  // Passing `mode` to the picker already prompts for it in Chrome 105+, in
-  // which case this resolves immediately; older implementations that ignored
-  // the option get the explicit prompt instead.
+  // The explicit permission prompt for `mode`; see the note above on why this
+  // must stay the prompting step rather than the picker's `mode` option.
   let granted: boolean;
   try {
     granted = await requestPermission(handle, mode);

--- a/packages/js-lib/native-fs/src/types.ts
+++ b/packages/js-lib/native-fs/src/types.ts
@@ -12,7 +12,12 @@ export interface DirectoryPickerOpts {
    * reopens the picker where the user left off.
    */
   id?: string;
-  /** Requesting `readwrite` up front avoids a second permission prompt. */
+  /**
+   * Permission mode `pickDirectory` explicitly requests after picking
+   * (defaults to `readwrite`). Requested via `requestPermission`, not the
+   * picker's own `mode` option, so the grant is persisted across sessions —
+   * see the note in `pickDirectory`.
+   */
   mode?: NativeFsPermissionMode;
   startIn?: FileSystemHandle | string;
 }


### PR DESCRIPTION
## Problem

Since #622 replaced baby-fs, `pickDirectory` forwarded `mode: 'readwrite'` to `showDirectoryPicker`, so the directory grant happened at pick time and the follow-up `requestPermission` call became a silent no-op (single prompt at workspace creation).

Chrome only reliably records grants made through the explicit `requestPermission()` prompt path as *persisted grant objects*. Without a persisted grant from the prior session, a returning visit is not eligible for the three-way restore prompt — the one that offers **"Allow on every visit"** (`ChromeFileSystemAccessPermissionContext::IsEligibleToUpgradePermissionRequestToRestorePrompt` requires `HasPersistedGrantObject(...)` for the handle's path). Users instead get a plain Allow/Don't-allow prompt with no way to grant permanently, so closing the tab and coming back re-prompts on every visit.

## Fix

Restore the pre-#622 baby-fs prompting shape in `pickDirectory`:

- pick with the default read-only picker (no `mode` forwarded), then
- explicitly `requestPermission({ mode: 'readwrite' })` upfront.

The explicit prompt is what Chrome persists across sessions, restoring eligibility for the "Allow on every visit" restore prompt on return visits. Comments in `picker.ts`/`types.ts` pin the rationale so `mode` doesn't get re-forwarded in a future cleanup.

## Tests

- New regression spec: picker is never called with `mode`; `requestPermission` is explicitly invoked with the requested mode.
- `pnpm local-ci-check` green end to end (lint:ci, 2096 unit tests, full Playwright E2E + CT, build, Electron persistence smoke).
- Note: the Chrome permission UI itself is not automatable; the cross-session behavior needs a one-time manual check on real Chrome (create Native FS workspace → close tab → reopen → the prompt should offer "Allow on every visit").

🤖 Generated with [Claude Code](https://claude.com/claude-code)