### PR TITLE
feat(editor): upload assets from slash command

### DIFF
--- a/packages/core/editor/src/__tests__/asset-file-plugin.spec.ts
+++ b/packages/core/editor/src/__tests__/asset-file-plugin.spec.ts
@@ -47,11 +47,12 @@ function createView({
     signal: AbortSignal,
   ) => Promise<StoredMarkdownAsset[]>;
 }) {
-  const pluginFactory = setupAssetFilePlugin({
+  const assetFilePlugin = setupAssetFilePlugin({
     cleanupStoredFiles,
     resolveAssetReference,
     storeFiles,
-  }).plugin?.handleDropPasteFiles;
+  });
+  const pluginFactory = assetFilePlugin.plugin?.handleDropPasteFiles;
   if (!pluginFactory) {
     throw new Error('Expected asset file plugin factory');
   }
@@ -69,7 +70,7 @@ function createView({
   const mount = document.createElement('div');
   document.body.append(mount);
   const view = new EditorView({ mount }, { state });
-  return { view, mount };
+  return { assetFilePlugin, view, mount };
 }
 
 function dispatchPaste(view: EditorView, file: File, text?: string) {
@@ -166,6 +167,57 @@ afterEach(() => {
 });
 
 describe('setupAssetFilePlugin', () => {
+  it('reports selected files as insertable without storing them during a dry run', () => {
+    const storeFiles = vi.fn(async () => []);
+    const { assetFilePlugin, view } = createView({ storeFiles });
+    const file = new File(['%PDF-1.4\n'], 'Picked.pdf', {
+      type: 'application/pdf',
+    });
+
+    expect(
+      assetFilePlugin.command.insertFiles([file])(view.state, undefined, view),
+    ).toBe(true);
+    expect(storeFiles).not.toHaveBeenCalled();
+    view.destroy();
+  });
+
+  it('inserts explicitly selected files through the shared asset lifecycle', async () => {
+    const stored = deferred<StoredMarkdownAsset[]>();
+    const storeFiles = vi.fn(() => stored.promise);
+    const { assetFilePlugin, view } = createView({ storeFiles });
+    const file = new File(['%PDF-1.4\n'], 'Picked.pdf', {
+      type: 'application/pdf',
+    });
+
+    expect(
+      assetFilePlugin.command.insertFiles([file])(
+        view.state,
+        view.dispatch,
+        view,
+      ),
+    ).toBe(true);
+    expect(storeFiles).toHaveBeenCalledWith(
+      view,
+      [file],
+      expect.any(AbortSignal),
+    );
+
+    stored.resolve([
+      {
+        file,
+        wsPath: WsFilePath.fromString('workspace:notes/assets/picked.pdf'),
+        href: 'assets/picked.pdf',
+        label: 'Picked.pdf',
+        isImage: false,
+      },
+    ]);
+
+    await vi.waitFor(() => {
+      expect(view.state.doc.textContent).toBe('Hello Picked.pdf');
+    });
+    view.destroy();
+  });
+
   it('maps delayed asset insertion through edits made while storage is pending', async () => {
     const stored = deferred<StoredMarkdownAsset[]>();
     const storeFiles = vi.fn(() => stored.promise);

--- a/packages/core/editor/src/asset-file-plugin.ts
+++ b/packages/core/editor/src/asset-file-plugin.ts
@@ -1,4 +1,5 @@
 import {
+  type Command,
   closeHistory,
   collection,
   dropPoint,
@@ -484,6 +485,23 @@ export function setupAssetFilePlugin(config: AssetFilePluginConfig) {
 
   return collection({
     id: 'asset-file-plugin',
+    command: {
+      insertFiles:
+        (files: readonly File[]): Command =>
+        (_state, dispatch, view) => {
+          if (!view || files.length === 0) {
+            return false;
+          }
+          if (!dispatch) {
+            return true;
+          }
+
+          return handleFilesAtRange(view, files, {
+            from: view.state.selection.from,
+            to: view.state.selection.to,
+          });
+        },
+    },
     plugin: {
       handleDropPasteFiles: () =>
         setPriority(

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -43,6 +43,7 @@ export function SlashCommand({
 }): ReactElement | null {
   const suggestions = useAtomValue($suggestions);
   const commandRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const prevSelectedIndexRef = useRef<number>(0);
   const { editorEngine } = useEditorCoreServices();
   const editorView = editorEngine.getEditor(editorName);
@@ -130,8 +131,39 @@ export function SlashCommand({
     })(editorView.state, editorView.dispatch, editorView);
   }, [editorView, active, ext]);
 
+  const openFilePicker = useCallback(() => {
+    if (!editorView || !active) {
+      return;
+    }
+
+    dismissCommandUi();
+    fileInputRef.current?.click();
+  }, [editorView, active, dismissCommandUi]);
+
+  const fileInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      multiple
+      className="hidden"
+      aria-hidden="true"
+      tabIndex={-1}
+      onChange={(event) => {
+        const files = Array.from(event.currentTarget.files ?? []);
+        event.currentTarget.value = '';
+        const insertFiles = ext.assetFilePlugin?.command.insertFiles;
+        if (files.length === 0 || !editorView || !insertFiles) {
+          return;
+        }
+
+        insertFiles(files)(editorView.state, editorView.dispatch, editorView);
+        editorView.focus();
+      }}
+    />
+  );
+
   if (!editorView || !active?.show) {
-    return null;
+    return fileInput;
   }
 
   const run = (command: PMCommand, { refocus }: { refocus?: boolean } = {}) => {
@@ -148,68 +180,72 @@ export function SlashCommand({
     run,
     insertText: (text) => run(ext.base.command.insertText({ text })),
     openDatePicker,
+    openFilePicker: ext.assetFilePlugin ? openFilePicker : undefined,
   });
 
   const labels = t.app.editor.slashCommand;
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: focus guard for a floating menu, not an interactive control.
-    <div
-      ref={slashRef}
-      style={FLOATING_INITIAL_STYLE}
-      onMouseDown={(event) => {
-        // The editor must keep focus and its selection while the menu is
-        // clicked — the menu is an extension of typing, like Notion's. Only
-        // the list element itself is exempt so its scrollbar stays draggable.
-        if (
-          !(event.target instanceof HTMLElement) ||
-          !event.target.hasAttribute('cmdk-list')
-        ) {
-          event.preventDefault();
-        }
-      }}
-    >
-      <Command
-        ref={commandRef}
-        filter={slashMenuFilter}
-        data-testid="slash-command-menu"
-        className="w-72 overflow-hidden rounded-lg border bg-popover text-popover-foreground shadow-lg"
+    <>
+      {fileInput}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: focus guard for a floating menu, not an interactive control. */}
+      <div
+        ref={slashRef}
+        style={FLOATING_INITIAL_STYLE}
+        onMouseDown={(event) => {
+          // The editor must keep focus and its selection while the menu is
+          // clicked — the menu is an extension of typing, like Notion's. Only
+          // the list element itself is exempt so its scrollbar stays draggable.
+          if (
+            !(event.target instanceof HTMLElement) ||
+            !event.target.hasAttribute('cmdk-list')
+          ) {
+            event.preventDefault();
+          }
+        }}
       >
-        <CommandInput
-          hidden
-          value={active.text.slice(1)}
-          onValueChange={() => {}}
-        />
-        <CommandEmpty>
-          <span className="text-muted-foreground">{labels.empty}</span>
-        </CommandEmpty>
-        <CommandList className="max-h-[330px] overscroll-contain">
-          {groups.map((group, groupIndex) => (
-            <React.Fragment key={group.heading}>
-              {groupIndex > 0 && <CommandSeparator />}
-              <CommandGroup heading={group.heading}>
-                {group.items.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <CommandItem
-                      key={item.value}
-                      value={item.value}
-                      onSelect={item.onSelect}
-                    >
-                      <CommandMenuRow
-                        icon={<Icon aria-hidden />}
-                        title={item.title}
-                        description={item.description}
-                      />
-                    </CommandItem>
-                  );
-                })}
-              </CommandGroup>
-            </React.Fragment>
-          ))}
-        </CommandList>
-        <CommandHints hints={[labels.hintSelect, labels.hintDismiss]} />
-      </Command>
-    </div>
+        <Command
+          ref={commandRef}
+          filter={slashMenuFilter}
+          data-testid="slash-command-menu"
+          className="w-72 overflow-hidden rounded-lg border bg-popover text-popover-foreground shadow-lg"
+        >
+          <CommandInput
+            hidden
+            value={active.text.slice(1)}
+            onValueChange={() => {}}
+          />
+          <CommandEmpty>
+            <span className="text-muted-foreground">{labels.empty}</span>
+          </CommandEmpty>
+          <CommandList className="max-h-[330px] overscroll-contain">
+            {groups.map((group, groupIndex) => (
+              <React.Fragment key={group.heading}>
+                {groupIndex > 0 && <CommandSeparator />}
+                <CommandGroup heading={group.heading}>
+                  {group.items.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <CommandItem
+                        key={item.value}
+                        value={item.value}
+                        onSelect={item.onSelect}
+                      >
+                        <CommandMenuRow
+                          icon={<Icon aria-hidden />}
+                          title={item.title}
+                          description={item.description}
+                        />
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              </React.Fragment>
+            ))}
+          </CommandList>
+          <CommandHints hints={[labels.hintSelect, labels.hintDismiss]} />
+        </Command>
+      </div>
+    </>
   );
 }

--- a/packages/core/editor/src/components/slash-items.ts
+++ b/packages/core/editor/src/components/slash-items.ts
@@ -27,6 +27,7 @@ import {
   Sigma,
   Table,
   Type,
+  Upload,
 } from 'lucide-react';
 
 import type { setupExtensions } from '../extensions';
@@ -57,6 +58,7 @@ export type SlashMenuActions = {
   run: (command: PMCommand, opts?: { refocus?: boolean }) => void;
   insertText: (text: string) => void;
   openDatePicker: () => void;
+  openFilePicker?: () => void;
 };
 
 /**
@@ -93,7 +95,7 @@ export function buildSlashMenuGroups(
   state: EditorState,
   actions: SlashMenuActions,
 ): SlashMenuGroup[] {
-  const { run, insertText, openDatePicker } = actions;
+  const { run, insertText, openDatePicker, openFilePicker } = actions;
   const labels = t.app.editor.slashCommand;
 
   const timeGroup: SlashMenuGroup = {
@@ -139,6 +141,23 @@ export function buildSlashMenuGroups(
     ],
   };
 
+  const assetGroups: SlashMenuGroup[] = openFilePicker
+    ? [
+        {
+          heading: labels.groupAssets,
+          items: [
+            {
+              value: 'upload-file asset attachment image media',
+              title: labels.uploadFile,
+              description: labels.uploadFileDesc,
+              icon: Upload,
+              onSelect: openFilePicker,
+            },
+          ],
+        },
+      ]
+    : [];
+
   // Inside a table the block transforms don't apply (cells hold inline
   // content only), so the menu switches to the shared table actions —
   // gated by the same command dry-run the hover table menu uses, so e.g.
@@ -156,6 +175,7 @@ export function buildSlashMenuGroups(
           onSelect: () => run(action.command(ext)),
         })),
       },
+      ...assetGroups,
       timeGroup,
     ];
   }
@@ -260,6 +280,7 @@ export function buildSlashMenuGroups(
         },
       ],
     },
+    ...assetGroups,
     timeGroup,
   ];
 }

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -112,6 +112,7 @@ export const t = {
       slashCommand: {
         groupBasic: 'Basic blocks',
         groupLists: 'Lists',
+        groupAssets: 'Assets',
         groupTime: 'Time',
         groupTable: 'Table',
         empty: 'No results',
@@ -137,6 +138,8 @@ export const t = {
         numberedListDesc: 'List with numbering',
         todoList: 'To-do list',
         todoListDesc: 'Track tasks with checkboxes',
+        uploadFile: 'Upload file',
+        uploadFileDesc: 'Insert an image or file',
         date: 'Date',
         dateDesc: 'Pick a date from the calendar',
         today: 'Today',

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -258,6 +258,39 @@ test('slash command can insert a persisted code block', async ({ page }) => {
     .toBe('```\nconst viaSlash = true;\n```');
 });
 
+test('slash command uploads a file that persists after reload', async ({
+  page,
+}) => {
+  const workspaceName = 'slash-command-upload-file';
+  const noteName = 'Home';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('/');
+  await expect(page.getByTestId('slash-command-menu')).toBeVisible();
+  await page.keyboard.insertText('upload');
+
+  const fileChooserPromise = page.waitForEvent('filechooser');
+  await page.getByTestId('slash-command-menu').getByText('Upload file').click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
+    name: 'Slash Upload.pdf',
+    mimeType: 'application/pdf',
+    buffer: Buffer.from('%PDF-1.4\n'),
+  });
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toMatch(/^\[Slash Upload\.pdf\]\(assets\/slash-upload-.*\.pdf\)$/);
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(
+    editor.getByRole('link', { name: 'Slash Upload.pdf' }),
+  ).toBeVisible();
+});
+
 // Matches the date-fns `PP` format used by the slash command
 // (e.g. "Dec 15, 2028").
 function formatDateLabel(date: Date): string {


### PR DESCRIPTION
## Summary

- add an **Upload file** action to the editor slash-command menu
- reuse the existing asset plugin lifecycle for storage, mapped insertion ranges, cancellation, cleanup, and Markdown-backed image/link insertion
- keep the action available in regular blocks and table cells when asset support is configured
- add unit coverage for dispatched insertion and side-effect-free ProseMirror command dry-runs
- add Playwright coverage for choosing a file, persisting its relative Markdown link, and rendering it after reload

## Why

Users could add attachments through paste or drag-and-drop, but had no discoverable file-picker path. This closes #659 without creating a parallel upload implementation.

## Root cause

The asset plugin only exposed DOM paste/drop entry points. The slash menu therefore had no typed way to invoke the existing durable asset-storage and insertion lifecycle.

## Validation

- `pnpm local-ci-check`
  - 160 Vitest files passed (3,029 passed, 1 skipped)
  - lint, workspace validation, TypeScript, Biome, and Knip passed
  - 169 browser E2Es passed
  - 8 Playwright component tests passed
  - desktop tests/build and Electron persistence smoke passed
- focused upload/persist/reload Playwright test passed
- thermonuclear code-quality review completed; its one worthwhile command dry-run finding was fixed and the amended diff passed re-review with no remaining high-confidence findings