### PR TITLE
fix(pwa): detect installed overlay windows

### DIFF
--- a/packages/core/app/src/common/__tests__/pwa-install.spec.ts
+++ b/packages/core/app/src/common/__tests__/pwa-install.spec.ts
@@ -86,6 +86,47 @@ describe('PWA install prompt tracking', () => {
       installedThisSession: true,
     });
   });
+
+  it('treats window-controls-overlay as an installed app window', () => {
+    const originalMatchMedia = Object.getOwnPropertyDescriptor(
+      window,
+      'matchMedia',
+    );
+    const matchMedia = vi.fn((query: string) => {
+      const mediaQuery = new EventTarget() as EventTarget & {
+        matches: boolean;
+      };
+      mediaQuery.matches = query === '(display-mode: window-controls-overlay)';
+      return mediaQuery as unknown as MediaQueryList;
+    });
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: matchMedia,
+    });
+
+    try {
+      pwaInstall.initializePwaInstallPromptTracking(window);
+      const event = makeInstallPromptEvent();
+      window.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(pwaInstall.getPwaInstallSnapshot()).toMatchObject({
+        canInstall: false,
+        isInstalled: true,
+        isStandalone: true,
+        canOpenInApp: false,
+      });
+      expect(matchMedia).toHaveBeenCalledWith(
+        '(display-mode: window-controls-overlay)',
+      );
+    } finally {
+      if (originalMatchMedia) {
+        Object.defineProperty(window, 'matchMedia', originalMatchMedia);
+      } else {
+        Reflect.deleteProperty(window, 'matchMedia');
+      }
+    }
+  });
 });
 
 describe('installed related apps detection', () => {

--- a/packages/core/app/src/common/pwa-install.ts
+++ b/packages/core/app/src/common/pwa-install.ts
@@ -4,6 +4,7 @@ export interface PwaInstallSnapshot {
   canInstall: boolean;
   isInstalled: boolean;
   isInstalling: boolean;
+  /** True when this page is running in the installed app's own window. */
   isStandalone: boolean;
   canOpenInApp: boolean;
   /**
@@ -91,6 +92,12 @@ const TITLEBAR_EDGE_OCCLUSION_EPSILON = 0.5;
 const PWA_PROTOCOL_LAUNCH_URL = 'web+bangle://open';
 const PWA_LAUNCH_QUERY_PARAM = 'launch';
 const PWA_SHORTCUT_QUERY_PARAM = 'shortcut';
+const INSTALLED_APP_DISPLAY_MODE_QUERIES = [
+  '(display-mode: standalone)',
+  // Bangle prefers this mode through manifest `display_override`. It is a
+  // distinct active display mode, so the standalone query does not match it.
+  '(display-mode: window-controls-overlay)',
+] as const;
 
 let initializedWindow: Window | undefined;
 let trackingAbortController: AbortController | undefined;
@@ -158,14 +165,15 @@ function getCurrentWindow() {
   return typeof window === 'undefined' ? undefined : window;
 }
 
-function isStandaloneDisplay(windowRef: Window) {
+function isInstalledAppDisplay(windowRef: Window) {
   const navigatorWithStandalone = windowRef.navigator as Navigator & {
     standalone?: boolean;
   };
 
   return (
-    windowRef.matchMedia?.('(display-mode: standalone)').matches === true ||
-    navigatorWithStandalone.standalone === true
+    INSTALLED_APP_DISPLAY_MODE_QUERIES.some(
+      (query) => windowRef.matchMedia?.(query).matches === true,
+    ) || navigatorWithStandalone.standalone === true
   );
 }
 
@@ -297,7 +305,7 @@ export function initializePwaInstallPromptTracking(
   windowRef.addEventListener(
     'beforeinstallprompt',
     (event) => {
-      if (isStandaloneDisplay(windowRef)) {
+      if (isInstalledAppDisplay(windowRef)) {
         return;
       }
 
@@ -318,10 +326,13 @@ export function initializePwaInstallPromptTracking(
     { signal },
   );
 
-  const standaloneQuery = windowRef.matchMedia?.('(display-mode: standalone)');
-  standaloneQuery?.addEventListener?.('change', emitChange, { signal });
+  for (const query of INSTALLED_APP_DISPLAY_MODE_QUERIES) {
+    windowRef.matchMedia?.(query).addEventListener?.('change', emitChange, {
+      signal,
+    });
+  }
 
-  if (!isStandaloneDisplay(windowRef)) {
+  if (!isInstalledAppDisplay(windowRef)) {
     void probeInstalledRelatedApps(windowRef);
   }
 
@@ -435,7 +446,7 @@ function isSameOrigin(url: string, origin: string): boolean {
 
 function computePwaInstallSnapshot(): PwaInstallSnapshot {
   const windowRef = initializedWindow ?? getCurrentWindow();
-  const isStandalone = Boolean(windowRef && isStandaloneDisplay(windowRef));
+  const isStandalone = Boolean(windowRef && isInstalledAppDisplay(windowRef));
   const isInstalled = Boolean(
     windowRef &&
       (installedByAppEvent || installedRelatedAppDetected || isStandalone),

--- a/packages/tooling/e2e-tests/src/pwa-install.e2e.ts
+++ b/packages/tooling/e2e-tests/src/pwa-install.e2e.ts
@@ -108,6 +108,42 @@ test('sidebar shows a one-click install pill while the browser offers a PWA inst
   await expect(page.getByRole('alertdialog')).toHaveCount(0);
 });
 
+test('installed window-controls-overlay mode never offers to install the app', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    const nativeMatchMedia = window.matchMedia.bind(window);
+    window.matchMedia = (query) => {
+      const mediaQuery = nativeMatchMedia(query);
+      if (query !== '(display-mode: window-controls-overlay)') {
+        return mediaQuery;
+      }
+
+      return new Proxy(mediaQuery, {
+        get(target, property) {
+          if (property === 'matches') {
+            return true;
+          }
+
+          const value = Reflect.get(target, property, target);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+    };
+  });
+
+  await page.goto('/');
+
+  const defaultPrevented = await page.evaluate(() => {
+    const event = new Event('beforeinstallprompt', { cancelable: true });
+    window.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+
+  expect(defaultPrevented).toBe(false);
+  await expect(page.getByTestId('sidebar-pwa-action')).toHaveCount(0);
+});
+
 test('installed app detected from a browser tab shows a one-time open-in-app dialog', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- Treat `window-controls-overlay` as an installed-app display mode alongside `standalone`.
- Suppress install affordances inside either installed window mode.
- Add unit and browser regression coverage.

## Why

Bangle prefers `window-controls-overlay` in its manifest, but the runtime only queried `display-mode: standalone`. An installed window could therefore be mistaken for a browser tab and show “Install app.” Installed state remains browser-derived rather than persisted, so uninstalling cannot leave stale application state.

## Validation

- `pnpm local-ci-check`