### PR TITLE
fix(editor): keep Safari cursor stable after dismissing suggestions

### DIFF
--- a/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
@@ -546,10 +546,13 @@ describe('synthetic suggestions and composition', () => {
 
     expect(handleTextInput(view, 6, 6, '/')).toBe(true);
     expect(view.state.doc.textContent).toBe('note /');
+    view.focus();
+    const domAtPos = vi.spyOn(view, 'domAtPos');
 
     expect(pressKey(view, 'Escape')).toBe(true);
     expect(view.state.doc.textContent).toBe('note /');
     expect(editorStore.get(view.state, $suggestions).get(view)).toBeUndefined();
+    expect(domAtPos).toHaveBeenCalledWith(view.state.selection.head);
   });
 
   it('ignores menu keys while an IME composition is active', () => {

--- a/packages/js-lib/banger-editor/src/suggestions/keymap.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/keymap.ts
@@ -1,4 +1,5 @@
 import { keybinding, PRIORITY } from '../common';
+import type { EditorView } from '../pm';
 import { store } from '../store';
 import {
   $suggestion,
@@ -20,10 +21,14 @@ export const suggestionKeymap = () =>
           if (suggestion) {
             // removeSuggestMark keeps typed trigger text but deletes
             // synthetic (programmatically opened) triggers entirely.
-            return removeSuggestMark({
+            const handled = removeSuggestMark({
               markName: suggestion.markName,
               selection: state.selection,
             })(state, dispatch, view);
+            if (handled && view) {
+              resyncDOMCursor(view);
+            }
+            return handled;
           }
           return false;
         },
@@ -101,3 +106,19 @@ export const suggestionKeymap = () =>
     'suggestion',
     PRIORITY.suggestionKey,
   );
+
+/**
+ * Removing a suggestion mark unwraps the text node that owns the browser
+ * selection. Safari can leave its native caret associated with that old DOM
+ * shape even though ProseMirror's selection is unchanged. Its next native
+ * Option-Backspace then inserts a paragraph instead of deleting backward.
+ * Explicitly collapsing the DOM selection onto the current document node
+ * keeps the browser and editor selections aligned after Escape.
+ */
+function resyncDOMCursor(view: EditorView) {
+  if (!view.hasFocus() || !view.state.selection.empty) {
+    return;
+  }
+  const { node, offset } = view.domAtPos(view.state.selection.head);
+  view.dom.ownerDocument.getSelection()?.collapse(node, offset);
+}

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -3,6 +3,7 @@ import {
   collapseEditorSelectionAfterText,
   createBrowserWorkspaceAndNote,
   getEditorLocator,
+  isDarwin,
   readStoredMarkdown,
   waitForEditorFocus,
   writeStoredMarkdown,
@@ -14,6 +15,36 @@ import {
 test.use({ locale: 'en-US' });
 
 const FIXED_CALENDAR_DATE = new Date('2028-12-15T12:00:00');
+
+test('option backspace deletes a slash query after Escape', async ({
+  page,
+}) => {
+  test.skip(!isDarwin, 'Option+Backspace is a macOS word-delete shortcut');
+
+  const workspaceName = 'slash-command-option-backspace';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('/');
+  await expect(page.getByTestId('slash-command-menu')).toBeVisible();
+  await page.keyboard.insertText('////');
+
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('slash-command-menu')).toBeHidden();
+  await page.keyboard.down('Alt');
+  await page.keyboard.press('Backspace');
+  await page.keyboard.up('Alt');
+
+  await expect(editor.locator('p')).toHaveCount(1);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe('');
+});
 
 test('slash command stays active with multiple suggestion providers registered', async ({
   page,


### PR DESCRIPTION
## Summary

- Resync the browser caret after Escape removes a suggestion mark so Safari word deletion uses the current editor cursor.
- Add unit and macOS E2E coverage for dismissing `/////` and pressing Option+Backspace.

## Root cause

Safari retained a native selection associated with the DOM shape that was unwrapped when the suggestion mark was removed. The next Option+Backspace inserted a paragraph even though the ProseMirror selection had not moved.

Validated with the full local CI gate and the original workflow in Safari.