### PR TITLE
fix: prevent workspace home horizontal overflow

### DIFF
--- a/packages/core/service-core/src/user-activity-service.ts
+++ b/packages/core/service-core/src/user-activity-service.ts
@@ -54,7 +54,6 @@ export class UserActivityService extends BaseService {
   private activityCooldownMs!: number;
   private $refreshActivityCounter = atom(0);
   private $_timesAppLoaded: PrimitiveAtom<number> | undefined;
-  private $starredItemsChangeCounter = atom(0);
   private starredItemManager: StarredItemManager;
 
   $isNewUser = atom((get) => {
@@ -145,7 +144,6 @@ export class UserActivityService extends BaseService {
   $starredWsPaths = createAsyncAtom(
     async (get): Promise<string[]> => {
       await this.mountPromise;
-      get(this.$starredItemsChangeCounter);
       get(this.workspaceOps.$workspaceInfoChange);
       const wsPaths = get(this.workspaceState.$noteWsPaths);
       const wsName = get(this.workspaceState.$currentWsName);
@@ -156,7 +154,7 @@ export class UserActivityService extends BaseService {
         await this.starredItemManager.getStarredItems(wsName);
       return starredWsPaths;
     },
-    () => [],
+    (previous) => previous ?? [],
     this.emitAppError,
   );
 
@@ -401,7 +399,6 @@ export class UserActivityService extends BaseService {
   ): Promise<void> {
     await this.mountPromise;
     await this.starredItemManager.toggleStarItem(item, desiredState);
-    this.store.set(this.$starredItemsChangeCounter, (c) => c + 1);
   }
 
   /**
@@ -423,11 +420,7 @@ export class UserActivityService extends BaseService {
     await this.mountPromise;
 
     try {
-      const relocated =
-        await this.starredItemManager.relocateStarredItems(relocations);
-      if (relocated) {
-        this.store.set(this.$starredItemsChangeCounter, (c) => c + 1);
-      }
+      await this.starredItemManager.relocateStarredItems(relocations);
       return 'succeeded';
     } catch (error) {
       this.logger.error('Unable to migrate starred items after relocation', {
@@ -505,14 +498,14 @@ class StarredItemManager {
 
   async relocateStarredItems(
     relocations: readonly { oldItem: WsPath; newItem: WsPath }[],
-  ): Promise<boolean> {
+  ): Promise<void> {
     if (relocations.length === 0) {
-      return false;
+      return;
     }
 
     const wsName = relocations[0]?.oldItem.wsName;
     if (!wsName) {
-      return false;
+      return;
     }
     for (const { oldItem, newItem } of relocations) {
       if (oldItem.wsName !== wsName || newItem.wsName !== wsName) {
@@ -534,7 +527,6 @@ class StarredItemManager {
         newItem.wsPath,
       ]),
     );
-    let relocated = false;
     await this.workspaceOps.updateWorkspaceMetadata(
       wsName,
       (currentMetadata) => {
@@ -554,8 +546,6 @@ class StarredItemManager {
           return currentMetadata;
         }
 
-        relocated = true;
-
         const relocatedItems = currentRawStarredItems.map(
           (wsPath) => relocationByOldWsPath.get(wsPath) ?? wsPath,
         );
@@ -566,8 +556,6 @@ class StarredItemManager {
         };
       },
     );
-
-    return relocated;
   }
 
   async getStarredItems(wsName: string): Promise<string[]> {

--- a/packages/tooling/e2e-tests/src/ws-home-notes-table.e2e.ts
+++ b/packages/tooling/e2e-tests/src/ws-home-notes-table.e2e.ts
@@ -1,5 +1,8 @@
 import { expect, type Locator, type Page, test } from '@playwright/test';
-import { createBrowserWorkspaceAndNote } from './common';
+import {
+  createBrowserWorkspaceAndNote,
+  expectNoPageHorizontalOverflow,
+} from './common';
 
 function notesTable(page: Page): Locator {
   return page.getByTestId('ws-home-notes-table');
@@ -17,7 +20,7 @@ async function createNoteFromHome(page: Page, noteName: string) {
 }
 
 async function goHome(page: Page) {
-  await page.getByRole('link', { name: 'Home' }).click();
+  await page.getByRole('link', { name: 'Home', exact: true }).click();
   await expect(notesTable(page)).toBeVisible();
 }
 
@@ -127,4 +130,40 @@ test('notes table row actions star and delete a note', async ({ page }) => {
   await expect(
     page.getByText('No notes found in this workspace.'),
   ).toBeVisible();
+});
+
+test('workspace home stays within compact desktop and mobile viewports', async ({
+  page,
+}) => {
+  const noteName =
+    'a-very-long-note-name-that-should-not-expand-the-workspace-home-layout';
+  await page.setViewportSize({ width: 900, height: 800 });
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'responsive-notes-table-ws',
+    noteName,
+  });
+  await goHome(page);
+
+  const tableContainer = notesTable(page).locator(
+    '[data-slot="table-container"]',
+  );
+  await expectNoPageHorizontalOverflow(page);
+  await expect(
+    page.getByRole('button', { name: 'Switch Workspace' }),
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: 'New Note' })).toBeVisible();
+  await expect
+    .poll(() =>
+      tableContainer.evaluate(
+        (element) => element.scrollWidth - element.clientWidth,
+      ),
+    )
+    .toBeGreaterThan(0);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expectNoPageHorizontalOverflow(page);
+  await expect(
+    notesTable(page).getByRole('link', { name: noteName }),
+  ).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Columns' })).toBeVisible();
 });

--- a/packages/tooling/e2e-tests/src/ws-home-notes-table.e2e.ts
+++ b/packages/tooling/e2e-tests/src/ws-home-notes-table.e2e.ts
@@ -102,15 +102,38 @@ test('notes table row actions star and delete a note', async ({ page }) => {
   await goHome(page);
 
   // Star through the row menu: the star indicator appears in the row and the
-  // note joins the sidebar starred section.
+  // note joins the sidebar starred section without flashing off and on.
+  const targetRow = noteRows(page).first();
+  await targetRow.evaluate((element) => {
+    const readStarredState = () =>
+      element.textContent?.includes('Starred') ?? false;
+    const history = [readStarredState()];
+    element.dataset.starredStateHistory = JSON.stringify(history);
+
+    new MutationObserver(() => {
+      const nextState = readStarredState();
+      if (history.at(-1) !== nextState) {
+        history.push(nextState);
+        element.dataset.starredStateHistory = JSON.stringify(history);
+      }
+    }).observe(element, { childList: true, subtree: true });
+  });
   await page.getByRole('button', { name: 'Actions for action-target' }).click();
   await page.getByRole('menuitem', { name: 'Star' }).click();
-  await expect(
-    noteRows(page).first().getByText('Starred', { exact: true }),
-  ).toBeAttached();
+  await expect(targetRow.getByText('Starred', { exact: true })).toBeAttached();
   await expect(
     page.getByText('Starred', { exact: true }).first(),
   ).toBeVisible();
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  await expect(targetRow).toHaveAttribute(
+    'data-starred-state-history',
+    '[false,true]',
+  );
 
   // Delete through the row menu with explicit confirmation.
   await page.getByRole('button', { name: 'Actions for action-target' }).click();

--- a/packages/ui/ui-components/src/sidebar.tsx
+++ b/packages/ui/ui-components/src/sidebar.tsx
@@ -461,7 +461,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        'relative flex min-h-svh w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
+        'relative flex min-h-svh w-full min-w-0 flex-1 flex-col bg-background md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm',
         className,
       )}
       {...props}


### PR DESCRIPTION
Fixes two workspace-home regressions affecting compact layouts and starred-note updates.

- Allow the shared sidebar inset to shrink so wide notes tables stay inside their local scroll container instead of widening the document.
- Use the canonical workspace-metadata invalidation for starred paths and retain the last resolved state while it refreshes, preventing the star indicator from flashing off and on.
- Add Playwright coverage at 900px and 390px, plus an exact DOM state-transition check for starring from the notes table.

The responsive check also confirms the note view and mobile sidebar remain within the viewport.
