### PR TITLE
docs: refresh plans after July grooming

### DIFF
--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-15
-updated: 2026-07-18
+updated: 2026-07-19
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
@@ -22,6 +22,7 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/644
   - https://github.com/bangle-io/bangle-io/pull/648
   - https://github.com/bangle-io/bangle-io/pull/649
+  - https://github.com/bangle-io/bangle-io/pull/658
 related_issues: []
 ---
 
@@ -215,6 +216,12 @@ workflows, recovery gaps, and the open package-boundary items below.
     facade and proves the current graph performs the write. Browser E2E forces
     a save failure, emits the real `event::app:reload-ui`, retries through the
     disposed graph, and verifies the edit is durable after a full page reload.
+- 2026-07-19 list-fidelity cleanup (PR #658, open):
+  - The pending implementation preserves tight/loose list semantics, ordered
+    task-list container kind, and structural nested-list indentation across
+    both editor engines.
+  - P1.3 remains in progress until the PR merges; its shared corpus, command,
+    codec, DOM, and persistence coverage are already part of the PR.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -459,10 +466,11 @@ Current status:
   mixed, linked, marked-up, and empty task items for both editor engines.
 - ProseMirror explicitly ignores wrapper `bullet_list`/`ordered_list` tokens
   and derives flat list items from the configured kind/checked attributes.
-- Nested content under an ordered parent still has a documented indentation
-  fidelity gap and is deliberately excluded from the passing corpus. That is
-  the remaining correctness item; the original general task-list coverage gap
-  is resolved.
+- The original general task-list coverage gap is resolved.
+- PR #658 is open with the remaining implementation: preserve tight/loose
+  list semantics, keep ordered task lists ordered, and use structural marker
+  widths for stable nested indentation. This section is not complete until
+  that PR merges.
 
 Evidence:
 
@@ -475,8 +483,8 @@ Plan:
 - [x] Derive task-list state from standard Markdown tokens or configure the parser
   explicitly to emit the required attrs.
 - [x] Document task-list normalization rules in tests.
-- Fix or intentionally normalize nested list indentation under ordered parents,
-  then add that case to the golden corpus.
+- [ ] Merge PR #658, including nested ordered-list indentation in the golden
+  corpus and fixed-point coverage.
 
 Verification:
 

--- a/plans/006-image-embeds-and-paste-assets.md
+++ b/plans/006-image-embeds-and-paste-assets.md
@@ -4,11 +4,12 @@ status: active
 type: plan
 archived: false
 created: 2026-06-30
-updated: 2026-07-12
+updated: 2026-07-19
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/587
   - https://github.com/bangle-io/bangle-io/pull/610
+  - https://github.com/bangle-io/bangle-io/pull/661
 related_issues: []
 ---
 
@@ -38,6 +39,10 @@ The target behavior is:
   Playwright persistence coverage for images and PDFs.
 - PR #610 fixed duplicate image nodes when browsers surface the same clipboard
   file through multiple transfer-list views.
+- PR #661 added a discoverable **Upload file** slash action that reuses the
+  existing durable asset pipeline for mapped insertion, cancellation, cleanup,
+  and Markdown-backed image/link persistence. This completes the file-picker
+  entry point; image metadata, replacement, sizing, and recovery UI remain.
 - `packages/js-lib/banger-editor/src/image.ts` owns the image schema and
   Markdown parse/serialize behavior; `packages/core/editor/src/asset-file-plugin.ts`
   and `local-image-node-view.ts` own Bangle's durable asset workflow.

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-05
-updated: 2026-07-12
+updated: 2026-07-19
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/609
@@ -14,6 +14,8 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/620
   - https://github.com/bangle-io/bangle-io/pull/623
   - https://github.com/bangle-io/bangle-io/pull/630
+  - https://github.com/bangle-io/bangle-io/pull/655
+  - https://github.com/bangle-io/bangle-io/pull/658
 related_issues: []
 ---
 
@@ -50,6 +52,14 @@ Key upstream facts (as of 2026-07-05):
   `wordgard` skill that teaches agents to write idiomatic Wordgard code.
 
 ## Current status
+
+2026-07-19 update:
+
+- PR #655 fixed nested multiline code serialization inside block delimiters in
+  the Wordgard Markdown codec.
+- PR #658 is open with shared list-syntax and codec work that preserves list
+  kind, task state, tightness, and structural indentation across both editor
+  engines. The migration remains in progress while that parity work is pending.
 
 Active. Landed so far (PR #609):
 

--- a/plans/012-markdown-feature-parity.md
+++ b/plans/012-markdown-feature-parity.md
@@ -12,6 +12,7 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/637
   - https://github.com/bangle-io/bangle-io/pull/650
   - https://github.com/bangle-io/bangle-io/pull/653
+  - https://github.com/bangle-io/bangle-io/pull/658
 related_issues: []
 ---
 
@@ -50,6 +51,10 @@ Active and partially implemented:
   tokenization, editable inline/display nodes, KaTeX rendering, exact-source
   safeguards, and Playwright persistence coverage. That PR also added a
   separate Plan 016 for lazy-loading the renderer after the first release.
+- PR #658 is open with a cross-engine list-fidelity slice: tight/loose list
+  semantics, ordered task-list kind, split/input-rule transitions, and stable
+  structural indentation. It strengthens the parity baseline but does not
+  complete one of the numbered milestones below.
 - M1 footnotes, M2 bare-URL autolinks, M3 highlight, and M5-M7 remain
   unstarted. The plan stays active rather than completed when M4 lands.
 

--- a/plans/013-live-markdown-source-editor.md
+++ b/plans/013-live-markdown-source-editor.md
@@ -5,11 +5,12 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-12
-updated: 2026-07-12
-owner: agent
+updated: 2026-07-19
+owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/630
-related_issues: []
+related_issues:
+  - https://github.com/bangle-io/bangle-io/issues/527
 ---
 
 # Live Markdown Source Editor

--- a/plans/014-block-handle-slash-menu-hardening.md
+++ b/plans/014-block-handle-slash-menu-hardening.md
@@ -5,10 +5,11 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-12
-updated: 2026-07-12
+updated: 2026-07-19
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/633
+  - https://github.com/bangle-io/bangle-io/pull/656
 related_issues: []
 ---
 
@@ -32,8 +33,11 @@ Large / Editor).
 
 ## Current status
 
-Not started. All items are refinements on top of merged behavior; none block
-release of PR #633.
+Partially complete. PR #656 completed item 6 by adding a typed editor-engine
+availability contract, hiding unavailable omni editor commands, retaining the
+last-focused live editor across external-focus handoffs, and revalidating at
+execution. Items 1-5 and 7-8 remain in Backlog; none block release of the
+merged PR #633 behavior.
 
 ## Scope
 
@@ -91,15 +95,11 @@ and encode it in tests before enabling handles on nested structures.
 
 ### 6. Omni editor-command availability
 
-`command::editor:*` commands always appear in omni search; when the engine
-cannot apply them (cursor in a table cell, no mounted editor, read-only
-wordgard engine) the handler now shows an "unavailable" toast
-(`t.app.toasts.editorCommandUnavailable`) instead of failing silently. The
-remaining follow-up is first-class availability: hide or disable commands in
-the omni list based on live engine/selection state, then revalidate at
-execution (PM commands already self-validate). Requires a dynamic
-availability hook on the command registry — design it against more consumers
-than these four commands before building.
+Completed in PR #656. A narrow typed editor-engine availability contract now
+hides unavailable heading and table commands in omni search while handlers
+still revalidate at execution. The implementation also retains the
+last-focused live editor across omni/external focus handoffs and covers the
+multi-editor edge case without adding a generic dynamic command registry.
 
 ### 7. Intentional undo grouping
 
@@ -126,6 +126,8 @@ neither blurs the editor nor selects an item.
   synthetic-marked text on every deactivation path, and the save path
   serializes through `stripSyntheticSuggestionText`, so a "+"-opened `/`
   can never reach storage (navigate-away e2e covers the repro).
+- Omni editor-command availability: PR #656 hides invalid heading/table
+  actions from omni search and retains execution-time validation.
 
 ## Out of scope
 
@@ -160,5 +162,5 @@ None.
 1. Item 1 (mapped positions) first — items 2 and 4 want the same per-view
    state container it introduces.
 2. Items 3 and 4 are small and independent; good warm-ups.
-3. Items 6–8 are behavior decisions; confirm the intended UX (one-line answer
+3. Items 7–8 are behavior decisions; confirm the intended UX (one-line answer
    each) before implementing.

--- a/plans/015-file-change-eventing-consolidation.md
+++ b/plans/015-file-change-eventing-consolidation.md
@@ -5,10 +5,11 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/652
+  - https://github.com/bangle-io/bangle-io/pull/626
 related_issues:
   - https://github.com/bangle-io/bangle-io/issues/521
 ---
@@ -33,7 +34,9 @@ the actual design should be decided when the work is picked up.
 Documented during the notes-table work (PR #652), which added two more
 consumers (note file stats scan + targeted patch) and hit one of the implicit
 contracts described below as a real bug during review (force-update did not
-refresh stats).
+refresh stats). PR #626 is still open and activates Native FS external-change
+observation, making this consolidation more important, but the consolidation
+itself has not started.
 
 ## The problem
 

--- a/plans/archived/017-pwa-install-open-in-app.md
+++ b/plans/archived/017-pwa-install-open-in-app.md
@@ -1,15 +1,24 @@
 ---
 title: PWA install surface and open-in-app routing
-status: active
+status: completed
 type: plan
-archived: false
-archived_on:
+archived: true
+archived_on: 2026-07-19
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-19
 owner: mixed
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/657
 related_issues: []
 ---
+
+> DONE (2026-07-19): PR #657 delivered the install/open-in-app surfaces,
+> deployment-aware manifest, protocol deep links, focus-existing launches, and
+> app shortcuts. Native in-place Markdown file handling was deliberately
+> removed from this scope and remains a separate storage initiative. Automated
+> coverage and local browser smoke testing were completed with the
+> implementation; the real installed-PWA check remains part of release-time
+> verification.
 
 # PWA install surface and open-in-app routing
 
@@ -31,6 +40,13 @@ Three user-visible surfaces, all driven by one install-state snapshot:
    installed but being used from a browser tab. Dismissal is persisted, so it
    shows at most once per browser profile. It never displaces an already-open
    alert dialog; it waits for the shared alert slot to free up.
+
+## Completion status
+
+Completed in PR #657. Phase 1 and the retained phase 2 scope shipped. The
+file-handler import experiment was removed before completion because native
+in-place editing needs a separate single-file storage and save-lifecycle
+design. That follow-up is explicitly out of scope for this completed plan.
 
 ## Browser API basis (verified July 2026)
 
@@ -141,5 +157,6 @@ Three user-visible surfaces, all driven by one install-state snapshot:
 
 ## Next steps
 
-- Implement, then PR review (including an external high-effort model review).
-- Follow-up plan for service worker/offline if prioritized.
+- No remaining work is required for this plan.
+- Create separate plans for service worker/offline support or native in-place
+  Markdown file handling if either is prioritized.


### PR DESCRIPTION
## Summary

- reconcile active plans with the latest merged and open pull requests
- record partial completion for image upload, editor availability, Markdown lists, and Wordgard parity
- archive the completed PWA install/open-in-app plan
- link Live Markdown and file-eventing work to their related tickets