### PR TITLE
feat(desktop): native Electron config persistence

### DIFF
--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -19,6 +19,8 @@ import {
   BrowserErrorHandlerService,
   BrowserLocalStorageSyncDatabaseService,
   BrowserRouterService,
+  DesktopHybridDatabaseService,
+  DesktopNativeDatabaseService,
   FileStorageIndexedDB,
   FileStorageNativeFs,
   HashStrategy,
@@ -27,7 +29,9 @@ import {
 import type {
   BaseServiceCommonOptions,
   CommandHandler,
+  DesktopConfigBridge,
   RootEmitter,
+  WindowWithDesktopBridge,
 } from '@bangle.io/types';
 import { createServiceSetup } from './service-setup';
 
@@ -38,6 +42,18 @@ export function readEditorEngineFromUrl(
     EDITOR_ENGINE_QUERY_PARAM,
   );
   return isEditorEngineId(engineId) ? engineId : DEFAULT_EDITOR_ENGINE;
+}
+
+/**
+ * The native config bridge the Electron preload injects on `window` before any
+ * renderer script runs. Present only inside the desktop shell; `undefined` in a
+ * plain browser, which keeps the browser wiring on IndexedDB.
+ */
+function getDesktopConfigBridge(): DesktopConfigBridge | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+  return (window as WindowWithDesktopBridge).bangleDesktop?.configDb;
 }
 
 export function initializeServices(
@@ -54,7 +70,10 @@ export function initializeServices(
   // setup is created and only runs after services are instantiated.
   let getWorkspaceOps: (() => WorkspaceOpsService) | undefined;
 
-  const browserPlatformServices = {
+  // Platform slots shared by the browser and desktop composition. Only the
+  // `database` seam differs between environments (see below); everything here —
+  // including the localStorage sync database — is identical.
+  const commonPlatformServices = {
     errorService: slot(BrowserErrorHandlerService, () => ({
       onError: (params) => {
         rootEmitter.emit('event::error:uncaught-error', {
@@ -63,7 +82,6 @@ export function initializeServices(
         });
       },
     })),
-    database: IdbDatabaseService,
     syncDatabase: BrowserLocalStorageSyncDatabaseService,
     fileStorageIdb: slot(FileStorageIndexedDB, () => ({
       onChange: (change) => {
@@ -104,21 +122,56 @@ export function initializeServices(
     })),
   };
 
-  const setup = createServiceSetup({
+  const commonSetupOptions = {
     commonOpts,
     rootEmitter,
     commands,
     commandHandlers,
     themeManager: theme,
     shortcutTarget: document,
-    platformServices: browserPlatformServices,
-    fileStorageSlots: ['fileStorageIdb', 'fileStorageNativeFs'],
+    fileStorageSlots: ['fileStorageIdb', 'fileStorageNativeFs'] as const,
     editorEngineId,
     editorSaveCoordinator,
+  };
+
+  const desktopConfigBridge = getDesktopConfigBridge();
+
+  // On desktop the async `database` seam is served by a native, file-backed
+  // store (via IPC). A hybrid fronts it and IndexedDB, keeping records that
+  // carry a non-serializable native-FS handle in IndexedDB. In the browser the
+  // seam stays on IndexedDB directly.
+  if (desktopConfigBridge) {
+    const setup = createServiceSetup({
+      ...commonSetupOptions,
+      platformServices: {
+        ...commonPlatformServices,
+        database: slot(DesktopHybridDatabaseService),
+        nativeConfigDatabase: slot(DesktopNativeDatabaseService, () => ({
+          bridge: desktopConfigBridge,
+        })),
+        idbDatabase: IdbDatabaseService,
+      },
+    });
+
+    getWorkspaceOps = () => setup.getServices().workspaceOps;
+    setup.instantiate();
+
+    return {
+      coreServices: setup.coreServices(),
+      mountAll: setup.mountAll,
+      describe: setup.describe,
+    };
+  }
+
+  const setup = createServiceSetup({
+    ...commonSetupOptions,
+    platformServices: {
+      ...commonPlatformServices,
+      database: IdbDatabaseService,
+    },
   });
 
   getWorkspaceOps = () => setup.getServices().workspaceOps;
-
   setup.instantiate();
 
   return {

--- a/packages/platform/service-platform/src/__tests__/desktop-hybrid-database.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/desktop-hybrid-database.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { DATABASE_TABLE_NAME } from '@bangle.io/constants';
+import { makeTestCommonOpts } from '@bangle.io/test-utils';
+import type {
+  DatabaseQueryOptions,
+  DesktopConfigBridge,
+} from '@bangle.io/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  containsFileSystemHandle,
+  DesktopHybridDatabaseService,
+} from '../desktop-hybrid-database';
+import { DesktopNativeDatabaseService } from '../desktop-native-database';
+import { MemoryDatabaseService } from '../memory-database';
+
+const options: DatabaseQueryOptions = {
+  tableName: DATABASE_TABLE_NAME.workspaceInfo,
+};
+
+/**
+ * Stand-in for a native-FS directory handle. A real `FileSystemDirectoryHandle`
+ * is a platform object that `structuredClone` (used by the change bus) can copy;
+ * a plain object with a function property cannot. Using a class keeps the
+ * `requestPermission` method on the prototype so `structuredClone` skips it
+ * (copying only own-enumerable `kind`/`name`) while direct access still detects
+ * the handle.
+ */
+class FakeDirectoryHandle {
+  kind = 'directory' as const;
+  name = 'my-folder';
+  async requestPermission() {
+    return 'granted' as const;
+  }
+}
+
+function fakeDirHandle(): FakeDirectoryHandle {
+  return new FakeDirectoryHandle();
+}
+
+/** In-memory `DesktopConfigBridge` that mirrors the main-process ConfigStore. */
+function makeFakeBridge(): DesktopConfigBridge {
+  const tables = new Map<string, Map<string, unknown>>();
+  const table = (name: string) => {
+    let t = tables.get(name);
+    if (!t) {
+      t = new Map();
+      tables.set(name, t);
+    }
+    return t;
+  };
+  return {
+    async getEntry(key, opts) {
+      const t = table(opts.tableName);
+      return { found: t.has(key), value: t.get(key) };
+    },
+    async getAllEntries(opts) {
+      return [...table(opts.tableName).values()];
+    },
+    async putEntry(key, value, opts) {
+      table(opts.tableName).set(key, value);
+    },
+    async deleteEntry(key, opts) {
+      table(opts.tableName).delete(key);
+    },
+  };
+}
+
+async function setup() {
+  const { commonOpts } = makeTestCommonOpts();
+  const context = {
+    ctx: commonOpts,
+    serviceContext: { abortSignal: commonOpts.rootAbortSignal },
+  };
+
+  const native = new DesktopNativeDatabaseService(context, null, {
+    bridge: makeFakeBridge(),
+  });
+  const idb = new MemoryDatabaseService(context, null);
+  const hybrid = new DesktopHybridDatabaseService(context, {
+    nativeConfigDatabase: native,
+    idbDatabase: idb,
+  });
+  await hybrid.mount();
+
+  return { hybrid, native, idb };
+}
+
+describe('containsFileSystemHandle', () => {
+  it('detects a top-level or nested handle and ignores plain data', () => {
+    expect(containsFileSystemHandle(fakeDirHandle())).toBe(true);
+    expect(
+      containsFileSystemHandle({
+        metadata: { rootDirHandle: fakeDirHandle() },
+      }),
+    ).toBe(true);
+    expect(containsFileSystemHandle([1, { a: fakeDirHandle() }])).toBe(true);
+    expect(containsFileSystemHandle({ name: 'ws', type: 'browser' })).toBe(
+      false,
+    );
+    expect(containsFileSystemHandle(null)).toBe(false);
+  });
+
+  it('does not infinitely recurse on cyclic values', () => {
+    const cyclic: Record<string, unknown> = { name: 'ws' };
+    cyclic.self = cyclic;
+    expect(containsFileSystemHandle(cyclic)).toBe(false);
+  });
+});
+
+describe('DesktopHybridDatabaseService', () => {
+  it('routes serializable records to the native store', async () => {
+    const { hybrid, native, idb } = await setup();
+
+    await hybrid.updateEntry(
+      'ws1',
+      () => ({ value: { name: 'ws1', type: 'browser', metadata: {} } }),
+      options,
+    );
+
+    expect((await native.getEntry('ws1', options)).found).toBe(true);
+    expect((await idb.getEntry('ws1', options)).found).toBe(false);
+    expect(await hybrid.getEntry('ws1', options)).toEqual({
+      found: true,
+      value: { name: 'ws1', type: 'browser', metadata: {} },
+    });
+  });
+
+  it('routes native-FS handle records to IndexedDB', async () => {
+    const { hybrid, native, idb } = await setup();
+    const value = {
+      name: 'ws2',
+      type: 'native-fs',
+      metadata: { rootDirHandle: fakeDirHandle() },
+    };
+
+    await hybrid.updateEntry('ws2', () => ({ value }), options);
+
+    expect((await idb.getEntry('ws2', options)).found).toBe(true);
+    expect((await native.getEntry('ws2', options)).found).toBe(false);
+    expect((await hybrid.getEntry('ws2', options)).found).toBe(true);
+  });
+
+  it('merges getAllEntries across both backends', async () => {
+    const { hybrid } = await setup();
+    await hybrid.updateEntry(
+      'browser-ws',
+      () => ({ value: { name: 'browser-ws', metadata: {} } }),
+      options,
+    );
+    await hybrid.updateEntry(
+      'native-ws',
+      () => ({
+        value: {
+          name: 'native-ws',
+          metadata: { rootDirHandle: fakeDirHandle() },
+        },
+      }),
+      options,
+    );
+
+    const all = (await hybrid.getAllEntries(options)) as Array<{
+      name: string;
+    }>;
+    expect(all.map((v) => v.name).sort()).toEqual(['browser-ws', 'native-ws']);
+  });
+
+  it('moves a record to IndexedDB and deletes the stale native copy', async () => {
+    const { hybrid, native, idb } = await setup();
+
+    await hybrid.updateEntry(
+      'ws',
+      () => ({ value: { name: 'ws', metadata: {} } }),
+      options,
+    );
+    expect((await native.getEntry('ws', options)).found).toBe(true);
+
+    // The workspace becomes native-FS (gains a handle) -> must live in IDB now.
+    await hybrid.updateEntry(
+      'ws',
+      (existing) => ({
+        value: {
+          ...(existing.value as Record<string, unknown>),
+          metadata: { rootDirHandle: fakeDirHandle() },
+        },
+      }),
+      options,
+    );
+
+    expect((await native.getEntry('ws', options)).found).toBe(false);
+    expect((await idb.getEntry('ws', options)).found).toBe(true);
+    // No duplicate across stores.
+    expect(await hybrid.getAllEntries(options)).toHaveLength(1);
+  });
+
+  it('notifies subscribers on changes from either backend', async () => {
+    const { hybrid } = await setup();
+    const callback = vi.fn();
+    const controller = new AbortController();
+    hybrid.subscribe(options, callback, controller.signal);
+
+    await hybrid.updateEntry(
+      'browser-ws',
+      () => ({ value: { name: 'browser-ws', metadata: {} } }),
+      options,
+    );
+    await hybrid.updateEntry(
+      'native-ws',
+      () => ({
+        value: {
+          name: 'native-ws',
+          metadata: { rootDirHandle: fakeDirHandle() },
+        },
+      }),
+      options,
+    );
+
+    const keys = callback.mock.calls.map((call) => call[0].key);
+    expect(keys).toContain('browser-ws');
+    expect(keys).toContain('native-ws');
+
+    controller.abort();
+  });
+});

--- a/packages/platform/service-platform/src/desktop-hybrid-database.ts
+++ b/packages/platform/service-platform/src/desktop-hybrid-database.ts
@@ -1,0 +1,169 @@
+import { BaseService, type BaseServiceContext } from '@bangle.io/base-utils';
+import { SERVICE_NAME } from '@bangle.io/constants';
+import type {
+  BaseAppDatabase,
+  BaseDatabaseService,
+  DatabaseChange,
+  DatabaseQueryOptions,
+} from '@bangle.io/types';
+
+/**
+ * Composite `BaseAppDatabase` for the Electron desktop. It fronts two backends:
+ *
+ * - `nativeConfigDatabase` — the native, file-backed store (serializable config).
+ * - `idbDatabase` — Chromium IndexedDB, which alone can persist records carrying
+ *   a non-serializable value such as a native-FS `FileSystemDirectoryHandle`.
+ *
+ * Each record lives in exactly one backend. Writes route by whether the new
+ * value contains a file-system handle; when a record moves between backends the
+ * stale copy in the other store is deleted, so reads and `getAllEntries` never
+ * see a key twice.
+ */
+export class DesktopHybridDatabaseService
+  extends BaseService
+  implements BaseAppDatabase
+{
+  static deps = ['nativeConfigDatabase', 'idbDatabase'] as const;
+
+  constructor(
+    context: BaseServiceContext,
+    private dep: {
+      nativeConfigDatabase: BaseDatabaseService;
+      idbDatabase: BaseDatabaseService;
+    },
+  ) {
+    super(SERVICE_NAME.desktopHybridDatabaseService, context, dep);
+  }
+
+  async hookMount(): Promise<void> {}
+
+  private get native(): BaseDatabaseService {
+    return this.dep.nativeConfigDatabase;
+  }
+
+  private get idb(): BaseDatabaseService {
+    return this.dep.idbDatabase;
+  }
+
+  async getEntry(
+    key: string,
+    options: DatabaseQueryOptions,
+  ): Promise<{ found: boolean; value: unknown }> {
+    const nativeResult = await this.native.getEntry(key, options);
+    if (nativeResult.found) {
+      return nativeResult;
+    }
+    return this.idb.getEntry(key, options);
+  }
+
+  async updateEntry(
+    key: string,
+    updateCallback: (options: { value: unknown; found: boolean }) => {
+      value: unknown;
+    } | null,
+    options: DatabaseQueryOptions,
+  ): Promise<{ value: unknown; found: boolean }> {
+    // Find where the record currently lives so the callback sees the real value,
+    // then route the write by the serializability of the new value.
+    const nativeExisting = await this.native.getEntry(key, options);
+    const existing = nativeExisting.found
+      ? nativeExisting
+      : await this.idb.getEntry(key, options);
+
+    // The callback may throw (e.g. "already exists"); let that propagate.
+    const updated = updateCallback({
+      found: existing.found,
+      value: existing.value,
+    });
+
+    if (!updated) {
+      return { found: false, value: undefined };
+    }
+
+    const routeToIdb = containsFileSystemHandle(updated.value);
+    const target = routeToIdb ? this.idb : this.native;
+
+    const result = await target.updateEntry(
+      key,
+      () => ({ value: updated.value }),
+      options,
+    );
+
+    // Drop a stale copy left in the other backend when the record migrated.
+    const existedInNative = nativeExisting.found;
+    const existedInIdb = existing.found && !nativeExisting.found;
+    if (routeToIdb && existedInNative) {
+      await this.native.deleteEntry(key, options);
+    } else if (!routeToIdb && existedInIdb) {
+      await this.idb.deleteEntry(key, options);
+    }
+
+    return result;
+  }
+
+  async deleteEntry(key: string, options: DatabaseQueryOptions): Promise<void> {
+    await Promise.all([
+      this.native.deleteEntry(key, options),
+      this.idb.deleteEntry(key, options),
+    ]);
+  }
+
+  async getAllEntries(options: DatabaseQueryOptions): Promise<unknown[]> {
+    const [nativeEntries, idbEntries] = await Promise.all([
+      this.native.getAllEntries(options),
+      this.idb.getAllEntries(options),
+    ]);
+    // A key resides in exactly one backend, so concatenation cannot duplicate.
+    return [...nativeEntries, ...idbEntries];
+  }
+
+  subscribe(
+    options: DatabaseQueryOptions,
+    callback: (change: DatabaseChange) => void,
+    signal: AbortSignal,
+  ): void {
+    this.native.subscribe(options, callback, signal);
+    this.idb.subscribe(options, callback, signal);
+  }
+}
+
+/**
+ * Whether a value (recursively) contains a File System Access handle, which can
+ * be persisted by IndexedDB (structured clone) but not serialized to a JSON
+ * file. Cycles are guarded with a visited set.
+ */
+export function containsFileSystemHandle(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): boolean {
+  if (isFileSystemHandleLike(value)) {
+    return true;
+  }
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsFileSystemHandle(item, seen));
+  }
+  return Object.values(value as Record<string, unknown>).some((item) =>
+    containsFileSystemHandle(item, seen),
+  );
+}
+
+function isFileSystemHandleLike(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  const requestPermission = (value as { requestPermission?: unknown })
+    .requestPermission;
+  return (
+    (kind === 'file' || kind === 'directory') &&
+    typeof requestPermission === 'function'
+  );
+}

--- a/packages/platform/service-platform/src/desktop-native-database.ts
+++ b/packages/platform/service-platform/src/desktop-native-database.ts
@@ -1,0 +1,191 @@
+import {
+  BaseService,
+  type BaseServiceContext,
+  isAppError,
+  throwAppError,
+} from '@bangle.io/base-utils';
+import { TypedBroadcastBus } from '@bangle.io/browser-utils';
+import { BROWSING_CONTEXT_ID } from '@bangle.io/config';
+import { SERVICE_NAME } from '@bangle.io/constants';
+import type {
+  BaseAppDatabase,
+  DatabaseChange,
+  DatabaseQueryOptions,
+  DesktopConfigBridge,
+} from '@bangle.io/types';
+
+/**
+ * Async `BaseAppDatabase` backed by the Electron native config store. Every
+ * operation is delegated over IPC to `window.bangleDesktop.configDb`, which the
+ * preload exposes and the main process fulfils against a JSON file under the OS
+ * user-data directory.
+ *
+ * Only serializable values reach this service — `DesktopHybridDatabaseService`
+ * routes records carrying a native-FS handle to IndexedDB before they get here.
+ *
+ * `updateEntry` performs read-modify-write in the renderer (the callback is
+ * renderer code and cannot cross IPC). A per-key promise chain serializes those
+ * cycles so an older completion can never overwrite a newer edit. The desktop is
+ * effectively single-writer, so this ordering plus the main-process write queue
+ * is sufficient; cross-window change propagation is a documented extension.
+ */
+export class DesktopNativeDatabaseService
+  extends BaseService
+  implements BaseAppDatabase
+{
+  private readonly bridge: DesktopConfigBridge;
+  private changeBus!: TypedBroadcastBus<DatabaseChange>;
+  private readonly writeChains = new Map<string, Promise<unknown>>();
+
+  constructor(
+    context: BaseServiceContext,
+    dependencies: null,
+    config: { bridge: DesktopConfigBridge },
+  ) {
+    super(SERVICE_NAME.desktopNativeDatabaseService, context, dependencies);
+    this.bridge = config.bridge;
+  }
+
+  async hookMount(): Promise<void> {
+    this.changeBus = new TypedBroadcastBus({
+      name: this.name,
+      senderId: BROWSING_CONTEXT_ID,
+      logger: this.logger.child('bus'),
+      useMemoryChannel: true,
+      signal: this.abortSignal,
+    });
+  }
+
+  async getEntry(
+    key: string,
+    options: DatabaseQueryOptions,
+  ): Promise<{ found: boolean; value: unknown }> {
+    await this.mountPromise;
+    try {
+      return await this.bridge.getEntry(key, options);
+    } catch (error) {
+      this.throwError(error);
+    }
+  }
+
+  async updateEntry(
+    key: string,
+    updateCallback: (options: { value: unknown; found: boolean }) => {
+      value: unknown;
+    } | null,
+    options: DatabaseQueryOptions,
+  ): Promise<{ value: unknown; found: boolean }> {
+    await this.mountPromise;
+    return this.enqueue(options.tableName, key, async () => {
+      try {
+        const existing = await this.bridge.getEntry(key, options);
+        const updated = updateCallback({
+          found: existing.found,
+          value: existing.value,
+        });
+
+        if (!updated) {
+          return { found: false, value: undefined };
+        }
+
+        await this.bridge.putEntry(key, updated.value, options);
+
+        const change: DatabaseChange = {
+          type: existing.found ? 'update' : 'create',
+          tableName: options.tableName,
+          key,
+          value: updated.value,
+        };
+        this.changeBus.send(change);
+
+        return { found: true, value: updated.value };
+      } catch (error) {
+        this.throwError(error);
+      }
+    });
+  }
+
+  async deleteEntry(key: string, options: DatabaseQueryOptions): Promise<void> {
+    await this.mountPromise;
+    await this.enqueue(options.tableName, key, async () => {
+      try {
+        await this.bridge.deleteEntry(key, options);
+        this.changeBus.send({
+          type: 'delete',
+          tableName: options.tableName,
+          key,
+          value: undefined,
+        });
+      } catch (error) {
+        this.throwError(error);
+      }
+    });
+  }
+
+  async getAllEntries(options: DatabaseQueryOptions): Promise<unknown[]> {
+    await this.mountPromise;
+    try {
+      return await this.bridge.getAllEntries(options);
+    } catch (error) {
+      this.throwError(error);
+    }
+  }
+
+  subscribe(
+    options: DatabaseQueryOptions,
+    callback: (change: DatabaseChange) => void,
+    signal: AbortSignal,
+  ): void {
+    if (this.aborted) {
+      return;
+    }
+    this.changeBus.subscribe((msg) => {
+      if (msg.data.tableName === options.tableName) {
+        callback(msg.data);
+      }
+    }, signal);
+  }
+
+  /**
+   * Serializes read-modify-write cycles per (table, key). Later work chains onto
+   * the prior promise; a rejected step does not wedge the chain.
+   */
+  private enqueue<T>(
+    tableName: string,
+    key: string,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const chainKey = `${tableName}:${key}`;
+    const previous = this.writeChains.get(chainKey) ?? Promise.resolve();
+    const next = previous.then(task, task);
+    this.writeChains.set(
+      chainKey,
+      next.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return next;
+  }
+
+  private throwError(error: unknown): never {
+    if (isAppError(error)) {
+      this.logger.error('App error:', error);
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      this.logger.error('Unknown error:', error);
+      throwAppError(
+        'error::database:unknown-error',
+        'Failed to perform database operation',
+        {
+          error,
+          databaseName: this.name,
+        },
+      );
+    }
+    this.logger.error('Unknown non-Error object:', error);
+    throw error;
+  }
+}

--- a/packages/platform/service-platform/src/index.ts
+++ b/packages/platform/service-platform/src/index.ts
@@ -1,5 +1,10 @@
 export { BrowserErrorHandlerService } from './browser-error-handler';
 export { BrowserLocalStorageSyncDatabaseService } from './browser-local-storage-sync-database';
+export {
+  containsFileSystemHandle,
+  DesktopHybridDatabaseService,
+} from './desktop-hybrid-database';
+export { DesktopNativeDatabaseService } from './desktop-native-database';
 export { FileStorageIndexedDB } from './file-storage-indexeddb';
 export { FileStorageMemory } from './file-storage-memory';
 export { FileStorageNativeFs } from './file-storage-nativefs';

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -104,6 +104,8 @@ export const SERVICE_NAME = {
   browserRouterService: 'browser-router',
   commandDispatchService: 'command-dispatch',
   commandRegistryService: 'command-registry',
+  desktopHybridDatabaseService: 'desktop-hybrid-database',
+  desktopNativeDatabaseService: 'desktop-native-database',
   editorService: 'editor',
   fileStorageIndexedDBService: 'file-storage-indexeddb',
   fileStorageMemoryService: 'file-storage-memory',

--- a/packages/shared/types/desktop-bridge.ts
+++ b/packages/shared/types/desktop-bridge.ts
@@ -1,0 +1,43 @@
+import type { DatabaseQueryOptions } from './base-database';
+
+/**
+ * The configuration key/value bridge the Electron preload exposes to the
+ * renderer as `window.bangleDesktop.configDb`. It mirrors the async subset of
+ * `BaseAppDatabase` (get/getAll/put/delete) and is the IPC contract between the
+ * desktop main process (owner of the on-disk store) and the renderer-side
+ * `DesktopNativeDatabaseService`.
+ *
+ * Only structured-clone/JSON-serializable values ever cross this bridge; records
+ * carrying a non-serializable value (e.g. a native-FS `FileSystemDirectoryHandle`)
+ * are routed to IndexedDB by the renderer and never reach it.
+ */
+export interface DesktopConfigBridge {
+  getEntry(
+    key: string,
+    options: DatabaseQueryOptions,
+  ): Promise<{ found: boolean; value: unknown }>;
+
+  getAllEntries(options: DatabaseQueryOptions): Promise<unknown[]>;
+
+  putEntry(
+    key: string,
+    value: unknown,
+    options: DatabaseQueryOptions,
+  ): Promise<void>;
+
+  deleteEntry(key: string, options: DatabaseQueryOptions): Promise<void>;
+}
+
+/**
+ * The full surface exposed on `window.bangleDesktop` by the Electron preload.
+ * `configDb` is optional so older desktop shells (which only exposed
+ * `platform`) still satisfy the type.
+ */
+export interface DesktopBridge {
+  platform: string;
+  configDb?: DesktopConfigBridge;
+}
+
+export type WindowWithDesktopBridge = Window & {
+  bangleDesktop?: DesktopBridge;
+};

--- a/packages/shared/types/index.ts
+++ b/packages/shared/types/index.ts
@@ -12,6 +12,7 @@ export type * from './base-database';
 export type * from './base-file-storage';
 export type * from './base-router';
 export type * from './commands';
+export type * from './desktop-bridge';
 export type * from './emitter';
 export type * from './services';
 export type * from './workspace';

--- a/packages/tooling/desktop-entry/package.json
+++ b/packages/tooling/desktop-entry/package.json
@@ -36,7 +36,7 @@
   "main": "dist/main.cjs",
   "productName": "Bangle.io",
   "scripts": {
-    "build": "vite build --configLoader runner",
+    "build": "vite build --configLoader runner && BANGLE_DESKTOP_ENTRY=preload vite build --configLoader runner",
     "ci": "pnpm run test && pnpm -w run desktop:build && node scripts/smoke-test.mjs --skip-if-not-darwin",
     "dist": "tsx scripts/dist.ts",
     "release:stable": "tsx scripts/release-stable.ts",
@@ -45,6 +45,7 @@
     "test": "vitest run src --configLoader runner"
   },
   "dependencies": {
+    "@bangle.io/types": "workspace:*",
     "electron": "43.0.0",
     "electron-updater": "^6.8.9",
     "vite": "^8.1.3"

--- a/packages/tooling/desktop-entry/scripts/smoke-test.mjs
+++ b/packages/tooling/desktop-entry/scripts/smoke-test.mjs
@@ -45,6 +45,12 @@ for (const requiredPath of [
 const userDataDir = await NodeFSP.mkdtemp(
   NodePath.join(NodeOS.tmpdir(), 'bangle-desktop-smoke-'),
 );
+// The native config store writes one JSON file per table under <userData>/config.
+const configWorkspaceInfoPath = NodePath.join(
+  userDataDir,
+  'config',
+  'WorkspaceInfo.json',
+);
 const workspaceName = `desktop-smoke-${Date.now()}`;
 const noteName = 'smoke-note';
 const noteContent = `Desktop smoke ${Date.now()}`;
@@ -190,6 +196,45 @@ async function waitForEditorText(page, expected, label) {
   );
 }
 
+async function readConfigWorkspaceNames() {
+  let raw;
+  try {
+    raw = await NodeFSP.readFile(configWorkspaceInfoPath, 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+  const parsed = JSON.parse(raw);
+  return Object.values(parsed)
+    .map((entry) =>
+      entry && typeof entry === 'object' ? entry.name : undefined,
+    )
+    .filter((name) => typeof name === 'string');
+}
+
+async function waitForWorkspaceInConfigFile(label) {
+  const deadline = Date.now() + 10_000;
+  let lastNames = [];
+
+  while (Date.now() < deadline) {
+    lastNames = await readConfigWorkspaceNames();
+    if (lastNames.includes(workspaceName)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error(
+    `[desktop-smoke] Expected workspace ${JSON.stringify(
+      workspaceName,
+    )} in the native config store after ${label} (${configWorkspaceInfoPath}); found ${JSON.stringify(
+      lastNames,
+    )}.`,
+  );
+}
+
 let app = await launchApp();
 let page = await firstWindow(app);
 
@@ -199,6 +244,12 @@ try {
 
   console.log('[desktop-smoke] Creating Browser workspace and note.');
   await createBrowserWorkspaceAndNote(page);
+
+  console.log(
+    '[desktop-smoke] Verifying workspace persisted to the native config store.',
+  );
+  await waitForWorkspaceInConfigFile('create');
+
   await page.locator(editorSelector).click();
   await page.locator(editorSelector).pressSequentially(noteContent, {
     delay: 10,
@@ -216,6 +267,10 @@ try {
   await app.close();
   app = await launchApp();
   page = await firstWindow(app);
+
+  // The workspace list must come back from the native config file, not Chromium.
+  await waitForWorkspaceInConfigFile('restart');
+
   await openNoteRoute(page);
   await page.locator(editorSelector).waitFor();
 

--- a/packages/tooling/desktop-entry/src/__tests__/config-store.spec.ts
+++ b/packages/tooling/desktop-entry/src/__tests__/config-store.spec.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ConfigStore } from '../config-store';
+
+const TABLE = 'WorkspaceInfo';
+
+function silentLogger() {
+  return { info() {}, warn() {}, error() {} };
+}
+
+describe('ConfigStore', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'bangle-config-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('round-trips put / get / getAll / delete', async () => {
+    const store = new ConfigStore({ dir });
+
+    expect(await store.getEntry('a', TABLE)).toEqual({
+      found: false,
+      value: undefined,
+    });
+
+    await store.putEntry('a', { name: 'a', n: 1 }, TABLE);
+    await store.putEntry('b', { name: 'b', n: 2 }, TABLE);
+
+    expect(await store.getEntry('a', TABLE)).toEqual({
+      found: true,
+      value: { name: 'a', n: 1 },
+    });
+    expect(await store.getAllEntries(TABLE)).toEqual([
+      { name: 'a', n: 1 },
+      { name: 'b', n: 2 },
+    ]);
+
+    await store.deleteEntry('a', TABLE);
+
+    expect(await store.getEntry('a', TABLE)).toEqual({
+      found: false,
+      value: undefined,
+    });
+    expect(await store.getAllEntries(TABLE)).toEqual([{ name: 'b', n: 2 }]);
+  });
+
+  it('persists across store instances (reload)', async () => {
+    const first = new ConfigStore({ dir });
+    await first.putEntry('a', { v: 1 }, TABLE);
+
+    const second = new ConfigStore({ dir });
+    expect(await second.getEntry('a', TABLE)).toEqual({
+      found: true,
+      value: { v: 1 },
+    });
+  });
+
+  it('writes atomically: valid JSON on disk and no leftover temp file', async () => {
+    const store = new ConfigStore({ dir });
+    await store.putEntry('a', { v: 1 }, TABLE);
+
+    const filePath = join(dir, `${TABLE}.json`);
+    const raw = await readFile(filePath, 'utf8');
+    expect(JSON.parse(raw)).toEqual({ a: { v: 1 } });
+
+    await expect(readFile(`${filePath}.tmp`, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('preserves a corrupt file on read and surfaces empty (no clobber)', async () => {
+    const filePath = join(dir, `${TABLE}.json`);
+    await writeFile(filePath, '{ this is not valid json', 'utf8');
+
+    const store = new ConfigStore({ dir, logger: silentLogger() });
+
+    expect(await store.getEntry('a', TABLE)).toEqual({
+      found: false,
+      value: undefined,
+    });
+    expect(await store.getAllEntries(TABLE)).toEqual([]);
+
+    // A failed load must never rewrite the file — the bytes stay intact.
+    expect(await readFile(filePath, 'utf8')).toBe('{ this is not valid json');
+  });
+
+  it('serializes concurrent writes without losing updates', async () => {
+    const store = new ConfigStore({ dir });
+
+    await Promise.all(
+      Array.from({ length: 25 }, (_, i) => store.putEntry(`k${i}`, i, TABLE)),
+    );
+
+    const all = (await store.getAllEntries(TABLE)) as number[];
+    expect([...all].sort((a, b) => a - b)).toEqual(
+      Array.from({ length: 25 }, (_, i) => i),
+    );
+
+    const raw = await readFile(join(dir, `${TABLE}.json`), 'utf8');
+    expect(Object.keys(JSON.parse(raw))).toHaveLength(25);
+  });
+});

--- a/packages/tooling/desktop-entry/src/config-channels.ts
+++ b/packages/tooling/desktop-entry/src/config-channels.ts
@@ -1,0 +1,11 @@
+/**
+ * IPC channel names for the desktop configuration store. Defined in a module
+ * with no `electron`/node imports so both the sandboxed preload and the main
+ * process can share them without pulling `ipcMain`/`fs` into the preload bundle.
+ */
+export const CONFIG_IPC = {
+  getEntry: 'bangle:config:get-entry',
+  getAllEntries: 'bangle:config:get-all-entries',
+  putEntry: 'bangle:config:put-entry',
+  deleteEntry: 'bangle:config:delete-entry',
+} as const;

--- a/packages/tooling/desktop-entry/src/config-ipc.ts
+++ b/packages/tooling/desktop-entry/src/config-ipc.ts
@@ -1,0 +1,57 @@
+import type { IpcMain } from 'electron';
+import { CONFIG_IPC } from './config-channels';
+import type { ConfigStore } from './config-store';
+
+export interface RegisterConfigIpcInput {
+  ipcMain: IpcMain;
+  store: ConfigStore;
+}
+
+/**
+ * Wires the config-store IPC channels. Handlers run in the main process and are
+ * the only path the sandboxed renderer has to persistent native config, so they
+ * validate their arguments defensively rather than trusting the renderer.
+ */
+export function registerConfigIpc(input: RegisterConfigIpcInput): void {
+  const { ipcMain, store } = input;
+
+  ipcMain.handle(
+    CONFIG_IPC.getEntry,
+    (_event, key: unknown, options: unknown) =>
+      store.getEntry(assertKey(key), assertTableName(options)),
+  );
+
+  ipcMain.handle(CONFIG_IPC.getAllEntries, (_event, options: unknown) =>
+    store.getAllEntries(assertTableName(options)),
+  );
+
+  ipcMain.handle(
+    CONFIG_IPC.putEntry,
+    (_event, key: unknown, value: unknown, options: unknown) =>
+      store.putEntry(assertKey(key), value, assertTableName(options)),
+  );
+
+  ipcMain.handle(
+    CONFIG_IPC.deleteEntry,
+    (_event, key: unknown, options: unknown) =>
+      store.deleteEntry(assertKey(key), assertTableName(options)),
+  );
+}
+
+function assertKey(key: unknown): string {
+  if (typeof key !== 'string') {
+    throw new TypeError('Config key must be a string');
+  }
+  return key;
+}
+
+function assertTableName(options: unknown): string {
+  if (
+    typeof options !== 'object' ||
+    options === null ||
+    typeof (options as { tableName?: unknown }).tableName !== 'string'
+  ) {
+    throw new TypeError('Config options.tableName must be a string');
+  }
+  return (options as { tableName: string }).tableName;
+}

--- a/packages/tooling/desktop-entry/src/config-store.ts
+++ b/packages/tooling/desktop-entry/src/config-store.ts
@@ -1,0 +1,174 @@
+import { mkdir, open, readFile, rename } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+type Table = Record<string, unknown>;
+
+type ConfigLogger = Pick<Console, 'info' | 'warn' | 'error'>;
+
+export interface ConfigStoreOptions {
+  /** Directory that holds one JSON file per table, e.g. `<userData>/config`. */
+  dir: string;
+  logger?: ConfigLogger;
+}
+
+/**
+ * Native, file-backed key/value store for Bangle desktop **configuration** (the
+ * workspace list and misc app config — never note content). One JSON file per
+ * table lives under the OS user-data directory.
+ *
+ * Data-safety guarantees (config is app data; a corrupt or lost file must never
+ * be created by this store):
+ * - Writes are atomic: serialize to a `*.tmp` sibling, `fsync`, then `rename`
+ *   over the target. A crash mid-write leaves the previous file intact.
+ * - All writes are serialized through a single queue so concurrent puts/deletes
+ *   cannot interleave or let an older completion clobber a newer one.
+ * - A read that fails to parse does NOT overwrite the file: the corrupt bytes
+ *   are preserved and the table is surfaced as empty, so a failed load can never
+ *   destroy data on its own.
+ */
+export class ConfigStore {
+  private readonly dir: string;
+  private readonly logger: ConfigLogger;
+  /** In-memory table snapshots, loaded lazily and then kept authoritative. */
+  private readonly tables = new Map<string, Table>();
+  /** De-dupes concurrent first loads of the same table. */
+  private readonly loading = new Map<string, Promise<Table>>();
+  /** Global write serialization; every persist chains onto the previous. */
+  private writeQueue: Promise<unknown> = Promise.resolve();
+
+  constructor(options: ConfigStoreOptions) {
+    this.dir = options.dir;
+    this.logger = options.logger ?? console;
+  }
+
+  async getEntry(
+    key: string,
+    tableName: string,
+  ): Promise<{ found: boolean; value: unknown }> {
+    const table = await this.loadTable(tableName);
+    const found = Object.hasOwn(table, key);
+    return { found, value: found ? table[key] : undefined };
+  }
+
+  async getAllEntries(tableName: string): Promise<unknown[]> {
+    const table = await this.loadTable(tableName);
+    return Object.values(table);
+  }
+
+  async putEntry(
+    key: string,
+    value: unknown,
+    tableName: string,
+  ): Promise<void> {
+    const table = await this.loadTable(tableName);
+    table[key] = value;
+    await this.persist(tableName, table);
+  }
+
+  async deleteEntry(key: string, tableName: string): Promise<void> {
+    const table = await this.loadTable(tableName);
+    if (!Object.hasOwn(table, key)) {
+      return;
+    }
+    delete table[key];
+    await this.persist(tableName, table);
+  }
+
+  private loadTable(tableName: string): Promise<Table> {
+    const cached = this.tables.get(tableName);
+    if (cached) {
+      return Promise.resolve(cached);
+    }
+
+    const inFlight = this.loading.get(tableName);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const load = this.readTableFromDisk(tableName).then((table) => {
+      this.tables.set(tableName, table);
+      this.loading.delete(tableName);
+      return table;
+    });
+    this.loading.set(tableName, load);
+    return load;
+  }
+
+  private async readTableFromDisk(tableName: string): Promise<Table> {
+    let raw: string;
+    try {
+      raw = await readFile(this.filePath(tableName), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return {};
+      }
+      // A read failure that is not "missing file" must not be treated as data
+      // loss; keep the file untouched and start from an empty in-memory view.
+      this.logger.error(
+        `[config] failed to read table "${tableName}"; leaving file intact`,
+        error,
+      );
+      return {};
+    }
+
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Table;
+      }
+      this.logger.error(
+        `[config] table "${tableName}" has an unexpected shape; ignoring`,
+      );
+      return {};
+    } catch (error) {
+      // Preserve the corrupt file (do not overwrite on load) so it can be
+      // recovered manually; surface an empty table for this session.
+      this.logger.error(
+        `[config] failed to parse table "${tableName}"; preserving file`,
+        error,
+      );
+      return {};
+    }
+  }
+
+  private persist(tableName: string, table: Table): Promise<void> {
+    const run = this.writeQueue.then(() =>
+      this.atomicWrite(tableName, { ...table }),
+    );
+    // Keep the queue alive even if a write rejects, so later writes still run.
+    this.writeQueue = run.catch(() => {});
+    return run;
+  }
+
+  private async atomicWrite(tableName: string, table: Table): Promise<void> {
+    const file = this.filePath(tableName);
+    await mkdir(dirname(file), { recursive: true });
+
+    const tmp = `${file}.tmp`;
+    const data = JSON.stringify(table, null, 2);
+    const handle = await open(tmp, 'w');
+    try {
+      await handle.writeFile(data, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await rename(tmp, file);
+  }
+
+  private filePath(tableName: string): string {
+    return join(this.dir, `${sanitizeTableName(tableName)}.json`);
+  }
+}
+
+/**
+ * Table names come from the renderer over IPC. Constrain them to a safe file
+ * name so a hostile or malformed value cannot escape the config directory.
+ */
+function sanitizeTableName(tableName: string): string {
+  const safe = tableName.replace(/[^A-Za-z0-9_-]/g, '_');
+  if (!safe) {
+    throw new Error(`Invalid config table name: ${JSON.stringify(tableName)}`);
+  }
+  return safe;
+}

--- a/packages/tooling/desktop-entry/src/desktop-document.ts
+++ b/packages/tooling/desktop-entry/src/desktop-document.ts
@@ -4,8 +4,9 @@ export function markDesktopPlatform(
   documentRef: Pick<Document, 'documentElement'>,
   platform: string,
 ): void {
-  documentRef.documentElement.setAttribute(
-    DESKTOP_PLATFORM_ATTRIBUTE,
-    platform,
-  );
+  // In a sandboxed preload this can run before the document is parsed, so
+  // `documentElement` may be null. Skip silently; the marker is also applied
+  // on `dom-ready` from the main process (see `installDesktopDocumentMarker`).
+  const root: HTMLElement | null = documentRef.documentElement;
+  root?.setAttribute(DESKTOP_PLATFORM_ATTRIBUTE, platform);
 }

--- a/packages/tooling/desktop-entry/src/main.ts
+++ b/packages/tooling/desktop-entry/src/main.ts
@@ -1,8 +1,18 @@
 import { access } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, BrowserWindow, dialog, net, protocol, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  net,
+  protocol,
+  shell,
+} from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { registerConfigIpc } from './config-ipc';
+import { ConfigStore } from './config-store';
 import { APP_PROTOCOL, APP_URL } from './protocol';
 import { registerAppProtocol as registerDesktopAppProtocol } from './protocol-handler';
 import { configureAutoUpdater } from './updater';
@@ -14,6 +24,19 @@ import {
 
 const mainDir = dirname(fileURLToPath(import.meta.url));
 let mainWindow: BrowserWindow | null = null;
+
+/**
+ * Registers the native config-store IPC once. The store persists desktop
+ * configuration (workspace list + misc app config, never note content) under
+ * the OS user-data directory, replacing the browser IndexedDB path for the
+ * async `database` seam. Sync UI preferences remain on localStorage.
+ */
+function installConfigStore(): void {
+  const store = new ConfigStore({
+    dir: join(app.getPath('userData'), 'config'),
+  });
+  registerConfigIpc({ ipcMain, store });
+}
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -99,6 +122,7 @@ app.on('activate', () => {
 
 void app.whenReady().then(async () => {
   try {
+    installConfigStore();
     await createMainWindow();
     configureAutoUpdater({
       app,

--- a/packages/tooling/desktop-entry/src/preload.ts
+++ b/packages/tooling/desktop-entry/src/preload.ts
@@ -1,10 +1,26 @@
-import { contextBridge } from 'electron';
+import type { DesktopConfigBridge } from '@bangle.io/types';
+import { contextBridge, ipcRenderer } from 'electron';
+import { CONFIG_IPC } from './config-channels';
 import { markDesktopPlatform } from './desktop-document';
+
+const configDb: DesktopConfigBridge = {
+  getEntry: (key, options) =>
+    ipcRenderer.invoke(CONFIG_IPC.getEntry, key, options),
+  getAllEntries: (options) =>
+    ipcRenderer.invoke(CONFIG_IPC.getAllEntries, options),
+  putEntry: (key, value, options) =>
+    ipcRenderer.invoke(CONFIG_IPC.putEntry, key, value, options),
+  deleteEntry: (key, options) =>
+    ipcRenderer.invoke(CONFIG_IPC.deleteEntry, key, options),
+};
+
+// Expose the bridge first so nothing below can prevent the renderer from
+// reaching native config.
+contextBridge.exposeInMainWorld('bangleDesktop', {
+  platform: process.platform,
+  configDb,
+});
 
 if (typeof document !== 'undefined') {
   markDesktopPlatform(document, process.platform);
 }
-
-contextBridge.exposeInMainWorld('bangleDesktop', {
-  platform: process.platform,
-});

--- a/packages/tooling/desktop-entry/vite.config.ts
+++ b/packages/tooling/desktop-entry/vite.config.ts
@@ -9,18 +9,24 @@ const nodeBuiltins = [
   ...builtinModules.map((id) => `node:${id}`),
 ];
 
+// Build one entry per invocation so each output is a fully self-contained CJS
+// bundle (`codeSplitting: false` requires a single input). This matters for the
+// sandboxed Electron preload: it can only `require` electron/node builtins,
+// never a sibling chunk, so main and preload must not share an emitted chunk.
+// The `build` script runs this twice (main, then preload).
+const entry =
+  process.env.BANGLE_DESKTOP_ENTRY === 'preload' ? 'preload' : 'main';
+
 export default defineConfig({
   ssr: {
     noExternal: ['electron-updater'],
   },
   build: {
-    emptyOutDir: true,
+    // Only the first (main) pass clears dist; the preload pass appends to it.
+    emptyOutDir: entry === 'main',
     ssr: true,
     lib: {
-      entry: {
-        main: resolve(packageDir, 'src/main.ts'),
-        preload: resolve(packageDir, 'src/preload.ts'),
-      },
+      entry: { [entry]: resolve(packageDir, `src/${entry}.ts`) },
       formats: ['cjs'],
     },
     outDir: 'dist',
@@ -28,6 +34,7 @@ export default defineConfig({
       external: ['electron', ...nodeBuiltins],
       output: {
         entryFileNames: '[name].cjs',
+        codeSplitting: false,
       },
     },
     sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -886,6 +886,9 @@ importers:
 
   packages/tooling/desktop-entry:
     dependencies:
+      '@bangle.io/types':
+        specifier: workspace:*
+        version: link:../../shared/types
       electron:
         specifier: 43.0.0
         version: 43.0.0


### PR DESCRIPTION
Serves app **configuration** (the workspace list, not note content) from a native, file-backed store under the OS user-data directory when running inside the Electron shell. The browser is unchanged and stays on IndexedDB. This exercises the existing `database` platform slot — core, UI, and note storage are untouched.

- **Native store**: main-process `ConfigStore` writes one JSON file per table (`<userData>/config/*.json`) with atomic writes (tmp + fsync + rename), a serialized write queue, and non-destructive reads on parse failure. Reached from the sandboxed renderer over a typed IPC bridge on the preload.
- **Hybrid routing**: on desktop the `database` seam is a hybrid that keeps workspace records carrying a non-serializable native-FS directory handle in IndexedDB, and routes all other serializable config to the native store. A key lives in exactly one backend.
- **Unchanged by decision**: the synchronous UI-preference store stays on localStorage; there is no data migration (fresh start on desktop).

### Reviewer callouts
- **Fixes a pre-existing desktop bug**: `window.bangleDesktop` never actually reached the renderer in the packaged app. The sandboxed preload could not `require` the shared build chunk (main and preload are now built as separate self-contained bundles), and the preload set an attribute on `document.documentElement` before the DOM was parsed. Both are fixed here.
- The desktop composition selects the hybrid only when the preload bridge is present, so the browser path is bit-for-bit the same.

### Tests
- `ConfigStore` unit tests (round-trip, atomic write, corrupt-file preservation, concurrent-write serialization).
- Hybrid routing unit tests (native vs IndexedDB routing, merge, cross-store move, subscribe).
- The desktop smoke test now asserts the workspace lands in the native `WorkspaceInfo.json` and survives reload + restart.

Follow-ups (out of scope): a native store for the sync UI-pref seam, a path-based native-FS file storage so handles leave IndexedDB, one-time migration of existing desktop config, and audit cleanups (dead `MiscTable`, DB version migration, runtime value validation).