### PR TITLE
fix: keep editor save retries on current service graph

### DIFF
--- a/packages/core/editor/src/__tests__/editor-save-queue.spec.ts
+++ b/packages/core/editor/src/__tests__/editor-save-queue.spec.ts
@@ -1,7 +1,7 @@
 import { type BaseError, getAppErrorCause } from '@bangle.io/base-utils';
 import { describe, expect, it, vi } from 'vitest';
 import {
-  createEditorSaveQueueStore,
+  createEditorSaveCoordinator,
   EditorSaveQueue,
 } from '../editor-save-queue';
 
@@ -376,9 +376,9 @@ describe('EditorSaveQueue', () => {
     expect(queue.getStatus('workspace:note.md')).toEqual({ status: 'clean' });
   });
 
-  it('serializes writes across queue instances that share a store', async () => {
+  it('serializes writes across queue instances that share a coordinator', async () => {
     const firstWrite = createDeferred<void>();
-    const store = createEditorSaveQueueStore();
+    const coordinator = createEditorSaveCoordinator();
     const writes: Array<{ doc: string; source: string }> = [];
     const firstQueue = new EditorSaveQueue(
       vi.fn((_: string, doc: string) => {
@@ -386,18 +386,20 @@ describe('EditorSaveQueue', () => {
         return firstWrite.promise;
       }),
       vi.fn(),
-      store,
+      coordinator,
     );
+
+    firstQueue.enqueue('workspace:note.md', 'old service content');
+
     const secondQueue = new EditorSaveQueue(
       vi.fn((_: string, doc: string) => {
         writes.push({ doc, source: 'second' });
         return Promise.resolve();
       }),
       vi.fn(),
-      store,
+      coordinator,
     );
 
-    firstQueue.enqueue('workspace:note.md', 'old service content');
     secondQueue.enqueue('workspace:note.md', 'new service content');
 
     expect(writes).toEqual([{ doc: 'old service content', source: 'first' }]);
@@ -414,18 +416,64 @@ describe('EditorSaveQueue', () => {
     });
   });
 
-  it('notifies subscribers across queue instances that share a store', async () => {
+  it('retries a retained failure through the current service graph', async () => {
+    const coordinator = createEditorSaveCoordinator();
+    const oldFailure = new Error('old service graph unavailable');
+    const oldWriter = vi.fn(() => Promise.reject(oldFailure));
+    const oldEmitAppError = vi.fn<(error: BaseError) => void>();
+    const oldQueue = new EditorSaveQueue(
+      oldWriter,
+      oldEmitAppError,
+      coordinator,
+    );
+
+    oldQueue.enqueue('workspace:note.md', 'retained unsaved content');
+    await flushMicrotasks();
+
+    expect(oldQueue.getStatus('workspace:note.md')).toEqual({
+      error: oldFailure,
+      status: 'failed',
+    });
+
+    const currentWriter = vi.fn(() => Promise.resolve());
+    const currentEmitAppError = vi.fn<(error: BaseError) => void>();
+    const currentQueue = new EditorSaveQueue(
+      currentWriter,
+      currentEmitAppError,
+      coordinator,
+    );
+
+    // A retry action retained by the previous UI graph still enters through
+    // its old queue facade. The coordinator must resolve the new graph's
+    // writer when the retained document actually executes.
+    expect(oldQueue.retryFailed('workspace:note.md')).toBe(true);
+    await flushMicrotasks();
+
+    expect(oldWriter).toHaveBeenCalledTimes(1);
+    expect(currentWriter).toHaveBeenCalledWith(
+      'workspace:note.md',
+      'retained unsaved content',
+    );
+    expect(currentQueue.getStatus('workspace:note.md')).toEqual({
+      status: 'clean',
+    });
+    expect(currentEmitAppError).not.toHaveBeenCalled();
+  });
+
+  it('notifies subscribers across queue instances that share a coordinator', async () => {
     const firstWrite = createDeferred<void>();
-    const store = createEditorSaveQueueStore();
+    const coordinator = createEditorSaveCoordinator();
     const firstQueue = new EditorSaveQueue(
       vi.fn(() => firstWrite.promise),
       vi.fn(),
-      store,
+      coordinator,
     );
-    const secondQueue = new EditorSaveQueue(vi.fn(), vi.fn(), store);
-    const secondListener = vi.fn();
 
     firstQueue.enqueue('workspace:note.md', 'old service content');
+
+    const secondQueue = new EditorSaveQueue(vi.fn(), vi.fn(), coordinator);
+    const secondListener = vi.fn();
+
     expect(secondQueue.hasPendingOrFailed()).toBe(true);
 
     const unsubscribe = secondQueue.subscribe(secondListener);

--- a/packages/core/editor/src/editor-save-queue.ts
+++ b/packages/core/editor/src/editor-save-queue.ts
@@ -10,6 +10,9 @@ type ErrorHandler = (error: BaseError) => void;
 
 type SaveTask = {
   doc: string;
+};
+
+type EditorSaveSession = {
   emitAppError: ErrorHandler;
   writeDoc: SaveWriter;
 };
@@ -32,13 +35,19 @@ type SaveStatusSubscription = {
   wsPath?: string;
 };
 
-type EditorSaveQueueStore = {
+/**
+ * Browser-root state shared by each editor service graph created in this tab.
+ * Queued documents can outlive a UI reload, while the current session always
+ * points at the newest graph's writer and error boundary.
+ */
+export type EditorSaveCoordinator = {
+  currentSession?: EditorSaveSession;
   entries: Map<string, SaveEntry>;
   lastHasPendingOrFailed: boolean;
   subscriptions: Set<SaveStatusSubscription>;
 };
 
-export function createEditorSaveQueueStore(): EditorSaveQueueStore {
+export function createEditorSaveCoordinator(): EditorSaveCoordinator {
   return {
     entries: new Map(),
     lastHasPendingOrFailed: false,
@@ -48,19 +57,17 @@ export function createEditorSaveQueueStore(): EditorSaveQueueStore {
 
 export class EditorSaveQueue {
   constructor(
-    private writeDoc: SaveWriter,
-    private emitAppError: ErrorHandler,
-    private store: EditorSaveQueueStore = createEditorSaveQueueStore(),
-  ) {}
+    writeDoc: SaveWriter,
+    emitAppError: ErrorHandler,
+    private coordinator: EditorSaveCoordinator = createEditorSaveCoordinator(),
+  ) {
+    this.coordinator.currentSession = { writeDoc, emitAppError };
+  }
 
   enqueue(wsPath: string, doc: string): void {
     const entry = this.getEntry(wsPath);
     entry.failedTask = undefined;
-    entry.pendingTask = {
-      doc,
-      emitAppError: this.emitAppError,
-      writeDoc: this.writeDoc,
-    };
+    entry.pendingTask = { doc };
     entry.status = { status: 'pending' };
     this.notifySaveStatusChanged(wsPath);
 
@@ -70,7 +77,7 @@ export class EditorSaveQueue {
   }
 
   getStatus(wsPath: string): EditorSaveStatus {
-    return this.store.entries.get(wsPath)?.status ?? { status: 'clean' };
+    return this.coordinator.entries.get(wsPath)?.status ?? { status: 'clean' };
   }
 
   hasPendingOrFailed(wsPath?: string): boolean {
@@ -78,7 +85,7 @@ export class EditorSaveQueue {
       return this.getStatus(wsPath).status !== 'clean';
     }
 
-    for (const entry of this.store.entries.values()) {
+    for (const entry of this.coordinator.entries.values()) {
       if (entry.status.status !== 'clean') {
         return true;
       }
@@ -89,9 +96,9 @@ export class EditorSaveQueue {
 
   subscribe(listener: SaveStatusListener, wsPath?: string): () => void {
     const subscription = { listener, wsPath };
-    this.store.subscriptions.add(subscription);
+    this.coordinator.subscriptions.add(subscription);
     return () => {
-      this.store.subscriptions.delete(subscription);
+      this.coordinator.subscriptions.delete(subscription);
     };
   }
 
@@ -105,11 +112,11 @@ export class EditorSaveQueue {
       return;
     }
 
-    const entry = this.store.entries.get(oldWsPath);
+    const entry = this.coordinator.entries.get(oldWsPath);
     if (!entry) {
       return;
     }
-    const destinationEntry = this.store.entries.get(newWsPath);
+    const destinationEntry = this.coordinator.entries.get(newWsPath);
     if (destinationEntry && destinationEntry !== entry) {
       // The durable rename makes the source entry authoritative. Retire any
       // stale destination producer, then replay the latest source task after
@@ -129,14 +136,14 @@ export class EditorSaveQueue {
       if (entry.activeTask) {
         entry.pendingTask ??= entry.activeTask;
       }
-      if (this.store.entries.get(newWsPath) === destinationEntry) {
-        this.store.entries.delete(newWsPath);
+      if (this.coordinator.entries.get(newWsPath) === destinationEntry) {
+        this.coordinator.entries.delete(newWsPath);
       }
     }
 
-    this.store.entries.delete(oldWsPath);
+    this.coordinator.entries.delete(oldWsPath);
     entry.wsPath = newWsPath;
-    this.store.entries.set(newWsPath, entry);
+    this.coordinator.entries.set(newWsPath, entry);
 
     if (!entry.active && entry.failedTask) {
       entry.pendingTask = entry.failedTask;
@@ -152,7 +159,7 @@ export class EditorSaveQueue {
   }
 
   retryFailed(wsPath: string): boolean {
-    const entry = this.store.entries.get(wsPath);
+    const entry = this.coordinator.entries.get(wsPath);
     if (!entry || entry.active || !entry.failedTask) {
       return false;
     }
@@ -167,7 +174,7 @@ export class EditorSaveQueue {
   }
 
   private getEntry(wsPath: string): SaveEntry {
-    const existing = this.store.entries.get(wsPath);
+    const existing = this.coordinator.entries.get(wsPath);
     if (existing) {
       return existing;
     }
@@ -178,7 +185,7 @@ export class EditorSaveQueue {
       status: { status: 'clean' },
       wsPath,
     };
-    this.store.entries.set(wsPath, entry);
+    this.coordinator.entries.set(wsPath, entry);
     return entry;
   }
 
@@ -199,7 +206,11 @@ export class EditorSaveQueue {
       entry.activeTask = task;
 
       try {
-        await task.writeDoc(writeWsPath, task.doc);
+        const session = this.coordinator.currentSession;
+        if (!session) {
+          throw new Error('Editor save coordinator has no active session');
+        }
+        await session.writeDoc(writeWsPath, task.doc);
       } catch (cause) {
         if (entry.retired) {
           continue;
@@ -219,7 +230,7 @@ export class EditorSaveQueue {
           entry.failedTask = task;
           entry.status = { error, status: 'failed' };
           this.notifySaveStatusChanged(entry.wsPath);
-          task.emitAppError(
+          this.coordinator.currentSession?.emitAppError(
             createAppError('error::editor:save-failed', 'Unable to save note', {
               error,
               wsPath: entry.wsPath,
@@ -255,8 +266,8 @@ export class EditorSaveQueue {
 
     if (entry.status.status === 'clean') {
       entry.failedTask = undefined;
-      if (this.store.entries.get(entry.wsPath) === entry) {
-        this.store.entries.delete(entry.wsPath);
+      if (this.coordinator.entries.get(entry.wsPath) === entry) {
+        this.coordinator.entries.delete(entry.wsPath);
       }
     }
   }
@@ -282,10 +293,10 @@ export class EditorSaveQueue {
   private notifySaveStatusChanged(changedWsPath: string): void {
     const hasPendingOrFailed = this.hasPendingOrFailed();
     const globalStatusChanged =
-      hasPendingOrFailed !== this.store.lastHasPendingOrFailed;
-    this.store.lastHasPendingOrFailed = hasPendingOrFailed;
+      hasPendingOrFailed !== this.coordinator.lastHasPendingOrFailed;
+    this.coordinator.lastHasPendingOrFailed = hasPendingOrFailed;
 
-    for (const subscription of this.store.subscriptions) {
+    for (const subscription of this.coordinator.subscriptions) {
       if (
         subscription.wsPath === changedWsPath ||
         (subscription.wsPath === undefined && globalStatusChanged)

--- a/packages/core/editor/src/index.tsx
+++ b/packages/core/editor/src/index.tsx
@@ -13,7 +13,14 @@ import {
 } from './components';
 import { useEditorCoreServices } from './use-editor-core-services';
 
-export { PmEditorService } from './pm-editor-service';
+export {
+  createEditorSaveCoordinator,
+  type EditorSaveCoordinator,
+} from './editor-save-queue';
+export {
+  PmEditorService,
+  type PmEditorServiceConfig,
+} from './pm-editor-service';
 export { useEditorCoreServices } from './use-editor-core-services';
 export function Editor({
   wsPath,

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -43,7 +43,7 @@ import {
 import { atom } from 'jotai';
 import type { MarkdownAssetReference } from './asset-file-plugin';
 import {
-  createEditorSaveQueueStore,
+  type EditorSaveCoordinator,
   EditorSaveQueue,
   type EditorSaveStatus,
 } from './editor-save-queue';
@@ -57,9 +57,12 @@ import {
 } from './remembered-cursor';
 import { isMarkdownRoundTripPreserved } from './round-trip-check';
 
-const editorSaveQueueStore = createEditorSaveQueueStore();
 const ASSET_TOAST_FILE_NAME_MAX_LENGTH = 44;
 const EMPTY_WS_PATH_SET: ReadonlySet<string> = new Set();
+
+export type PmEditorServiceConfig = {
+  saveCoordinator: EditorSaveCoordinator;
+};
 
 function formatFileSize(bytes: number): string {
   const units = ['B', 'KB', 'MB', 'GB'];
@@ -156,6 +159,7 @@ export class PmEditorService
       workbenchState: WorkbenchStateService;
       workspaceState: WorkspaceStateService;
     },
+    config: PmEditorServiceConfig,
   ) {
     super(SERVICE_NAME.pmEditorService, context, dependencies);
 
@@ -208,7 +212,7 @@ export class PmEditorService
         );
       },
       this.emitAppError,
-      editorSaveQueueStore,
+      config.saveCoordinator,
     );
   }
 

--- a/packages/core/initialize-services/setup.ts
+++ b/packages/core/initialize-services/setup.ts
@@ -4,5 +4,6 @@
  * loaded.
  */
 
+export { createEditorSaveCoordinator } from '@bangle.io/editor';
 export type { CoreConfigOverrides } from './src/service-setup';
 export { createServiceSetup } from './src/service-setup';

--- a/packages/core/initialize-services/src/__tests__/initialize-services.spec.ts
+++ b/packages/core/initialize-services/src/__tests__/initialize-services.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { BaseService } from '@bangle.io/base-utils';
 import { ThemeManager } from '@bangle.io/color-scheme-manager';
+import { createEditorSaveCoordinator } from '@bangle.io/editor';
 import { makeTestCommonOpts } from '@bangle.io/test-utils';
 import { expect, test } from 'vitest';
 import { initializeServices } from '../index';
@@ -17,6 +18,7 @@ test('initializeServices returns unique service names', async () => {
     commonOpts.store,
     new ThemeManager(),
     controller.signal,
+    createEditorSaveCoordinator(),
   );
 
   const serviceNames = Object.keys(services.core);

--- a/packages/core/initialize-services/src/__tests__/service-setup.spec.ts
+++ b/packages/core/initialize-services/src/__tests__/service-setup.spec.ts
@@ -1,6 +1,7 @@
 import type { ThemeManager } from '@bangle.io/color-scheme-manager';
 import { commandHandlers } from '@bangle.io/command-handlers';
 import { getEnabledCommands } from '@bangle.io/commands';
+import { createEditorSaveCoordinator } from '@bangle.io/editor';
 import { slot } from '@bangle.io/poor-mans-di';
 import {
   FileStorageMemory,
@@ -49,6 +50,7 @@ function makeSetup({
     },
     fileStorageSlots: ['fileStorageMemory'],
     editorEngineId: 'prosemirror',
+    editorSaveCoordinator: createEditorSaveCoordinator(),
   });
 
   return { setup, controller };
@@ -90,6 +92,7 @@ describe('createServiceSetup', () => {
       },
       fileStorageSlots: [],
       editorEngineId: 'prosemirror',
+      editorSaveCoordinator: createEditorSaveCoordinator(),
     });
 
     controller.abort();
@@ -120,6 +123,7 @@ describe('createServiceSetup', () => {
       },
       fileStorageSlots: [],
       editorEngineId: 'prosemirror',
+      editorSaveCoordinator: createEditorSaveCoordinator(),
     });
 
     controller.abort();
@@ -177,6 +181,7 @@ describe('createServiceSetup', () => {
       },
       fileStorageSlots: ['fileStorageMemory', 'fileStorageMemoryDuplicate'],
       editorEngineId: 'prosemirror',
+      editorSaveCoordinator: createEditorSaveCoordinator(),
     });
 
     expect(() => setup.instantiate()).toThrow(
@@ -234,6 +239,7 @@ describe('createServiceSetup', () => {
       },
       fileStorageSlots: ['fileStorageMemory'],
       editorEngineId: 'prosemirror',
+      editorSaveCoordinator: createEditorSaveCoordinator(),
       coreConfigOverrides: {
         commandRegistry: (base) => ({
           ...base,

--- a/packages/core/initialize-services/src/index.ts
+++ b/packages/core/initialize-services/src/index.ts
@@ -3,6 +3,7 @@ import type { ThemeManager } from '@bangle.io/color-scheme-manager';
 import { commandHandlers } from '@bangle.io/command-handlers';
 import { getEnabledCommands } from '@bangle.io/commands';
 import type { Services } from '@bangle.io/context';
+import type { EditorSaveCoordinator } from '@bangle.io/editor';
 
 import type {
   BaseServiceCommonOptions,
@@ -11,6 +12,10 @@ import type {
 } from '@bangle.io/types';
 import { initializeServices as initializeServices2 } from './initialize-services';
 
+export {
+  createEditorSaveCoordinator,
+  type EditorSaveCoordinator,
+} from '@bangle.io/editor';
 export { readEditorEngineFromUrl } from './initialize-services';
 
 export function initializeServices(
@@ -19,6 +24,7 @@ export function initializeServices(
   store: Store,
   theme: ThemeManager,
   abortSignal: AbortSignal,
+  editorSaveCoordinator: EditorSaveCoordinator,
 ): Promise<Services> {
   const commonOpts: BaseServiceCommonOptions = {
     logger,
@@ -41,6 +47,7 @@ export function initializeServices(
     getEnabledCommands(),
     commandHandlers,
     theme,
+    editorSaveCoordinator,
   );
 
   return services.mountAll().then(() => ({

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -11,6 +11,7 @@ import {
   type EditorEngineId,
   isEditorEngineId,
 } from '@bangle.io/constants';
+import type { EditorSaveCoordinator } from '@bangle.io/editor';
 import { isFileSystemDirectoryHandle } from '@bangle.io/native-fs';
 import { slot } from '@bangle.io/poor-mans-di';
 import type { WorkspaceOpsService } from '@bangle.io/service-core';
@@ -45,6 +46,7 @@ export function initializeServices(
   commands: EnabledBangleAppCommand[],
   commandHandlers: Array<{ id: string; handler: CommandHandler }>,
   theme: ThemeManager,
+  editorSaveCoordinator: EditorSaveCoordinator,
 ) {
   const editorEngineId = readEditorEngineFromUrl();
   // Native FS root-handle resolution needs workspace metadata, which lives in
@@ -112,6 +114,7 @@ export function initializeServices(
     platformServices: browserPlatformServices,
     fileStorageSlots: ['fileStorageIdb', 'fileStorageNativeFs'],
     editorEngineId,
+    editorSaveCoordinator,
   });
 
   getWorkspaceOps = () => setup.getServices().workspaceOps;

--- a/packages/core/initialize-services/src/service-setup.ts
+++ b/packages/core/initialize-services/src/service-setup.ts
@@ -3,7 +3,7 @@ import type { ThemeManager } from '@bangle.io/color-scheme-manager';
 import type { EnabledBangleAppCommand } from '@bangle.io/commands';
 import type { EditorEngineId } from '@bangle.io/constants';
 import type { CoreServices, EditorEngineContract } from '@bangle.io/context';
-import { PmEditorService } from '@bangle.io/editor';
+import { type EditorSaveCoordinator, PmEditorService } from '@bangle.io/editor';
 import { EditorWService } from '@bangle.io/editor-w';
 import {
   type ConstructorConfig,
@@ -227,6 +227,8 @@ export type ServiceSetupOptions<TPlatformMap extends PlatformServiceMap> = {
   fileStorageSlots: ReadonlyArray<FileStorageSlot<TPlatformMap>>;
   /** The editor engine powering the editing surface. */
   editorEngineId: EditorEngineId;
+  /** Browser-root save state retained when the UI service graph reloads. */
+  editorSaveCoordinator: EditorSaveCoordinator;
   /** Optional per-slot decorators over the canonical core configs. */
   coreConfigOverrides?: CoreConfigOverrides;
 };
@@ -287,6 +289,7 @@ export function createServiceSetup<
     shortcutTarget,
     fileStorageSlots,
     editorEngineId,
+    editorSaveCoordinator,
     coreConfigOverrides,
   } = options;
   const platformServices: TPlatformMap = options.platformServices;
@@ -411,9 +414,12 @@ export function createServiceSetup<
         ),
       })),
     ),
-    editorEngine: slot(
-      editorEngineId === 'wordgard' ? EditorWService : PmEditorService,
-    ),
+    editorEngine:
+      editorEngineId === 'wordgard'
+        ? slot(EditorWService)
+        : slot(PmEditorService, () => ({
+            saveCoordinator: editorSaveCoordinator,
+          })),
   } satisfies Record<CoreServiceSlotId, AppServiceMapEntry>;
 
   // Core slots always win the join; the annotation drops any phantom core

--- a/packages/tooling/browser-entry/src/main.tsx
+++ b/packages/tooling/browser-entry/src/main.tsx
@@ -4,7 +4,10 @@ import './index.css';
 import { App } from '@bangle.io/app';
 import { ThemeManager } from '@bangle.io/color-scheme-manager';
 import { THEME_MANAGER_CONFIG } from '@bangle.io/constants';
-import { initializeServices } from '@bangle.io/initialize-services';
+import {
+  createEditorSaveCoordinator,
+  initializeServices,
+} from '@bangle.io/initialize-services';
 import { Logger } from '@bangle.io/logger';
 import { createStore } from 'jotai';
 import React, { StrictMode } from 'react';
@@ -17,6 +20,7 @@ const isDebug =
   window.location.search.includes('debug=true');
 
 const startupLogger = new Logger('', isDebug ? 'debug' : 'info');
+const editorSaveCoordinator = createEditorSaveCoordinator();
 
 void main(startupLogger).catch((error) => {
   handleStartupFailure(error, startupLogger);
@@ -51,6 +55,7 @@ async function main(logger: Logger) {
       store,
       themeManager,
       abortController.signal,
+      editorSaveCoordinator,
     );
   } catch (error) {
     abortController.abort();

--- a/packages/tooling/e2e-tests/src/editor-save-reload.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-save-reload.e2e.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspaceAndNote,
+  getEditorLocator,
+  readStoredMarkdown,
+  waitForEditorFocus,
+} from './common';
+
+type DebugServices = {
+  core: {
+    editorEngine: {
+      retryFailedSave: (wsPath: string) => boolean;
+    };
+    fileSystem: {
+      writeFile: (wsPath: string, file: File) => Promise<void>;
+    };
+    workbenchState: {
+      reloadUi: () => void;
+    };
+  };
+};
+
+type DebugWindow = Window &
+  typeof globalThis & {
+    previousBangleServices?: DebugServices;
+    services: DebugServices;
+  };
+
+test('retrying a failed save after UI reload uses the current service graph', async ({
+  page,
+}) => {
+  const workspaceName = 'editor-save-ui-reload';
+  const noteName = 'retained-edit';
+  const content = 'Unsaved content retained across the UI service reload';
+
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  // The full CI runner serves on 127.0.0.1, where debug globals are disabled
+  // unless explicitly requested. Reload the same editor route with the test
+  // hook enabled so this regression can replace one storage write and retain
+  // the old service graph across the real app reload event.
+  const debugUrl = new URL(page.url());
+  debugUrl.searchParams.set('debug', 'true');
+  await page.goto(debugUrl.toString(), { waitUntil: 'domcontentloaded' });
+  await expect
+    .poll(() =>
+      page.evaluate(() => Boolean((window as Partial<DebugWindow>).services)),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    const debugWindow = window as DebugWindow;
+    debugWindow.services.core.fileSystem.writeFile = async () => {
+      throw new Error('Injected write failure before UI reload');
+    };
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText(content);
+
+  const retrySave = page.getByRole('button', { name: 'Retry save' });
+  await expect(retrySave).toBeVisible();
+
+  await page.evaluate(() => {
+    const debugWindow = window as DebugWindow;
+    debugWindow.previousBangleServices = debugWindow.services;
+    debugWindow.services.core.workbenchState.reloadUi();
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const debugWindow = window as DebugWindow;
+        return debugWindow.services !== debugWindow.previousBangleServices;
+      }),
+    )
+    .toBe(true);
+  await expect(editor).toHaveAttribute(
+    'data-editor-name',
+    new RegExp(`${workspaceName}:${noteName}\\.md`),
+  );
+
+  const retriedThroughDisposedGraph = await page.evaluate(
+    ({ wsPath }) => {
+      const debugWindow = window as DebugWindow;
+      return debugWindow.previousBangleServices?.core.editorEngine.retryFailedSave(
+        wsPath,
+      );
+    },
+    { wsPath: `${workspaceName}:${noteName}.md` },
+  );
+  expect(retriedThroughDisposedGraph).toBe(true);
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toContain(content);
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(getEditorLocator(page, {})).toContainText(content);
+});

--- a/packages/tooling/test-utils/test-service-setup.ts
+++ b/packages/tooling/test-utils/test-service-setup.ts
@@ -8,6 +8,7 @@ import {
 import type { CoreServices } from '@bangle.io/context';
 import {
   type CoreConfigOverrides,
+  createEditorSaveCoordinator,
   createServiceSetup,
 } from '@bangle.io/initialize-services/setup';
 import { type ContainerDescription, slot } from '@bangle.io/poor-mans-di';
@@ -94,6 +95,7 @@ function createTestServiceSetup(
     },
     fileStorageSlots: ['fileStorageMemory'],
     editorEngineId,
+    editorSaveCoordinator: createEditorSaveCoordinator(),
     coreConfigOverrides,
   });
 }

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-15
-updated: 2026-07-14
+updated: 2026-07-15
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
@@ -18,6 +18,10 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/641
   - https://github.com/bangle-io/bangle-io/pull/645
   - https://github.com/bangle-io/bangle-io/pull/646
+  - https://github.com/bangle-io/bangle-io/pull/640
+  - https://github.com/bangle-io/bangle-io/pull/644
+  - https://github.com/bangle-io/bangle-io/pull/648
+  - https://github.com/bangle-io/bangle-io/pull/649
 related_issues: []
 ---
 
@@ -54,8 +58,9 @@ cleanup.
   for explicit retry, and `PmEditorService` exposes save status/dirty APIs and
   change subscriptions. Pending or failed saves now activate browser
   navigation/reload protection, failed saves show a persistent translated retry
-  action, and a successful retry clears protection. Store ownership across UI
-  reload/service-graph replacement remains C4 below.
+  action, and a successful retry clears protection. PR #649 resolves the
+  cross-reload lifetime boundary through the explicit browser-root save
+  coordinator described by C4 below.
 - P0.2 started with explicit editor load rejection handling that emits an app
   error instead of leaving the mount promise silently pending. Failed load
   status and a same-node retry API are now exposed. Parse-failure isolation and
@@ -191,6 +196,16 @@ cleanup.
     service-architecture and Knip worktrees cover broader boundary/dead-code
     changes. C6, C8, P1.3, P4.4, and P5.2 are narrowed below to match current
     code instead of retaining stale claims.
+- 2026-07-15 editor save-coordinator lifetime cleanup (PR #649):
+  - C4 resolved: the browser composition root now owns an explicit
+    `EditorSaveCoordinator` and injects it into every replacement UI service
+    graph. Queued and failed tasks retain document state only; execution and
+    error reporting resolve through the newest graph's writer and error
+    boundary instead of callbacks captured from a disposed service.
+  - Focused queue coverage retries a retained failure through the old graph's
+    facade and proves the current graph performs the write. Browser E2E forces
+    a save failure, emits the real `event::app:reload-ui`, retries through the
+    disposed graph, and verifies the edit is durable after a full page reload.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -979,7 +994,7 @@ listed so future agents do not rediscover it or accidentally restore it.
 | C1 | Resolved in 2026-07-13 workspace refresh continuity cleanup | `WorkspaceStateService` now derives `$workspaces` from an explicit `$workspaceListState` resource. Failed refreshes retain the last successful data and error, preserve `$currentWsName`, and can recover to `ready`; real-service coverage forces the full success-failure-recovery sequence. | Critical / medium |
 | C2 | Resolved in PR #631 | `PmEditorService` now caches `markdownLoader` instances per ProseMirror `Schema` in a `WeakMap`. A real two-editor regression proves paste uses the active editor schema. | High / small-medium |
 | C3 | Partial | PR #631 made the Native FS metadata lookup awaitable and report invalid metadata as command failure. `CommandDispatchService.dispatch()` still returns `void`, reports a missing handler as success, converts null args with `args || {}`, releases cycle/focus state before async completion, and detaches non-app async errors. Native FS permission work also occurs later in a dialog callback, outside command completion. Make command completion an awaitable typed result and move callback-owned workflows behind feature controllers. | Critical / medium |
-| C4 | Open; coordinate after PR #640 | The editor save-queue store remains module-global while each queued task captures the writer and error emitter from the service instance that enqueued it. UI reload rebuilds the service graph, so retrying a retained failure can execute through a disposed graph. PR #640 is actively changing relocation and save-queue behavior but does not own this service-graph lifetime boundary. Move the store to an explicit root-lifetime coordinator and resolve the current writer at execution time; test a failed save across `event::app:reload-ui`. | Critical data safety / medium |
+| C4 | Resolved in [PR #649](https://github.com/bangle-io/bangle-io/pull/649) | The module-global save store is replaced by an explicit browser-root `EditorSaveCoordinator` injected into each UI service graph. Retained tasks carry document state but resolve the writer and error boundary from the current graph at execution time. Unit coverage retries through a disposed graph facade, and browser E2E forces a failed save across `event::app:reload-ui` before proving durable recovery after a full reload. | Critical data safety / medium |
 | C5 | Resolved in 2026-07-12 workspace dialog cleanup | `CreateWorkspaceDialog` now accepts and awaits async durable creation, blocks duplicate submission and dismissal while pending, preserves the dialog with an alert on failure, and permits retry. Component coverage counts one callback for a double-click; app E2E exercises the real duplicate-workspace service rejection. | High / medium |
 | C6 | Partial; plan 006 owns the UX | `PageAsset` now has distinct internal `missing` and `error` states, but its catch still discards storage/permission/decode/object-URL causes and both states render the same generic unavailable copy. Emit/log the retained error, expose retry/recovery, and test Native FS permission loss after PR #626's external-sync work settles. | High / small-medium |
 | C7 | Resolved in PR #631 | Workspace info cache entries are keyed by workspace name and filtered after lookup. Memory storage now compares parsed workspace names exactly and rejects rename over an existing destination, with focused contract regressions. | Medium-high / small |
@@ -1028,17 +1043,15 @@ listed so future agents do not rediscover it or accidentally restore it.
 
 ### Recommended Next Batches
 
-1. C4 save-coordinator lifetime, because a retained task can outlive its
-   service graph and endanger unsaved user data.
-2. C3 command completion, with real-service failure tests and no detached
+1. C3 command completion, with real-service failure tests and no detached
    promises. C5 async workspace creation is complete.
-3. C6 asset read/recovery semantics, aligned with plan 006.
-4. A1-A4 boundary work in independently reviewable slices; do not combine the
+2. C6 asset read/recovery semantics, aligned with plan 006.
+3. A1-A4 boundary work in independently reviewable slices; do not combine the
    command kernel, Native FS session provider, and service-graph derivation in
    one PR.
-5. A5, A6, A9, A10, and A11 as code-reduction batches with user-visible E2E
+4. A5, A6, A9, A10, and A11 as code-reduction batches with user-visible E2E
    coverage where navigation or interaction changes.
-6. A8 through plan 007, after correcting the temporary index's failure and
+5. A8 through plan 007, after correcting the temporary index's failure and
    concurrency assumptions.
 
 ## Original 2026-06-15 Suggested Execution Order


### PR DESCRIPTION
## Summary

- replace the module-global editor save store with an explicit browser-root coordinator
- resolve queued writes and error reporting through the newest UI service graph
- retain failed documents and subscriptions across `event::app:reload-ui` without retaining disposed graph callbacks
- cover stale-facade retry behavior in unit tests and a real UI-reload persistence workflow in Playwright

## Verification

- `pnpm typecheck`
- focused editor queue and service-wiring Vitest suites (26 tests)
- focused `editor-save-reload.e2e.ts` against both localhost and the CI 127.0.0.1 host
- `pnpm local-ci-check`
  - 2,133 Vitest tests (1 skipped)
  - 157 Playwright E2E tests
  - 8 Playwright component tests
  - 28 desktop tests
  - lint, TypeScript, workspace validation, Knip, browser/desktop builds, and Electron persistence smoke

The final full E2E run passed with three unrelated retries in browser history navigation, cursor restoration, and file explorer editing. The new save-reload regression passed without retry.

No deployment performed.