### PR TITLE
feat: add editor action availability

### DIFF
--- a/packages/core/context/src/service-types.ts
+++ b/packages/core/context/src/service-types.ts
@@ -48,6 +48,9 @@ export type EditorEngineContract = BaseService & {
   getSelectionMarkdown: () => string | null;
   hasPendingOrFailedSave: (wsPath?: string) => boolean;
   insertMarkdownAtSelection: (markdownText: string) => boolean;
+  /** Reports whether an app-level editor action can run against the current
+   * active editor and selection. Callers must still revalidate on execution. */
+  isActionAvailable: (action: EditorAction) => boolean;
   /** Inserts a starter table at the current selection in the active editor
    * and focuses its first cell. Returns false when there is no active
    * editor or the position cannot hold a table. */
@@ -67,6 +70,10 @@ export type EditorEngineContract = BaseService & {
   toggleHeadingCollapse: () => boolean;
   uncollapseAllHeadings: () => boolean;
 };
+
+export type EditorAction =
+  | { type: 'insert-table' }
+  | { type: 'toggle-heading'; level: 1 | 2 | 3 };
 
 export type CoreServices<
   TEditorEngine extends EditorEngineContract = EditorEngineContract,

--- a/packages/core/editor-w/src/editor-w-service.ts
+++ b/packages/core/editor-w/src/editor-w-service.ts
@@ -4,7 +4,7 @@ import {
   createAppError,
 } from '@bangle.io/base-utils';
 import { type EditorEngineId, SERVICE_NAME } from '@bangle.io/constants';
-import type { EditorEngineContract } from '@bangle.io/context';
+import type { EditorAction, EditorEngineContract } from '@bangle.io/context';
 import type { FileSystemService } from '@bangle.io/service-core';
 import { WsPath } from '@bangle.io/ws-path';
 import { atom } from 'jotai';
@@ -131,6 +131,10 @@ export class EditorWService
   }
 
   insertMarkdownAtSelection(_markdownText: string): boolean {
+    return false;
+  }
+
+  isActionAvailable(_action: EditorAction): boolean {
     return false;
   }
 

