### PR TITLE
feat: add privacy-safe bug reporting controls

### DIFF
--- a/knip.production-dependencies.json
+++ b/knip.production-dependencies.json
@@ -13,7 +13,6 @@
         "@bangle.io/mini-js-utils",
         "@bangle.io/root-emitter",
         "@bangle.io/translations",
-        "@sentry/browser",
         "@sentry/vite-plugin",
         "@tailwindcss/vite",
         "@vitejs/plugin-react",

--- a/packages/core/app/src/__tests__/app-error-handler.spec.ts
+++ b/packages/core/app/src/__tests__/app-error-handler.spec.ts
@@ -1,6 +1,6 @@
+import { shouldReportAppError } from '@bangle.io/base-utils';
 import type { AppError } from '@bangle.io/types';
 import { describe, expect, test } from 'vitest';
-import { shouldReportAppError } from '../app-error-handler';
 
 describe('shouldReportAppError', () => {
   test.each([

--- a/packages/core/app/src/app-error-handler.tsx
+++ b/packages/core/app/src/app-error-handler.tsx
@@ -1,31 +1,9 @@
 import { getGithubUrl, handleAppError } from '@bangle.io/base-utils';
 import { SERVICE_NAME } from '@bangle.io/constants';
 import { useCoreServices, useLogger } from '@bangle.io/context';
-import type { AppError, RootEmitter } from '@bangle.io/types';
+import type { RootEmitter } from '@bangle.io/types';
 import { toast } from '@bangle.io/ui-components';
 import React, { useEffect } from 'react';
-
-export function shouldReportAppError(appError: AppError): boolean {
-  switch (appError.name) {
-    case 'error::file:already-existing':
-    case 'error::file:size-too-large':
-    case 'error::file-storage:file-does-not-exist':
-    case 'error::workspace:native-fs-auth-needed':
-    case 'error::workspace:native-fs-locate-failed':
-    case 'error::workspace:native-fs-reconnect-failed':
-    case 'error::workspace:no-note-opened':
-    case 'error::workspace:no-notes-found':
-    case 'error::workspace:not-opened':
-    case 'error::ws-path:create-new-note':
-    case 'error::ws-path:invalid-markdown-path':
-    case 'error::ws-path:invalid-note-path':
-    case 'error::ws-path:invalid-ws-name':
-    case 'error::ws-path:invalid-ws-path':
-      return false;
-    default:
-      return true;
-  }
-}
 
 export function AppErrorHandler({ rootEmitter }: { rootEmitter: RootEmitter }) {
   const coreServices = useCoreServices();
@@ -67,12 +45,6 @@ export function AppErrorHandler({ rootEmitter }: { rootEmitter: RootEmitter }) {
 
     const handleAppLikeError = (error: Error) => {
       return handleAppError(error, (appError, error) => {
-        if (shouldReportAppError(appError)) {
-          logger.error(error);
-        } else {
-          logger.warn('Handled app error:', error.message);
-        }
-
         switch (appError.name) {
           case 'error::editor:save-failed': {
             const toastId = `editor-save-failed:${appError.payload.wsPath}`;

--- a/packages/core/app/src/components/feedback/error-boundary.tsx
+++ b/packages/core/app/src/components/feedback/error-boundary.tsx
@@ -23,7 +23,7 @@ export function ErrorBoundary({ children }: ErrorBoundaryProps) {
   return (
     <ReactErrorBoundary
       onError={(error, errorInfo) => {
-        logger.error('ErrorBoundary caught error:', error, errorInfo);
+        logger.error(error, 'ErrorBoundary caught error:', errorInfo);
       }}
       fallbackRender={({ error }) => {
         const reportError = toError(error);

--- a/packages/core/app/src/dialogs/manual-bug-report-dialog.tsx
+++ b/packages/core/app/src/dialogs/manual-bug-report-dialog.tsx
@@ -1,0 +1,113 @@
+import { useCoreServices } from '@bangle.io/context';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  toast,
+} from '@bangle.io/ui-components';
+import { useAtomValue } from 'jotai';
+import React from 'react';
+
+export function ManualBugReportDialog() {
+  const { errorReporting } = useCoreServices();
+  const report = useAtomValue(errorReporting.$manualReportPrompt);
+  const sending = useAtomValue(errorReporting.$sendingReports);
+
+  if (!report) {
+    return null;
+  }
+
+  const keepForLater = () => {
+    errorReporting.dismissManualReportPrompt(report.id);
+  };
+
+  const deleteReport = async () => {
+    try {
+      await errorReporting.deletePendingReport(report.id);
+    } catch {
+      toast.error(t.app.bugReportPrompt.reportDeleteFailed);
+    }
+  };
+
+  const sendReport = async () => {
+    try {
+      if (await errorReporting.sendPendingReport(report.id)) {
+        toast.success(t.app.bugReportPrompt.reportSent);
+      } else {
+        toast.error(t.app.bugReportPrompt.reportSendFailed);
+      }
+    } catch {
+      toast.error(t.app.bugReportPrompt.reportSendFailed);
+    }
+  };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          keepForLater();
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{t.app.bugReportPrompt.title}</DialogTitle>
+          <DialogDescription>
+            {t.app.bugReportPrompt.description}
+          </DialogDescription>
+        </DialogHeader>
+
+        <p className="text-muted-foreground text-sm">
+          {t.app.bugReportPrompt.reassurance}
+        </p>
+
+        <div className="min-w-0">
+          <h3 className="mb-2 font-medium text-sm">
+            {t.app.bugReportPrompt.previewLabel}
+          </h3>
+          <pre
+            className="max-h-64 overflow-auto rounded-md border bg-muted/40 p-3 text-xs"
+            data-testid="manual-bug-report-preview"
+          >
+            {JSON.stringify(report, null, 2)}
+          </pre>
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <Button
+            disabled={sending}
+            onClick={() => void deleteReport()}
+            type="button"
+            variant="ghost"
+          >
+            {t.app.bugReportPrompt.deleteReport}
+          </Button>
+          <div className="flex flex-col-reverse gap-2 sm:flex-row">
+            <Button
+              disabled={sending}
+              onClick={keepForLater}
+              type="button"
+              variant="outline"
+            >
+              {t.app.bugReportPrompt.keepForLater}
+            </Button>
+            <Button
+              disabled={sending}
+              onClick={() => void sendReport()}
+              type="button"
+            >
+              {sending
+                ? t.app.bugReportPrompt.sendingReport
+                : t.app.bugReportPrompt.sendReport}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/core/app/src/index.tsx
+++ b/packages/core/app/src/index.tsx
@@ -19,6 +19,7 @@ import {
 import { PwaLaunchActions } from './common/pwa-launch-actions';
 import { ErrorBoundary } from './components/feedback/error-boundary';
 import { AppDialogs } from './dialogs/app-dialogs';
+import { ManualBugReportDialog } from './dialogs/manual-bug-report-dialog';
 import { PwaOpenInAppPrompt } from './dialogs/pwa-open-in-app-prompt';
 import { AppSidebar } from './layout/app-sidebar';
 import {
@@ -53,6 +54,7 @@ export function App({
     <LoggerProvider logger={logger}>
       <Provider store={store}>
         <CoreServiceProvider services={services.core}>
+          <ManualBugReportDialog />
           <ErrorBoundary>
             <BrowserAppDocumentSetup />
             <AppDialogs />

--- a/packages/core/app/src/pages/page-not-found.tsx
+++ b/packages/core/app/src/pages/page-not-found.tsx
@@ -37,9 +37,7 @@ export function PageNotFound() {
                 label: t.app.pageNotFound.reportButton,
                 variant: 'outline',
                 onClick: () => {
-                  const error = new Error(
-                    `404 Page Not Found: ${window.location.href}`,
-                  );
+                  const error = new Error('Bangle route was not found');
                   logger.error(error);
                   window.open(getGithubUrl(error, logger), '_blank');
                 },

--- a/packages/core/app/src/pages/page-settings.tsx
+++ b/packages/core/app/src/pages/page-settings.tsx
@@ -23,8 +23,10 @@ import {
   SelectTrigger,
   SelectValue,
   SettingsPage,
+  Switch,
+  toast,
 } from '@bangle.io/ui-components';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import {
   ArrowLeft,
   BriefcaseBusiness,
@@ -155,7 +157,7 @@ export function PageSettings() {
 }
 
 function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
-  const { navigation, workbenchState } = useCoreServices();
+  const { errorReporting, navigation, workbenchState } = useCoreServices();
   const routeInfo = useAtomValue(navigation.$routeInfo);
   const themePref = useAtomValue(workbenchState.$themePref);
   const [wideEditor, setWideEditor] = useAtom(workbenchState.$wideEditor);
@@ -163,6 +165,12 @@ function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
   const [assetLocationPreference, setAssetLocationPreference] = useAtom(
     workbenchState.$assetLocationPreference,
   );
+  const automaticErrorReporting = useAtomValue(
+    errorReporting.$automaticReportingEnabled,
+  );
+  const pendingReportCount = useAtomValue(errorReporting.$pendingReportCount);
+  const sendingReports = useAtomValue(errorReporting.$sendingReports);
+  const setAlertDialog = useSetAtom(workbenchState.$alertDialog);
   const returnTo = safeAppHref(getSettingsReturnTo(routeInfo));
 
   const backHref =
@@ -318,6 +326,112 @@ function SettingsLayout({ activePage }: { activePage: SettingsPageId }) {
                     description={t.app.settings.general.wideEditorDescription}
                     title={t.app.settings.general.wideEditorTitle}
                   />
+                </SettingsPage.SettingsSection>
+
+                <SettingsPage.SettingsSection
+                  title={t.app.settings.general.privacySection}
+                >
+                  <SettingsPage.SettingsRow
+                    control={
+                      <Switch
+                        aria-label={
+                          t.app.settings.general.automaticBugReportsToggle
+                        }
+                        checked={automaticErrorReporting}
+                        onCheckedChange={(checked) => {
+                          if (checked) {
+                            void errorReporting.setAutomaticReportingEnabled(
+                              true,
+                            );
+                            return;
+                          }
+
+                          setAlertDialog({
+                            dialogId: 'dialog::disable-automatic-bug-reports',
+                            title:
+                              t.app.settings.general.disableBugReportsTitle,
+                            description:
+                              t.app.settings.general
+                                .disableBugReportsDescription,
+                            cancelText:
+                              t.app.settings.general.keepBugReportsEnabled,
+                            continueText:
+                              t.app.settings.general.disableBugReportsButton,
+                            onCancel: () => {},
+                            onContinue: () => {
+                              void errorReporting.setAutomaticReportingEnabled(
+                                false,
+                              );
+                            },
+                          });
+                        }}
+                      />
+                    }
+                    description={
+                      t.app.settings.general.automaticBugReportsDescription
+                    }
+                    title={t.app.settings.general.automaticBugReportsTitle}
+                  />
+                  {!automaticErrorReporting || pendingReportCount > 0 ? (
+                    <SettingsPage.SettingsRow
+                      control={
+                        <div className="flex flex-wrap justify-end gap-2">
+                          <Button
+                            disabled={
+                              pendingReportCount === 0 || sendingReports
+                            }
+                            onClick={() => {
+                              void errorReporting
+                                .sendPendingReports()
+                                .then(({ sent, remaining }) => {
+                                  if (sent > 0 && remaining === 0) {
+                                    toast.success(
+                                      t.app.settings.general
+                                        .pendingBugReportsSent,
+                                    );
+                                  } else if (remaining > 0) {
+                                    toast.error(
+                                      t.app.settings.general
+                                        .pendingBugReportsSendFailed,
+                                    );
+                                  }
+                                });
+                            }}
+                            type="button"
+                            variant="outline"
+                          >
+                            {sendingReports
+                              ? t.app.settings.general.sendingBugReports
+                              : t.app.settings.general.sendBugReports}
+                          </Button>
+                          <Button
+                            disabled={
+                              pendingReportCount === 0 || sendingReports
+                            }
+                            onClick={() => {
+                              void errorReporting.clearPendingReports();
+                            }}
+                            type="button"
+                            variant="ghost"
+                          >
+                            {t.app.settings.general.deleteBugReports}
+                          </Button>
+                        </div>
+                      }
+                      description={
+                        automaticErrorReporting
+                          ? t.app.settings.general.pendingBugReportsDescription(
+                              {
+                                count: pendingReportCount,
+                              },
+                            )
+                          : t.app.settings.general.manualBugReportsDescription({
+                              count: pendingReportCount,
+                            })
+                      }
+                      title={t.app.settings.general.pendingBugReportsTitle}
+                    />
+                  ) : null}
                 </SettingsPage.SettingsSection>
               </>
             ) : (

--- a/packages/core/context/src/service-types.ts
+++ b/packages/core/context/src/service-types.ts
@@ -3,6 +3,7 @@ import type {
   CommandDispatchService,
   CommandRegistryService,
   EditorService,
+  ErrorReportingService,
   FileSystemService,
   NavigationService,
   ShortcutService,
@@ -82,6 +83,7 @@ export type CoreServices<
   commandRegistry: CommandRegistryService;
   editorEngine: TEditorEngine;
   editorService: EditorService;
+  errorReporting: ErrorReportingService;
   fileSystem: FileSystemService;
   navigation: NavigationService;
   shortcut: ShortcutService;

--- a/packages/core/initialize-services/src/__tests__/initialize-services.spec.ts
+++ b/packages/core/initialize-services/src/__tests__/initialize-services.spec.ts
@@ -3,7 +3,7 @@ import { BaseService } from '@bangle.io/base-utils';
 import { ThemeManager } from '@bangle.io/color-scheme-manager';
 import { createEditorSaveCoordinator } from '@bangle.io/editor';
 import { makeTestCommonOpts } from '@bangle.io/test-utils';
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { initializeServices } from '../index';
 
 test('works', () => {
@@ -19,6 +19,7 @@ test('initializeServices returns unique service names', async () => {
     new ThemeManager(),
     controller.signal,
     createEditorSaveCoordinator(),
+    commonOpts.errorReporting,
   );
 
   const serviceNames = Object.keys(services.core);
@@ -37,4 +38,26 @@ test('initializeServices returns unique service names', async () => {
       throw new Error('Unexpected service type');
     }
   }
+});
+
+test('captures a browser error before React error subscribers mount', async () => {
+  const { commonOpts, rootEmitter, controller } = makeTestCommonOpts();
+  const error = new Error('private startup failure');
+
+  const servicesPromise = initializeServices(
+    commonOpts.logger,
+    rootEmitter,
+    commonOpts.store,
+    new ThemeManager(),
+    controller.signal,
+    createEditorSaveCoordinator(),
+    commonOpts.errorReporting,
+  );
+  window.dispatchEvent(new ErrorEvent('error', { error }));
+  await servicesPromise;
+
+  expect(
+    vi.mocked(commonOpts.errorReporting.captureException),
+  ).toHaveBeenCalledWith(error);
+  controller.abort();
 });

--- a/packages/core/initialize-services/src/index.ts
+++ b/packages/core/initialize-services/src/index.ts
@@ -1,4 +1,8 @@
-import { getEventSenderMetadata, type Logger } from '@bangle.io/base-utils';
+import {
+  captureReportableError,
+  getEventSenderMetadata,
+  type Logger,
+} from '@bangle.io/base-utils';
 import type { ThemeManager } from '@bangle.io/color-scheme-manager';
 import { commandHandlers } from '@bangle.io/command-handlers';
 import { getEnabledCommands } from '@bangle.io/commands';
@@ -7,15 +11,22 @@ import type { EditorSaveCoordinator } from '@bangle.io/editor';
 
 import type {
   BaseServiceCommonOptions,
+  ErrorReportingController,
   RootEmitter,
   Store,
 } from '@bangle.io/types';
 import { initializeServices as initializeServices2 } from './initialize-services';
 
+export { createPrivacySafeErrorReport } from '@bangle.io/base-utils';
 export {
   createEditorSaveCoordinator,
   type EditorSaveCoordinator,
 } from '@bangle.io/editor';
+export type {
+  ErrorReportingController,
+  ManualErrorReportHandler,
+  PrivacySafeErrorReport,
+} from '@bangle.io/types';
 export { readEditorEngineFromUrl } from './initialize-services';
 
 export function initializeServices(
@@ -25,12 +36,15 @@ export function initializeServices(
   theme: ThemeManager,
   abortSignal: AbortSignal,
   editorSaveCoordinator: EditorSaveCoordinator,
+  errorReporting: ErrorReportingController,
 ): Promise<Services> {
   const commonOpts: BaseServiceCommonOptions = {
     logger,
+    errorReporting,
     store,
     rootAbortSignal: abortSignal,
     emitAppError(error) {
+      captureReportableError(errorReporting, error);
       rootEmitter.emit('event::error:uncaught-error', {
         error,
         isAppError: true,

--- a/packages/core/initialize-services/src/index.ts
+++ b/packages/core/initialize-services/src/index.ts
@@ -17,7 +17,10 @@ import type {
 } from '@bangle.io/types';
 import { initializeServices as initializeServices2 } from './initialize-services';
 
-export { createPrivacySafeErrorReport } from '@bangle.io/base-utils';
+export {
+  createPrivacySafeErrorReport,
+  getCurrentBuildAssetDebugIds,
+} from '@bangle.io/base-utils';
 export {
   createEditorSaveCoordinator,
   type EditorSaveCoordinator,

--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -1,5 +1,6 @@
 import {
   assertIsDefined,
+  captureReportableError,
   getEventSenderMetadata,
   throwAppError,
 } from '@bangle.io/base-utils';
@@ -57,6 +58,7 @@ export function initializeServices(
   const browserPlatformServices = {
     errorService: slot(BrowserErrorHandlerService, () => ({
       onError: (params) => {
+        captureReportableError(commonOpts.errorReporting, params.error);
         rootEmitter.emit('event::error:uncaught-error', {
           ...params,
           sender: getEventSenderMetadata({ tag: 'BrowserErrorHandlerService' }),

--- a/packages/core/initialize-services/src/service-setup.ts
+++ b/packages/core/initialize-services/src/service-setup.ts
@@ -21,6 +21,7 @@ import {
   CommandDispatchService,
   CommandRegistryService,
   EditorService,
+  ErrorReportingService,
   FileSystemService,
   NavigationService,
   ShortcutService,
@@ -58,6 +59,7 @@ export const coreServiceClasses = {
   navigation: NavigationService,
   shortcut: ShortcutService,
   editorService: EditorService,
+  errorReporting: ErrorReportingService,
   workbenchState: WorkbenchStateService,
   workspaceOps: WorkspaceOpsService,
   workspaceState: WorkspaceStateService,
@@ -261,6 +263,7 @@ function toCoreServices(s: CoreInstances): CoreServices {
     navigation: s.navigation,
     shortcut: s.shortcut,
     editorService: s.editorService,
+    errorReporting: s.errorReporting,
     workbenchState: s.workbenchState,
     workspaceOps: s.workspaceOps,
     workspaceState: s.workspaceState,
@@ -323,6 +326,7 @@ export function createServiceSetup<
           const {
             commandDispatcher: _commandDispatcher,
             commandRegistry: _commandRegistry,
+            errorReporting: _errorReporting,
             ...exposed
           } = toCoreServices(getCoreInstances());
           return exposed;
@@ -393,6 +397,7 @@ export function createServiceSetup<
         ),
       })),
     ),
+    errorReporting: slot(ErrorReportingService),
     workbenchState: slot(
       WorkbenchStateService,
       withOverride('workbenchState', () => ({
@@ -455,6 +460,7 @@ export function createServiceSetup<
       navigation: s.navigation,
       shortcut: s.shortcut,
       editorService: s.editorService,
+      errorReporting: s.errorReporting,
       workbenchState: s.workbenchState,
       workspaceOps: s.workspaceOps,
       workspaceState: s.workspaceState,

--- a/packages/core/service-core/src/__tests__/error-reporting-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/error-reporting-service.spec.ts
@@ -1,0 +1,102 @@
+import { DATABASE_TABLE_NAME } from '@bangle.io/constants';
+import { createTestEnvironment } from '@bangle.io/test-utils';
+import type {
+  ManualErrorReportHandler,
+  PrivacySafeErrorReport,
+} from '@bangle.io/types';
+import { describe, expect, test, vi } from 'vitest';
+
+function makeReport(id = 'fb3b15d4-c536-4bf5-8d06-f328247b9619') {
+  return {
+    schemaVersion: 1,
+    id,
+    capturedAt: '2026-07-19T12:00:00.000Z',
+    errorType: 'TypeError',
+    route: 'editor',
+    release: 'bangle.io@1.2.3+abcdef12',
+    environment: 'production',
+    frames: [
+      {
+        filename: '/assets/index.js',
+        lineNumber: 10,
+        columnNumber: 20,
+      },
+    ],
+  } satisfies PrivacySafeErrorReport;
+}
+
+async function setup() {
+  const env = createTestEnvironment();
+  const services = env.instantiateAll('errorReporting');
+  await env.mountAll();
+  const handler = vi
+    .mocked(env.commonOpts.errorReporting.setManualReportHandler)
+    .mock.calls.find(
+      ([candidate]) => candidate,
+    )?.[0] as ManualErrorReportHandler;
+
+  return { env, services, handler };
+}
+
+describe('ErrorReportingService', () => {
+  test('persists only validated privacy-safe reports in the database', async () => {
+    const { env, services, handler } = await setup();
+
+    await handler(makeReport());
+
+    const values = await services.database.getAllEntries({
+      tableName: DATABASE_TABLE_NAME.misc,
+    });
+    expect(values).toEqual([makeReport()]);
+    expect(JSON.stringify(values)).not.toContain('PRIVATE_NOTE.md');
+    expect(env.store.get(services.errorReporting.$pendingReportCount)).toBe(1);
+  });
+
+  test('deletes reports only after the manual transport confirms success', async () => {
+    const { env, services, handler } = await setup();
+    const report = makeReport();
+    await handler(report);
+
+    vi.mocked(env.commonOpts.errorReporting.sendReports).mockResolvedValueOnce({
+      sentReportIds: [],
+    });
+    await expect(services.errorReporting.sendPendingReports()).resolves.toEqual(
+      { sent: 0, remaining: 1 },
+    );
+
+    vi.mocked(env.commonOpts.errorReporting.sendReports).mockResolvedValueOnce({
+      sentReportIds: [report.id],
+    });
+    await expect(services.errorReporting.sendPendingReports()).resolves.toEqual(
+      { sent: 1, remaining: 0 },
+    );
+  });
+
+  test('persists the opt-out preference and updates capture immediately', async () => {
+    const { env, services } = await setup();
+
+    await services.errorReporting.setAutomaticReportingEnabled(false);
+
+    expect(
+      env.store.get(services.errorReporting.$automaticReportingEnabled),
+    ).toBe(false);
+    expect(
+      env.commonOpts.errorReporting.setAutomaticReportingEnabled,
+    ).toHaveBeenLastCalledWith(false);
+  });
+
+  test('keeps at most 50 local reports', async () => {
+    const { env, services, handler } = await setup();
+
+    for (let index = 0; index < 55; index += 1) {
+      await handler(makeReport(crypto.randomUUID()));
+    }
+
+    expect(env.store.get(services.errorReporting.$pendingReportCount)).toBe(50);
+    expect(
+      await services.database.getAllEntries({
+        tableName: DATABASE_TABLE_NAME.misc,
+      }),
+    ).toHaveLength(50);
+  });
+});

--- a/packages/core/service-core/src/__tests__/error-reporting-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/error-reporting-service.spec.ts
@@ -1,4 +1,8 @@
-import { DATABASE_TABLE_NAME } from '@bangle.io/constants';
+import {
+  AUTOMATIC_ERROR_REPORTING_PREFERENCE_KEY,
+  DATABASE_TABLE_NAME,
+  SERVICE_NAME,
+} from '@bangle.io/constants';
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import type {
   ManualErrorReportHandler,
@@ -7,8 +11,9 @@ import type {
 import { describe, expect, test, vi } from 'vitest';
 
 function makeReport(id = 'fb3b15d4-c536-4bf5-8d06-f328247b9619') {
+  const debugId = '4c346747-7b26-4ea3-9657-1f6776a4e8b2';
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     id,
     capturedAt: '2026-07-19T12:00:00.000Z',
     errorType: 'TypeError',
@@ -17,7 +22,8 @@ function makeReport(id = 'fb3b15d4-c536-4bf5-8d06-f328247b9619') {
     environment: 'production',
     frames: [
       {
-        filename: '/assets/index.js',
+        debugId,
+        filename: `/assets/bangle-${debugId}.js`,
         lineNumber: 10,
         columnNumber: 20,
       },
@@ -85,18 +91,110 @@ describe('ErrorReportingService', () => {
     ).toHaveBeenLastCalledWith(false);
   });
 
-  test('keeps at most 50 local reports', async () => {
+  test('keeps the bootstrap fail-closed state when storage is invalid', async () => {
+    const env = createTestEnvironment();
+    vi.mocked(
+      env.commonOpts.errorReporting.getAutomaticReportingEnabled,
+    ).mockReturnValue(false);
+    const services = env.instantiateAll('errorReporting');
+    services.syncDatabase.updateEntry(
+      `${SERVICE_NAME.errorReportingService}:${AUTOMATIC_ERROR_REPORTING_PREFERENCE_KEY}`,
+      () => ({ value: 'invalid-preference' }),
+      { tableName: 'sync' },
+    );
+
+    await env.mountAll();
+
+    expect(
+      env.store.get(services.errorReporting.$automaticReportingEnabled),
+    ).toBe(false);
+    expect(
+      env.commonOpts.errorReporting.setAutomaticReportingEnabled,
+    ).toHaveBeenLastCalledWith(false);
+  });
+
+  test('prompts with the exact persisted report when automatic sending is off', async () => {
     const { env, services, handler } = await setup();
+    const report = makeReport();
+    await services.errorReporting.setAutomaticReportingEnabled(false);
 
-    for (let index = 0; index < 55; index += 1) {
-      await handler(makeReport(crypto.randomUUID()));
-    }
+    await handler(report);
 
-    expect(env.store.get(services.errorReporting.$pendingReportCount)).toBe(50);
+    expect(env.store.get(services.errorReporting.$manualReportPrompt)).toEqual(
+      report,
+    );
+    services.errorReporting.dismissManualReportPrompt(report.id);
+    expect(
+      env.store.get(services.errorReporting.$manualReportPrompt),
+    ).toBeUndefined();
     expect(
       await services.database.getAllEntries({
         tableName: DATABASE_TABLE_NAME.misc,
       }),
-    ).toHaveLength(50);
+    ).toEqual([report]);
+  });
+
+  test('sends and deletes one approved report from the prompt', async () => {
+    const { env, services, handler } = await setup();
+    const report = makeReport();
+    await services.errorReporting.setAutomaticReportingEnabled(false);
+    await handler(report);
+    vi.mocked(env.commonOpts.errorReporting.sendReports).mockResolvedValueOnce({
+      sentReportIds: [report.id],
+    });
+
+    await expect(
+      services.errorReporting.sendPendingReport(report.id),
+    ).resolves.toBe(true);
+
+    expect(env.commonOpts.errorReporting.sendReports).toHaveBeenCalledWith([
+      report,
+    ]);
+    expect(
+      env.store.get(services.errorReporting.$manualReportPrompt),
+    ).toBeUndefined();
+    expect(env.store.get(services.errorReporting.$pendingReportCount)).toBe(0);
+  });
+
+  test('offers each report for review when several errors arrive together', async () => {
+    const { env, services, handler } = await setup();
+    const first = makeReport();
+    const second = makeReport('ce52fe73-c36c-4f43-b62f-99949acb9c24');
+    await services.errorReporting.setAutomaticReportingEnabled(false);
+
+    await handler(first);
+    await handler(second);
+
+    expect(env.store.get(services.errorReporting.$manualReportPrompt)).toEqual(
+      first,
+    );
+    services.errorReporting.dismissManualReportPrompt(first.id);
+    expect(env.store.get(services.errorReporting.$manualReportPrompt)).toEqual(
+      second,
+    );
+    services.errorReporting.dismissManualReportPrompt(second.id);
+    expect(
+      env.store.get(services.errorReporting.$manualReportPrompt),
+    ).toBeUndefined();
+  });
+
+  test('keeps at most 50 local reports', async () => {
+    const { env, services, handler } = await setup();
+    await services.errorReporting.setAutomaticReportingEnabled(false);
+
+    await Promise.all(
+      Array.from({ length: 55 }, () =>
+        handler(makeReport(crypto.randomUUID())),
+      ),
+    );
+
+    expect(env.store.get(services.errorReporting.$pendingReportCount)).toBe(50);
+    const persisted = await services.database.getAllEntries({
+      tableName: DATABASE_TABLE_NAME.misc,
+    });
+    expect(persisted).toHaveLength(50);
+    expect(persisted).toContainEqual(
+      env.store.get(services.errorReporting.$manualReportPrompt),
+    );
   });
 });

--- a/packages/core/service-core/src/error-reporting-service.ts
+++ b/packages/core/service-core/src/error-reporting-service.ts
@@ -1,0 +1,180 @@
+import {
+  atomStorage,
+  BaseService,
+  type BaseServiceContext,
+  isPrivacySafeErrorReport,
+} from '@bangle.io/base-utils';
+import {
+  AUTOMATIC_ERROR_REPORTING_PREFERENCE_KEY,
+  DATABASE_TABLE_NAME,
+  SERVICE_NAME,
+} from '@bangle.io/constants';
+import { T } from '@bangle.io/mini-js-utils';
+import type {
+  BaseDatabaseService,
+  BaseSyncDatabaseService,
+  PrivacySafeErrorReport,
+} from '@bangle.io/types';
+import { atom, type PrimitiveAtom } from 'jotai';
+
+const REPORT_KEY_PREFIX = 'privacy-safe-error-report:';
+const MAX_PENDING_REPORTS = 50;
+
+export class ErrorReportingService extends BaseService {
+  static deps = ['database', 'syncDatabase'] as const;
+
+  private $_automaticReportingEnabled: PrimitiveAtom<boolean> | undefined;
+  readonly $pendingReportCount = atom(0);
+  readonly $sendingReports = atom(false);
+
+  constructor(
+    context: BaseServiceContext,
+    private dep: {
+      database: BaseDatabaseService;
+      syncDatabase: BaseSyncDatabaseService;
+    },
+  ) {
+    super(SERVICE_NAME.errorReportingService, context, dep);
+  }
+
+  async hookMount(): Promise<void> {
+    this.commonOptions.errorReporting.setManualReportHandler((report) =>
+      this.persistReport(report),
+    );
+    await this.commonOptions.errorReporting.setAutomaticReportingEnabled(
+      this.store.get(this.$automaticReportingEnabled),
+    );
+    await this.refreshPendingCount();
+
+    this.addCleanup(
+      () => this.commonOptions.errorReporting.setManualReportHandler(undefined),
+      this.store.sub(this.$automaticReportingEnabled, () => {
+        void this.commonOptions.errorReporting.setAutomaticReportingEnabled(
+          this.store.get(this.$automaticReportingEnabled),
+        );
+      }),
+    );
+
+    this.dep.database.subscribe(
+      { tableName: DATABASE_TABLE_NAME.misc },
+      (change) => {
+        if (change.key.startsWith(REPORT_KEY_PREFIX)) {
+          void this.refreshPendingCount();
+        }
+      },
+      this.abortSignal,
+    );
+  }
+
+  get $automaticReportingEnabled(): PrimitiveAtom<boolean> {
+    if (!this.$_automaticReportingEnabled) {
+      this.$_automaticReportingEnabled = atomStorage({
+        serviceName: this.name,
+        key: AUTOMATIC_ERROR_REPORTING_PREFERENCE_KEY,
+        initValue: true,
+        syncDb: this.dep.syncDatabase,
+        validator: T.Boolean,
+        logger: this.logger,
+      });
+    }
+    return this.$_automaticReportingEnabled;
+  }
+
+  async setAutomaticReportingEnabled(enabled: boolean): Promise<void> {
+    await this.commonOptions.errorReporting.setAutomaticReportingEnabled(
+      enabled,
+    );
+    this.store.set(this.$automaticReportingEnabled, enabled);
+  }
+
+  async sendPendingReports(): Promise<{ sent: number; remaining: number }> {
+    if (this.store.get(this.$sendingReports)) {
+      return {
+        sent: 0,
+        remaining: this.store.get(this.$pendingReportCount),
+      };
+    }
+
+    this.store.set(this.$sendingReports, true);
+    try {
+      const reports = await this.getPendingReports();
+      const { sentReportIds } =
+        await this.commonOptions.errorReporting.sendReports(reports);
+      await Promise.all(
+        sentReportIds.map((id) =>
+          this.dep.database.deleteEntry(this.getReportKey(id), {
+            tableName: DATABASE_TABLE_NAME.misc,
+          }),
+        ),
+      );
+      await this.refreshPendingCount();
+      return {
+        sent: sentReportIds.length,
+        remaining: this.store.get(this.$pendingReportCount),
+      };
+    } finally {
+      this.store.set(this.$sendingReports, false);
+    }
+  }
+
+  async clearPendingReports(): Promise<void> {
+    const reports = await this.getPendingReports();
+    await Promise.all(
+      reports.map((report) =>
+        this.dep.database.deleteEntry(this.getReportKey(report.id), {
+          tableName: DATABASE_TABLE_NAME.misc,
+        }),
+      ),
+    );
+    await this.refreshPendingCount();
+  }
+
+  private async persistReport(report: PrivacySafeErrorReport): Promise<void> {
+    if (!isPrivacySafeErrorReport(report)) {
+      return;
+    }
+
+    await this.dep.database.updateEntry(
+      this.getReportKey(report.id),
+      () => ({ value: report }),
+      { tableName: DATABASE_TABLE_NAME.misc },
+    );
+    await this.prunePendingReports();
+    await this.refreshPendingCount();
+  }
+
+  private async getPendingReports(): Promise<PrivacySafeErrorReport[]> {
+    const entries = await this.dep.database.getAllEntries({
+      tableName: DATABASE_TABLE_NAME.misc,
+    });
+    return entries
+      .filter(isPrivacySafeErrorReport)
+      .sort((a, b) => a.capturedAt.localeCompare(b.capturedAt));
+  }
+
+  private async prunePendingReports(): Promise<void> {
+    const reports = await this.getPendingReports();
+    const excess = reports.length - MAX_PENDING_REPORTS;
+    if (excess <= 0) {
+      return;
+    }
+    await Promise.all(
+      reports.slice(0, excess).map((report) =>
+        this.dep.database.deleteEntry(this.getReportKey(report.id), {
+          tableName: DATABASE_TABLE_NAME.misc,
+        }),
+      ),
+    );
+  }
+
+  private async refreshPendingCount(): Promise<void> {
+    this.store.set(
+      this.$pendingReportCount,
+      (await this.getPendingReports()).length,
+    );
+  }
+
+  private getReportKey(id: string): string {
+    return `${REPORT_KEY_PREFIX}${id}`;
+  }
+}

--- a/packages/core/service-core/src/error-reporting-service.ts
+++ b/packages/core/service-core/src/error-reporting-service.ts
@@ -24,6 +24,11 @@ export class ErrorReportingService extends BaseService {
   static deps = ['database', 'syncDatabase'] as const;
 
   private $_automaticReportingEnabled: PrimitiveAtom<boolean> | undefined;
+  private manualReportPromptQueue: PrivacySafeErrorReport[] = [];
+  private reportPersistenceChain: Promise<void> = Promise.resolve();
+  readonly $manualReportPrompt = atom<PrivacySafeErrorReport | undefined>(
+    undefined,
+  );
   readonly $pendingReportCount = atom(0);
   readonly $sendingReports = atom(false);
 
@@ -39,7 +44,7 @@ export class ErrorReportingService extends BaseService {
 
   async hookMount(): Promise<void> {
     this.commonOptions.errorReporting.setManualReportHandler((report) =>
-      this.persistReport(report),
+      this.queueReportPersistence(report),
     );
     await this.commonOptions.errorReporting.setAutomaticReportingEnabled(
       this.store.get(this.$automaticReportingEnabled),
@@ -71,7 +76,8 @@ export class ErrorReportingService extends BaseService {
       this.$_automaticReportingEnabled = atomStorage({
         serviceName: this.name,
         key: AUTOMATIC_ERROR_REPORTING_PREFERENCE_KEY,
-        initValue: true,
+        initValue:
+          this.commonOptions.errorReporting.getAutomaticReportingEnabled(),
         syncDb: this.dep.syncDatabase,
         validator: T.Boolean,
         logger: this.logger,
@@ -85,6 +91,39 @@ export class ErrorReportingService extends BaseService {
       enabled,
     );
     this.store.set(this.$automaticReportingEnabled, enabled);
+    if (enabled) {
+      this.manualReportPromptQueue = [];
+      this.store.set(this.$manualReportPrompt, undefined);
+    }
+  }
+
+  dismissManualReportPrompt(reportId: string): void {
+    this.clearManualReportPrompt(reportId);
+  }
+
+  async sendPendingReport(reportId: string): Promise<boolean> {
+    if (this.store.get(this.$sendingReports)) {
+      return false;
+    }
+
+    this.store.set(this.$sendingReports, true);
+    try {
+      await this.reportPersistenceChain;
+      const report = await this.getPendingReport(reportId);
+      if (!report) {
+        this.clearManualReportPrompt(reportId);
+        return false;
+      }
+      const { sentReportIds } =
+        await this.commonOptions.errorReporting.sendReports([report]);
+      if (!sentReportIds.includes(reportId)) {
+        return false;
+      }
+      await this.deletePendingReport(reportId);
+      return true;
+    } finally {
+      this.store.set(this.$sendingReports, false);
+    }
   }
 
   async sendPendingReports(): Promise<{ sent: number; remaining: number }> {
@@ -97,6 +136,7 @@ export class ErrorReportingService extends BaseService {
 
     this.store.set(this.$sendingReports, true);
     try {
+      await this.reportPersistenceChain;
       const reports = await this.getPendingReports();
       const { sentReportIds } =
         await this.commonOptions.errorReporting.sendReports(reports);
@@ -107,6 +147,9 @@ export class ErrorReportingService extends BaseService {
           }),
         ),
       );
+      for (const id of sentReportIds) {
+        this.clearManualReportPrompt(id);
+      }
       await this.refreshPendingCount();
       return {
         sent: sentReportIds.length,
@@ -118,6 +161,7 @@ export class ErrorReportingService extends BaseService {
   }
 
   async clearPendingReports(): Promise<void> {
+    await this.reportPersistenceChain;
     const reports = await this.getPendingReports();
     await Promise.all(
       reports.map((report) =>
@@ -126,6 +170,17 @@ export class ErrorReportingService extends BaseService {
         }),
       ),
     );
+    this.manualReportPromptQueue = [];
+    this.store.set(this.$manualReportPrompt, undefined);
+    await this.refreshPendingCount();
+  }
+
+  async deletePendingReport(reportId: string): Promise<void> {
+    await this.reportPersistenceChain;
+    await this.dep.database.deleteEntry(this.getReportKey(reportId), {
+      tableName: DATABASE_TABLE_NAME.misc,
+    });
+    this.clearManualReportPrompt(reportId);
     await this.refreshPendingCount();
   }
 
@@ -141,6 +196,58 @@ export class ErrorReportingService extends BaseService {
     );
     await this.prunePendingReports();
     await this.refreshPendingCount();
+    if (!this.store.get(this.$automaticReportingEnabled)) {
+      this.enqueueManualReportPrompt(report);
+    }
+  }
+
+  private queueReportPersistence(
+    report: PrivacySafeErrorReport,
+  ): Promise<void> {
+    const persistence = this.reportPersistenceChain.then(() =>
+      this.persistReport(report),
+    );
+    this.reportPersistenceChain = persistence.catch(() => {});
+    return persistence;
+  }
+
+  private clearManualReportPrompt(reportId: string): void {
+    if (this.store.get(this.$manualReportPrompt)?.id !== reportId) {
+      this.manualReportPromptQueue = this.manualReportPromptQueue.filter(
+        (report) => report.id !== reportId,
+      );
+      return;
+    }
+    this.store.set(
+      this.$manualReportPrompt,
+      this.manualReportPromptQueue.shift(),
+    );
+  }
+
+  private enqueueManualReportPrompt(report: PrivacySafeErrorReport): void {
+    if (
+      this.store.get(this.$manualReportPrompt)?.id === report.id ||
+      this.manualReportPromptQueue.some((queued) => queued.id === report.id)
+    ) {
+      return;
+    }
+    if (!this.store.get(this.$manualReportPrompt)) {
+      this.store.set(this.$manualReportPrompt, report);
+      return;
+    }
+    this.manualReportPromptQueue.push(report);
+  }
+
+  private async getPendingReport(
+    reportId: string,
+  ): Promise<PrivacySafeErrorReport | undefined> {
+    const entry = await this.dep.database.getEntry(
+      this.getReportKey(reportId),
+      { tableName: DATABASE_TABLE_NAME.misc },
+    );
+    return entry.found && isPrivacySafeErrorReport(entry.value)
+      ? entry.value
+      : undefined;
   }
 
   private async getPendingReports(): Promise<PrivacySafeErrorReport[]> {
@@ -158,13 +265,17 @@ export class ErrorReportingService extends BaseService {
     if (excess <= 0) {
       return;
     }
+    const reportsToPrune = reports.slice(0, excess);
     await Promise.all(
-      reports.slice(0, excess).map((report) =>
+      reportsToPrune.map((report) =>
         this.dep.database.deleteEntry(this.getReportKey(report.id), {
           tableName: DATABASE_TABLE_NAME.misc,
         }),
       ),
     );
+    for (const report of reportsToPrune) {
+      this.clearManualReportPrompt(report.id);
+    }
   }
 
   private async refreshPendingCount(): Promise<void> {

--- a/packages/core/service-core/src/index.ts
+++ b/packages/core/service-core/src/index.ts
@@ -3,6 +3,7 @@ export type { CommandHandlerConfig } from './command-registry-service';
 export { CommandRegistryService } from './command-registry-service';
 export { waitForSaveQueueToDrain } from './editor-save-status';
 export { EditorService } from './editor-service';
+export { ErrorReportingService } from './error-reporting-service';
 export type {
   FileContentUpdateEvent,
   FileCreateEvent,

--- a/packages/core/service-core/src/user-activity-service.ts
+++ b/packages/core/service-core/src/user-activity-service.ts
@@ -423,7 +423,11 @@ export class UserActivityService extends BaseService {
       await this.starredItemManager.relocateStarredItems(relocations);
       return 'succeeded';
     } catch (error) {
-      this.logger.error('Unable to migrate starred items after relocation', {
+      this.reportError(
+        error,
+        'Unable to migrate starred items after relocation',
+      );
+      this.logger.debug('Starred item relocation details', {
         error,
         relocations: relocations.map(({ oldItem, newItem }) => ({
           newWsPath: newItem.wsPath,
@@ -462,6 +466,7 @@ class StarredItemManager {
       const rawStarredItems = metadata[STARRED_ITEMS_KEY] ?? [];
       if (!Array.isArray(rawStarredItems)) {
         this.logger.error(
+          new Error('Invalid starred items metadata'),
           `Invalid starred items metadata for ${wsName}. Expected array, got ${typeof rawStarredItems}.`,
         );
       }
@@ -564,6 +569,7 @@ class StarredItemManager {
 
     if (!Array.isArray(rawStarredItems)) {
       this.logger.error(
+        new Error('Invalid starred items metadata'),
         `Invalid starred items metadata for ${wsName}. Expected array, got ${typeof rawStarredItems}.`,
       );
       return [];

--- a/packages/core/service-core/src/workspace-state-service.ts
+++ b/packages/core/service-core/src/workspace-state-service.ts
@@ -202,7 +202,7 @@ export class WorkspaceStateService extends BaseService {
           throw error;
         }
 
-        this.logger.error('Failed to build backlink index', error);
+        this.reportError(error, 'Failed to build backlink index');
         return {
           status: 'error',
           byTargetWsPath: EMPTY_BACKLINKS,
@@ -457,7 +457,7 @@ export class WorkspaceStateService extends BaseService {
               if (error instanceof Error && isAppError(error)) {
                 this.emitAppError(error);
               } else {
-                this.logger.error('Failed to list workspaces', error);
+                this.reportError(error, 'Failed to list workspaces');
               }
             },
           );
@@ -535,9 +535,9 @@ export class WorkspaceStateService extends BaseService {
                 if (error instanceof Error && isAppError(error)) {
                   this.emitAppError(error);
                 } else {
-                  this.logger.error(
-                    `Failed to list files for workspace ${wsName}`,
+                  this.reportError(
                     error,
+                    `Failed to list files for workspace ${wsName}`,
                   );
                 }
               },

--- a/packages/js-lib/logger/__tests__/logger.spec.ts
+++ b/packages/js-lib/logger/__tests__/logger.spec.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { Logger, setGlobalLogLevel } from '../index';
+import { Logger, setErrorReporter, setGlobalLogLevel } from '../index';
 
 describe('Logger', () => {
   function makeLogger(): any {
@@ -16,6 +16,7 @@ describe('Logger', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    setErrorReporter(null);
     setGlobalLogLevel('info');
   });
 
@@ -165,5 +166,18 @@ describe('Logger', () => {
       '[TestLogger]',
       'Info message',
     );
+  });
+
+  test('reports only an Error in the explicit first argument position', () => {
+    const reporter = { captureException: vi.fn() };
+    const logger = new Logger('TestLogger', null, makeLogger());
+    const reportable = new Error('reportable');
+    setErrorReporter(reporter);
+
+    logger.error(reportable, 'diagnostic context');
+    logger.error('diagnostic only', new Error('nested context'));
+
+    expect(reporter.captureException).toHaveBeenCalledOnce();
+    expect(reporter.captureException).toHaveBeenCalledWith(reportable);
   });
 });

--- a/packages/js-lib/logger/index.ts
+++ b/packages/js-lib/logger/index.ts
@@ -71,9 +71,12 @@ export class Logger {
   public error(...message: unknown[]): void {
     this.log('error', ...message);
 
-    // If the first message is an Error instance, send it to the error reporter
-    if (errorReporter && message.length > 0 && message[0] instanceof Error) {
-      errorReporter.captureException(message[0]);
+    // Report the first Error regardless of its position. Callers often lead
+    // with a static diagnostic label; the reporting boundary itself converts
+    // the Error into a privacy-safe allowlisted payload.
+    const error = message.find((item): item is Error => item instanceof Error);
+    if (errorReporter && error) {
+      errorReporter.captureException(error);
     }
   }
 

--- a/packages/js-lib/logger/index.ts
+++ b/packages/js-lib/logger/index.ts
@@ -20,7 +20,7 @@ let errorReporter: ErrorReporter | null = null;
 export function setGlobalLogLevel(level: LogLevelName) {
   GLOBAL_LOG_LEVEL = level;
 }
-export function setErrorReporter(reporter: ErrorReporter) {
+export function setErrorReporter(reporter: ErrorReporter | null) {
   errorReporter = reporter;
 }
 export class Logger {
@@ -71,12 +71,11 @@ export class Logger {
   public error(...message: unknown[]): void {
     this.log('error', ...message);
 
-    // Report the first Error regardless of its position. Callers often lead
-    // with a static diagnostic label; the reporting boundary itself converts
-    // the Error into a privacy-safe allowlisted payload.
-    const error = message.find((item): item is Error => item instanceof Error);
-    if (errorReporter && error) {
-      errorReporter.captureException(error);
+    // Preserve the explicit reporting convention: an Error in the first
+    // position is a report boundary; later Errors are diagnostic context.
+    // App/service boundaries capture their wrapped errors separately.
+    if (errorReporter && message[0] instanceof Error) {
+      errorReporter.captureException(message[0]);
     }
   }
 

--- a/packages/platform/service-platform/src/__tests__/error-handler-service.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/error-handler-service.spec.ts
@@ -61,6 +61,35 @@ describe('error handler services', () => {
     );
   });
 
+  it('normalizes non-Error promise rejections instead of dropping them', async () => {
+    const { commonOpts } = setup();
+    const onError = vi.fn();
+    const service = new BrowserErrorHandlerService(
+      {
+        ctx: commonOpts,
+        serviceContext: { abortSignal: commonOpts.rootAbortSignal },
+      },
+      null,
+      { onError },
+    );
+    await service.mount();
+
+    const rejectionEvent = new Event('unhandledrejection');
+    Object.defineProperty(rejectionEvent, 'reason', {
+      value: 'private rejection value',
+    });
+    window.dispatchEvent(rejectionEvent);
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          message: 'Unhandled non-Error promise rejection',
+        }),
+        isRejection: true,
+      }),
+    );
+  });
+
   it('replays node error events queued before mount', async () => {
     const { commonOpts } = setup();
     const onError = vi.fn();

--- a/packages/platform/service-platform/src/browser-error-handler.ts
+++ b/packages/platform/service-platform/src/browser-error-handler.ts
@@ -64,13 +64,19 @@ export class BrowserErrorHandlerService extends BaseErrorService {
     const isRejection = 'reason' in event;
 
     if (isRejection) {
-      error = event.reason instanceof Error ? event.reason : undefined;
+      error =
+        event.reason instanceof Error
+          ? event.reason
+          : new Error('Unhandled non-Error promise rejection');
     } else {
-      error = event.error instanceof Error ? event.error : undefined;
+      error =
+        event.error instanceof Error
+          ? event.error
+          : new Error('Unhandled browser error');
     }
 
-    if (!error || isAbortError(error)) {
-      this.logger.debug(`AbortError ${error?.message}`);
+    if (isAbortError(error)) {
+      this.logger.debug(`AbortError ${error.message}`);
       event.preventDefault();
       return;
     }

--- a/packages/platform/service-platform/src/browser-local-storage-sync-database.ts
+++ b/packages/platform/service-platform/src/browser-local-storage-sync-database.ts
@@ -171,6 +171,8 @@ export class BrowserLocalStorageSyncDatabaseService
     try {
       return { parsed: true, value: JSON.parse(item) };
     } catch (error) {
+      // Corrupt external state is handled by each setting's safe fallback. It
+      // is diagnostic context, not an application defect to report/prompt.
       this.logger.error('Failed to parse JSON from local storage', error);
       return { parsed: false };
     }
@@ -180,7 +182,7 @@ export class BrowserLocalStorageSyncDatabaseService
     try {
       return JSON.stringify(value);
     } catch (error) {
-      this.logger.error('Failed to stringify JSON for local storage', error);
+      this.reportError(error, 'Failed to stringify JSON for local storage');
       return null;
     }
   }

--- a/packages/platform/service-platform/src/router/browser-router.ts
+++ b/packages/platform/service-platform/src/router/browser-router.ts
@@ -152,9 +152,9 @@ export class BrowserRouterService
     if (!this.mounted) {
       this.logger.warn('Cannot navigate because the service is not mounted.');
       this.mountPromise.then(doNavigate, (error) => {
-        this.logger.error(
-          'Dropped a navigation queued before mount because mounting failed',
+        this.reportError(
           error,
+          'Dropped a navigation queued before mount because mounting failed',
         );
       });
     } else {

--- a/packages/shared/base-utils/__tests__/error-reporting-policy.spec.ts
+++ b/packages/shared/base-utils/__tests__/error-reporting-policy.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test, vi } from 'vitest';
+import { captureReportableError } from '../error-reporting-policy';
+import { createAppError } from '../throw-app-error';
+
+describe('captureReportableError', () => {
+  test('captures ordinary and reportable app failures at the boundary', () => {
+    const reporter = { captureException: vi.fn() };
+    const ordinaryError = new Error('private message');
+    const saveError = createAppError(
+      'error::editor:save-failed',
+      'private save message',
+      { error: new Error('private cause'), wsPath: 'private:note.md' },
+    );
+
+    expect(captureReportableError(reporter, ordinaryError)).toBe(true);
+    expect(captureReportableError(reporter, saveError)).toBe(true);
+    expect(reporter.captureException).toHaveBeenNthCalledWith(1, ordinaryError);
+    expect(reporter.captureException).toHaveBeenNthCalledWith(2, saveError);
+  });
+
+  test('does not capture expected user-facing app outcomes', () => {
+    const reporter = { captureException: vi.fn() };
+    const expectedError = createAppError(
+      'error::workspace:no-note-opened',
+      'private workspace message',
+      { wsPath: 'private:note.md' },
+    );
+
+    expect(captureReportableError(reporter, expectedError)).toBe(false);
+    expect(reporter.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/base-utils/__tests__/github-buger-url.spec.ts
+++ b/packages/shared/base-utils/__tests__/github-buger-url.spec.ts
@@ -3,7 +3,6 @@
 import { makeTestLogger } from '@bangle.io/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getGithubUrl } from '../github-bug-url';
-import { throwAppError } from '../throw-app-error';
 
 describe('getGithubUrl', () => {
   let logger = makeTestLogger().logger;
@@ -13,38 +12,35 @@ describe('getGithubUrl', () => {
     ({ logger } = makeTestLogger());
   });
 
-  it('should generate a GitHub URL with error details', () => {
-    const error = new Error('Test error');
-    error.stack = 'Error stack trace';
+  it('generates a GitHub URL with only privacy-safe diagnostics', () => {
+    const error = new TypeError('PRIVATE_NOTE_CONTENT');
+    error.stack =
+      'TypeError: PRIVATE_NOTE_CONTENT\n    at save (https://app.bangle.io/assets/index-abcdef12.js?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:10:20)';
 
     const url = getGithubUrl(error, logger);
 
     const search = new URL(url).searchParams;
-    expect(search.get('body')).toContain('Details');
-    expect(search.get('body')).toContain('Test error');
+    expect(search.get('body')).toContain('Privacy-safe diagnostics');
+    expect(search.get('body')).toContain('TypeError');
+    expect(search.get('body')).toContain('/assets/index.js:10:20');
+    expect(search.get('body')).not.toContain('PRIVATE_NOTE_CONTENT');
+    expect(search.get('body')).not.toContain('PRIVATE_WORKSPACE');
+    expect(search.get('body')).not.toContain('PRIVATE_NOTE.md');
   });
 
-  it('should include app error', () => {
-    let error: Error | undefined;
-
-    try {
-      throwAppError('error::ws-path:invalid-ws-path', 'Test error message', {
-        invalidPath: 'test-path',
-      });
-    } catch (e) {
-      if (e instanceof Error) {
-        error = e;
-      }
-    }
-
-    if (!error) {
-      throw new Error('Failed to throw app error');
-    }
-
+  it('does not include custom error names, causes, or properties', () => {
+    const error = new Error('PRIVATE_MESSAGE', {
+      cause: new Error('PRIVATE_CAUSE'),
+    });
+    error.name = 'PRIVATE_ERROR_NAME';
+    Object.assign(error, { wsPath: 'PRIVATE_WORKSPACE:PRIVATE_NOTE.md' });
     const url = getGithubUrl(error, logger);
     const search = new URL(url).searchParams;
-    expect(search.get('body')).toContain('BaseError: Test error');
-    expect(search.get('body')).toContain('Test error message');
-    expect(search.get('body')).toContain('test-path');
+    const body = search.get('body');
+    expect(body).toContain('**Error type:** Error');
+    expect(body).not.toContain('PRIVATE_MESSAGE');
+    expect(body).not.toContain('PRIVATE_CAUSE');
+    expect(body).not.toContain('PRIVATE_ERROR_NAME');
+    expect(body).not.toContain('PRIVATE_WORKSPACE');
   });
 });

--- a/packages/shared/base-utils/__tests__/github-buger-url.spec.ts
+++ b/packages/shared/base-utils/__tests__/github-buger-url.spec.ts
@@ -1,15 +1,31 @@
 // @vitest-environment happy-dom
 
 import { makeTestLogger } from '@bangle.io/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getGithubUrl } from '../github-bug-url';
 
 describe('getGithubUrl', () => {
+  const debugId = '4c346747-7b26-4ea3-9657-1f6776a4e8b2';
   let logger = makeTestLogger().logger;
 
   beforeEach(() => {
     vi.clearAllMocks();
     ({ logger } = makeTestLogger());
+    (
+      globalThis as typeof globalThis & {
+        _sentryDebugIds?: Record<string, string>;
+      }
+    )._sentryDebugIds = {
+      'Error\n at https://app.bangle.io/assets/index-abcdef12.js:1:1': debugId,
+    };
+  });
+
+  afterEach(() => {
+    delete (
+      globalThis as typeof globalThis & {
+        _sentryDebugIds?: Record<string, string>;
+      }
+    )._sentryDebugIds;
   });
 
   it('generates a GitHub URL with only privacy-safe diagnostics', () => {
@@ -22,7 +38,7 @@ describe('getGithubUrl', () => {
     const search = new URL(url).searchParams;
     expect(search.get('body')).toContain('Privacy-safe diagnostics');
     expect(search.get('body')).toContain('TypeError');
-    expect(search.get('body')).toContain('/assets/index.js:10:20');
+    expect(search.get('body')).toContain(`/assets/bangle-${debugId}.js:10:20`);
     expect(search.get('body')).not.toContain('PRIVATE_NOTE_CONTENT');
     expect(search.get('body')).not.toContain('PRIVATE_WORKSPACE');
     expect(search.get('body')).not.toContain('PRIVATE_NOTE.md');

--- a/packages/shared/base-utils/__tests__/privacy-safe-error-report.spec.ts
+++ b/packages/shared/base-utils/__tests__/privacy-safe-error-report.spec.ts
@@ -2,6 +2,7 @@ import type { PrivacySafeErrorReport } from '@bangle.io/types';
 import { describe, expect, test } from 'vitest';
 import {
   createPrivacySafeErrorReport,
+  getCurrentBuildAssetDebugIds,
   getPrivacySafeStackFrames,
   isPrivacySafeErrorReport,
 } from '../privacy-safe-error-report';
@@ -14,6 +15,8 @@ const PRIVATE_MARKERS = [
   'PRIVATE_PROPERTY',
   'browser-extension.example',
 ];
+const DEBUG_ID = '4c346747-7b26-4ea3-9657-1f6776a4e8b2';
+const INDEX_ASSET = '/assets/index-abcdef12.js';
 
 function makeReport(): PrivacySafeErrorReport {
   const error = new TypeError('SECRET_NOTE_CONTENT', {
@@ -25,7 +28,7 @@ function makeReport(): PrivacySafeErrorReport {
   });
   error.stack = [
     'TypeError: SECRET_NOTE_CONTENT',
-    '    at save (https://app.bangle.io/assets/index-SECRET_NOTE_CONTENT.js?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:10:20)',
+    '    at save (https://app.bangle.io/assets/index-abcdef12.js?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:10:20)',
     '    at extension (https://browser-extension.example/PRIVATE_NOTE.md:30:40)',
   ].join('\n');
 
@@ -35,6 +38,7 @@ function makeReport(): PrivacySafeErrorReport {
     route: 'editor',
     release: 'bangle.io@1.2.3+abcdef12',
     environment: 'production',
+    buildAssetDebugIds: new Map([[INDEX_ASSET, DEBUG_ID]]),
   });
 }
 
@@ -44,7 +48,7 @@ describe('privacy-safe error reports', () => {
     const serialized = JSON.stringify(report);
 
     expect(report).toEqual({
-      schemaVersion: 1,
+      schemaVersion: 2,
       id: 'fb3b15d4-c536-4bf5-8d06-f328247b9619',
       capturedAt: '2026-07-19T12:00:00.000Z',
       errorType: 'TypeError',
@@ -53,7 +57,8 @@ describe('privacy-safe error reports', () => {
       environment: 'production',
       frames: [
         {
-          filename: '/assets/index.js',
+          debugId: DEBUG_ID,
+          filename: `/assets/bangle-${DEBUG_ID}.js`,
           lineNumber: 10,
           columnNumber: 20,
         },
@@ -79,22 +84,98 @@ describe('privacy-safe error reports', () => {
     expect(report.route).toBe('unknown');
   });
 
-  test.each([
-    'code-highlight-shiki',
-    'core',
-    'engine-javascript',
-    'index',
-  ])('drops the entire untrusted suffix for the %s bundle', (prefix) => {
+  test('uses a build debug ID for any loaded chunk and drops its raw name', () => {
+    const assetPath = '/assets/future-editor-SECRET_NOTE_CONTENT-abcdef12.js';
     const frames = getPrivacySafeStackFrames(
-      `Error: hidden\n at x (https://app.bangle.io/assets/${prefix}-SECRET_NOTE_CONTENT.js?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:7:9)`,
+      `Error: hidden\n at x (https://app.bangle.io${assetPath}?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:7:9)`,
+      new Map([[assetPath, DEBUG_ID]]),
     );
 
     expect(frames).toEqual([
-      { filename: `/assets/${prefix}.js`, lineNumber: 7, columnNumber: 9 },
+      {
+        debugId: DEBUG_ID,
+        filename: `/assets/bangle-${DEBUG_ID}.js`,
+        lineNumber: 7,
+        columnNumber: 9,
+      },
     ]);
     expect(JSON.stringify(frames)).not.toContain('SECRET_NOTE_CONTENT');
     expect(JSON.stringify(frames)).not.toContain('PRIVATE_WORKSPACE');
     expect(JSON.stringify(frames)).not.toContain('PRIVATE_NOTE.md');
+  });
+
+  test('reads only validated build asset debug IDs from the injected registry', () => {
+    const globalWithDebugIds = globalThis as typeof globalThis & {
+      _sentryDebugIds?: Record<string, unknown>;
+    };
+    globalWithDebugIds._sentryDebugIds = {
+      [`Error\n at https://app.bangle.io${INDEX_ASSET}:1:1`]: DEBUG_ID,
+      'Error\n at https://app.bangle.io/assets/private-note.js:1:1':
+        'PRIVATE_WORKSPACE',
+    };
+    try {
+      expect(getCurrentBuildAssetDebugIds()).toEqual(
+        new Map([[INDEX_ASSET, DEBUG_ID]]),
+      );
+    } finally {
+      delete globalWithDebugIds._sentryDebugIds;
+    }
+  });
+
+  test('keeps first-line Firefox and single-line Safari frames', () => {
+    const buildAssets = new Map([[INDEX_ASSET, DEBUG_ID]]);
+
+    expect(
+      getPrivacySafeStackFrames(
+        `save@https://app.bangle.io${INDEX_ASSET}:10:20`,
+        buildAssets,
+      ),
+    ).toEqual([
+      {
+        columnNumber: 20,
+        debugId: DEBUG_ID,
+        filename: `/assets/bangle-${DEBUG_ID}.js`,
+        lineNumber: 10,
+      },
+    ]);
+    expect(
+      getPrivacySafeStackFrames(
+        `https://app.bangle.io${INDEX_ASSET}:30:40`,
+        buildAssets,
+      ),
+    ).toEqual([
+      {
+        columnNumber: 40,
+        debugId: DEBUG_ID,
+        filename: `/assets/bangle-${DEBUG_ID}.js`,
+        lineNumber: 30,
+      },
+    ]);
+  });
+
+  test('does not treat an asset-shaped error message as a stack frame', () => {
+    const frames = getPrivacySafeStackFrames(
+      `Error: PRIVATE@email.example https://app.bangle.io${INDEX_ASSET}?note=PRIVATE_NOTE.md:123456:789`,
+      new Map([[INDEX_ASSET, DEBUG_ID]]),
+    );
+
+    expect(frames).toEqual([]);
+  });
+
+  test('reads a debug ID from a first-line injected stack', () => {
+    const globalWithDebugIds = globalThis as typeof globalThis & {
+      _sentryDebugIds?: Record<string, unknown>;
+    };
+    globalWithDebugIds._sentryDebugIds = {
+      [`https://app.bangle.io${INDEX_ASSET}:1:1`]: DEBUG_ID,
+    };
+    try {
+      expect(getCurrentBuildAssetDebugIds()).toEqual(
+        new Map([[INDEX_ASSET, DEBUG_ID]]),
+      );
+    } finally {
+      delete globalWithDebugIds._sentryDebugIds;
+    }
   });
 
   test('rejects reports and frames with any non-allowlisted field', () => {
@@ -123,6 +204,7 @@ describe('privacy-safe error reports', () => {
         ...report,
         frames: [
           {
+            debugId: DEBUG_ID,
             filename: '/assets/PRIVATE_NOTE-abcdef12.js',
             lineNumber: 10,
             columnNumber: 20,

--- a/packages/shared/base-utils/__tests__/privacy-safe-error-report.spec.ts
+++ b/packages/shared/base-utils/__tests__/privacy-safe-error-report.spec.ts
@@ -1,0 +1,134 @@
+import type { PrivacySafeErrorReport } from '@bangle.io/types';
+import { describe, expect, test } from 'vitest';
+import {
+  createPrivacySafeErrorReport,
+  getPrivacySafeStackFrames,
+  isPrivacySafeErrorReport,
+} from '../privacy-safe-error-report';
+
+const PRIVATE_MARKERS = [
+  'SECRET_NOTE_CONTENT',
+  'PRIVATE_WORKSPACE',
+  'PRIVATE_NOTE.md',
+  'PRIVATE_CAUSE',
+  'PRIVATE_PROPERTY',
+  'browser-extension.example',
+];
+
+function makeReport(): PrivacySafeErrorReport {
+  const error = new TypeError('SECRET_NOTE_CONTENT', {
+    cause: new Error('PRIVATE_CAUSE'),
+  });
+  Object.assign(error, {
+    wsPath: 'PRIVATE_WORKSPACE:PRIVATE_NOTE.md',
+    privateProperty: 'PRIVATE_PROPERTY',
+  });
+  error.stack = [
+    'TypeError: SECRET_NOTE_CONTENT',
+    '    at save (https://app.bangle.io/assets/index-SECRET_NOTE_CONTENT.js?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:10:20)',
+    '    at extension (https://browser-extension.example/PRIVATE_NOTE.md:30:40)',
+  ].join('\n');
+
+  return createPrivacySafeErrorReport(error, {
+    id: 'fb3b15d4-c536-4bf5-8d06-f328247b9619',
+    capturedAt: '2026-07-19T12:00:00.000Z',
+    route: 'editor',
+    release: 'bangle.io@1.2.3+abcdef12',
+    environment: 'production',
+  });
+}
+
+describe('privacy-safe error reports', () => {
+  test('reconstructs an allowlisted report without user-controlled error data', () => {
+    const report = makeReport();
+    const serialized = JSON.stringify(report);
+
+    expect(report).toEqual({
+      schemaVersion: 1,
+      id: 'fb3b15d4-c536-4bf5-8d06-f328247b9619',
+      capturedAt: '2026-07-19T12:00:00.000Z',
+      errorType: 'TypeError',
+      route: 'editor',
+      release: 'bangle.io@1.2.3+abcdef12',
+      environment: 'production',
+      frames: [
+        {
+          filename: '/assets/index.js',
+          lineNumber: 10,
+          columnNumber: 20,
+        },
+      ],
+    });
+    for (const marker of PRIVATE_MARKERS) {
+      expect(serialized).not.toContain(marker);
+    }
+  });
+
+  test('maps custom names and routes to fixed values', () => {
+    const error = new Error('SECRET_NOTE_CONTENT');
+    error.name = 'PRIVATE_WORKSPACE';
+    const report = createPrivacySafeErrorReport(error, {
+      id: 'fb3b15d4-c536-4bf5-8d06-f328247b9619',
+      capturedAt: '2026-07-19T12:00:00.000Z',
+      route: 'PRIVATE_NOTE.md',
+      release: 'bangle.io@1.2.3+abcdef12',
+      environment: 'production',
+    });
+
+    expect(report.errorType).toBe('Error');
+    expect(report.route).toBe('unknown');
+  });
+
+  test.each([
+    'code-highlight-shiki',
+    'core',
+    'engine-javascript',
+    'index',
+  ])('drops the entire untrusted suffix for the %s bundle', (prefix) => {
+    const frames = getPrivacySafeStackFrames(
+      `Error: hidden\n at x (https://app.bangle.io/assets/${prefix}-SECRET_NOTE_CONTENT.js?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:7:9)`,
+    );
+
+    expect(frames).toEqual([
+      { filename: `/assets/${prefix}.js`, lineNumber: 7, columnNumber: 9 },
+    ]);
+    expect(JSON.stringify(frames)).not.toContain('SECRET_NOTE_CONTENT');
+    expect(JSON.stringify(frames)).not.toContain('PRIVATE_WORKSPACE');
+    expect(JSON.stringify(frames)).not.toContain('PRIVATE_NOTE.md');
+  });
+
+  test('rejects reports and frames with any non-allowlisted field', () => {
+    const report = makeReport();
+
+    expect(isPrivacySafeErrorReport(report)).toBe(true);
+    expect(
+      isPrivacySafeErrorReport({
+        ...report,
+        noteName: 'PRIVATE_NOTE.md',
+      }),
+    ).toBe(false);
+    expect(
+      isPrivacySafeErrorReport({
+        ...report,
+        frames: [
+          {
+            ...report.frames[0],
+            functionName: 'PRIVATE_PROPERTY',
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      isPrivacySafeErrorReport({
+        ...report,
+        frames: [
+          {
+            filename: '/assets/PRIVATE_NOTE-abcdef12.js',
+            lineNumber: 10,
+            columnNumber: 20,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/base-utils/base-service.ts
+++ b/packages/shared/base-utils/base-service.ts
@@ -42,6 +42,16 @@ export abstract class BaseService implements Service<BaseServiceCommonOptions> {
     return this.__context.ctx;
   }
 
+  /** Reports a caught defect that will not reach a global error boundary. */
+  protected reportError(error: unknown, diagnostic: string): Error {
+    const reportableError =
+      error instanceof Error
+        ? error
+        : new Error('Unexpected application error');
+    this.logger.error(reportableError, diagnostic);
+    return reportableError;
+  }
+
   constructor(
     public name: string,
     private __context: BaseServiceContext,

--- a/packages/shared/base-utils/base-service.ts
+++ b/packages/shared/base-utils/base-service.ts
@@ -38,6 +38,10 @@ export abstract class BaseService implements Service<BaseServiceCommonOptions> {
     return this.__context.ctx.store;
   }
 
+  protected get commonOptions(): BaseServiceCommonOptions {
+    return this.__context.ctx;
+  }
+
   constructor(
     public name: string,
     private __context: BaseServiceContext,

--- a/packages/shared/base-utils/error-reporting-policy.ts
+++ b/packages/shared/base-utils/error-reporting-policy.ts
@@ -1,0 +1,41 @@
+import type { ErrorReporter } from '@bangle.io/logger';
+import type { AppError } from '@bangle.io/types';
+import { getAppErrorCause, isAppError } from './throw-app-error';
+
+export function shouldReportAppError(appError: AppError): boolean {
+  switch (appError.name) {
+    case 'error::file:already-existing':
+    case 'error::file:size-too-large':
+    case 'error::file-storage:file-does-not-exist':
+    case 'error::workspace:native-fs-auth-needed':
+    case 'error::workspace:native-fs-locate-failed':
+    case 'error::workspace:native-fs-reconnect-failed':
+    case 'error::workspace:no-note-opened':
+    case 'error::workspace:no-notes-found':
+    case 'error::workspace:not-opened':
+    case 'error::ws-path:create-new-note':
+    case 'error::ws-path:invalid-markdown-path':
+    case 'error::ws-path:invalid-note-path':
+    case 'error::ws-path:invalid-ws-name':
+    case 'error::ws-path:invalid-ws-path':
+      return false;
+    default:
+      return true;
+  }
+}
+
+/** Captures at the error boundary, before UI error subscribers are mounted. */
+export function captureReportableError(
+  reporter: ErrorReporter,
+  error: Error,
+): boolean {
+  if (isAppError(error)) {
+    const appError = getAppErrorCause(error);
+    if (appError && !shouldReportAppError(appError)) {
+      return false;
+    }
+  }
+
+  reporter.captureException(error);
+  return true;
+}

--- a/packages/shared/base-utils/github-bug-url.ts
+++ b/packages/shared/base-utils/github-bug-url.ts
@@ -1,99 +1,53 @@
 import type { Logger } from '@bangle.io/logger';
-import { getAppErrorCause } from './throw-app-error';
+import { getPrivacySafeStackFrames } from './privacy-safe-error-report';
 
 export function getGithubUrl(error: Error, logger: Logger): string {
   const MAX_URL_LENGTH = 2000;
-  const bodySections: string[] = [];
+  const safeType = getSafeErrorType(error.name);
+  const safeFrames = getPrivacySafeStackFrames(error.stack).slice(-5);
+  const body = `
+## What happened?
+<!-- Please describe what you were doing and what went wrong. Avoid including private note content. -->
 
-  // Add initial details
-  bodySections.push(formatInitialDetails(error));
+## Privacy-safe diagnostics
 
-  try {
-    const appErrorCause = getAppErrorCause(error);
-    if (appErrorCause) {
-      bodySections.push(formatAppError(appErrorCause));
-    } else {
-      bodySections.push(...formatErrorCauses(error));
-    }
-  } catch (e) {
-    logger.error('Error in getGithubUrl', e);
-    if (e instanceof Error) {
-      bodySections.push(formatErrorSection('Error in getGithubUrl', e));
-    }
-  }
+**Error type:** ${safeType}
 
-  const joinedBody = bodySections.join('\n\n');
-  let encodedBody = encodeURIComponent(joinedBody);
+**App code locations:**
+\`\`\`
+${
+  safeFrames
+    .map(
+      (frame) => `${frame.filename}:${frame.lineNumber}:${frame.columnNumber}`,
+    )
+    .join('\n') || 'No app stack frames were available.'
+}
+\`\`\`
 
+Workspace names, note names, note contents, page URLs, route parameters, error messages, and error causes are intentionally excluded.
+  `.trim();
+
+  const encodedBody = encodeURIComponent(body);
   if (encodedBody.length > MAX_URL_LENGTH) {
-    logger.error(
-      `Error report body is too long (${encodedBody.length} characters)`,
-    );
-    const excess = encodedBody.length - MAX_URL_LENGTH;
-    const maxBodyLength = joinedBody.length - excess - 3;
-    const truncatedBody = `${joinedBody.substring(0, maxBodyLength)}...`;
-    encodedBody = encodeURIComponent(truncatedBody);
+    logger.warn('Privacy-safe error report exceeded the GitHub URL limit.');
   }
 
-  return `https://github.com/bangle-io/bangle-io/issues/new?title=Error%20Report&body=${encodedBody}`;
+  return `https://github.com/bangle-io/bangle-io/issues/new?title=Error%20Report&body=${encodedBody.slice(0, MAX_URL_LENGTH)}`;
 }
 
-function getImportantStackLines(stack: string | undefined, lines = 4): string {
-  if (!stack) return '';
-  const stackLines = stack.split('\n');
-  return stackLines.slice(0, lines).join('\n');
-}
-
-function formatInitialDetails(error: Error): string {
-  return `
-## Details
-<!-- Please provide details -->
-## Reproduction
-**User Agent**
-${navigator.userAgent}
-
-**Error**
-  \`\`\`
-  ${error.message}
-  ${getImportantStackLines(error.stack, 5)}
-  \`\`\`
-    `.trim();
-}
-
-function formatAppError(appErrorCause: {
-  name: string;
-  payload: unknown;
-}): string {
-  return `
-**App Error**
-\`\`\`
-${appErrorCause.name}
-${JSON.stringify(appErrorCause.payload)}
-\`\`\`
-    `.trim();
-}
-
-function formatErrorSection(title: string, error: Error): string {
-  return `
-**${title}**
-\`\`\`
-${error.message}
-${getImportantStackLines(error.stack, 3)}
-\`\`\`
-    `.trim();
-}
-
-function formatErrorCauses(error: Error): string[] {
-  const sections: string[] = [];
-  let currentError = error.cause;
-  let level = 1;
-
-  while (currentError instanceof Error && level <= 2) {
-    const title = `Cause ${level}`;
-    sections.push(formatErrorSection(title, currentError));
-    currentError = currentError.cause;
-    level++;
+function getSafeErrorType(name: string): string {
+  switch (name) {
+    case 'AggregateError':
+    case 'DOMException':
+    case 'Error':
+    case 'EvalError':
+    case 'RangeError':
+    case 'ReferenceError':
+    case 'SyntaxError':
+    case 'TypeError':
+    case 'URIError':
+      return name;
+    default:
+      return 'Error';
   }
-
-  return sections;
 }

--- a/packages/shared/base-utils/index.ts
+++ b/packages/shared/base-utils/index.ts
@@ -43,6 +43,10 @@ export { BaseErrorService } from './base-error-service';
 export type { BaseServiceContext } from './base-service';
 export { BaseService } from './base-service';
 export { cx } from './cx';
+export {
+  captureReportableError,
+  shouldReportAppError,
+} from './error-reporting-policy';
 export { getGithubUrl } from './github-bug-url';
 export {
   arrayEqual,
@@ -56,6 +60,12 @@ export {
   listenToResize,
   setRootWidescreenClass,
 } from './misc';
+export {
+  createPrivacySafeErrorReport,
+  getPrivacySafeRoute,
+  getPrivacySafeStackFrames,
+  isPrivacySafeErrorReport,
+} from './privacy-safe-error-report';
 export {
   acquireLockIfAvailable,
   rafSchedule,

--- a/packages/shared/base-utils/index.ts
+++ b/packages/shared/base-utils/index.ts
@@ -62,6 +62,7 @@ export {
 } from './misc';
 export {
   createPrivacySafeErrorReport,
+  getCurrentBuildAssetDebugIds,
   getPrivacySafeRoute,
   getPrivacySafeStackFrames,
   isPrivacySafeErrorReport,

--- a/packages/shared/base-utils/privacy-safe-error-report.ts
+++ b/packages/shared/base-utils/privacy-safe-error-report.ts
@@ -30,14 +30,9 @@ const SAFE_ROUTES = new Set<AppRouteInfo['route']>([
 const MAX_STACK_FRAMES = 40;
 const STACK_LOCATION =
   /((?:https?|bangle|file):\/\/[^\s)]+|\/[^\s)]+):(\d+):(\d+)\)?$/;
-const GENERATED_BUNDLE_NAME =
-  /^([a-zA-Z0-9_-]+)-[a-zA-Z0-9_-]{6,}\.(?:js|mjs)$/;
-const SAFE_BUNDLE_PREFIXES = new Set([
-  'code-highlight-shiki',
-  'core',
-  'engine-javascript',
-  'index',
-]);
+const DEBUG_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const BUILD_ASSET_PATH = /^\/assets\/[a-zA-Z0-9._-]+\.(?:js|mjs)$/;
 const SAFE_CONTEXT_VALUE = /^[a-zA-Z0-9._+/@-]{1,160}$/;
 const REPORT_KEYS = [
   'capturedAt',
@@ -49,7 +44,12 @@ const REPORT_KEYS = [
   'route',
   'schemaVersion',
 ] as const;
-const FRAME_KEYS = ['columnNumber', 'filename', 'lineNumber'] as const;
+const FRAME_KEYS = [
+  'columnNumber',
+  'debugId',
+  'filename',
+  'lineNumber',
+] as const;
 
 function getSafeErrorType(name: string): PrivacySafeErrorType {
   return SAFE_ERROR_TYPES.has(name as PrivacySafeErrorType)
@@ -65,49 +65,102 @@ export function getPrivacySafeRoute(
     : 'unknown';
 }
 
-function sanitizeFrameFilename(filename: string): string | undefined {
+function getBuildAssetPath(filename: string): string | undefined {
   try {
     const url = new URL(filename, 'https://bangle.invalid');
-    const basename = url.pathname.split('/').filter(Boolean).at(-1);
-    if (
-      !basename ||
-      !url.pathname.includes('/assets/') ||
-      !SAFE_BUNDLE_PREFIXES.has(GENERATED_BUNDLE_NAME.exec(basename)?.[1] ?? '')
-    ) {
-      return undefined;
-    }
-    // The suffix is derived from Error.stack and is therefore untrusted even
-    // when it resembles a build hash. Keep only a fixed, code-owned label.
-    return `/assets/${GENERATED_BUNDLE_NAME.exec(basename)?.[1]}.js`;
+    return BUILD_ASSET_PATH.test(url.pathname) ? url.pathname : undefined;
   } catch {
     return undefined;
   }
 }
 
+function matchStackFrameLocation(line: string): RegExpMatchArray | undefined {
+  const trimmed = line.trim();
+  const match = trimmed.match(STACK_LOCATION);
+  if (!match) {
+    return undefined;
+  }
+  const locationStart = match.index ?? -1;
+  const firefoxPrefix = trimmed.slice(0, locationStart);
+  const hasEngineFrameShape =
+    trimmed.startsWith('at ') ||
+    locationStart === 0 ||
+    (firefoxPrefix.endsWith('@') && !firefoxPrefix.includes(':'));
+  return hasEngineFrameShape ? match : undefined;
+}
+
+/**
+ * Builds a trusted asset-to-debug-ID registry from snippets injected by the
+ * Sentry Vite plugin. The stack strings never leave the browser; reports use
+ * opaque aliases derived only from validated build IDs.
+ */
+export function getCurrentBuildAssetDebugIds(): ReadonlyMap<string, string> {
+  const registry = new Map<string, string>();
+  const rawDebugIds = (
+    globalThis as typeof globalThis & {
+      _sentryDebugIds?: Record<string, unknown>;
+    }
+  )._sentryDebugIds;
+  if (!rawDebugIds) {
+    return registry;
+  }
+
+  for (const [stack, value] of Object.entries(rawDebugIds)) {
+    if (typeof value !== 'string' || !DEBUG_ID.test(value)) {
+      continue;
+    }
+    for (const line of stack.split('\n')) {
+      const match = matchStackFrameLocation(line);
+      const assetPath = getBuildAssetPath(match?.[1] ?? '');
+      if (assetPath) {
+        registry.set(assetPath, value.toLowerCase());
+        break;
+      }
+    }
+  }
+
+  return registry;
+}
+
 export function getPrivacySafeStackFrames(
   stack: string | undefined,
+  buildAssetDebugIds: ReadonlyMap<
+    string,
+    string
+  > = getCurrentBuildAssetDebugIds(),
 ): PrivacySafeStackFrame[] {
   if (!stack) {
     return [];
   }
 
   const frames: PrivacySafeStackFrame[] = [];
-  for (const line of stack.split('\n').slice(1)) {
-    const match = line.match(STACK_LOCATION);
+  for (const line of stack.split('\n')) {
+    const match = matchStackFrameLocation(line);
     if (!match) {
       continue;
     }
-    const filename = sanitizeFrameFilename(match[1] ?? '');
+    const assetPath = getBuildAssetPath(match[1] ?? '');
+    const debugId = assetPath
+      ? buildAssetDebugIds.get(assetPath)?.toLowerCase()
+      : undefined;
     const lineNumber = Number(match[2]);
     const columnNumber = Number(match[3]);
     if (
-      !filename ||
+      !debugId ||
+      !DEBUG_ID.test(debugId) ||
       !Number.isSafeInteger(lineNumber) ||
-      !Number.isSafeInteger(columnNumber)
+      lineNumber <= 0 ||
+      !Number.isSafeInteger(columnNumber) ||
+      columnNumber <= 0
     ) {
       continue;
     }
-    frames.push({ filename, lineNumber, columnNumber });
+    frames.push({
+      columnNumber,
+      debugId,
+      filename: `/assets/bangle-${debugId}.js`,
+      lineNumber,
+    });
     if (frames.length === MAX_STACK_FRAMES) {
       break;
     }
@@ -124,6 +177,7 @@ export function createPrivacySafeErrorReport(
     route: string | undefined;
     release: string;
     environment: string;
+    buildAssetDebugIds?: ReadonlyMap<string, string>;
   },
 ): PrivacySafeErrorReport {
   let errorName = 'Error';
@@ -140,14 +194,17 @@ export function createPrivacySafeErrorReport(
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     id: context.id,
     capturedAt: context.capturedAt,
     errorType: getSafeErrorType(errorName),
     route: getPrivacySafeRoute(context.route),
     release: context.release,
     environment: context.environment,
-    frames: getPrivacySafeStackFrames(errorStack),
+    frames: getPrivacySafeStackFrames(
+      errorStack,
+      context.buildAssetDebugIds ?? getCurrentBuildAssetDebugIds(),
+    ),
   };
 }
 
@@ -160,7 +217,7 @@ export function isPrivacySafeErrorReport(
   const report = value as Partial<PrivacySafeErrorReport>;
   return (
     hasExactKeys(report, REPORT_KEYS) &&
-    report.schemaVersion === 1 &&
+    report.schemaVersion === 2 &&
     typeof report.id === 'string' &&
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
       report.id,
@@ -181,19 +238,16 @@ export function isPrivacySafeErrorReport(
     report.frames.every(
       (frame) =>
         hasExactKeys(frame, FRAME_KEYS) &&
+        typeof frame?.debugId === 'string' &&
+        DEBUG_ID.test(frame.debugId) &&
         typeof frame?.filename === 'string' &&
-        isCanonicalFrameFilename(frame.filename) &&
+        frame.filename === `/assets/bangle-${frame.debugId.toLowerCase()}.js` &&
         Number.isSafeInteger(frame.lineNumber) &&
         frame.lineNumber > 0 &&
         Number.isSafeInteger(frame.columnNumber) &&
         frame.columnNumber > 0,
     )
   );
-}
-
-function isCanonicalFrameFilename(value: string): boolean {
-  const match = /^\/assets\/([a-zA-Z0-9_-]+)\.js$/.exec(value);
-  return SAFE_BUNDLE_PREFIXES.has(match?.[1] ?? '');
 }
 
 function hasExactKeys(

--- a/packages/shared/base-utils/privacy-safe-error-report.ts
+++ b/packages/shared/base-utils/privacy-safe-error-report.ts
@@ -1,0 +1,219 @@
+import type {
+  AppRouteInfo,
+  PrivacySafeErrorReport,
+  PrivacySafeErrorType,
+  PrivacySafeStackFrame,
+} from '@bangle.io/types';
+
+const SAFE_ERROR_TYPES = new Set<PrivacySafeErrorType>([
+  'AggregateError',
+  'DOMException',
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+]);
+
+const SAFE_ROUTES = new Set<AppRouteInfo['route']>([
+  'asset',
+  'editor',
+  'not-found',
+  'settings-general',
+  'settings-workspaces',
+  'welcome',
+  'ws-home',
+]);
+
+const MAX_STACK_FRAMES = 40;
+const STACK_LOCATION =
+  /((?:https?|bangle|file):\/\/[^\s)]+|\/[^\s)]+):(\d+):(\d+)\)?$/;
+const GENERATED_BUNDLE_NAME =
+  /^([a-zA-Z0-9_-]+)-[a-zA-Z0-9_-]{6,}\.(?:js|mjs)$/;
+const SAFE_BUNDLE_PREFIXES = new Set([
+  'code-highlight-shiki',
+  'core',
+  'engine-javascript',
+  'index',
+]);
+const SAFE_CONTEXT_VALUE = /^[a-zA-Z0-9._+/@-]{1,160}$/;
+const REPORT_KEYS = [
+  'capturedAt',
+  'environment',
+  'errorType',
+  'frames',
+  'id',
+  'release',
+  'route',
+  'schemaVersion',
+] as const;
+const FRAME_KEYS = ['columnNumber', 'filename', 'lineNumber'] as const;
+
+function getSafeErrorType(name: string): PrivacySafeErrorType {
+  return SAFE_ERROR_TYPES.has(name as PrivacySafeErrorType)
+    ? (name as PrivacySafeErrorType)
+    : 'Error';
+}
+
+export function getPrivacySafeRoute(
+  value: string | undefined,
+): PrivacySafeErrorReport['route'] {
+  return SAFE_ROUTES.has(value as AppRouteInfo['route'])
+    ? (value as AppRouteInfo['route'])
+    : 'unknown';
+}
+
+function sanitizeFrameFilename(filename: string): string | undefined {
+  try {
+    const url = new URL(filename, 'https://bangle.invalid');
+    const basename = url.pathname.split('/').filter(Boolean).at(-1);
+    if (
+      !basename ||
+      !url.pathname.includes('/assets/') ||
+      !SAFE_BUNDLE_PREFIXES.has(GENERATED_BUNDLE_NAME.exec(basename)?.[1] ?? '')
+    ) {
+      return undefined;
+    }
+    // The suffix is derived from Error.stack and is therefore untrusted even
+    // when it resembles a build hash. Keep only a fixed, code-owned label.
+    return `/assets/${GENERATED_BUNDLE_NAME.exec(basename)?.[1]}.js`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getPrivacySafeStackFrames(
+  stack: string | undefined,
+): PrivacySafeStackFrame[] {
+  if (!stack) {
+    return [];
+  }
+
+  const frames: PrivacySafeStackFrame[] = [];
+  for (const line of stack.split('\n').slice(1)) {
+    const match = line.match(STACK_LOCATION);
+    if (!match) {
+      continue;
+    }
+    const filename = sanitizeFrameFilename(match[1] ?? '');
+    const lineNumber = Number(match[2]);
+    const columnNumber = Number(match[3]);
+    if (
+      !filename ||
+      !Number.isSafeInteger(lineNumber) ||
+      !Number.isSafeInteger(columnNumber)
+    ) {
+      continue;
+    }
+    frames.push({ filename, lineNumber, columnNumber });
+    if (frames.length === MAX_STACK_FRAMES) {
+      break;
+    }
+  }
+
+  return frames.reverse();
+}
+
+export function createPrivacySafeErrorReport(
+  error: Error,
+  context: {
+    id: string;
+    capturedAt: string;
+    route: string | undefined;
+    release: string;
+    environment: string;
+  },
+): PrivacySafeErrorReport {
+  let errorName = 'Error';
+  let errorStack: string | undefined;
+  try {
+    errorName = typeof error.name === 'string' ? error.name : 'Error';
+  } catch {
+    // A custom Error subclass may expose a throwing getter.
+  }
+  try {
+    errorStack = typeof error.stack === 'string' ? error.stack : undefined;
+  } catch {
+    // A custom Error subclass may expose a throwing getter.
+  }
+
+  return {
+    schemaVersion: 1,
+    id: context.id,
+    capturedAt: context.capturedAt,
+    errorType: getSafeErrorType(errorName),
+    route: getPrivacySafeRoute(context.route),
+    release: context.release,
+    environment: context.environment,
+    frames: getPrivacySafeStackFrames(errorStack),
+  };
+}
+
+export function isPrivacySafeErrorReport(
+  value: unknown,
+): value is PrivacySafeErrorReport {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const report = value as Partial<PrivacySafeErrorReport>;
+  return (
+    hasExactKeys(report, REPORT_KEYS) &&
+    report.schemaVersion === 1 &&
+    typeof report.id === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      report.id,
+    ) &&
+    typeof report.capturedAt === 'string' &&
+    isCanonicalIsoDate(report.capturedAt) &&
+    typeof report.errorType === 'string' &&
+    SAFE_ERROR_TYPES.has(report.errorType as PrivacySafeErrorType) &&
+    typeof report.route === 'string' &&
+    (report.route === 'unknown' ||
+      SAFE_ROUTES.has(report.route as AppRouteInfo['route'])) &&
+    typeof report.release === 'string' &&
+    SAFE_CONTEXT_VALUE.test(report.release) &&
+    typeof report.environment === 'string' &&
+    SAFE_CONTEXT_VALUE.test(report.environment) &&
+    Array.isArray(report.frames) &&
+    report.frames.length <= MAX_STACK_FRAMES &&
+    report.frames.every(
+      (frame) =>
+        hasExactKeys(frame, FRAME_KEYS) &&
+        typeof frame?.filename === 'string' &&
+        isCanonicalFrameFilename(frame.filename) &&
+        Number.isSafeInteger(frame.lineNumber) &&
+        frame.lineNumber > 0 &&
+        Number.isSafeInteger(frame.columnNumber) &&
+        frame.columnNumber > 0,
+    )
+  );
+}
+
+function isCanonicalFrameFilename(value: string): boolean {
+  const match = /^\/assets\/([a-zA-Z0-9_-]+)\.js$/.exec(value);
+  return SAFE_BUNDLE_PREFIXES.has(match?.[1] ?? '');
+}
+
+function hasExactKeys(
+  value: unknown,
+  expectedKeys: readonly string[],
+): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const keys = Object.keys(value).sort();
+  return (
+    keys.length === expectedKeys.length &&
+    keys.every((key, index) => key === expectedKeys[index])
+  );
+}
+
+function isCanonicalIsoDate(value: string): boolean {
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}

--- a/packages/shared/config/index.ts
+++ b/packages/shared/config/index.ts
@@ -34,10 +34,6 @@ export const sentryConfig = {
   environment: APP_ENV,
   dsn: SENTRY_DSN,
   release: RELEASE_ID,
-  tracesSampleRate:
-    APP_ENV === 'production' ? 0.8 : APP_ENV === 'staging' ? 1 : 0,
-  replaysSessionSampleRate: APP_ENV === 'production' ? 0.1 : 1,
-  replaysOnErrorSampleRate: 1.0,
 };
 
 if (config.build.nodeEnv !== 'test') {

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -105,6 +105,7 @@ export const SERVICE_NAME = {
   commandDispatchService: 'command-dispatch',
   commandRegistryService: 'command-registry',
   editorService: 'editor',
+  errorReportingService: 'error-reporting',
   fileStorageIndexedDBService: 'file-storage-indexeddb',
   fileStorageMemoryService: 'file-storage-memory',
   fileStorageNativeFsService: 'file-storage-nativefs',
@@ -124,6 +125,10 @@ export const SERVICE_NAME = {
   pmEditorService: 'pmEditorService',
   editorWService: 'editor-w',
 } as const;
+
+export const AUTOMATIC_ERROR_REPORTING_PREFERENCE_KEY =
+  'automatic-error-reporting';
+export const AUTOMATIC_ERROR_REPORTING_STORAGE_KEY = `${SERVICE_NAME.browserLocalStorageSyncDatabaseService}.sync:${SERVICE_NAME.errorReportingService}:${AUTOMATIC_ERROR_REPORTING_PREFERENCE_KEY}`;
 export const APP_MAIN_CONTENT_PADDING = 'px-4 py-4 pt-0 md:px-6';
 /**
  * Left gutter for the editor page: wider than the default content padding so

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -31,6 +31,22 @@ export const t = {
       starItem: 'Als Favorit markieren',
       unstarItem: 'Favorit entfernen',
     },
+    bugReportPrompt: {
+      title: 'Hilfst du uns, diesen Fehler zu beheben?',
+      description:
+        'Automatische Fehlerberichte sind deaktiviert. Bangle hat diesen Bericht auf deinem Gerät gespeichert, damit du ihn vor dem Senden prüfen kannst.',
+      reassurance:
+        'Dies ist die vollständige Diagnosenutzlast, die Bangle erstellt. Sie enthält keine Notizinhalte, Arbeitsbereichs- oder Notiznamen, Seiten-URLs, Routenparameter, Fehlermeldungen oder Fehlerursachen. Wie bei jeder direkten Webanfrage kann Sentry Netzwerkmetadaten wie deine IP-Adresse und den User-Agent deines Browsers empfangen.',
+      previewLabel: 'Diagnosenutzlast, die Bangle sendet',
+      keepForLater: 'Für später behalten',
+      deleteReport: 'Bericht löschen',
+      sendReport: 'Bericht senden',
+      sendingReport: 'Wird gesendet...',
+      reportSent: 'Fehlerbericht gesendet. Vielen Dank.',
+      reportSendFailed:
+        'Der Bericht konnte nicht gesendet werden und bleibt auf diesem Gerät.',
+      reportDeleteFailed: 'Der Bericht konnte nicht gelöscht werden.',
+    },
     toolbar: {
       toggleMaxWidth: 'Maximale Breite umschalten',
     },
@@ -199,7 +215,7 @@ export const t = {
         automaticBugReportsToggle: 'Fehlerberichte automatisch senden',
         disableBugReportsTitle: 'Automatische Fehlerberichte deaktivieren?',
         disableBugReportsDescription:
-          'Automatische Berichte sind wichtig, um Fehler zu finden und zu beheben. Bangle schließt deine Notizdaten und identifizierende Namen aus. Wenn du dies deaktivierst, bleiben bereinigte Berichte auf diesem Gerät, bis du sie sendest.',
+          'Automatische Berichte sind wichtig, um Fehler zu finden und zu beheben. Bangle schließt deine Notizdaten und identifizierende Namen aus der Diagnosenutzlast aus. Wenn du dies deaktivierst, zeigt Bangle jeden bereinigten Bericht zur Freigabe an und speichert bis zu 50 aktuelle Berichte auf diesem Gerät.',
         keepBugReportsEnabled: 'Automatische Berichte beibehalten',
         disableBugReportsButton: 'Deaktivieren',
         pendingBugReportsTitle: 'Ausstehende Fehlerberichte',
@@ -210,7 +226,7 @@ export const t = {
         manualBugReportsDescription: ({ count }: { count: number }) =>
           count === 1
             ? '1 datenschutzfreundlicher Bericht ist nur auf diesem Gerät gespeichert. Sende ihn, wenn du bereit bist.'
-            : `${count} datenschutzfreundliche Berichte sind nur auf diesem Gerät gespeichert. Sende sie, wenn du bereit bist.`,
+            : `${count} aktuelle datenschutzfreundliche Berichte sind nur auf diesem Gerät gespeichert. Sende sie, wenn du bereit bist.`,
         sendBugReports: 'Berichte senden',
         sendingBugReports: 'Wird gesendet...',
         deleteBugReports: 'Berichte löschen',

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -192,6 +192,31 @@ export const t = {
         wideEditorToggle: 'Breiten Editor verwenden',
         defaultWidth: 'Standard',
         wideWidth: 'Breit',
+        privacySection: 'Datenschutz',
+        automaticBugReportsTitle: 'Automatische Fehlerberichte',
+        automaticBugReportsDescription:
+          'Hilf Bangle, Fehler zu beheben, indem datenschutzfreundliche Diagnosedaten automatisch gesendet werden. Berichte enthalten niemals Notizinhalte, Arbeitsbereichs- oder Notiznamen, Seiten-URLs oder Routenparameter, Fehlermeldungen oder Fehlerursachen.',
+        automaticBugReportsToggle: 'Fehlerberichte automatisch senden',
+        disableBugReportsTitle: 'Automatische Fehlerberichte deaktivieren?',
+        disableBugReportsDescription:
+          'Automatische Berichte sind wichtig, um Fehler zu finden und zu beheben. Bangle schließt deine Notizdaten und identifizierende Namen aus. Wenn du dies deaktivierst, bleiben bereinigte Berichte auf diesem Gerät, bis du sie sendest.',
+        keepBugReportsEnabled: 'Automatische Berichte beibehalten',
+        disableBugReportsButton: 'Deaktivieren',
+        pendingBugReportsTitle: 'Ausstehende Fehlerberichte',
+        pendingBugReportsDescription: ({ count }: { count: number }) =>
+          count === 1
+            ? '1 datenschutzfreundlicher Bericht wartet, weil das automatische Senden fehlgeschlagen ist.'
+            : `${count} datenschutzfreundliche Berichte warten, weil das automatische Senden fehlgeschlagen ist.`,
+        manualBugReportsDescription: ({ count }: { count: number }) =>
+          count === 1
+            ? '1 datenschutzfreundlicher Bericht ist nur auf diesem Gerät gespeichert. Sende ihn, wenn du bereit bist.'
+            : `${count} datenschutzfreundliche Berichte sind nur auf diesem Gerät gespeichert. Sende sie, wenn du bereit bist.`,
+        sendBugReports: 'Berichte senden',
+        sendingBugReports: 'Wird gesendet...',
+        deleteBugReports: 'Berichte löschen',
+        pendingBugReportsSent: 'Ausstehende Fehlerberichte wurden gesendet.',
+        pendingBugReportsSendFailed:
+          'Einige Fehlerberichte konnten nicht gesendet werden und verbleiben auf diesem Gerät.',
         enabled: 'Aktiviert',
         disabled: 'Deaktiviert',
       },

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -241,6 +241,31 @@ export const t = {
         wideEditorToggle: 'Use wide editor',
         defaultWidth: 'Default',
         wideWidth: 'Wide',
+        privacySection: 'Privacy',
+        automaticBugReportsTitle: 'Automatic bug reports',
+        automaticBugReportsDescription:
+          'Help improve Bangle by automatically sending privacy-safe diagnostics when something breaks. Reports never include note contents, workspace or note names, page URLs or route parameters, error messages, or error causes.',
+        automaticBugReportsToggle: 'Automatically send bug reports',
+        disableBugReportsTitle: 'Turn off automatic bug reports?',
+        disableBugReportsDescription:
+          'Automatic reports are vital for finding and fixing failures. Bangle excludes your note data and identifying names. If you turn this off, sanitized reports stay only on this device until you choose to send them.',
+        keepBugReportsEnabled: 'Keep automatic reports',
+        disableBugReportsButton: 'Turn off',
+        pendingBugReportsTitle: 'Pending bug reports',
+        pendingBugReportsDescription: ({ count }: { count: number }) =>
+          count === 1
+            ? '1 privacy-safe report is waiting because an automatic send failed.'
+            : `${count} privacy-safe reports are waiting because automatic sends failed.`,
+        manualBugReportsDescription: ({ count }: { count: number }) =>
+          count === 1
+            ? '1 privacy-safe report is stored only on this device. Send it when you are ready.'
+            : `${count} privacy-safe reports are stored only on this device. Send them when you are ready.`,
+        sendBugReports: 'Send reports',
+        sendingBugReports: 'Sending...',
+        deleteBugReports: 'Delete reports',
+        pendingBugReportsSent: 'Pending bug reports sent.',
+        pendingBugReportsSendFailed:
+          'Some bug reports could not be sent and remain on this device.',
         enabled: 'Enabled',
         disabled: 'Disabled',
       },

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -36,6 +36,22 @@ export const t = {
       starItem: 'Star this item',
       unstarItem: 'Unstar this item',
     },
+    bugReportPrompt: {
+      title: 'Help us fix this bug?',
+      description:
+        'Automatic bug reports are off. Bangle saved this report on your device so you can review it before deciding whether to send it.',
+      reassurance:
+        'This is the complete diagnostic payload Bangle creates. It contains no note contents, workspace or note names, page URLs, route parameters, error messages, or error causes. Like any direct web request, Sentry may receive network metadata such as your IP address and browser User-Agent.',
+      previewLabel: 'Diagnostic payload Bangle sends',
+      keepForLater: 'Keep for later',
+      deleteReport: 'Delete report',
+      sendReport: 'Send report',
+      sendingReport: 'Sending...',
+      reportSent: 'Bug report sent. Thank you.',
+      reportSendFailed:
+        'The report could not be sent and remains on this device.',
+      reportDeleteFailed: 'The report could not be deleted.',
+    },
     toolbar: {
       toggleMaxWidth: 'Toggle Max Width',
     },
@@ -248,7 +264,7 @@ export const t = {
         automaticBugReportsToggle: 'Automatically send bug reports',
         disableBugReportsTitle: 'Turn off automatic bug reports?',
         disableBugReportsDescription:
-          'Automatic reports are vital for finding and fixing failures. Bangle excludes your note data and identifying names. If you turn this off, sanitized reports stay only on this device until you choose to send them.',
+          'Automatic reports are vital for finding and fixing failures. Bangle excludes your note data and identifying names from the diagnostic payload. If you turn this off, Bangle will show each sanitized report for your approval and keep up to 50 recent reports on this device.',
         keepBugReportsEnabled: 'Keep automatic reports',
         disableBugReportsButton: 'Turn off',
         pendingBugReportsTitle: 'Pending bug reports',
@@ -259,7 +275,7 @@ export const t = {
         manualBugReportsDescription: ({ count }: { count: number }) =>
           count === 1
             ? '1 privacy-safe report is stored only on this device. Send it when you are ready.'
-            : `${count} privacy-safe reports are stored only on this device. Send them when you are ready.`,
+            : `${count} recent privacy-safe reports are stored only on this device. Send them when you are ready.`,
         sendBugReports: 'Send reports',
         sendingBugReports: 'Sending...',
         deleteBugReports: 'Delete reports',

--- a/packages/shared/types/error-reporting.ts
+++ b/packages/shared/types/error-reporting.ts
@@ -12,6 +12,7 @@ export type PrivacySafeErrorType =
   | 'URIError';
 
 export type PrivacySafeStackFrame = {
+  debugId: string;
   filename: string;
   lineNumber: number;
   columnNumber: number;
@@ -25,7 +26,7 @@ export type PrivacySafeStackFrame = {
  * cross this boundary.
  */
 export type PrivacySafeErrorReport = {
-  schemaVersion: 1;
+  schemaVersion: 2;
   id: string;
   capturedAt: string;
   errorType: PrivacySafeErrorType;
@@ -40,7 +41,8 @@ export type ManualErrorReportHandler = (
 ) => Promise<void>;
 
 export type ErrorReportingController = {
-  captureException: (error: Error) => void;
+  captureException: (error: Error) => PrivacySafeErrorReport | undefined;
+  getAutomaticReportingEnabled: () => boolean;
   setAutomaticReportingEnabled: (enabled: boolean) => Promise<void>;
   setManualReportHandler: (
     handler: ManualErrorReportHandler | undefined,

--- a/packages/shared/types/error-reporting.ts
+++ b/packages/shared/types/error-reporting.ts
@@ -1,0 +1,51 @@
+import type { AppRouteInfo } from './base-router';
+
+export type PrivacySafeErrorType =
+  | 'AggregateError'
+  | 'DOMException'
+  | 'Error'
+  | 'EvalError'
+  | 'RangeError'
+  | 'ReferenceError'
+  | 'SyntaxError'
+  | 'TypeError'
+  | 'URIError';
+
+export type PrivacySafeStackFrame = {
+  filename: string;
+  lineNumber: number;
+  columnNumber: number;
+};
+
+/**
+ * The complete payload Bangle is allowed to persist or send for a bug report.
+ *
+ * This type intentionally has no free-form message, URL, breadcrumb, user,
+ * cause, or context fields. User-controlled note and workspace data must never
+ * cross this boundary.
+ */
+export type PrivacySafeErrorReport = {
+  schemaVersion: 1;
+  id: string;
+  capturedAt: string;
+  errorType: PrivacySafeErrorType;
+  route: AppRouteInfo['route'] | 'unknown';
+  release: string;
+  environment: string;
+  frames: PrivacySafeStackFrame[];
+};
+
+export type ManualErrorReportHandler = (
+  report: PrivacySafeErrorReport,
+) => Promise<void>;
+
+export type ErrorReportingController = {
+  captureException: (error: Error) => void;
+  setAutomaticReportingEnabled: (enabled: boolean) => Promise<void>;
+  setManualReportHandler: (
+    handler: ManualErrorReportHandler | undefined,
+  ) => void;
+  sendReports: (
+    reports: readonly PrivacySafeErrorReport[],
+  ) => Promise<{ sentReportIds: readonly string[] }>;
+};

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -13,5 +13,6 @@ export type * from './base-file-storage';
 export type * from './base-router';
 export type * from './commands';
 export type * from './emitter';
+export type * from './error-reporting';
 export type * from './services';
 export type * from './workspace';

--- a/packages/shared/types/services.ts
+++ b/packages/shared/types/services.ts
@@ -4,6 +4,7 @@ import type { createStore } from 'jotai';
 import type { BaseAppDatabase, BaseAppSyncDatabase } from './base-database';
 import type { BaseFileStorageProvider } from './base-file-storage';
 import type { BaseRouter } from './base-router';
+import type { ErrorReportingController } from './error-reporting';
 
 export type ServiceKind = 'platform' | 'core';
 
@@ -13,6 +14,7 @@ export type BaseServiceCommonOptions = {
   rootAbortSignal: AbortSignal;
   logger: Logger;
   store: Store;
+  errorReporting: ErrorReportingController;
   // for cases where throwing an error is not possible
   emitAppError: (error: BaseError) => void;
 };
@@ -28,6 +30,7 @@ export type CoreServiceSlotId =
   | 'commandRegistry'
   | 'editorEngine'
   | 'editorService'
+  | 'errorReporting'
   | 'fileSystem'
   | 'navigation'
   | 'shortcut'
@@ -49,7 +52,8 @@ export type AllServiceName = CoreServiceSlotId | PlatformServiceSlotId;
 
 export type CommandExcludedServiceSlotId =
   | 'commandDispatcher'
-  | 'commandRegistry';
+  | 'commandRegistry'
+  | 'errorReporting';
 
 export type CommandExposedServiceSlotId = Exclude<
   CoreServiceSlotId,

--- a/packages/tooling/browser-entry/package.json
+++ b/packages/tooling/browser-entry/package.json
@@ -43,7 +43,6 @@
     "@bangle.io/mini-js-utils": "workspace:*",
     "@bangle.io/root-emitter": "workspace:*",
     "@bangle.io/translations": "workspace:*",
-    "@sentry/browser": "^10.63.0",
     "@sentry/vite-plugin": "^5.3.0",
     "@tailwindcss/vite": "^4.3.2",
     "@vitejs/plugin-react": "^6.0.3",

--- a/packages/tooling/browser-entry/src/__tests__/main.spec.tsx
+++ b/packages/tooling/browser-entry/src/__tests__/main.spec.tsx
@@ -52,6 +52,27 @@ describe('browser entry startup', () => {
     timeout: 30_000,
   }, async () => {
     const error = new Error('database mount failed');
+    const report = {
+      schemaVersion: 2,
+      id: 'fb3b15d4-c536-4bf5-8d06-f328247b9619',
+      capturedAt: '2026-07-19T12:00:00.000Z',
+      errorType: 'Error',
+      route: 'welcome',
+      release: 'bangle.io@1.2.3+abcdef12',
+      environment: 'production',
+      frames: [],
+    } as const;
+    const sendReports = vi.fn().mockResolvedValue({
+      sentReportIds: [report.id],
+    });
+    mocks.readAutomaticErrorReportingPreference.mockReturnValueOnce(false);
+    mocks.initializeSentry.mockReturnValueOnce({
+      captureException: vi.fn().mockReturnValue(report),
+      getAutomaticReportingEnabled: vi.fn().mockReturnValue(false),
+      sendReports,
+      setAutomaticReportingEnabled: vi.fn().mockResolvedValue(undefined),
+      setManualReportHandler: vi.fn(),
+    });
     let startupSignal: AbortSignal | undefined;
     mocks.initializeServices.mockImplementationOnce(
       (
@@ -85,6 +106,16 @@ describe('browser entry startup', () => {
     expect(document.getElementById('root')?.textContent ?? '').toContain(
       error.message,
     );
+    expect(
+      document.querySelector('[data-testid="startup-bug-report-preview"]')
+        ?.textContent ?? '',
+    ).toContain('"schemaVersion": 2');
+    const sendButton = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent === t.app.bugReportPrompt.sendReport,
+    );
+    expect(sendButton).toBeDefined();
+    sendButton?.click();
+    await vi.waitFor(() => expect(sendReports).toHaveBeenCalledWith([report]));
     expect(startupSignal?.aborted).toBe(true);
   });
 });

--- a/packages/tooling/browser-entry/src/__tests__/main.spec.tsx
+++ b/packages/tooling/browser-entry/src/__tests__/main.spec.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   consumePwaLaunchParams: vi.fn(),
   initializeSentry: vi.fn(),
   initializeServices: vi.fn(),
+  readAutomaticErrorReportingPreference: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock('@bangle.io/app', () => ({
@@ -23,6 +24,8 @@ vi.mock('@bangle.io/initialize-services', async (importOriginal) => ({
 
 vi.mock('../setup-sentry', () => ({
   initializeSentry: mocks.initializeSentry,
+  readAutomaticErrorReportingPreference:
+    mocks.readAutomaticErrorReportingPreference,
 }));
 
 describe('browser entry startup', () => {

--- a/packages/tooling/browser-entry/src/__tests__/setup-sentry.spec.ts
+++ b/packages/tooling/browser-entry/src/__tests__/setup-sentry.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import type { PrivacySafeErrorReport } from '@bangle.io/initialize-services';
+import { Logger } from '@bangle.io/logger';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  initializeSentry,
+  readAutomaticErrorReportingPreference,
+  serializeSentryEnvelope,
+} from '../setup-sentry';
+
+const PRIVATE_MARKERS = [
+  'SECRET_NOTE_CONTENT',
+  'PRIVATE_WORKSPACE',
+  'PRIVATE_NOTE.md',
+  'PRIVATE_CAUSE',
+  'PRIVATE_PROPERTY',
+];
+
+function makePrivateError(): Error {
+  const error = new TypeError('SECRET_NOTE_CONTENT', {
+    cause: new Error('PRIVATE_CAUSE'),
+  });
+  Object.assign(error, {
+    wsPath: 'PRIVATE_WORKSPACE:PRIVATE_NOTE.md',
+    privateProperty: 'PRIVATE_PROPERTY',
+  });
+  error.stack =
+    'TypeError: SECRET_NOTE_CONTENT\n    at save (https://app.bangle.io/assets/index-abcdef12.js?wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md:10:20)';
+  return error;
+}
+
+function expectNoPrivateMarkers(value: unknown): void {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+  for (const marker of PRIVATE_MARKERS) {
+    expect(serialized).not.toContain(marker);
+  }
+}
+
+describe('privacy-safe Sentry transport', () => {
+  beforeEach(() => {
+    window.history.replaceState(
+      null,
+      '',
+      '/#route=editor&wsPath=PRIVATE_WORKSPACE:PRIVATE_NOTE.md',
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true } satisfies Pick<Response, 'ok'>),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test('sends only a reconstructed allowlisted envelope in automatic mode', async () => {
+    const controller = initializeSentry(new Logger('', 'debug'), true);
+    const error = makePrivateError();
+
+    controller.captureException(error);
+    controller.captureException(error);
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    const request = vi.mocked(fetch).mock.calls[0]?.[1];
+    const body = request?.body;
+    expect(typeof body).toBe('string');
+    expect(body).toContain('Bangle application error');
+    expect(body).toContain('"route":"editor"');
+    expectNoPrivateMarkers(body);
+    expect(request?.credentials).toBe('omit');
+    expect(request?.referrerPolicy).toBe('no-referrer');
+  });
+
+  test('stores a sanitized report without making a request when disabled', async () => {
+    const controller = initializeSentry(new Logger('', 'debug'), false);
+    const persist = vi.fn().mockResolvedValue(undefined);
+
+    controller.captureException(makePrivateError());
+    controller.setManualReportHandler(persist);
+
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(1));
+    expect(fetch).not.toHaveBeenCalled();
+    const report = persist.mock.calls[0]?.[0];
+    expect(report.route).toBe('editor');
+    expectNoPrivateMarkers(report);
+  });
+
+  test('aborts an automatic request when reporting is disabled', async () => {
+    let requestSignal: AbortSignal | null | undefined;
+    vi.mocked(fetch).mockImplementationOnce((_input, init) => {
+      requestSignal = init?.signal;
+      return new Promise(() => {});
+    });
+    const controller = initializeSentry(new Logger('', 'debug'), true);
+
+    controller.captureException(makePrivateError());
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    await controller.setAutomaticReportingEnabled(false);
+
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  test('bounds reports captured before IndexedDB is ready', async () => {
+    const controller = initializeSentry(new Logger('', 'debug'), false);
+    for (let index = 0; index < 55; index += 1) {
+      controller.captureException(makePrivateError());
+    }
+    const persist = vi.fn().mockResolvedValue(undefined);
+
+    controller.setManualReportHandler(persist);
+
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(50));
+  });
+
+  test('manual envelopes do not gain fields from the original error', () => {
+    const report: PrivacySafeErrorReport = {
+      schemaVersion: 1,
+      id: 'fb3b15d4-c536-4bf5-8d06-f328247b9619',
+      capturedAt: '2026-07-19T12:00:00.000Z',
+      errorType: 'TypeError',
+      route: 'editor',
+      release: 'bangle.io@1.2.3+abcdef12',
+      environment: 'production',
+      frames: [
+        {
+          filename: '/assets/index.js',
+          lineNumber: 10,
+          columnNumber: 20,
+        },
+      ],
+    };
+
+    const envelope = serializeSentryEnvelope(report, 'manual');
+    expect(envelope).toContain('"reporting_mode":"manual"');
+    expectNoPrivateMarkers(envelope);
+  });
+
+  test('defaults on and honors only an explicit stored false preference', () => {
+    const getItem = vi.fn();
+    expect(readAutomaticErrorReportingPreference('key', { getItem })).toBe(
+      true,
+    );
+
+    getItem.mockReturnValueOnce('false');
+    expect(readAutomaticErrorReportingPreference('key', { getItem })).toBe(
+      false,
+    );
+
+    getItem.mockReturnValueOnce('invalid-json');
+    expect(readAutomaticErrorReportingPreference('key', { getItem })).toBe(
+      true,
+    );
+  });
+});

--- a/packages/tooling/browser-entry/src/__tests__/setup-sentry.spec.ts
+++ b/packages/tooling/browser-entry/src/__tests__/setup-sentry.spec.ts
@@ -18,6 +18,7 @@ const PRIVATE_MARKERS = [
   'PRIVATE_CAUSE',
   'PRIVATE_PROPERTY',
 ];
+const DEBUG_ID = '4c346747-7b26-4ea3-9657-1f6776a4e8b2';
 
 function makePrivateError(): Error {
   const error = new TypeError('SECRET_NOTE_CONTENT', {
@@ -41,6 +42,13 @@ function expectNoPrivateMarkers(value: unknown): void {
 
 describe('privacy-safe Sentry transport', () => {
   beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        _sentryDebugIds?: Record<string, string>;
+      }
+    )._sentryDebugIds = {
+      'Error\n at https://app.bangle.io/assets/index-abcdef12.js:1:1': DEBUG_ID,
+    };
     window.history.replaceState(
       null,
       '',
@@ -53,6 +61,11 @@ describe('privacy-safe Sentry transport', () => {
   });
 
   afterEach(() => {
+    delete (
+      globalThis as typeof globalThis & {
+        _sentryDebugIds?: Record<string, string>;
+      }
+    )._sentryDebugIds;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -70,6 +83,9 @@ describe('privacy-safe Sentry transport', () => {
     expect(typeof body).toBe('string');
     expect(body).toContain('Bangle application error');
     expect(body).toContain('"route":"editor"');
+    expect(body).toContain('"debug_meta"');
+    expect(body).toContain(`"debug_id":"${DEBUG_ID}"`);
+    expect(body).toContain(`/assets/bangle-${DEBUG_ID}.js`);
     expectNoPrivateMarkers(body);
     expect(request?.credentials).toBe('omit');
     expect(request?.referrerPolicy).toBe('no-referrer');
@@ -102,6 +118,7 @@ describe('privacy-safe Sentry transport', () => {
     await controller.setAutomaticReportingEnabled(false);
 
     expect(requestSignal?.aborted).toBe(true);
+    expect(controller.getAutomaticReportingEnabled()).toBe(false);
   });
 
   test('bounds reports captured before IndexedDB is ready', async () => {
@@ -116,9 +133,25 @@ describe('privacy-safe Sentry transport', () => {
     await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(50));
   });
 
+  test('retries a failed local persistence without recursive reporting', async () => {
+    const controller = initializeSentry(new Logger('', 'debug'), false);
+    const persist = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValue(undefined);
+    controller.setManualReportHandler(persist);
+
+    controller.captureException(makePrivateError());
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(1));
+    controller.captureException(makePrivateError());
+
+    await vi.waitFor(() => expect(persist).toHaveBeenCalledTimes(3));
+    expectNoPrivateMarkers(persist.mock.calls);
+  });
+
   test('manual envelopes do not gain fields from the original error', () => {
     const report: PrivacySafeErrorReport = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       id: 'fb3b15d4-c536-4bf5-8d06-f328247b9619',
       capturedAt: '2026-07-19T12:00:00.000Z',
       errorType: 'TypeError',
@@ -127,7 +160,8 @@ describe('privacy-safe Sentry transport', () => {
       environment: 'production',
       frames: [
         {
-          filename: '/assets/index.js',
+          debugId: DEBUG_ID,
+          filename: `/assets/bangle-${DEBUG_ID}.js`,
           lineNumber: 10,
           columnNumber: 20,
         },
@@ -139,8 +173,8 @@ describe('privacy-safe Sentry transport', () => {
     expectNoPrivateMarkers(envelope);
   });
 
-  test('defaults on and honors only an explicit stored false preference', () => {
-    const getItem = vi.fn();
+  test('defaults on only when missing and fails closed for unreadable values', () => {
+    const getItem = vi.fn().mockReturnValueOnce(null);
     expect(readAutomaticErrorReportingPreference('key', { getItem })).toBe(
       true,
     );
@@ -152,7 +186,14 @@ describe('privacy-safe Sentry transport', () => {
 
     getItem.mockReturnValueOnce('invalid-json');
     expect(readAutomaticErrorReportingPreference('key', { getItem })).toBe(
-      true,
+      false,
+    );
+
+    getItem.mockImplementationOnce(() => {
+      throw new DOMException('blocked', 'SecurityError');
+    });
+    expect(readAutomaticErrorReportingPreference('key', { getItem })).toBe(
+      false,
     );
   });
 });

--- a/packages/tooling/browser-entry/src/main.tsx
+++ b/packages/tooling/browser-entry/src/main.tsx
@@ -3,7 +3,10 @@ import './index.css';
 
 import { App, consumePwaLaunchParams } from '@bangle.io/app';
 import { ThemeManager } from '@bangle.io/color-scheme-manager';
-import { THEME_MANAGER_CONFIG } from '@bangle.io/constants';
+import {
+  AUTOMATIC_ERROR_REPORTING_STORAGE_KEY,
+  THEME_MANAGER_CONFIG,
+} from '@bangle.io/constants';
 import {
   createEditorSaveCoordinator,
   initializeServices,
@@ -13,7 +16,10 @@ import { createStore } from 'jotai';
 import React, { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { setupRootEmitter } from './setup-root-emitter';
-import { initializeSentry } from './setup-sentry';
+import {
+  initializeSentry,
+  readAutomaticErrorReportingPreference,
+} from './setup-sentry';
 
 const isDebug =
   window.location.hostname === 'localhost' ||
@@ -34,8 +40,12 @@ async function main(logger: Logger) {
   // in-app fallback consumer stays harmless.
   consumePwaLaunchParams(window);
 
-  // Initialize Sentry with privacy protections
-  initializeSentry(logger, isDebug);
+  const errorReporting = initializeSentry(
+    logger,
+    readAutomaticErrorReportingPreference(
+      AUTOMATIC_ERROR_REPORTING_STORAGE_KEY,
+    ),
+  );
 
   const rootElement = document.getElementById('root');
   if (!rootElement) {
@@ -63,6 +73,7 @@ async function main(logger: Logger) {
       themeManager,
       abortController.signal,
       editorSaveCoordinator,
+      errorReporting,
     );
   } catch (error) {
     abortController.abort();
@@ -106,7 +117,10 @@ async function main(logger: Logger) {
 }
 
 function handleStartupFailure(error: unknown, logger: Logger) {
-  logger.error('Unable to start Bangle', error);
+  logger.error(
+    error instanceof Error ? error : new Error('Unable to start Bangle'),
+    'Unable to start Bangle',
+  );
   renderStartupError(error);
 }
 

--- a/packages/tooling/browser-entry/src/main.tsx
+++ b/packages/tooling/browser-entry/src/main.tsx
@@ -9,7 +9,9 @@ import {
 } from '@bangle.io/constants';
 import {
   createEditorSaveCoordinator,
+  type ErrorReportingController,
   initializeServices,
+  type PrivacySafeErrorReport,
 } from '@bangle.io/initialize-services';
 import { Logger } from '@bangle.io/logger';
 import { createStore } from 'jotai';
@@ -27,25 +29,25 @@ const isDebug =
 
 const startupLogger = new Logger('', isDebug ? 'debug' : 'info');
 const editorSaveCoordinator = createEditorSaveCoordinator();
+const errorReporting = initializeSentry(
+  startupLogger,
+  readAutomaticErrorReportingPreference(AUTOMATIC_ERROR_REPORTING_STORAGE_KEY),
+);
 
-void main(startupLogger).catch((error) => {
-  handleStartupFailure(error, startupLogger);
+void main(startupLogger, errorReporting).catch((error) => {
+  handleStartupFailure(error, startupLogger, errorReporting);
 });
 
-async function main(logger: Logger) {
+async function main(
+  logger: Logger,
+  errorReportingController: ErrorReportingController,
+) {
   // Consume PWA launch params (?launch=, ?shortcut=) before any service is
   // constructed: the router captures `window.location.search` at creation
   // and re-emits it on every navigation, so a param still present here
   // would be re-added to the URL and replayed on reload. Idempotent, so the
   // in-app fallback consumer stays harmless.
   consumePwaLaunchParams(window);
-
-  const errorReporting = initializeSentry(
-    logger,
-    readAutomaticErrorReportingPreference(
-      AUTOMATIC_ERROR_REPORTING_STORAGE_KEY,
-    ),
-  );
 
   const rootElement = document.getElementById('root');
   if (!rootElement) {
@@ -73,7 +75,7 @@ async function main(logger: Logger) {
       themeManager,
       abortController.signal,
       editorSaveCoordinator,
-      errorReporting,
+      errorReportingController,
     );
   } catch (error) {
     abortController.abort();
@@ -107,8 +109,8 @@ async function main(logger: Logger) {
       logger.info('-------------Reloading UI-------------');
       abortController.abort();
       queueMicrotask(() => {
-        void main(logger).catch((error) => {
-          handleStartupFailure(error, logger);
+        void main(logger, errorReportingController).catch((error) => {
+          handleStartupFailure(error, logger, errorReportingController);
         });
       });
     },
@@ -116,15 +118,34 @@ async function main(logger: Logger) {
   );
 }
 
-function handleStartupFailure(error: unknown, logger: Logger) {
-  logger.error(
-    error instanceof Error ? error : new Error('Unable to start Bangle'),
-    'Unable to start Bangle',
+function handleStartupFailure(
+  error: unknown,
+  logger: Logger,
+  errorReportingController: ErrorReportingController,
+) {
+  const reportableError =
+    error instanceof Error ? error : new Error('Unable to start Bangle');
+  logger.error('Unable to start Bangle', reportableError);
+  // The normal IndexedDB-backed UI did not finish mounting. Keep this report
+  // in the controller's bounded memory queue so the standalone recovery view
+  // owns its send lifecycle and cannot leave a duplicate durable row behind.
+  errorReportingController.setManualReportHandler(undefined);
+  const report = errorReportingController.captureException(reportableError);
+  renderStartupError(
+    error,
+    report && !errorReportingController.getAutomaticReportingEnabled()
+      ? { controller: errorReportingController, report }
+      : undefined,
   );
-  renderStartupError(error);
 }
 
-export function renderStartupError(error: unknown) {
+export function renderStartupError(
+  error: unknown,
+  manualBugReport?: {
+    controller: ErrorReportingController;
+    report: PrivacySafeErrorReport;
+  },
+) {
   const rootElement = document.getElementById('root');
   if (!rootElement) {
     console.error('Unable to show startup failure because #root is missing');
@@ -133,12 +154,24 @@ export function renderStartupError(error: unknown) {
 
   createRoot(rootElement).render(
     <StrictMode>
-      <StartupErrorView error={error} />
+      <StartupErrorView error={error} manualBugReport={manualBugReport} />
     </StrictMode>,
   );
 }
 
-function StartupErrorView({ error }: { error: unknown }) {
+function StartupErrorView({
+  error,
+  manualBugReport,
+}: {
+  error: unknown;
+  manualBugReport?: {
+    controller: ErrorReportingController;
+    report: PrivacySafeErrorReport;
+  };
+}) {
+  const [sendState, setSendState] = React.useState<
+    'idle' | 'sending' | 'sent' | 'failed'
+  >('idle');
   const message =
     error instanceof Error
       ? error.message
@@ -167,6 +200,54 @@ function StartupErrorView({ error }: { error: unknown }) {
             {message}
           </pre>
         </details>
+        {manualBugReport ? (
+          <section className="mt-4 rounded-md border bg-muted/40 p-3">
+            <h2 className="font-semibold text-lg">
+              {t.app.bugReportPrompt.title}
+            </h2>
+            <p className="mt-2 text-muted-foreground text-sm">
+              {t.app.bugReportPrompt.reassurance}
+            </p>
+            <h3 className="mt-3 font-medium text-sm">
+              {t.app.bugReportPrompt.previewLabel}
+            </h3>
+            <pre
+              className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words text-muted-foreground text-xs"
+              data-testid="startup-bug-report-preview"
+            >
+              {JSON.stringify(manualBugReport.report, null, 2)}
+            </pre>
+            <button
+              className="mt-3 inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground text-sm disabled:opacity-50"
+              disabled={sendState === 'sending' || sendState === 'sent'}
+              type="button"
+              onClick={() => {
+                setSendState('sending');
+                void manualBugReport.controller
+                  .sendReports([manualBugReport.report])
+                  .then(({ sentReportIds }) => {
+                    setSendState(
+                      sentReportIds.includes(manualBugReport.report.id)
+                        ? 'sent'
+                        : 'failed',
+                    );
+                  })
+                  .catch(() => setSendState('failed'));
+              }}
+            >
+              {sendState === 'sending'
+                ? t.app.bugReportPrompt.sendingReport
+                : sendState === 'sent'
+                  ? t.app.bugReportPrompt.reportSent
+                  : t.app.bugReportPrompt.sendReport}
+            </button>
+            {sendState === 'failed' ? (
+              <p className="mt-2 text-destructive text-sm" role="status">
+                {t.app.bugReportPrompt.reportSendFailed}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
         <button
           className="mt-5 inline-flex h-10 items-center justify-center rounded-md bg-primary px-4 py-2 font-medium text-primary-foreground text-sm"
           type="button"

--- a/packages/tooling/browser-entry/src/setup-sentry.ts
+++ b/packages/tooling/browser-entry/src/setup-sentry.ts
@@ -1,40 +1,215 @@
-import { sentryConfig } from '@bangle.io/config';
-import type { Logger } from '@bangle.io/logger';
-import { setErrorReporter } from '@bangle.io/logger';
-import * as Sentry from '@sentry/browser';
+import { APP_ENV, RELEASE_ID, sentryConfig } from '@bangle.io/config';
+import {
+  createPrivacySafeErrorReport,
+  type ErrorReportingController,
+  type ManualErrorReportHandler,
+  type PrivacySafeErrorReport,
+} from '@bangle.io/initialize-services';
+import { type Logger, setErrorReporter } from '@bangle.io/logger';
 
-export function initializeSentry(logger: Logger, _isDebug: boolean): void {
-  Sentry.init({
-    ...sentryConfig,
-    sendDefaultPii: false,
-    /**
-     * Intercepts events before they are sent to Sentry.
-     * Used here to scrub sensitive data from the URL like query params and hash.
-     */
-    beforeSend(event, _hint) {
-      try {
-        // Check if the event contains request URL information
-        if (event.request?.url) {
-          const url = new URL(event.request.url);
-          // Clear query parameters
-          url.search = '';
-          // Clear hash fragment
-          url.hash = '';
-          // Update the event with the scrubbed URL
-          event.request.url = url.toString();
-        }
-      } catch (error) {
-        logger.warn('Failed to scrub URL in Sentry beforeSend:', error);
+const REPORTING_MODE = {
+  automatic: 'automatic',
+  manual: 'manual',
+} as const;
+
+type ReportingMode = (typeof REPORTING_MODE)[keyof typeof REPORTING_MODE];
+const MAX_REPORTS_AWAITING_STORE = 50;
+
+export function readAutomaticErrorReportingPreference(
+  storageKey: string,
+  storage: Pick<Storage, 'getItem'> = window.localStorage,
+): boolean {
+  try {
+    const stored = storage.getItem(storageKey);
+    return stored === null ? true : JSON.parse(stored) !== false;
+  } catch {
+    return true;
+  }
+}
+
+export function initializeSentry(
+  logger: Logger,
+  automaticReportingEnabled: boolean,
+): ErrorReportingController {
+  let automaticEnabled = automaticReportingEnabled;
+  let automaticAbortController = new AbortController();
+  let manualReportHandler: ManualErrorReportHandler | undefined;
+  const capturedErrors = new WeakSet<Error>();
+  const reportsAwaitingStore: PrivacySafeErrorReport[] = [];
+
+  const keepAwaitingStoreBounded = (report: PrivacySafeErrorReport) => {
+    reportsAwaitingStore.push(report);
+    if (reportsAwaitingStore.length > MAX_REPORTS_AWAITING_STORE) {
+      reportsAwaitingStore.splice(
+        0,
+        reportsAwaitingStore.length - MAX_REPORTS_AWAITING_STORE,
+      );
+    }
+  };
+
+  const queueLocally = async (report: PrivacySafeErrorReport) => {
+    if (!manualReportHandler) {
+      keepAwaitingStoreBounded(report);
+      return;
+    }
+    try {
+      await manualReportHandler(report);
+    } catch {
+      // Do not log here: reporting a queue failure through the same logger
+      // would recurse. Keep the already-sanitized report in memory instead.
+      keepAwaitingStoreBounded(report);
+    }
+  };
+
+  const controller: ErrorReportingController = {
+    captureException(error) {
+      if (capturedErrors.has(error)) {
+        return;
+      }
+      capturedErrors.add(error);
+      const report = createReport(error);
+      if (!automaticEnabled) {
+        void queueLocally(report);
+        return;
       }
 
-      return event;
+      void sendReport(
+        report,
+        REPORTING_MODE.automatic,
+        automaticAbortController.signal,
+      ).then((sent) => {
+        if (!sent) {
+          void queueLocally(report);
+        }
+      });
     },
-  });
+    async setAutomaticReportingEnabled(enabled) {
+      // This flag gates capture synchronously. No Sentry SDK is initialized,
+      // so disabling cannot leave global handlers or session envelopes behind.
+      automaticEnabled = enabled;
+      if (!enabled) {
+        automaticAbortController.abort();
+        automaticAbortController = new AbortController();
+      }
+    },
+    setManualReportHandler(handler) {
+      manualReportHandler = handler;
+      if (!handler || reportsAwaitingStore.length === 0) {
+        return;
+      }
 
-  setErrorReporter({
-    captureException: (error: Error) => {
-      Sentry.captureException(error);
-      logger.debug('Error reported to Sentry via logger:', error.message);
+      const pending = reportsAwaitingStore.splice(
+        0,
+        reportsAwaitingStore.length,
+      );
+      for (const report of pending) {
+        void queueLocally(report);
+      }
     },
+    async sendReports(reports) {
+      const sentReportIds: string[] = [];
+      for (const report of reports) {
+        if (await sendReport(report, REPORTING_MODE.manual)) {
+          sentReportIds.push(report.id);
+        }
+      }
+      return { sentReportIds };
+    },
+  };
+
+  setErrorReporter(controller);
+  logger.debug('Privacy-safe bug reporting initialized');
+  return controller;
+}
+
+function createReport(error: Error): PrivacySafeErrorReport {
+  const route = new URLSearchParams(window.location.hash.slice(1)).get('route');
+  return createPrivacySafeErrorReport(error, {
+    id: crypto.randomUUID(),
+    capturedAt: new Date().toISOString(),
+    route: route ?? undefined,
+    release: RELEASE_ID,
+    environment: APP_ENV,
   });
+}
+
+async function sendReport(
+  report: PrivacySafeErrorReport,
+  mode: ReportingMode,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  try {
+    const response = await fetch(getEnvelopeEndpoint(sentryConfig.dsn), {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      body: serializeSentryEnvelope(report, mode),
+      keepalive: true,
+      credentials: 'omit',
+      referrerPolicy: 'no-referrer',
+      signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+function getEnvelopeEndpoint(dsn: string): string {
+  const url = new URL(dsn);
+  const projectId = url.pathname.replace(/^\//, '');
+  return `${url.protocol}//${url.host}/api/${projectId}/envelope/?sentry_version=7&sentry_key=${encodeURIComponent(url.username)}`;
+}
+
+export function serializeSentryEnvelope(
+  report: PrivacySafeErrorReport,
+  mode: ReportingMode,
+): string {
+  const eventId = report.id.replaceAll('-', '');
+  const envelopeHeader = {
+    event_id: eventId,
+    sent_at: report.capturedAt,
+  };
+  const itemHeader = { type: 'event' };
+  const event = {
+    event_id: eventId,
+    timestamp: Date.parse(report.capturedAt) / 1000,
+    platform: 'javascript',
+    level: 'error',
+    environment: report.environment,
+    release: report.release,
+    exception: {
+      values: [
+        {
+          type: report.errorType,
+          value: 'Bangle application error',
+          stacktrace: {
+            frames: report.frames.map((frame) => ({
+              filename: frame.filename,
+              lineno: frame.lineNumber,
+              colno: frame.columnNumber,
+              in_app: true,
+            })),
+          },
+          mechanism: {
+            type: 'bangle.privacy-safe',
+            handled: true,
+          },
+        },
+      ],
+    },
+    tags: {
+      error_type: report.errorType,
+      report_schema: String(report.schemaVersion),
+      reporting_mode: mode,
+      route: report.route,
+    },
+    sdk: {
+      name: 'bangle.privacy-safe-reporting',
+      version: '1.0.0',
+    },
+  };
+
+  return [envelopeHeader, itemHeader, event]
+    .map((part) => JSON.stringify(part))
+    .join('\n');
 }

--- a/packages/tooling/browser-entry/src/setup-sentry.ts
+++ b/packages/tooling/browser-entry/src/setup-sentry.ts
@@ -2,6 +2,7 @@ import { APP_ENV, RELEASE_ID, sentryConfig } from '@bangle.io/config';
 import {
   createPrivacySafeErrorReport,
   type ErrorReportingController,
+  getCurrentBuildAssetDebugIds,
   type ManualErrorReportHandler,
   type PrivacySafeErrorReport,
 } from '@bangle.io/initialize-services';
@@ -21,9 +22,14 @@ export function readAutomaticErrorReportingPreference(
 ): boolean {
   try {
     const stored = storage.getItem(storageKey);
-    return stored === null ? true : JSON.parse(stored) !== false;
+    if (stored === null) {
+      return true;
+    }
+    return JSON.parse(stored) === true;
   } catch {
-    return true;
+    // Consent must fail closed. A stored opt-out cannot be distinguished from
+    // unavailable or corrupted storage, so do not send automatically.
+    return false;
   }
 }
 
@@ -36,6 +42,8 @@ export function initializeSentry(
   let manualReportHandler: ManualErrorReportHandler | undefined;
   const capturedErrors = new WeakSet<Error>();
   const reportsAwaitingStore: PrivacySafeErrorReport[] = [];
+  let reportStoreFlushScheduled = false;
+  let flushingReportStore = false;
 
   const keepAwaitingStoreBounded = (report: PrivacySafeErrorReport) => {
     reportsAwaitingStore.push(report);
@@ -47,18 +55,54 @@ export function initializeSentry(
     }
   };
 
-  const queueLocally = async (report: PrivacySafeErrorReport) => {
-    if (!manualReportHandler) {
-      keepAwaitingStoreBounded(report);
+  const flushReportStore = async () => {
+    if (flushingReportStore || !manualReportHandler) {
       return;
     }
+    flushingReportStore = true;
     try {
-      await manualReportHandler(report);
-    } catch {
-      // Do not log here: reporting a queue failure through the same logger
-      // would recurse. Keep the already-sanitized report in memory instead.
-      keepAwaitingStoreBounded(report);
+      while (reportsAwaitingStore.length > 0) {
+        const currentHandler = manualReportHandler;
+        if (!currentHandler) {
+          return;
+        }
+        const report = reportsAwaitingStore[0];
+        if (!report) {
+          return;
+        }
+        try {
+          await currentHandler(report);
+        } catch {
+          // Do not log here: reporting a queue failure through the same logger
+          // would recurse. A later capture or handler registration retries it.
+          return;
+        }
+        const index = reportsAwaitingStore.findIndex(
+          (candidate) => candidate.id === report.id,
+        );
+        if (index >= 0) {
+          reportsAwaitingStore.splice(index, 1);
+        }
+      }
+    } finally {
+      flushingReportStore = false;
     }
+  };
+
+  const scheduleReportStoreFlush = () => {
+    if (reportStoreFlushScheduled) {
+      return;
+    }
+    reportStoreFlushScheduled = true;
+    queueMicrotask(() => {
+      reportStoreFlushScheduled = false;
+      void flushReportStore();
+    });
+  };
+
+  const queueLocally = (report: PrivacySafeErrorReport) => {
+    keepAwaitingStoreBounded(report);
+    scheduleReportStoreFlush();
   };
 
   const controller: ErrorReportingController = {
@@ -69,8 +113,8 @@ export function initializeSentry(
       capturedErrors.add(error);
       const report = createReport(error);
       if (!automaticEnabled) {
-        void queueLocally(report);
-        return;
+        queueLocally(report);
+        return report;
       }
 
       void sendReport(
@@ -79,9 +123,13 @@ export function initializeSentry(
         automaticAbortController.signal,
       ).then((sent) => {
         if (!sent) {
-          void queueLocally(report);
+          queueLocally(report);
         }
       });
+      return report;
+    },
+    getAutomaticReportingEnabled() {
+      return automaticEnabled;
     },
     async setAutomaticReportingEnabled(enabled) {
       // This flag gates capture synchronously. No Sentry SDK is initialized,
@@ -94,16 +142,8 @@ export function initializeSentry(
     },
     setManualReportHandler(handler) {
       manualReportHandler = handler;
-      if (!handler || reportsAwaitingStore.length === 0) {
-        return;
-      }
-
-      const pending = reportsAwaitingStore.splice(
-        0,
-        reportsAwaitingStore.length,
-      );
-      for (const report of pending) {
-        void queueLocally(report);
+      if (handler) {
+        scheduleReportStoreFlush();
       }
     },
     async sendReports(reports) {
@@ -111,6 +151,18 @@ export function initializeSentry(
       for (const report of reports) {
         if (await sendReport(report, REPORTING_MODE.manual)) {
           sentReportIds.push(report.id);
+        }
+      }
+      if (sentReportIds.length > 0) {
+        const sentIds = new Set(sentReportIds);
+        for (
+          let index = reportsAwaitingStore.length - 1;
+          index >= 0;
+          index -= 1
+        ) {
+          if (sentIds.has(reportsAwaitingStore[index]?.id ?? '')) {
+            reportsAwaitingStore.splice(index, 1);
+          }
         }
       }
       return { sentReportIds };
@@ -130,6 +182,7 @@ function createReport(error: Error): PrivacySafeErrorReport {
     route: route ?? undefined,
     release: RELEASE_ID,
     environment: APP_ENV,
+    buildAssetDebugIds: getCurrentBuildAssetDebugIds(),
   });
 }
 
@@ -184,6 +237,7 @@ export function serializeSentryEnvelope(
           value: 'Bangle application error',
           stacktrace: {
             frames: report.frames.map((frame) => ({
+              abs_path: frame.filename,
               filename: frame.filename,
               lineno: frame.lineNumber,
               colno: frame.columnNumber,
@@ -196,6 +250,9 @@ export function serializeSentryEnvelope(
           },
         },
       ],
+    },
+    debug_meta: {
+      images: uniqueDebugImages(report.frames),
     },
     tags: {
       error_type: report.errorType,
@@ -212,4 +269,22 @@ export function serializeSentryEnvelope(
   return [envelopeHeader, itemHeader, event]
     .map((part) => JSON.stringify(part))
     .join('\n');
+}
+
+function uniqueDebugImages(frames: PrivacySafeErrorReport['frames']): Array<{
+  type: 'sourcemap';
+  code_file: string;
+  debug_id: string;
+}> {
+  const images = new Map<string, { code_file: string; debug_id: string }>();
+  for (const frame of frames) {
+    images.set(frame.debugId, {
+      code_file: frame.filename,
+      debug_id: frame.debugId,
+    });
+  }
+  return [...images.values()].map((image) => ({
+    type: 'sourcemap' as const,
+    ...image,
+  }));
 }

--- a/packages/tooling/e2e-tests/src/settings-general.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-general.e2e.ts
@@ -27,6 +27,42 @@ async function dispatchPrivateTestError(page: import('@playwright/test').Page) {
   });
 }
 
+async function triggerPrivateReactRenderCrash(
+  page: import('@playwright/test').Page,
+) {
+  await page.waitForFunction(() =>
+    Boolean(
+      (
+        window as typeof window & {
+          services?: { core?: { navigation?: unknown } };
+        }
+      ).services?.core?.navigation,
+    ),
+  );
+  await page.evaluate(() => {
+    const exposedWindow = window as typeof window & {
+      services?: {
+        core?: {
+          navigation?: {
+            $routeInfo: unknown;
+            store: {
+              set: (target: unknown, value: unknown) => void;
+            };
+          };
+        };
+      };
+    };
+    const navigation = exposedWindow.services?.core?.navigation;
+    if (!navigation) {
+      throw new Error('Debug navigation service is unavailable');
+    }
+    navigation.store.set(navigation.$routeInfo, {
+      route: 'PRIVATE_NOTE_RENDER_CRASH',
+      payload: {},
+    });
+  });
+}
+
 async function readPersistedPrivacySafeReports(
   page: import('@playwright/test').Page,
 ) {
@@ -180,7 +216,7 @@ test('bug reports exclude note data and respect the persistent manual-only setti
     'Automatic reports are vital for finding and fixing failures.',
   );
   await expect(confirmation).toContainText(
-    'Bangle excludes your note data and identifying names.',
+    'Bangle excludes your note data and identifying names from the diagnostic payload.',
   );
   await confirmation.getByRole('button', { name: 'Turn off' }).click();
   await expect(reportingSwitch).not.toBeChecked();
@@ -189,6 +225,35 @@ test('bug reports exclude note data and respect the persistent manual-only setti
   await page.reload({ waitUntil: 'networkidle' });
   await dispatchPrivateTestError(page);
 
+  const manualReportDialog = page.getByRole('dialog', {
+    name: 'Help us fix this bug?',
+  });
+  await expect(manualReportDialog).toBeVisible();
+  const preview = manualReportDialog.getByTestId('manual-bug-report-preview');
+  await expect(preview).toContainText('"schemaVersion": 2');
+  await expect(preview).toContainText('"errorType": "TypeError"');
+  await expect(preview).toContainText('"route": "editor"');
+  for (const marker of PRIVATE_BUG_REPORT_MARKERS) {
+    await expect(preview).not.toContainText(marker);
+  }
+  expect(envelopes).toHaveLength(1);
+
+  await manualReportDialog.getByRole('button', { name: 'Send report' }).click();
+  await expect(manualReportDialog).not.toBeVisible();
+  await expect.poll(() => envelopes.length).toBe(2);
+  expect(envelopes[1]).toContain('"reporting_mode":"manual"');
+  for (const marker of PRIVATE_BUG_REPORT_MARKERS) {
+    expect(envelopes[1]).not.toContain(marker);
+  }
+  await expect.poll(() => readPersistedPrivacySafeReports(page)).toEqual([]);
+
+  await dispatchPrivateTestError(page);
+  await expect(manualReportDialog).toBeVisible();
+  await manualReportDialog
+    .getByRole('button', { name: 'Keep for later' })
+    .click();
+  await expect(manualReportDialog).not.toBeVisible();
+
   await page.getByRole('button', { name: /Bangle\.io/ }).click();
   await page.getByRole('menuitem', { name: 'Settings' }).click();
   await expect(
@@ -196,7 +261,7 @@ test('bug reports exclude note data and respect the persistent manual-only setti
       '1 privacy-safe report is stored only on this device. Send it when you are ready.',
     ),
   ).toBeVisible();
-  expect(envelopes).toHaveLength(1);
+  expect(envelopes).toHaveLength(2);
 
   const persistedBeforeReload = await readPersistedPrivacySafeReports(page);
   expect(persistedBeforeReload).toHaveLength(1);
@@ -211,15 +276,83 @@ test('bug reports exclude note data and respect the persistent manual-only setti
   ).toBeEnabled();
   await page.getByRole('button', { name: 'Send reports' }).click();
 
-  await expect.poll(() => envelopes.length).toBe(2);
-  expect(envelopes[1]).toContain('"reporting_mode":"manual"');
+  await expect.poll(() => envelopes.length).toBe(3);
+  expect(envelopes[2]).toContain('"reporting_mode":"manual"');
   for (const marker of PRIVATE_BUG_REPORT_MARKERS) {
-    expect(envelopes[1]).not.toContain(marker);
+    expect(envelopes[2]).not.toContain(marker);
   }
   await expect(
     page.getByRole('button', { name: 'Send reports' }),
   ).toBeDisabled();
   await expect.poll(() => readPersistedPrivacySafeReports(page)).toEqual([]);
+});
+
+test('invalid bug report consent data fails closed after services mount', async ({
+  page,
+}) => {
+  const envelopes: string[] = [];
+  await page.route('https://o573373.ingest.us.sentry.io/**', async (route) => {
+    envelopes.push(route.request().postData() ?? '');
+    await route.fulfill({ status: 200, body: '{}' });
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'browser-local-storage-sync-database.sync:error-reporting:automatic-error-reporting',
+      'invalid-json',
+    );
+  });
+
+  await page.goto('/');
+  await dispatchPrivateTestError(page);
+
+  const manualReportDialog = page.getByRole('dialog', {
+    name: 'Help us fix this bug?',
+  });
+  await expect(manualReportDialog).toBeVisible();
+  expect(envelopes).toHaveLength(0);
+
+  await manualReportDialog
+    .getByRole('button', { name: 'Keep for later' })
+    .click();
+  await page.getByRole('button', { name: /Bangle\.io/ }).click();
+  await page.getByRole('menuitem', { name: 'Settings' }).click();
+  await expect(
+    page.getByRole('switch', { name: 'Automatically send bug reports' }),
+  ).not.toBeChecked();
+});
+
+test('manual report review survives a React render boundary crash', async ({
+  page,
+}) => {
+  const envelopes: string[] = [];
+  await page.route('https://o573373.ingest.us.sentry.io/**', async (route) => {
+    envelopes.push(route.request().postData() ?? '');
+    await route.fulfill({ status: 200, body: '{}' });
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'browser-local-storage-sync-database.sync:error-reporting:automatic-error-reporting',
+      'false',
+    );
+  });
+  await page.goto('/?debug=true');
+
+  await triggerPrivateReactRenderCrash(page);
+
+  await expect(page.getByText('Something went wrong')).toBeAttached();
+  const manualReportDialog = page.getByRole('dialog', {
+    name: 'Help us fix this bug?',
+  });
+  await expect(manualReportDialog).toBeVisible();
+  await expect(
+    manualReportDialog.getByTestId('manual-bug-report-preview'),
+  ).not.toContainText('PRIVATE_NOTE_RENDER_CRASH');
+  expect(envelopes).toHaveLength(0);
+
+  await manualReportDialog.getByRole('button', { name: 'Send report' }).click();
+  await expect.poll(() => envelopes.length).toBe(1);
+  expect(envelopes[0]).toContain('"reporting_mode":"manual"');
+  expect(envelopes[0]).not.toContain('PRIVATE_NOTE_RENDER_CRASH');
 });
 
 test('general settings rejects an external return target after path normalization', async ({

--- a/packages/tooling/e2e-tests/src/settings-general.e2e.ts
+++ b/packages/tooling/e2e-tests/src/settings-general.e2e.ts
@@ -1,6 +1,62 @@
 import { expect, test } from '@playwright/test';
 import { createBrowserWorkspaceAndNote } from './common';
 
+const PRIVATE_BUG_REPORT_MARKERS = [
+  'PRIVATE_WORKSPACE',
+  'PRIVATE_NOTE',
+  'SECRET_NOTE_CONTENT',
+  'PRIVATE_CAUSE',
+  'PRIVATE_PROPERTY',
+] as const;
+
+async function dispatchPrivateTestError(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    const error = new TypeError('SECRET_NOTE_CONTENT', {
+      cause: new Error('PRIVATE_CAUSE'),
+    });
+    Object.assign(error, {
+      wsPath: 'PRIVATE_WORKSPACE:PRIVATE_NOTE.md',
+      privateProperty: 'PRIVATE_PROPERTY',
+    });
+    window.dispatchEvent(
+      new ErrorEvent('error', {
+        error,
+        message: error.message,
+      }),
+    );
+  });
+}
+
+async function readPersistedPrivacySafeReports(
+  page: import('@playwright/test').Page,
+) {
+  return page.evaluate(
+    () =>
+      new Promise<unknown[]>((resolve, reject) => {
+        const openRequest = indexedDB.open('bangle-io-db');
+        openRequest.onerror = () => reject(openRequest.error);
+        openRequest.onsuccess = () => {
+          const database = openRequest.result;
+          const transaction = database.transaction('MiscTable', 'readonly');
+          const getAllRequest = transaction.objectStore('MiscTable').getAll();
+          getAllRequest.onerror = () => reject(getAllRequest.error);
+          getAllRequest.onsuccess = () => {
+            const values = (getAllRequest.result as Array<{ value?: unknown }>)
+              .map((record) => record.value)
+              .filter(
+                (value) =>
+                  value &&
+                  typeof value === 'object' &&
+                  'schemaVersion' in value,
+              );
+            database.close();
+            resolve(values);
+          };
+        };
+      }),
+  );
+}
+
 test('general settings update and persist user preferences', async ({
   page,
 }) => {
@@ -83,6 +139,87 @@ test('general settings returns to the route it was opened from', async ({
       .getByLabel('breadcrumb')
       .getByRole('button', { name: `${noteName}.md` }),
   ).toBeVisible();
+});
+
+test('bug reports exclude note data and respect the persistent manual-only setting', async ({
+  page,
+}) => {
+  test.slow();
+  const envelopes: string[] = [];
+  await page.route('https://o573373.ingest.us.sentry.io/**', async (route) => {
+    envelopes.push(route.request().postData() ?? '');
+    await route.fulfill({ status: 200, body: '{}' });
+  });
+
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'PRIVATE_WORKSPACE',
+    noteName: 'PRIVATE_NOTE',
+  });
+  await dispatchPrivateTestError(page);
+
+  await expect.poll(() => envelopes.length).toBe(1);
+  for (const marker of PRIVATE_BUG_REPORT_MARKERS) {
+    expect(envelopes[0]).not.toContain(marker);
+  }
+  expect(envelopes[0]).toContain('"reporting_mode":"automatic"');
+  expect(envelopes[0]).toContain('"route":"editor"');
+
+  await page.getByRole('button', { name: /Bangle\.io/ }).click();
+  await page.getByRole('menuitem', { name: 'Settings' }).click();
+
+  const reportingSwitch = page.getByRole('switch', {
+    name: 'Automatically send bug reports',
+  });
+  await expect(reportingSwitch).toBeChecked();
+  await reportingSwitch.click();
+
+  const confirmation = page.getByRole('alertdialog', {
+    name: 'Turn off automatic bug reports?',
+  });
+  await expect(confirmation).toContainText(
+    'Automatic reports are vital for finding and fixing failures.',
+  );
+  await expect(confirmation).toContainText(
+    'Bangle excludes your note data and identifying names.',
+  );
+  await confirmation.getByRole('button', { name: 'Turn off' }).click();
+  await expect(reportingSwitch).not.toBeChecked();
+
+  await page.getByRole('link', { name: 'Back to app' }).click();
+  await page.reload({ waitUntil: 'networkidle' });
+  await dispatchPrivateTestError(page);
+
+  await page.getByRole('button', { name: /Bangle\.io/ }).click();
+  await page.getByRole('menuitem', { name: 'Settings' }).click();
+  await expect(
+    page.getByText(
+      '1 privacy-safe report is stored only on this device. Send it when you are ready.',
+    ),
+  ).toBeVisible();
+  expect(envelopes).toHaveLength(1);
+
+  const persistedBeforeReload = await readPersistedPrivacySafeReports(page);
+  expect(persistedBeforeReload).toHaveLength(1);
+  for (const marker of PRIVATE_BUG_REPORT_MARKERS) {
+    expect(JSON.stringify(persistedBeforeReload)).not.toContain(marker);
+  }
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(reportingSwitch).not.toBeChecked();
+  await expect(
+    page.getByRole('button', { name: 'Send reports' }),
+  ).toBeEnabled();
+  await page.getByRole('button', { name: 'Send reports' }).click();
+
+  await expect.poll(() => envelopes.length).toBe(2);
+  expect(envelopes[1]).toContain('"reporting_mode":"manual"');
+  for (const marker of PRIVATE_BUG_REPORT_MARKERS) {
+    expect(envelopes[1]).not.toContain(marker);
+  }
+  await expect(
+    page.getByRole('button', { name: 'Send reports' }),
+  ).toBeDisabled();
+  await expect.poll(() => readPersistedPrivacySafeReports(page)).toEqual([]);
 });
 
 test('general settings rejects an external return target after path normalization', async ({

--- a/packages/tooling/test-utils/common-opts.ts
+++ b/packages/tooling/test-utils/common-opts.ts
@@ -60,6 +60,12 @@ export const makeTestCommonOpts = ({
   const commonOpts: BaseServiceCommonOptions = {
     logger,
     store: createStore(),
+    errorReporting: {
+      captureException: vi.fn(),
+      sendReports: vi.fn().mockResolvedValue({ sentReportIds: [] }),
+      setAutomaticReportingEnabled: vi.fn().mockResolvedValue(undefined),
+      setManualReportHandler: vi.fn(),
+    },
     emitAppError: vi.fn(),
     rootAbortSignal: controller.signal,
   };

--- a/packages/tooling/test-utils/common-opts.ts
+++ b/packages/tooling/test-utils/common-opts.ts
@@ -62,6 +62,7 @@ export const makeTestCommonOpts = ({
     store: createStore(),
     errorReporting: {
       captureException: vi.fn(),
+      getAutomaticReportingEnabled: vi.fn().mockReturnValue(true),
       sendReports: vi.fn().mockResolvedValue({ sentReportIds: [] }),
       setAutomaticReportingEnabled: vi.fn().mockResolvedValue(undefined),
       setManualReportHandler: vi.fn(),

--- a/packages/ui/base-ui/src/index.ts
+++ b/packages/ui/base-ui/src/index.ts
@@ -97,6 +97,7 @@ export {
   SheetTrigger,
 } from './sheet';
 export { Skeleton } from './skeleton';
+export { Switch } from './switch';
 export {
   Table,
   TableBody,

--- a/packages/ui/base-ui/src/switch.tsx
+++ b/packages/ui/base-ui/src/switch.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@bangle.io/ui-misc';
+import { Switch as SwitchPrimitive } from '@base-ui/react/switch';
+import * as React from 'react';
+
+function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        'inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border border-transparent bg-input shadow-xs outline-none transition-colors focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:bg-primary',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block size-5 translate-x-0 rounded-full bg-background shadow-sm transition-transform data-[checked]:translate-x-5"
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/packages/ui/ui-components/src/index.ts
+++ b/packages/ui/ui-components/src/index.ts
@@ -78,6 +78,7 @@ export {
   SheetTitle,
   SheetTrigger,
   Skeleton,
+  Switch,
   Table,
   TableBody,
   TableCaption,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,9 +813,6 @@ importers:
       '@bangle.io/translations':
         specifier: workspace:*
         version: link:../../shared/translations
-      '@sentry/browser':
-        specifier: ^10.63.0
-        version: 10.63.0
       '@sentry/vite-plugin':
         specifier: ^5.3.0
         version: 5.3.0(rollup@4.60.4)
@@ -3704,14 +3701,6 @@ packages:
     resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
     engines: {node: '>= 18'}
 
-  '@sentry/browser-utils@10.63.0':
-    resolution: {integrity: sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA==}
-    engines: {node: '>=18'}
-
-  '@sentry/browser@10.63.0':
-    resolution: {integrity: sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw==}
-    engines: {node: '>=18'}
-
   '@sentry/bundler-plugin-core@5.3.0':
     resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
     engines: {node: '>= 18'}
@@ -3767,22 +3756,6 @@ packages:
     resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
     engines: {node: '>= 10'}
     hasBin: true
-
-  '@sentry/core@10.63.0':
-    resolution: {integrity: sha512-OtUbsrnbEHffOF2S2+M5zXa3HIM0U2b4CDVLKMY1dgS0J3ivRF8XvkjvyIcEG/y8JXnwXbnprLyjhG+AqMdUZQ==}
-    engines: {node: '>=18'}
-
-  '@sentry/feedback@10.63.0':
-    resolution: {integrity: sha512-If/+72xFg9ylz4twUo3U9gUpZ+Ys+T/3Y09WH7r2gGhWEOF9bp+ta94+Pg7Lb0M2nVD7waz4OxIvB49GEvtLDA==}
-    engines: {node: '>=18'}
-
-  '@sentry/replay-canvas@10.63.0':
-    resolution: {integrity: sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A==}
-    engines: {node: '>=18'}
-
-  '@sentry/replay@10.63.0':
-    resolution: {integrity: sha512-u4fDaLbd4QmJbU0qGzV5g2B2hjw5utdeZzpTrmq565AS5o6mfaZdCz30zF9R2Unkn0g9SJr90piTN2RMwvDrkw==}
-    engines: {node: '>=18'}
 
   '@sentry/rollup-plugin@5.3.0':
     resolution: {integrity: sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==}
@@ -11664,18 +11637,6 @@ snapshots:
 
   '@sentry/babel-plugin-component-annotate@5.3.0': {}
 
-  '@sentry/browser-utils@10.63.0':
-    dependencies:
-      '@sentry/core': 10.63.0
-
-  '@sentry/browser@10.63.0':
-    dependencies:
-      '@sentry/browser-utils': 10.63.0
-      '@sentry/core': 10.63.0
-      '@sentry/feedback': 10.63.0
-      '@sentry/replay': 10.63.0
-      '@sentry/replay-canvas': 10.63.0
-
   '@sentry/bundler-plugin-core@5.3.0':
     dependencies:
       '@babel/core': 7.29.7
@@ -11732,22 +11693,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  '@sentry/core@10.63.0': {}
-
-  '@sentry/feedback@10.63.0':
-    dependencies:
-      '@sentry/core': 10.63.0
-
-  '@sentry/replay-canvas@10.63.0':
-    dependencies:
-      '@sentry/core': 10.63.0
-      '@sentry/replay': 10.63.0
-
-  '@sentry/replay@10.63.0':
-    dependencies:
-      '@sentry/browser-utils': 10.63.0
-      '@sentry/core': 10.63.0
 
   '@sentry/rollup-plugin@5.3.0(rollup@4.60.4)':
     dependencies:


### PR DESCRIPTION
## Summary

- replace browser Sentry SDK events with a strict allowlisted diagnostic envelope that excludes note/workspace data, URLs, route parameters, messages, causes, breadcrumbs, and user context
- add persistent opt-out controls with a bounded local queue plus immediate review, send, keep, and delete prompts, including render and startup failure recovery
- preserve source-map symbolication with build-injected debug IDs behind opaque asset aliases, and capture global, editor, service, and startup failures through shared reporting boundaries

## Reviewer callout

Direct Sentry requests may expose network metadata such as IP address and User-Agent; the app discloses this in the review UI. Confirm project-side IP scrubbing before making broader privacy claims.