### PR TITLE
fix: handle spaced wiki links and inactive file actions

### DIFF
--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -29,7 +29,7 @@ export const AppSidebar = ({ children }: SidebarProps) => {
   const fileTreeExpandedPathsByWorkspace = useAtomValue(
     workbenchState.$fileTreeExpandedPathsByWorkspace,
   );
-  const activeWsName = useAtomValue(navigation.$wsName);
+  const activeWsName = useAtomValue(workspaceState.$currentWsName);
   const activeWsPaths = useAtomValue(workspaceState.$activeWsPaths);
   const wsPaths = useAtomValue(workspaceState.$wsPaths);
   const noteWsPaths = useAtomValue(workspaceState.$noteWsPaths);

--- a/packages/core/app/src/layout/app-sidebar.tsx
+++ b/packages/core/app/src/layout/app-sidebar.tsx
@@ -147,7 +147,11 @@ export const AppSidebar = ({ children }: SidebarProps) => {
             payload: { wsName },
           })
         }
+        canCreateFiles={Boolean(activeWsName)}
         onCreateDirectory={(pathPrefix) => {
+          if (!activeWsName) {
+            return;
+          }
           commandDispatcher.dispatch(
             'command::ui:create-directory-dialog',
             {
@@ -157,6 +161,9 @@ export const AppSidebar = ({ children }: SidebarProps) => {
           );
         }}
         onCreateNote={(pathPrefix) => {
+          if (!activeWsName) {
+            return;
+          }
           commandDispatcher.dispatch(
             'command::ws:quick-new-note',
             {
@@ -246,7 +253,9 @@ export const AppSidebar = ({ children }: SidebarProps) => {
         getActionsForEntry={getActionsForEntry}
         pwaAction={pwaAction}
         footerTitle={t.app.sidebar.footerTitle}
-        footerChildren={<SidebarFooterMenu />}
+        footerChildren={
+          <SidebarFooterMenu canCreateFiles={Boolean(activeWsName)} />
+        }
       />
       <Sidebar.SidebarInset>{children}</Sidebar.SidebarInset>
     </Sidebar.SidebarProvider>

--- a/packages/core/app/src/layout/sidebar-footer-menu.tsx
+++ b/packages/core/app/src/layout/sidebar-footer-menu.tsx
@@ -24,7 +24,11 @@ import React from 'react';
  * actions, and external links. Extracted from AppSidebar so the sidebar
  * component stays a thin composition layer.
  */
-export function SidebarFooterMenu() {
+export function SidebarFooterMenu({
+  canCreateFiles,
+}: {
+  canCreateFiles: boolean;
+}) {
   const { commandDispatcher, workbenchState } = useCoreServices();
   const setOpenOmniSearch = useSetAtom(workbenchState.$openOmniSearch);
 
@@ -34,15 +38,19 @@ export function SidebarFooterMenu() {
         {t.app.sidebar.newLabel}
       </DropdownMenu.DropdownMenuLabel>
       <DropdownMenu.DropdownMenuItem
-        onClick={() =>
+        disabled={!canCreateFiles}
+        onClick={() => {
+          if (!canCreateFiles) {
+            return;
+          }
           commandDispatcher.dispatch(
             'command::ui:create-note-dialog',
             {
               prefillName: undefined,
             },
             'ui',
-          )
-        }
+          );
+        }}
       >
         <PlusIcon className="mr-2 h-4 w-4" />
         <span>{t.app.common.newNote}</span>

--- a/packages/core/omni-search/src/index.tsx
+++ b/packages/core/omni-search/src/index.tsx
@@ -339,9 +339,12 @@ export function OmniSearch() {
     editorEngine,
   } = useCoreServices();
   const [open, setOpen] = useAtom(workbenchState.$openOmniSearch);
+  const activeWsName = useAtomValue(workspaceState.$currentWsName);
   const commands = open
     ? commandRegistry
-        .getOmniSearchCommands()
+        .getOmniSearchCommands({
+        hasWorkspace: Boolean(activeWsName),
+        })
         .filter((command) => isCommandAvailable(command.id, editorEngine))
     : [];
 

--- a/packages/core/omni-search/src/index.tsx
+++ b/packages/core/omni-search/src/index.tsx
@@ -340,11 +340,15 @@ export function OmniSearch() {
   } = useCoreServices();
   const [open, setOpen] = useAtom(workbenchState.$openOmniSearch);
   const activeWsName = useAtomValue(workspaceState.$currentWsName);
+  const activeWsPath = useAtomValue(workspaceState.$currentWsPath);
+  const omniSearchScope = activeWsPath
+    ? 'note'
+    : activeWsName
+      ? 'workspace'
+      : 'global';
   const commands = open
     ? commandRegistry
-        .getOmniSearchCommands({
-        hasWorkspace: Boolean(activeWsName),
-        })
+        .getOmniSearchCommands(omniSearchScope)
         .filter((command) => isCommandAvailable(command.id, editorEngine))
     : [];
 

--- a/packages/core/service-core/src/__tests__/command-dispatch-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/command-dispatch-service.spec.ts
@@ -56,6 +56,7 @@ async function setup() {
   });
 
   const dispatchedCommands: CommandDispatchResult[] = [];
+  const focusEditor = vi.fn();
   const exposedServices = {
     fileSystem: new TestService(context, null),
   };
@@ -69,7 +70,7 @@ async function setup() {
       emitResult: (result) => {
         dispatchedCommands.push(result);
       },
-      focusEditor: () => {},
+      focusEditor,
       getExposedServices: () => exposedServices,
     },
   );
@@ -80,6 +81,7 @@ async function setup() {
     logger,
     commandRegistry,
     dispatchService,
+    focusEditor,
     mockLog: mockLog,
     dispatchedCommands,
     controller,
@@ -123,14 +125,19 @@ describe('CommandDispatchService', () => {
     expect(dispatchService.mounted).toBe(false);
   });
 
-  test('should dispatch a command successfully', async () => {
-    const { mockLog, commandRegistry, dispatchService, dispatchedCommands } =
-      await setup();
+  test('should dispatch an omni-search command and focus the editor by default', async () => {
+    const {
+      mockLog,
+      commandRegistry,
+      dispatchService,
+      dispatchedCommands,
+      focusEditor,
+    } = await setup();
     const command = {
       id: 'command::ui:toggle-sidebar',
       keywords: ['test', 'command'],
       dependencies: { services: ['fileSystem'] },
-      omniSearch: true,
+      omniSearch: 'global',
       args: null,
     } as const satisfies Command;
 
@@ -159,6 +166,7 @@ describe('CommandDispatchService', () => {
       command,
       from: 'testSource',
     });
+    expect(focusEditor).toHaveBeenCalledOnce();
 
     () => {
       // type checks
@@ -183,7 +191,7 @@ describe('CommandDispatchService', () => {
       id: 'command::ui:test-no-use',
       keywords: ['new', 'create', 'workspace'],
       dependencies: { services: ['fileSystem'] },
-      omniSearch: true,
+      omniSearch: 'global',
       args: {
         workspaceType: T.String,
       },
@@ -311,7 +319,7 @@ describe('CommandDispatchService', () => {
       id: 'command::ui:toggle-sidebar',
       keywords: ['test', 'command'],
       dependencies: { services: ['fileSystem'] },
-      omniSearch: true,
+      omniSearch: 'global',
       args: null,
     } as const satisfies Command;
 
@@ -330,7 +338,7 @@ describe('CommandDispatchService', () => {
       id: 'command::ui:toggle-sidebar',
       keywords: ['test', 'command'],
       dependencies: { services: [] },
-      omniSearch: true,
+      omniSearch: 'global',
       args: null,
     } as const satisfies Command;
     const handler = vi.fn();
@@ -372,7 +380,7 @@ describe('CommandDispatchService', () => {
       id: 'command::ui:toggle-sidebar',
       keywords: ['test', 'command'],
       dependencies: { services: ['unknown-service'] as any[] },
-      omniSearch: true,
+      omniSearch: 'global',
       args: null,
     } as const satisfies Command;
     const handler = vi.fn();
@@ -400,7 +408,7 @@ describe('CommandDispatchService', () => {
       id: 'command::ui:toggle-sidebar',
       keywords: ['test', 'command'],
       dependencies: { services: ['commandRegistry'] as any[] },
-      omniSearch: true,
+      omniSearch: 'global',
       args: null,
     } as const satisfies Command;
     const handler = vi.fn();

--- a/packages/core/service-core/src/__tests__/command-registry-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/command-registry-service.spec.ts
@@ -65,6 +65,36 @@ describe('CommandRegistryService', () => {
     expect(retrievedCommand).toEqual(command);
   });
 
+  test('filters workspace-required omni-search commands by availability', async () => {
+    const { service } = await setup();
+    const alwaysAvailable = {
+      id: 'alwaysAvailable',
+      keywords: ['always'],
+      omniSearch: true,
+      args: null,
+    } as const satisfies Command;
+    const workspaceRequired = {
+      id: 'workspaceRequired',
+      keywords: ['workspace'],
+      omniSearch: true,
+      requiresWorkspace: true,
+      args: null,
+    } as const satisfies Command;
+    service.register(alwaysAvailable);
+    service.register(workspaceRequired);
+
+    expect(
+      service
+        .getOmniSearchCommands({ hasWorkspace: false })
+        .map((command) => command.id),
+    ).toEqual(['alwaysAvailable']);
+    expect(
+      service
+        .getOmniSearchCommands({ hasWorkspace: true })
+        .map((command) => command.id),
+    ).toEqual(['alwaysAvailable', 'workspaceRequired']);
+  });
+
   test('should throw error when registering a duplicate command', async () => {
     const { service } = await setup();
     const command = {

--- a/packages/core/service-core/src/__tests__/command-registry-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/command-registry-service.spec.ts
@@ -65,34 +65,39 @@ describe('CommandRegistryService', () => {
     expect(retrievedCommand).toEqual(command);
   });
 
-  test('filters workspace-required omni-search commands by availability', async () => {
+  test('filters omni-search commands by active scope', async () => {
     const { service } = await setup();
-    const alwaysAvailable = {
-      id: 'alwaysAvailable',
-      keywords: ['always'],
-      omniSearch: true,
+    const globalCommand = {
+      id: 'globalCommand',
+      keywords: ['global'],
+      omniSearch: 'global',
       args: null,
     } as const satisfies Command;
-    const workspaceRequired = {
-      id: 'workspaceRequired',
+    const workspaceCommand = {
+      id: 'workspaceCommand',
       keywords: ['workspace'],
-      omniSearch: true,
-      requiresWorkspace: true,
+      omniSearch: 'workspace',
       args: null,
     } as const satisfies Command;
-    service.register(alwaysAvailable);
-    service.register(workspaceRequired);
+    const noteCommand = {
+      id: 'noteCommand',
+      keywords: ['note'],
+      omniSearch: 'note',
+      args: null,
+    } as const satisfies Command;
+    service.register(globalCommand);
+    service.register(workspaceCommand);
+    service.register(noteCommand);
 
     expect(
-      service
-        .getOmniSearchCommands({ hasWorkspace: false })
-        .map((command) => command.id),
-    ).toEqual(['alwaysAvailable']);
+      service.getOmniSearchCommands('global').map((command) => command.id),
+    ).toEqual(['globalCommand']);
     expect(
-      service
-        .getOmniSearchCommands({ hasWorkspace: true })
-        .map((command) => command.id),
-    ).toEqual(['alwaysAvailable', 'workspaceRequired']);
+      service.getOmniSearchCommands('workspace').map((command) => command.id),
+    ).toEqual(['globalCommand', 'workspaceCommand']);
+    expect(
+      service.getOmniSearchCommands('note').map((command) => command.id),
+    ).toEqual(['globalCommand', 'workspaceCommand', 'noteCommand']);
   });
 
   test('should throw error when registering a duplicate command', async () => {

--- a/packages/core/service-core/src/__tests__/user-activity-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/user-activity-service.spec.ts
@@ -223,7 +223,7 @@ describe('UserActivityService', () => {
       from: 'test',
       command: {
         id: 'test-command',
-        omniSearch: true,
+        omniSearch: 'global',
         args: {},
       },
     });

--- a/packages/core/service-core/src/command-dispatch-service.ts
+++ b/packages/core/service-core/src/command-dispatch-service.ts
@@ -167,7 +167,7 @@ export class CommandDispatchService extends BaseService {
       const autoFocus =
         options?.overrideAutoFocus ??
         command.autoFocusEditor ??
-        command.omniSearch;
+        Boolean(command.omniSearch);
 
       if (autoFocus === true) {
         this.config.focusEditor();

--- a/packages/core/service-core/src/command-registry-service.ts
+++ b/packages/core/service-core/src/command-registry-service.ts
@@ -89,7 +89,14 @@ export class CommandRegistryService extends BaseService {
     return command;
   }
 
-  public getOmniSearchCommands(): Command[] {
-    return this.getCommands().filter((cmd) => cmd.omniSearch);
+  public getOmniSearchCommands({
+    hasWorkspace,
+  }: {
+    hasWorkspace: boolean;
+  }): Command[] {
+    return this.getCommands().filter(
+      (command) =>
+        command.omniSearch && (!command.requiresWorkspace || hasWorkspace),
+    );
   }
 }

--- a/packages/core/service-core/src/command-registry-service.ts
+++ b/packages/core/service-core/src/command-registry-service.ts
@@ -4,7 +4,11 @@ import {
   type BaseServiceContext,
 } from '@bangle.io/base-utils';
 import { SERVICE_NAME } from '@bangle.io/constants';
-import type { Command, CommandHandler } from '@bangle.io/types';
+import type {
+  Command,
+  CommandHandler,
+  OmniSearchScope,
+} from '@bangle.io/types';
 
 export type CommandHandlerConfig = { id: string; handler: CommandHandler };
 
@@ -89,14 +93,18 @@ export class CommandRegistryService extends BaseService {
     return command;
   }
 
-  public getOmniSearchCommands({
-    hasWorkspace,
-  }: {
-    hasWorkspace: boolean;
-  }): Command[] {
-    return this.getCommands().filter(
-      (command) =>
-        command.omniSearch && (!command.requiresWorkspace || hasWorkspace),
-    );
+  public getOmniSearchCommands(activeScope: OmniSearchScope): Command[] {
+    return this.getCommands().filter((command) => {
+      switch (command.omniSearch) {
+        case 'global':
+          return true;
+        case 'workspace':
+          return activeScope !== 'global';
+        case 'note':
+          return activeScope === 'note';
+        default:
+          return false;
+      }
+    });
   }
 }

--- a/packages/js-lib/banger-editor/src/__tests__/wiki-link.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/wiki-link.spec.ts
@@ -19,6 +19,41 @@ afterEach(() => {
 });
 
 describe('wiki-link', () => {
+  it('trims surrounding target whitespace from its display text', () => {
+    const extensions = [setupBase(), setupParagraph(), setupWikiLink()];
+    const resolved = resolve(extensions);
+    const schema = new Schema({
+      nodes: resolved.nodes,
+      marks: resolved.marks,
+    });
+    const wikiLinkNode = schema.nodes.wiki_link;
+    if (!wikiLinkNode) {
+      throw new Error('wiki_link node missing from test schema');
+    }
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [
+        wikiLinkNode.create({ target: ' Existing.md ', label: null }),
+      ]),
+    ]);
+    const mount = document.createElement('div');
+    document.body.append(mount);
+    const view = new EditorView(
+      { mount },
+      {
+        state: EditorState.create({
+          doc,
+          schema,
+          plugins: resolved.resolvePlugins({ schema }),
+        }),
+      },
+    );
+    editors.push(view);
+
+    const link = view.dom.querySelector('[role="link"]');
+    expect(link?.textContent).toBe('Existing');
+    expect(link?.getAttribute('data-wiki-link')).toBe(' Existing.md ');
+  });
+
   it('uses the configured unresolved aria label for unresolved decorations', () => {
     const extensions = [
       setupBase(),

--- a/packages/js-lib/banger-editor/src/wiki-link.ts
+++ b/packages/js-lib/banger-editor/src/wiki-link.ts
@@ -38,8 +38,9 @@ function displayText(attrs: WikiLinkAttrs): string {
   if (attrs.label !== null) {
     return attrs.label;
   }
-  const finalSegment = attrs.target.split('/').filter(Boolean).at(-1);
-  return (finalSegment ?? attrs.target).replace(/\.(?:md|markdown)$/i, '');
+  const target = attrs.target.trim();
+  const finalSegment = target.split('/').filter(Boolean).at(-1);
+  return (finalSegment ?? target).replace(/\.(?:md|markdown)$/i, '');
 }
 
 function attrsFromDomTarget(target: EventTarget | null): WikiLinkAttrs | null {

--- a/packages/shared/commands/src/__tests__/commands.spec.ts
+++ b/packages/shared/commands/src/__tests__/commands.spec.ts
@@ -8,11 +8,55 @@ import {
   SETTINGS_PAGE_DEFINITIONS,
 } from '@bangle.io/constants';
 import { T } from '@bangle.io/mini-js-utils';
-import type { Command } from '@bangle.io/types';
+import type { Command, OmniSearchScope } from '@bangle.io/types';
 import { describe, expect, it } from 'vitest';
 import { areAllValuesOptional, bangleAppCommands } from '../index';
 
 const allCommands: Command[] = bangleAppCommands;
+
+const expectedOmniSearchCommandIds: Record<OmniSearchScope, string[]> = {
+  global: [
+    'command::ui:create-workspace-dialog',
+    'command::ui:delete-workspace-dialog',
+    'command::ui:open-settings',
+    'command::ui:open-settings-general',
+    'command::ui:open-settings-workspaces',
+    'command::ui:reload-app',
+    'command::ui:switch-editor-engine',
+    'command::ui:switch-theme',
+    'command::ui:switch-workspace',
+    'command::ui:toggle-sidebar',
+  ],
+  workspace: [
+    'command::ui:create-directory-dialog',
+    'command::ui:create-note-dialog',
+    'command::ui:toggle-all-files',
+    'command::ws:daily-note',
+    'command::ws:go-ws-home',
+    'command::ws:quick-new-note',
+    'command::ws:refresh-file-tree',
+  ],
+  note: [
+    'command::editor:insert-table',
+    'command::editor:toggle-heading-1',
+    'command::editor:toggle-heading-2',
+    'command::editor:toggle-heading-3',
+    'command::ui:collapse-all-headings-1',
+    'command::ui:collapse-all-headings-2',
+    'command::ui:collapse-all-headings-3',
+    'command::ui:copy-selection-as-markdown',
+    'command::ui:delete-note-dialog',
+    'command::ui:focus-editor',
+    'command::ui:move-note-dialog',
+    'command::ui:paste-from-markdown',
+    'command::ui:rename-note-dialog',
+    'command::ui:toggle-heading-collapse',
+    'command::ui:toggle-wide-editor',
+    'command::ui:uncollapse-all-headings',
+    'command::workspace:toggle-star',
+    'command::ws:clone-note',
+  ],
+};
 
 describe('Bangle App Commands Validation', () => {
   it('should have command IDs starting with "command::"', () => {
@@ -50,11 +94,22 @@ describe('Bangle App Commands Validation', () => {
     }
   });
 
+  it('assigns every omni-search command to its required app scope', () => {
+    for (const scope of ['global', 'workspace', 'note'] as const) {
+      expect(
+        allCommands
+          .filter((command) => command.omniSearch === scope)
+          .map((command) => command.id)
+          .sort(),
+      ).toEqual(expectedOmniSearchCommandIds[scope]);
+    }
+  });
+
   it('should return false when some args are not optional', () => {
     const commandWithMixedArgs: Command = {
       id: 'command::test:mixed-args',
       title: 'Test Mixed Args',
-      omniSearch: true,
+      omniSearch: 'global',
       dependencies: { services: ['navigation'] },
       args: {
         param1: T.String,
@@ -71,7 +126,7 @@ describe('Bangle App Commands Validation', () => {
     const commandWithMixedArgs: Command = {
       id: 'command::test:mixed-args',
       title: 'Test Mixed Args',
-      omniSearch: true,
+      omniSearch: 'global',
       dependencies: { services: ['navigation'] },
       args: {
         param1: T.Optional(T.String),
@@ -106,12 +161,12 @@ describe('Bangle App Commands Validation', () => {
       {
         id: SETTINGS_DEFAULT_COMMAND.id,
         title: SETTINGS_DEFAULT_COMMAND.title,
-        omniSearch: true,
+        omniSearch: 'global',
       },
       ...SETTINGS_PAGE_DEFINITIONS.map((page) => ({
         id: page.commandId,
         title: page.commandTitle,
-        omniSearch: true,
+        omniSearch: 'global',
       })),
     ]);
   });

--- a/packages/shared/commands/src/editor-commands.ts
+++ b/packages/shared/commands/src/editor-commands.ts
@@ -15,7 +15,7 @@ export const editorCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
   {
@@ -25,7 +25,7 @@ export const editorCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
   {
@@ -35,7 +35,7 @@ export const editorCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
   {
@@ -45,7 +45,7 @@ export const editorCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 ]);

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -42,7 +42,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['workbenchState'],
     },
-    omniSearch: true,
+    omniSearch: 'global',
     keybindings: ['ctrl', '\\'],
     args: null,
   },
@@ -53,7 +53,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['workbenchState'],
     },
-    omniSearch: true,
+    omniSearch: 'global',
     args: null,
   },
   {
@@ -68,7 +68,7 @@ export const uiCommands = narrow([
   {
     id: 'command::ui:switch-theme',
     title: 'Switch Theme',
-    omniSearch: true,
+    omniSearch: 'global',
     keywords: ['theme', 'change', 'switch'],
     dependencies: {
       services: ['workbenchState'],
@@ -80,7 +80,7 @@ export const uiCommands = narrow([
   {
     id: 'command::ui:switch-editor-engine',
     title: 'Switch Editor Engine',
-    omniSearch: true,
+    omniSearch: 'global',
     keywords: [
       'editor',
       'engine',
@@ -99,7 +99,7 @@ export const uiCommands = narrow([
     id: SETTINGS_DEFAULT_COMMAND.id,
     title: SETTINGS_DEFAULT_COMMAND.title,
     keywords: [...SETTINGS_DEFAULT_COMMAND.keywords],
-    omniSearch: true,
+    omniSearch: 'global',
     dependencies: {
       services: ['navigation'],
     },
@@ -110,7 +110,7 @@ export const uiCommands = narrow([
     id: GENERAL_SETTINGS_PAGE.commandId,
     title: GENERAL_SETTINGS_PAGE.commandTitle,
     keywords: [...GENERAL_SETTINGS_PAGE.commandKeywords],
-    omniSearch: true,
+    omniSearch: 'global',
     dependencies: {
       services: ['navigation'],
     },
@@ -121,7 +121,7 @@ export const uiCommands = narrow([
     id: WORKSPACES_SETTINGS_PAGE.commandId,
     title: WORKSPACES_SETTINGS_PAGE.commandTitle,
     keywords: [...WORKSPACES_SETTINGS_PAGE.commandKeywords],
-    omniSearch: true,
+    omniSearch: 'global',
     dependencies: {
       services: ['navigation'],
     },
@@ -138,8 +138,7 @@ export const uiCommands = narrow([
       services: ['workbenchState'],
       commands: ['command::ws:new-note-from-input', 'command::ui:focus-editor'],
     },
-    omniSearch: true,
-    requiresWorkspace: true,
+    omniSearch: 'workspace',
     autoFocusEditor: false,
     args: {
       prefillName: T.Optional(T.String),
@@ -148,7 +147,7 @@ export const uiCommands = narrow([
   {
     id: 'command::ui:delete-note-dialog',
     title: 'Delete Note',
-    omniSearch: true,
+    omniSearch: 'note',
     keywords: ['delete', 'note', 'remove'],
     dependencies: {
       services: ['workbenchState', 'workspaceState'],
@@ -193,7 +192,7 @@ export const uiCommands = narrow([
       services: ['workspaceState', 'workbenchState'],
       commands: ['command::ws:rename-ws-path', 'command::ui:focus-editor'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     autoFocusEditor: false,
     args: {
       wsPath: T.Optional(T.String),
@@ -236,7 +235,7 @@ export const uiCommands = narrow([
         'command::ui:create-directory-dialog',
       ],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     autoFocusEditor: false,
     args: {
       wsPath: T.Optional(T.String),
@@ -251,8 +250,7 @@ export const uiCommands = narrow([
       services: ['workbenchState', 'workspaceState'],
       commands: ['command::ws:create-directory'],
     },
-    omniSearch: true,
-    requiresWorkspace: true,
+    omniSearch: 'workspace',
     autoFocusEditor: false,
     args: {
       pathPrefix: T.Optional(T.String),
@@ -291,7 +289,7 @@ export const uiCommands = narrow([
     title: 'New Workspace',
     keywords: ['new', 'create', 'workspace'],
     dependencies: { services: ['workbenchState'] },
-    omniSearch: true,
+    omniSearch: 'global',
     autoFocusEditor: false,
     args: null,
   },
@@ -302,7 +300,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['workbenchState', 'workspaceState', 'navigation'],
     },
-    omniSearch: true,
+    omniSearch: 'global',
     args: null,
   },
   {
@@ -313,7 +311,7 @@ export const uiCommands = narrow([
       services: ['workbenchState', 'workspaceState'],
       commands: ['command::ws:delete-workspace'],
     },
-    omniSearch: true,
+    omniSearch: 'global',
     autoFocusEditor: false,
     args: null,
   },
@@ -363,7 +361,7 @@ export const uiCommands = narrow([
     title: 'View All Files',
     keywords: ['files', 'list', 'browse', 'all'],
     dependencies: { services: ['workbenchState'] },
-    omniSearch: true,
+    omniSearch: 'workspace',
     autoFocusEditor: false,
     args: {
       prefillInput: T.Optional(T.String),
@@ -377,7 +375,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['workbenchState', 'workspaceState'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 
@@ -388,7 +386,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['workbenchState', 'workspaceState', 'editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 
@@ -399,7 +397,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     autoFocusEditor: false,
     args: null,
   },
@@ -411,7 +409,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     autoFocusEditor: false,
     args: null,
   },
@@ -423,7 +421,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 
@@ -434,7 +432,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 
@@ -445,7 +443,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 
@@ -456,7 +454,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 
@@ -467,7 +465,7 @@ export const uiCommands = narrow([
     dependencies: {
       services: ['editorEngine'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     args: null,
   },
 ]);

--- a/packages/shared/commands/src/ui-commands.ts
+++ b/packages/shared/commands/src/ui-commands.ts
@@ -139,6 +139,7 @@ export const uiCommands = narrow([
       commands: ['command::ws:new-note-from-input', 'command::ui:focus-editor'],
     },
     omniSearch: true,
+    requiresWorkspace: true,
     autoFocusEditor: false,
     args: {
       prefillName: T.Optional(T.String),
@@ -251,6 +252,7 @@ export const uiCommands = narrow([
       commands: ['command::ws:create-directory'],
     },
     omniSearch: true,
+    requiresWorkspace: true,
     autoFocusEditor: false,
     args: {
       pathPrefix: T.Optional(T.String),

--- a/packages/shared/commands/src/ws-commands.ts
+++ b/packages/shared/commands/src/ws-commands.ts
@@ -22,8 +22,7 @@ export const wsCommands = narrow([
       services: ['workspaceState'],
       commands: ['command::ws:new-note-from-input'],
     },
-    omniSearch: true,
-    requiresWorkspace: true,
+    omniSearch: 'workspace',
     args: {
       pathPrefix: T.Optional(T.String),
     },
@@ -157,7 +156,7 @@ export const wsCommands = narrow([
     id: 'command::ws:go-ws-home',
     title: 'Go to Workspace Home',
     keywords: ['home', 'workspace', 'go'],
-    omniSearch: true,
+    omniSearch: 'workspace',
     dependencies: { services: ['navigation'] },
     args: null,
   },
@@ -165,14 +164,14 @@ export const wsCommands = narrow([
     id: 'command::ws:refresh-file-tree',
     title: 'Refresh Files',
     keywords: ['refresh', 'reload', 'rescan', 'files', 'file tree'],
-    omniSearch: true,
+    omniSearch: 'workspace',
     dependencies: { services: ['fileSystem'] },
     args: null,
   },
   {
     id: 'command::ws:clone-note',
     title: 'Clone Note',
-    omniSearch: true,
+    omniSearch: 'note',
     keywords: ['clone', 'duplicate', 'copy'],
     dependencies: { services: ['workspaceState', 'fileSystem', 'navigation'] },
     args: null,
@@ -181,7 +180,7 @@ export const wsCommands = narrow([
     id: 'command::ws:daily-note',
     title: 'Open Daily Note',
     keywords: ['daily', 'note', 'today', 'journal'],
-    omniSearch: true,
+    omniSearch: 'workspace',
     dependencies: {
       services: ['workspaceState', 'fileSystem', 'navigation'],
       commands: ['command::ws:create-note'],
@@ -197,7 +196,7 @@ export const wsCommands = narrow([
     dependencies: {
       services: ['workspaceState', 'userActivityService'],
     },
-    omniSearch: true,
+    omniSearch: 'note',
     keybindings: ['ctrl', 'shift', 's'],
     args: {
       wsPath: T.Optional(T.String),

--- a/packages/shared/commands/src/ws-commands.ts
+++ b/packages/shared/commands/src/ws-commands.ts
@@ -23,6 +23,7 @@ export const wsCommands = narrow([
       commands: ['command::ws:new-note-from-input'],
     },
     omniSearch: true,
+    requiresWorkspace: true,
     args: {
       pathPrefix: T.Optional(T.String),
     },

--- a/packages/shared/types/commands.ts
+++ b/packages/shared/types/commands.ts
@@ -10,6 +10,8 @@ export type AllowedValidator =
   | Validator<string[]>
   | Validator<string | boolean | number | undefined>;
 
+export type OmniSearchScope = 'global' | 'workspace' | 'note';
+
 export type Command = {
   id: string;
   title?: string;
@@ -29,13 +31,10 @@ export type Command = {
      */
     commands?: string[];
   };
-  // whether the command is available in the omni search
-  // default is false
-  omniSearch?: boolean;
-  /** Hide this command from global discovery when no workspace is active. */
-  requiresWorkspace?: boolean;
+  /** The narrowest app state where omni search should expose this command. */
+  omniSearch?: OmniSearchScope | false;
   // If false, the editor will not be focused after the command is dispatched.
-  // Defaults to true if omniSearch is true.
+  // Defaults to true when omniSearch is enabled.
   autoFocusEditor?: boolean;
   //   the args type info when dispatching this command
   args: {

--- a/packages/shared/types/commands.ts
+++ b/packages/shared/types/commands.ts
@@ -32,6 +32,8 @@ export type Command = {
   // whether the command is available in the omni search
   // default is false
   omniSearch?: boolean;
+  /** Hide this command from global discovery when no workspace is active. */
+  requiresWorkspace?: boolean;
   // If false, the editor will not be focused after the command is dispatched.
   // Defaults to true if omniSearch is true.
   autoFocusEditor?: boolean;

--- a/packages/shared/ws-path/src/__tests__/internal-link.spec.ts
+++ b/packages/shared/ws-path/src/__tests__/internal-link.spec.ts
@@ -67,6 +67,9 @@ describe('resolveWikiLinkTarget', () => {
     expect(resolveWikiLinkTarget(home, 'Mixed.md', index)?.wsPath).toBe(
       'notes:folder/Mixed.md',
     );
+    expect(resolveWikiLinkTarget(home, ' home.md ', index)?.wsPath).toBe(
+      'notes:home.md',
+    );
   });
 
   it('prefers exact-case stems over case-insensitive matches', () => {
@@ -180,6 +183,13 @@ describe('createMissingWikiLinkTarget', () => {
     expect(
       createMissingWikiLinkTarget(folderName, 'new note.markdown')?.wsPath,
     ).toBe('notes:new note.markdown');
+    expect(
+      createMissingWikiLinkTarget(folderName, ' new note.md ')?.wsPath,
+    ).toBe('notes:new note.md');
+    expect(
+      createMissingWikiLinkTarget(folderName, ' another note ')?.wsPath,
+    ).toBe('notes:another note.md');
+    expect(createMissingWikiLinkTarget(folderName, '   ')).toBeUndefined();
   });
 
   it('creates explicit targets at root-relative or current-relative paths', () => {

--- a/packages/shared/ws-path/src/internal-link.ts
+++ b/packages/shared/ws-path/src/internal-link.ts
@@ -24,6 +24,20 @@ function hasUnsafeEncoding(value: string): boolean {
   }
 }
 
+function normalizeWikiLinkTarget(target: string): string | undefined {
+  const normalizedTarget = target.trim();
+  return normalizedTarget &&
+    !normalizedTarget.includes('\\') &&
+    !normalizedTarget.includes(':') &&
+    !hasUnsafeEncoding(normalizedTarget)
+    ? normalizedTarget
+    : undefined;
+}
+
+function toExplicitWikiLinkBase(target: string): string {
+  return /^\.\.?\//.test(target) ? target : `/${target.replace(/^\//, '')}`;
+}
+
 /** Resolves a URL-style path without allowing workspace escape or separators hidden by encoding. */
 export function resolveInternalWsPath(
   currentWsPath: string | WsFilePath,
@@ -184,28 +198,17 @@ export function resolveWikiLinkTarget(
   index: WikiLinkIndex,
 ): WsFilePath | undefined {
   const current = WsPath.safeParse(currentWsPath).data?.asFile();
-  const normalizedTarget = target.trim();
-  if (
-    !current ||
-    !normalizedTarget ||
-    normalizedTarget.includes('\\') ||
-    normalizedTarget.includes(':') ||
-    hasUnsafeEncoding(normalizedTarget)
-  ) {
+  const normalizedTarget = normalizeWikiLinkTarget(target);
+  if (!current || !normalizedTarget) {
     return undefined;
   }
   if (index.wsName !== current.wsName) {
     return undefined;
   }
-  const explicitPath =
-    /^(?:\/|\.\.?\/)/.test(normalizedTarget) || normalizedTarget.includes('/');
+  const explicitPath = normalizedTarget.includes('/');
 
   if (explicitPath) {
-    const rootRelative =
-      normalizedTarget.startsWith('/') || !/^\.\.?\//.test(normalizedTarget);
-    const base = rootRelative
-      ? `/${normalizedTarget.replace(/^\//, '')}`
-      : normalizedTarget;
+    const base = toExplicitWikiLinkBase(normalizedTarget);
     for (const extension of ['', '.md', '.markdown']) {
       const resolved = resolveInternalWsPath(current, `${base}${extension}`);
       if (resolved) {
@@ -230,15 +233,12 @@ export function createMissingWikiLinkTarget(
   target: string,
 ): WsFilePath | undefined {
   const current = WsPath.safeParse(currentWsPath).data?.asFile();
-  const normalizedTarget = target.trim();
+  const normalizedTarget = normalizeWikiLinkTarget(target);
   if (
     !current ||
     !normalizedTarget ||
-    normalizedTarget.includes('\\') ||
-    normalizedTarget.includes(':') ||
     normalizedTarget.includes('#') ||
-    normalizedTarget.includes('?') ||
-    hasUnsafeEncoding(normalizedTarget)
+    normalizedTarget.includes('?')
   ) {
     return undefined;
   }
@@ -246,18 +246,13 @@ export function createMissingWikiLinkTarget(
   const targetWithExtension = hasMarkdownExtension(normalizedTarget)
     ? normalizedTarget
     : `${normalizedTarget}${WsPath.DEFAULT_NOTE_EXTENSION}`;
-  const explicitPath =
-    /^(?:\/|\.\.?\/)/.test(targetWithExtension) ||
-    targetWithExtension.includes('/');
+  const explicitPath = targetWithExtension.includes('/');
 
   if (explicitPath) {
-    const rootRelative =
-      targetWithExtension.startsWith('/') ||
-      !/^\.\.?\//.test(targetWithExtension);
-    const base = rootRelative
-      ? `/${targetWithExtension.replace(/^\//, '')}`
-      : targetWithExtension;
-    return resolveInternalWsPath(current, base);
+    return resolveInternalWsPath(
+      current,
+      toExplicitWikiLinkBase(targetWithExtension),
+    );
   }
 
   return WsPath.safeFromParts(

--- a/packages/shared/ws-path/src/internal-link.ts
+++ b/packages/shared/ws-path/src/internal-link.ts
@@ -184,23 +184,28 @@ export function resolveWikiLinkTarget(
   index: WikiLinkIndex,
 ): WsFilePath | undefined {
   const current = WsPath.safeParse(currentWsPath).data?.asFile();
+  const normalizedTarget = target.trim();
   if (
     !current ||
-    !target ||
-    target.includes('\\') ||
-    target.includes(':') ||
-    hasUnsafeEncoding(target)
+    !normalizedTarget ||
+    normalizedTarget.includes('\\') ||
+    normalizedTarget.includes(':') ||
+    hasUnsafeEncoding(normalizedTarget)
   ) {
     return undefined;
   }
   if (index.wsName !== current.wsName) {
     return undefined;
   }
-  const explicitPath = /^(?:\/|\.\.?\/)/.test(target) || target.includes('/');
+  const explicitPath =
+    /^(?:\/|\.\.?\/)/.test(normalizedTarget) || normalizedTarget.includes('/');
 
   if (explicitPath) {
-    const rootRelative = target.startsWith('/') || !/^\.\.?\//.test(target);
-    const base = rootRelative ? `/${target.replace(/^\//, '')}` : target;
+    const rootRelative =
+      normalizedTarget.startsWith('/') || !/^\.\.?\//.test(normalizedTarget);
+    const base = rootRelative
+      ? `/${normalizedTarget.replace(/^\//, '')}`
+      : normalizedTarget;
     for (const extension of ['', '.md', '.markdown']) {
       const resolved = resolveInternalWsPath(current, `${base}${extension}`);
       if (resolved) {
@@ -211,7 +216,7 @@ export function resolveWikiLinkTarget(
     return undefined;
   }
 
-  const stem = withoutMarkdownExtension(target);
+  const stem = withoutMarkdownExtension(normalizedTarget);
   const exact = index.byStem.get(stem) ?? [];
   const matches = exact.length
     ? exact
@@ -225,21 +230,22 @@ export function createMissingWikiLinkTarget(
   target: string,
 ): WsFilePath | undefined {
   const current = WsPath.safeParse(currentWsPath).data?.asFile();
+  const normalizedTarget = target.trim();
   if (
     !current ||
-    !target ||
-    target.includes('\\') ||
-    target.includes(':') ||
-    target.includes('#') ||
-    target.includes('?') ||
-    hasUnsafeEncoding(target)
+    !normalizedTarget ||
+    normalizedTarget.includes('\\') ||
+    normalizedTarget.includes(':') ||
+    normalizedTarget.includes('#') ||
+    normalizedTarget.includes('?') ||
+    hasUnsafeEncoding(normalizedTarget)
   ) {
     return undefined;
   }
 
-  const targetWithExtension = hasMarkdownExtension(target)
-    ? target
-    : `${target}${WsPath.DEFAULT_NOTE_EXTENSION}`;
+  const targetWithExtension = hasMarkdownExtension(normalizedTarget)
+    ? normalizedTarget
+    : `${normalizedTarget}${WsPath.DEFAULT_NOTE_EXTENSION}`;
   const explicitPath =
     /^(?:\/|\.\.?\/)/.test(targetWithExtension) ||
     targetWithExtension.includes('/');

--- a/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
+++ b/packages/tooling/e2e-tests/src/omni-search-focus.e2e.ts
@@ -109,7 +109,7 @@ test('command bar and all-commands route stay centered when translate utilities 
   await expectDialogCentered(page);
 });
 
-test('workspace-only command without an open note shows an app error and keeps the app usable', async ({
+test('note-only command stays hidden without an open note', async ({
   page,
 }) => {
   await createBrowserWorkspace(page, {
@@ -124,9 +124,13 @@ test('workspace-only command without an open note shows an app error and keeps t
   await page
     .getByPlaceholder('Type a command or search...')
     .fill('Toggle Star for Current Note');
-  await page.keyboard.press('Enter');
+  await expect(
+    page.getByRole('option').filter({
+      has: page.getByText('Toggle Star for Current Note', { exact: true }),
+    }),
+  ).toHaveCount(0);
+  await page.keyboard.press('Escape');
 
-  await expect(page.getByText('No note is currently open.')).toBeVisible();
   await expect(
     page.getByRole('heading', { name: 'omni-no-open-note' }),
   ).toBeVisible();

--- a/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
-import { clearEditor, getEditorLocator, getEditorText } from './common';
+import {
+  clearEditor,
+  getEditorLocator,
+  getEditorText,
+  pressAppShortcut,
+} from './common';
 
 test('Simple Workspace Creation Workflow', async ({ page }) => {
   await page.goto('/');
@@ -22,6 +27,16 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
     await expect(
       page.getByRole('menuitem', { name: 'New Workspace' }),
     ).toBeEnabled();
+    await page.keyboard.press('Escape');
+
+    await pressAppShortcut(page, 'k');
+    const commandInput = page.getByPlaceholder('Type a command or search...');
+    for (const commandTitle of ['New Note', 'Quick New Note', 'New Folder']) {
+      await commandInput.fill(commandTitle);
+      await expect(
+        page.getByRole('option', { name: commandTitle, exact: true }),
+      ).toHaveCount(0);
+    }
     await page.keyboard.press('Escape');
   });
 
@@ -58,6 +73,16 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
     await expect(
       page.getByRole('menuitem', { name: 'New Note' }),
     ).toBeEnabled();
+    await page.keyboard.press('Escape');
+
+    await pressAppShortcut(page, 'k');
+    const commandInput = page.getByPlaceholder('Type a command or search...');
+    for (const commandTitle of ['New Note', 'Quick New Note', 'New Folder']) {
+      await commandInput.fill(commandTitle);
+      await expect(
+        page.getByRole('option', { name: commandTitle, exact: true }),
+      ).toBeVisible();
+    }
     await page.keyboard.press('Escape');
   });
 

--- a/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
@@ -10,32 +10,9 @@ const WORKSPACE_COMMAND_TITLES = [
   'New Note',
   'Quick New Note',
   'New Folder',
-  'View All Files',
-  'Go to Workspace Home',
-  'Refresh Files',
-  'Open Daily Note',
 ] as const;
 
-const NOTE_COMMAND_TITLES = [
-  'Delete Note',
-  'Rename Note',
-  'Move Note',
-  'Toggle Wide Editor',
-  'Focus Editor',
-  'Copy Selection as Markdown',
-  'Paste from Markdown',
-  'Toggle Collapse Heading Section',
-  'Expand All Heading Sections',
-  'Collapse All Heading 1 Sections',
-  'Collapse All Heading 2 Sections',
-  'Collapse All Heading 3 Sections',
-  'Clone Note',
-  'Toggle Star for Current Note',
-  'Toggle Heading 1',
-  'Toggle Heading 2',
-  'Toggle Heading 3',
-  'Insert Table',
-] as const;
+const NOTE_COMMAND_TITLE = 'Toggle Star for Current Note';
 
 async function expectOmniSearchCommandVisibility(
   page: Page,
@@ -95,7 +72,7 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
 
     await expectOmniSearchCommandVisibility(page, {
       visible: ['New Workspace'],
-      hidden: [...WORKSPACE_COMMAND_TITLES, ...NOTE_COMMAND_TITLES],
+      hidden: [...WORKSPACE_COMMAND_TITLES, NOTE_COMMAND_TITLE],
     });
   });
 
@@ -136,7 +113,7 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
 
     await expectOmniSearchCommandVisibility(page, {
       visible: ['New Workspace', ...WORKSPACE_COMMAND_TITLES],
-      hidden: NOTE_COMMAND_TITLES,
+      hidden: [NOTE_COMMAND_TITLE],
     });
   });
 
@@ -160,7 +137,7 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
       visible: [
         'New Workspace',
         ...WORKSPACE_COMMAND_TITLES,
-        ...NOTE_COMMAND_TITLES,
+        NOTE_COMMAND_TITLE,
       ],
       hidden: [],
     });

--- a/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
@@ -1,10 +1,74 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import {
   clearEditor,
   getEditorLocator,
   getEditorText,
   pressAppShortcut,
 } from './common';
+
+const WORKSPACE_COMMAND_TITLES = [
+  'New Note',
+  'Quick New Note',
+  'New Folder',
+  'View All Files',
+  'Go to Workspace Home',
+  'Refresh Files',
+  'Open Daily Note',
+] as const;
+
+const NOTE_COMMAND_TITLES = [
+  'Delete Note',
+  'Rename Note',
+  'Move Note',
+  'Toggle Wide Editor',
+  'Focus Editor',
+  'Copy Selection as Markdown',
+  'Paste from Markdown',
+  'Toggle Collapse Heading Section',
+  'Expand All Heading Sections',
+  'Collapse All Heading 1 Sections',
+  'Collapse All Heading 2 Sections',
+  'Collapse All Heading 3 Sections',
+  'Clone Note',
+  'Toggle Star for Current Note',
+  'Toggle Heading 1',
+  'Toggle Heading 2',
+  'Toggle Heading 3',
+  'Insert Table',
+] as const;
+
+async function expectOmniSearchCommandVisibility(
+  page: Page,
+  {
+    visible,
+    hidden,
+  }: {
+    visible: readonly string[];
+    hidden: readonly string[];
+  },
+) {
+  await pressAppShortcut(page, 'k');
+  const commandInput = page.getByPlaceholder('Type a command or search...');
+
+  for (const commandTitle of visible) {
+    await commandInput.fill(commandTitle);
+    await expect(
+      page.getByRole('option').filter({
+        has: page.getByText(commandTitle, { exact: true }),
+      }),
+    ).toBeVisible();
+  }
+  for (const commandTitle of hidden) {
+    await commandInput.fill(commandTitle);
+    await expect(
+      page.getByRole('option').filter({
+        has: page.getByText(commandTitle, { exact: true }),
+      }),
+    ).toHaveCount(0);
+  }
+
+  await page.keyboard.press('Escape');
+}
 
 test('Simple Workspace Creation Workflow', async ({ page }) => {
   await page.goto('/');
@@ -29,15 +93,10 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
     ).toBeEnabled();
     await page.keyboard.press('Escape');
 
-    await pressAppShortcut(page, 'k');
-    const commandInput = page.getByPlaceholder('Type a command or search...');
-    for (const commandTitle of ['New Note', 'Quick New Note', 'New Folder']) {
-      await commandInput.fill(commandTitle);
-      await expect(
-        page.getByRole('option', { name: commandTitle, exact: true }),
-      ).toHaveCount(0);
-    }
-    await page.keyboard.press('Escape');
+    await expectOmniSearchCommandVisibility(page, {
+      visible: ['New Workspace'],
+      hidden: [...WORKSPACE_COMMAND_TITLES, ...NOTE_COMMAND_TITLES],
+    });
   });
 
   await test.step('create new workspace', async () => {
@@ -75,15 +134,10 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
     ).toBeEnabled();
     await page.keyboard.press('Escape');
 
-    await pressAppShortcut(page, 'k');
-    const commandInput = page.getByPlaceholder('Type a command or search...');
-    for (const commandTitle of ['New Note', 'Quick New Note', 'New Folder']) {
-      await commandInput.fill(commandTitle);
-      await expect(
-        page.getByRole('option', { name: commandTitle, exact: true }),
-      ).toBeVisible();
-    }
-    await page.keyboard.press('Escape');
+    await expectOmniSearchCommandVisibility(page, {
+      visible: ['New Workspace', ...WORKSPACE_COMMAND_TITLES],
+      hidden: NOTE_COMMAND_TITLES,
+    });
   });
 
   await test.step('create new note', async () => {
@@ -101,6 +155,15 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
         .getByLabel('breadcrumb')
         .getByRole('button', { name: 'test-note-1.md' }),
     ).toBeVisible();
+
+    await expectOmniSearchCommandVisibility(page, {
+      visible: [
+        'New Workspace',
+        ...WORKSPACE_COMMAND_TITLES,
+        ...NOTE_COMMAND_TITLES,
+      ],
+      hidden: [],
+    });
   });
 
   await test.step('verify toolbar', async () => {

--- a/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/simple-workspace-creation-worflow.e2e.ts
@@ -5,6 +5,25 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
   await page.goto('/');
 
   const mainContentLocator = page.locator('main.B-app-page-content');
+  const fileExplorer = page.getByTestId('bangle-file-explorer');
+
+  await test.step('disable file creation without a workspace', async () => {
+    await expect(
+      fileExplorer.getByRole('button', { name: 'New File' }),
+    ).toBeDisabled();
+    await expect(
+      fileExplorer.getByRole('button', { name: 'New Folder' }),
+    ).toBeDisabled();
+
+    await page.getByRole('button', { name: /Bangle\.io/ }).click();
+    await expect(
+      page.getByRole('menuitem', { name: 'New Note' }),
+    ).toBeDisabled();
+    await expect(
+      page.getByRole('menuitem', { name: 'New Workspace' }),
+    ).toBeEnabled();
+    await page.keyboard.press('Escape');
+  });
 
   await test.step('create new workspace', async () => {
     await page.getByRole('button', { name: 'Create Workspace' }).click();
@@ -28,6 +47,18 @@ test('Simple Workspace Creation Workflow', async ({ page }) => {
     await expect(mainContentLocator).toContainText(
       'No notes found in this workspace.',
     );
+    await expect(
+      fileExplorer.getByRole('button', { name: 'New File' }),
+    ).toBeEnabled();
+    await expect(
+      fileExplorer.getByRole('button', { name: 'New Folder' }),
+    ).toBeEnabled();
+
+    await page.getByRole('button', { name: /Bangle\.io/ }).click();
+    await expect(
+      page.getByRole('menuitem', { name: 'New Note' }),
+    ).toBeEnabled();
+    await page.keyboard.press('Escape');
   });
 
   await test.step('create new note', async () => {

--- a/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
+++ b/packages/tooling/e2e-tests/src/wiki-links.e2e.ts
@@ -136,6 +136,49 @@ test('authors, persists, reloads, and navigates wiki links safely', async ({
     .toBe('[[Home|Go home]] and [[Missing]]');
 });
 
+test('resolves spaced wiki targets without rewriting their Markdown', async ({
+  page,
+}) => {
+  const workspaceName = 'spaced-wiki-links';
+  const sourceMarkdown = '[[ Existing.md ]] and [[ Missing.md ]]';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+  await writeStoredMarkdown(page, workspaceName, 'Existing', 'existing body');
+  await writeStoredMarkdown(page, workspaceName, 'Home', sourceMarkdown);
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const existing = editor.locator('[data-wiki-link=" Existing.md "]');
+  await expect(existing).toHaveText('Existing');
+  await expect(existing).not.toHaveClass(/wiki-link-unresolved/);
+  await existing.click();
+  await expect(page).toHaveURL(
+    /ws#route=editor&wsPath=spaced-wiki-links%3AExisting\.md$/,
+  );
+  await expect(editor).toContainText('existing body');
+
+  await page.goBack({ waitUntil: 'networkidle' });
+  await expect(page).toHaveURL(
+    /ws#route=editor&wsPath=spaced-wiki-links%3AHome\.md$/,
+  );
+
+  const missing = editor.locator('[data-wiki-link=" Missing.md "]');
+  await expect(missing).toHaveText('Missing');
+  await expect(missing).toHaveClass(/wiki-link-unresolved/);
+  await missing.click();
+  await expect(page).toHaveURL(
+    /ws#route=editor&wsPath=spaced-wiki-links%3AMissing\.md$/,
+  );
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Missing'))
+    .toBe('');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe(sourceMarkdown);
+});
+
 test('does not offer the note being edited as a wiki-link suggestion', async ({
   page,
 }) => {

--- a/packages/ui/ui-components/src/app-sidebar.tsx
+++ b/packages/ui/ui-components/src/app-sidebar.tsx
@@ -60,6 +60,7 @@ type Workspace = {
 };
 
 export type AppSidebarProps = {
+  canCreateFiles: boolean;
   onNewWorkspaceClick: () => void;
   onManageWorkspacesClick: () => void;
   workspaces: Workspace[];
@@ -212,6 +213,7 @@ function DropdownButton({
 }
 
 export function AppSidebar({
+  canCreateFiles,
   onNewWorkspaceClick,
   onManageWorkspacesClick,
   workspaces,
@@ -293,6 +295,7 @@ export function AppSidebar({
               </div>
             )}
             <PierreFileTree
+              canCreateFiles={canCreateFiles}
               activePaths={activeFilePaths}
               filePaths={filePaths}
               getActionsForEntry={getActionsForEntry}

--- a/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
+++ b/packages/ui/ui-components/src/file-tree/pierre-file-tree.tsx
@@ -244,6 +244,7 @@ function getCurrentSelectedEntries(
 
 export interface PierreFileTreeProps {
   activePaths?: readonly string[];
+  canCreateFiles: boolean;
   className?: string;
   expandedPaths?: readonly string[];
   filePaths: readonly string[];
@@ -267,6 +268,7 @@ export interface PierreFileTreeProps {
 
 export function PierreFileTree({
   activePaths = EMPTY_PATHS,
+  canCreateFiles,
   className,
   expandedPaths = EMPTY_PATHS,
   filePaths,
@@ -677,18 +679,20 @@ export function PierreFileTree({
           </button>
           <button
             type="button"
-            className="inline-flex size-6 items-center justify-center rounded-sm text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            className="inline-flex size-6 items-center justify-center rounded-sm text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-40"
             aria-label={t.app.components.appSidebar.newFileActionTitle}
             title={t.app.components.appSidebar.newFileActionTitle}
+            disabled={!canCreateFiles}
             onClick={() => onCreateNote(undefined)}
           >
             <FilePlus2 className="size-3.5" />
           </button>
           <button
             type="button"
-            className="inline-flex size-6 items-center justify-center rounded-sm text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            className="inline-flex size-6 items-center justify-center rounded-sm text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-40"
             aria-label={t.app.components.appSidebar.newFolderActionTitle}
             title={t.app.components.appSidebar.newFolderActionTitle}
+            disabled={!canCreateFiles}
             onClick={() => onCreateDirectory(undefined)}
           >
             <FolderPlus className="size-3.5" />


### PR DESCRIPTION
## What changed

- normalize wiki-link targets for semantic resolution and creation while preserving their original Markdown source
- trim display-only whitespace from unlabeled wiki links
- disable and defensively gate New File, New Folder, and sidebar New Note actions when no workspace is active
- add unit and Playwright regressions for spaced wiki targets, Markdown fidelity, and inactive workspace actions

## Why

Seven-day Sentry triage identified two reproducible product defects:

1. A target such as `[[ explainability.md ]]` was treated as missing its Markdown extension, producing an invalid path ending in `.md .md`.
2. File-creation controls remained active without an open workspace and dispatched commands that could only fail.

## Impact

Spaced wiki links now resolve or create the intended note without rewriting stored Markdown, and users can no longer trigger invalid file-creation flows before opening a workspace.

## Validation

- `pnpm local-ci-check`
  - 3,014 unit tests passed (1 skipped)
  - lint, TypeScript, workspace validation, and Knip passed
  - 166 E2E tests passed with 1 unrelated retry-classified flaky cursor test
  - 8 component tests passed
  - browser/desktop builds and Electron persistence smoke passed
- independent Codex review completed; its one defensive-gating finding was addressed
- focused WebKit/Safari-engine attempt was blocked before the affected assertions by an existing IndexedDB `File` creation failure; Chromium coverage for both new regressions passes