--- a/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
+++ b/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
@@ -117,6 +117,11 @@ describe('PmEditorService', () => {
     }
     view.focus();
 
+    expect(
+      service.isActionAvailable({ type: 'toggle-heading', level: 2 }),
+    ).toBe(true);
+    expect(service.isActionAvailable({ type: 'insert-table' })).toBe(true);
+
     expect(service.toggleHeading(2)).toBe(true);
     expect(view.state.doc.firstChild?.type.name).toBe('heading');
     expect(view.state.doc.firstChild?.attrs.level).toBe(2);
@@ -134,6 +139,10 @@ describe('PmEditorService', () => {
       return !hasTable;
     });
     expect(hasTable).toBe(true);
+    expect(
+      service.isActionAvailable({ type: 'toggle-heading', level: 1 }),
+    ).toBe(false);
+    expect(service.isActionAvailable({ type: 'insert-table' })).toBe(false);
 
     unmount();
     await waitForExpect(() => {
@@ -142,6 +151,9 @@ describe('PmEditorService', () => {
     // With no active editor both refuse instead of throwing.
     expect(service.toggleHeading(1)).toBe(false);
     expect(service.insertTable()).toBe(false);
+    expect(
+      service.isActionAvailable({ type: 'toggle-heading', level: 1 }),
+    ).toBe(false);
 
     controller.abort();
     domNode.remove();

--- a/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
+++ b/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
@@ -207,13 +207,11 @@ describe('PmEditorService', () => {
     expect(service.insertTable()).toBe(true);
 
     secondEditor.focus();
-    expect(
-      service.isActionAvailable({ type: 'toggle-heading', level: 1 }),
-    ).toBe(true);
     omniInput.focus();
 
-    // Availability and execution continue to target the editor that opened
-    // the external surface, rather than falling back to mount order.
+    // The first service lookup happens only after focus leaves the editor:
+    // availability and execution must still target the editor that opened the
+    // external surface, rather than falling back to mount order.
     expect(
       service.isActionAvailable({ type: 'toggle-heading', level: 1 }),
     ).toBe(true);

--- a/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
+++ b/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
@@ -158,4 +158,78 @@ describe('PmEditorService', () => {
     controller.abort();
     domNode.remove();
   });
+
+  test('keeps the last active editor while another surface owns focus', async () => {
+    const controller = new AbortController();
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+
+    await services.workspaceOps.createWorkspaceInfo({
+      name: TEST_WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.fileSystem.createTextFile(`${TEST_WS_NAME}:first.md`, '');
+    await services.fileSystem.createTextFile(`${TEST_WS_NAME}:second.md`, '');
+
+    if (!(services.editorEngine instanceof PmEditorService)) {
+      throw new Error('Expected the ProseMirror editor engine');
+    }
+    const service = services.editorEngine;
+    const firstDomNode = document.createElement('div');
+    const secondDomNode = document.createElement('div');
+    const omniInput = document.createElement('input');
+    document.body.append(firstDomNode, secondDomNode, omniInput);
+
+    const unmountFirst = service.mountEditor({
+      domNode: firstDomNode,
+      wsPath: `${TEST_WS_NAME}:first.md`,
+      name: 'first-editor',
+    });
+    const unmountSecond = service.mountEditor({
+      domNode: secondDomNode,
+      wsPath: `${TEST_WS_NAME}:second.md`,
+      name: 'second-editor',
+    });
+    await waitForExpect(() => {
+      expect(service.getEditor('first-editor')).toBeDefined();
+      expect(service.getEditor('second-editor')).toBeDefined();
+    });
+
+    const firstEditor = service.getEditor('first-editor');
+    const secondEditor = service.getEditor('second-editor');
+    if (!firstEditor || !secondEditor) {
+      throw new Error('Expected both ProseMirror editors to be ready');
+    }
+
+    firstEditor.focus();
+    expect(service.insertTable()).toBe(true);
+
+    secondEditor.focus();
+    expect(
+      service.isActionAvailable({ type: 'toggle-heading', level: 1 }),
+    ).toBe(true);
+    omniInput.focus();
+
+    // Availability and execution continue to target the editor that opened
+    // the external surface, rather than falling back to mount order.
+    expect(
+      service.isActionAvailable({ type: 'toggle-heading', level: 1 }),
+    ).toBe(true);
+    expect(service.toggleHeading(1)).toBe(true);
+    expect(secondEditor.state.doc.firstChild?.type.name).toBe('heading');
+    expect(firstEditor.state.doc.firstChild?.type.name).toBe('table');
+
+    omniInput.focus();
+    service.focusEditor();
+    expect(secondEditor.hasFocus()).toBe(true);
+
+    unmountSecond();
+    unmountFirst();
+    controller.abort();
+    firstDomNode.remove();
+    secondDomNode.remove();
+    omniInput.remove();
+  });
 });

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -105,10 +105,10 @@ export function SlashCommand({
 
   const dismissCommandUi = useCallback(() => {
     if (!editorView || !active) {
-      return;
+      return false;
     }
 
-    ext.suggestions.command.replaceSuggestMarkWith({
+    return ext.suggestions.command.replaceSuggestMarkWith({
       content: '',
     })(editorView.state, editorView.dispatch, editorView);
   }, [editorView, active, ext]);
@@ -135,7 +135,9 @@ export function SlashCommand({
   }
 
   const run = (command: PMCommand, { refocus }: { refocus?: boolean } = {}) => {
-    dismissCommandUi();
+    if (!dismissCommandUi()) {
+      return;
+    }
     command(editorView.state, editorView.dispatch, editorView);
     if (refocus) {
       // Some inserts replace or move the focused block, dropping DOM focus;

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -6,7 +6,7 @@ import {
   isAppError,
 } from '@bangle.io/base-utils';
 import { SERVICE_NAME } from '@bangle.io/constants';
-import type { EditorEngineContract } from '@bangle.io/context';
+import type { EditorAction, EditorEngineContract } from '@bangle.io/context';
 import {
   type EditorView,
   markdownLoader,
@@ -923,6 +923,20 @@ export class PmEditorService
         return;
       }
     }
+  }
+
+  /** Dry-runs app-level editor actions against the live selection. */
+  isActionAvailable(action: EditorAction): boolean {
+    const view = this.getActiveEditorView();
+    if (!view) {
+      return false;
+    }
+    if (action.type === 'insert-table') {
+      return this.extensions.table.command.insertTable()(view.state);
+    }
+    return this.extensions.heading.command.toggleHeading(action.level)(
+      view.state,
+    );
   }
 
   /** Toggles the block at the current selection to/from a heading. */

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -104,6 +104,7 @@ type EditorEntry =
   | {
       name: string;
       editorView: ReturnType<typeof createEditor>;
+      removeFocusListener: () => void;
       wsPath: string;
     }
   | { name: string; status: 'failed'; error: Error; wsPath: string }
@@ -222,6 +223,7 @@ export class PmEditorService
       // Destroy all editor views
       for (const [_domNode, editor] of this.editors) {
         if ('editorView' in editor) {
+          editor.removeFocusListener();
           editor.editorView.destroy();
         }
       }
@@ -344,7 +346,18 @@ export class PmEditorService
         },
       });
 
-      this.editors.set(domNode, { name, editorView, wsPath });
+      const handleFocusIn = () => {
+        this.lastActiveEditorView = editorView;
+      };
+      editorView.dom.addEventListener('focusin', handleFocusIn);
+      this.editors.set(domNode, {
+        name,
+        editorView,
+        removeFocusListener: () => {
+          editorView.dom.removeEventListener('focusin', handleFocusIn);
+        },
+        wsPath,
+      });
       this.checkRoundTripFidelity({
         content: content ?? '',
         editorView,
@@ -402,6 +415,7 @@ export class PmEditorService
       } else {
         this.rememberedCursors.set(editor.wsPath, position);
       }
+      editor.removeFocusListener();
       editor.editorView.destroy();
     }
     this.editors.delete(domNode);

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -143,6 +143,7 @@ export class PmEditorService
   private saveQueue: EditorSaveQueue;
   private pendingHeading: { fragment: string; wsPath: string } | undefined;
   private rememberedCursors = new Map<string, number>();
+  private lastActiveEditorView: EditorView | undefined;
 
   private editors = new Map<HTMLElement, EditorEntry>();
 
@@ -225,6 +226,7 @@ export class PmEditorService
         }
       }
       this.editors.clear();
+      this.lastActiveEditorView = undefined;
       this.rememberedCursors.clear();
     });
     this.addCleanup(
@@ -389,6 +391,9 @@ export class PmEditorService
   private unmountEditor(domNode: HTMLElement) {
     const editor = this.editors.get(domNode);
     if (editor && 'editorView' in editor) {
+      if (this.lastActiveEditorView === editor.editorView) {
+        this.lastActiveEditorView = undefined;
+      }
       const position = getRememberedCursorPosition(
         editor.editorView.state.selection,
       );
@@ -913,16 +918,7 @@ export class PmEditorService
   }
 
   focusEditor() {
-    for (const [_, editor] of this.editors) {
-      if (
-        'editorView' in editor &&
-        !editor.editorView.isDestroyed &&
-        !editor.editorView.hasFocus()
-      ) {
-        editor.editorView.focus();
-        return;
-      }
-    }
+    this.getActiveEditorView()?.focus();
   }
 
   /** Dry-runs app-level editor actions against the live selection. */
@@ -1079,14 +1075,20 @@ export class PmEditorService
 
   private getActiveEditorView() {
     let fallback: ReturnType<typeof createEditor> | undefined;
+    let lastActive: ReturnType<typeof createEditor> | undefined;
     for (const editor of this.editors.values()) {
       if ('editorView' in editor && !editor.editorView.isDestroyed) {
         if (editor.editorView.hasFocus()) {
+          this.lastActiveEditorView = editor.editorView;
           return editor.editorView;
+        }
+        if (editor.editorView === this.lastActiveEditorView) {
+          lastActive = editor.editorView;
         }
         fallback ??= editor.editorView;
       }
     }
-    return fallback;
+    this.lastActiveEditorView = lastActive;
+    return lastActive ?? fallback;
   }
 }

--- a/packages/core/omni-search/src/index.tsx
+++ b/packages/core/omni-search/src/index.tsx
@@ -1,4 +1,8 @@
-import { useCoreServices } from '@bangle.io/context';
+import {
+  type EditorAction,
+  type EditorEngineContract,
+  useCoreServices,
+} from '@bangle.io/context';
 import {
   defaultFuzzySearch,
   rankedFuzzySearch,
@@ -24,6 +28,30 @@ const MAX_COMMANDS_PER_GROUP = 5;
 const MAX_FILES_GLOBAL = 100;
 const MAX_RECENT_FILES = 5;
 const MAX_RECENT_COMMANDS = 3;
+
+const EDITOR_ACTIONS_BY_COMMAND_ID: Readonly<Record<string, EditorAction>> = {
+  'command::editor:toggle-heading-1': {
+    type: 'toggle-heading',
+    level: 1,
+  },
+  'command::editor:toggle-heading-2': {
+    type: 'toggle-heading',
+    level: 2,
+  },
+  'command::editor:toggle-heading-3': {
+    type: 'toggle-heading',
+    level: 3,
+  },
+  'command::editor:insert-table': { type: 'insert-table' },
+};
+
+function isCommandAvailable(
+  commandId: string,
+  editorEngine: EditorEngineContract,
+): boolean {
+  const editorAction = EDITOR_ACTIONS_BY_COMMAND_ID[commandId];
+  return !editorAction || editorEngine.isActionAvailable(editorAction);
+}
 
 type CommandItemProp = {
   id: string;
@@ -308,12 +336,12 @@ export function OmniSearch() {
     userActivityService,
     workbenchState,
     commandRegistry,
+    editorEngine,
   } = useCoreServices();
-  const commands = useMemo(
-    () => commandRegistry.getOmniSearchCommands(),
-    [commandRegistry],
-  );
   const [open, setOpen] = useAtom(workbenchState.$openOmniSearch);
+  const commands = commandRegistry
+    .getOmniSearchCommands()
+    .filter((command) => isCommandAvailable(command.id, editorEngine));
 
   const commandInputRef = React.useRef<HTMLInputElement>(null);
 

--- a/packages/core/omni-search/src/index.tsx
+++ b/packages/core/omni-search/src/index.tsx
@@ -339,9 +339,11 @@ export function OmniSearch() {
     editorEngine,
   } = useCoreServices();
   const [open, setOpen] = useAtom(workbenchState.$openOmniSearch);
-  const commands = commandRegistry
-    .getOmniSearchCommands()
-    .filter((command) => isCommandAvailable(command.id, editorEngine));
+  const commands = open
+    ? commandRegistry
+        .getOmniSearchCommands()
+        .filter((command) => isCommandAvailable(command.id, editorEngine))
+    : [];
 
   const commandInputRef = React.useRef<HTMLInputElement>(null);
 

--- a/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
@@ -737,4 +737,36 @@ describe('replaceSuggestMarkWith', () => {
     expect(handled).toBe(false);
     expect(view.state.doc.textContent).toBe('/current plain');
   });
+
+  it('refuses provider marks split around unrelated text', () => {
+    const store = createStore();
+    const view = createEditor({
+      text: '/abcd',
+      markName: 'slash_command',
+      store,
+    });
+    const current = editorStore.get(view.state, $suggestions).get(view);
+    if (!current) throw new Error('missing active suggestion');
+    const slashMark = schema.mark('slash_command', { trigger: '/' });
+    const replacement = Fragment.fromArray([
+      schema.text('/a', [slashMark]),
+      schema.text('X'),
+      schema.text('bcd', [slashMark]),
+    ]);
+    const tr = view.state.tr.replaceWith(1, 6, replacement);
+    view.dispatch(tr.setSelection(TextSelection.atEnd(tr.doc)));
+
+    editorStore.set(
+      view.state,
+      $suggestions,
+      new Map([[view, { ...current, position: 1, text: '/abcd' }]]),
+    );
+
+    const handled = slashSuggestions.command.replaceSuggestMarkWith({
+      content: 'replacement',
+    })(view.state, view.dispatch, view);
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.textContent).toBe('/aXbcd');
+  });
 });

--- a/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
@@ -688,4 +688,53 @@ describe('replaceSuggestMarkWith', () => {
     expect(view.state.doc.textContent).toBe('$date');
     expect(view.state.selection.from).toBe(6);
   });
+
+  it('refuses replacement when the recorded suggestion no longer matches its mark', () => {
+    const store = createStore();
+    const view = createEditor({
+      text: '/current',
+      markName: 'slash_command',
+      store,
+    });
+    const current = editorStore.get(view.state, $suggestions).get(view);
+    if (!current) throw new Error('missing active suggestion');
+
+    editorStore.set(
+      view.state,
+      $suggestions,
+      new Map([[view, { ...current, text: '/stale' }]]),
+    );
+
+    const handled = slashSuggestions.command.replaceSuggestMarkWith({
+      content: 'replacement',
+    })(view.state, view.dispatch, view);
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.textContent).toBe('/current');
+  });
+
+  it('refuses a stale suggestion after the selection moves elsewhere', () => {
+    const store = createStore();
+    const view = createEditor({
+      text: '/current',
+      markName: 'slash_command',
+      store,
+    });
+    const current = editorStore.get(view.state, $suggestions).get(view);
+    if (!current) throw new Error('missing active suggestion');
+
+    const tr = view.state.tr.insert(
+      view.state.doc.content.size,
+      schema.text(' plain'),
+    );
+    view.dispatch(tr.setSelection(TextSelection.atEnd(tr.doc)));
+    editorStore.set(view.state, $suggestions, new Map([[view, current]]));
+
+    const handled = slashSuggestions.command.replaceSuggestMarkWith({
+      content: 'replacement',
+    })(view.state, view.dispatch, view);
+
+    expect(handled).toBe(false);
+    expect(view.state.doc.textContent).toBe('/current plain');
+  });
 });

--- a/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
@@ -559,8 +559,8 @@ export function replaceSuggestMarkWith({
     }
 
     const [scanRangeStart, scanRangeEnd] = clampRange(
-      state.selection.from - MARK_SCAN_RANGE_PADDING,
-      state.selection.to + MARK_SCAN_RANGE_PADDING,
+      suggestion.position,
+      suggestion.position + suggestion.text.length,
       state.doc.content.size,
     );
 
@@ -571,7 +571,13 @@ export function replaceSuggestMarkWith({
       scanRangeEnd,
     );
 
-    if (!queryMark) {
+    if (
+      !queryMark ||
+      queryMark.start !== suggestion.position ||
+      queryMark.text !== suggestion.text ||
+      state.selection.from < queryMark.start ||
+      state.selection.to > queryMark.end
+    ) {
       return false;
     }
 

--- a/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
@@ -558,9 +558,10 @@ export function replaceSuggestMarkWith({
       return false;
     }
 
+    const suggestionEnd = suggestion.position + suggestion.text.length;
     const [scanRangeStart, scanRangeEnd] = clampRange(
       suggestion.position,
-      suggestion.position + suggestion.text.length,
+      suggestionEnd,
       state.doc.content.size,
     );
 
@@ -574,6 +575,7 @@ export function replaceSuggestMarkWith({
     if (
       !queryMark ||
       queryMark.start !== suggestion.position ||
+      queryMark.end !== suggestionEnd ||
       queryMark.text !== suggestion.text ||
       state.selection.from < queryMark.start ||
       state.selection.to > queryMark.end

--- a/packages/tooling/e2e-tests/src/omni-editor-commands.e2e.ts
+++ b/packages/tooling/e2e-tests/src/omni-editor-commands.e2e.ts
@@ -54,7 +54,7 @@ test('omni search runs editor block commands on the active note', async ({
     .toMatch(/^# Make me a heading[\s\S]*\| first cell/);
 });
 
-test('omni editor commands report when they cannot run', async ({ page }) => {
+test('omni search hides editor commands that cannot run', async ({ page }) => {
   const workspaceName = 'omni-editor-commands-unavailable';
   await createBrowserWorkspaceAndNote(page, {
     workspaceName,
@@ -79,11 +79,8 @@ test('omni editor commands report when they cannot run', async ({ page }) => {
   await dialog
     .getByPlaceholder('Type a command or search...')
     .fill('toggle heading 1');
-  await dialog.getByText('Toggle Heading 1').click();
-
-  await expect(
-    page.getByText('That editor command cannot run here', { exact: false }),
-  ).toBeVisible();
+  await expect(dialog.getByText('Toggle Heading 1')).toHaveCount(0);
+  await expect(dialog.getByText('No results found.')).toBeVisible();
   await expect(editor.locator('table')).toHaveCount(1);
   await expect(editor.getByRole('heading')).toHaveCount(0);
 });

--- a/packages/tooling/e2e-tests/src/omni-editor-commands.e2e.ts
+++ b/packages/tooling/e2e-tests/src/omni-editor-commands.e2e.ts
@@ -81,6 +81,12 @@ test('omni search hides editor commands that cannot run', async ({ page }) => {
     .fill('toggle heading 1');
   await expect(dialog.getByText('Toggle Heading 1')).toHaveCount(0);
   await expect(dialog.getByText('No results found.')).toBeVisible();
+
+  await dialog
+    .getByPlaceholder('Type a command or search...')
+    .fill('insert table');
+  await expect(dialog.getByText('Insert Table')).toHaveCount(0);
+  await expect(dialog.getByText('No results found.')).toBeVisible();
   await expect(editor.locator('table')).toHaveCount(1);
   await expect(editor.getByRole('heading')).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

- add a small typed editor-engine availability contract for heading and table actions
- hide unavailable omni editor commands while retaining execution-time revalidation
- retain the last-focused live editor across Omni and other external focus handoffs
- make suggestion replacement fail closed unless provider, position, exact range, text, and selection agree
- abort slash follow-up actions when stale suggestion dismissal is refused

## Investigation notes

- kept slash and table ProseMirror mechanics local; no `CollectionType` metadata or generic slash registry was added
- current suggestion UI is scoped per `EditorView`; the replacement primitive validates its complete recorded invariant before starting a transaction
- exact-end validation protects unmarked or unrelated text between discontiguous same-provider marks
- this does not port or reuse PR #586's position-first fallback
- editor focus is recorded directly from each mounted editor's `focusin` event and the listener is removed with the editor lifecycle

## Review

- independent Codex and thermonuclear reviews both identified the multi-editor external-focus edge case
- the first fix retained a live editor after a service lookup; final Codex review caught that this could miss a direct editor-to-Omni handoff
- the final KISS fix observes editor focus directly and has a regression test whose first service lookup occurs only after external focus takes over
- both reviews found the exact-range suggestion targeting and slash guard sound
- registry centralization was intentionally deferred because it would add architecture without a stronger current guarantee

## Verification

- `pnpm local-ci-check`: 3,017 unit tests passed (1 skipped), 166 E2E scenarios completed (2 passed on configured retry), 8 component tests passed, 28 desktop tests passed, desktop build/persistence smoke passed, lint/type/dependency checks passed
- focused PM editor service suite: 3 passed
- focused suggestion suite: 23 passed
- focused omni editor commands E2E: 2 passed
- manual `playwright-cli`: paragraph availability, table-context hiding, Browser workspace edit and table persistence across reload

## Review focus

- typed editor-engine boundary and narrow four-command mapping
- external-focus behavior with multiple mounted editors and listener cleanup
- stale suggestion mutation bounds and exact recorded-range invariant
- unchanged undo behavior: failed validation creates no transaction and successful execution retains the existing flow
