### PR TITLE
fix: preserve newer navigation after note creation

### DIFF
--- a/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
@@ -21,6 +21,51 @@ function createDeferred<T>() {
 
 describe('WS command handlers', () => {
   describe('command::ws:create-note', () => {
+    test('does not overwrite a newer navigation while creation is pending', async () => {
+      const CURRENT_WS_PATH = 'test-ws:current.md';
+      const NEW_WS_PATH = 'test-ws:new.md';
+      const { dispatch, services, getCommandResults } = await setupTest({
+        targetId: 'command::ws:create-note',
+        workspaces: [{ name: 'test-ws', notes: [CURRENT_WS_PATH] }],
+        autoNavigate: 'ws-path',
+      });
+      const createStarted = createDeferred<void>();
+      const allowCreate = createDeferred<void>();
+      const createFile = services.fileSystem.createFile.bind(
+        services.fileSystem,
+      );
+      vi.spyOn(services.fileSystem, 'createFile').mockImplementationOnce(
+        async (...args) => {
+          createStarted.resolve();
+          await allowCreate.promise;
+          return createFile(...args);
+        },
+      );
+
+      dispatch('command::ws:create-note', {
+        navigate: true,
+        wsPath: NEW_WS_PATH,
+      });
+
+      await createStarted.promise;
+      // Re-selecting the current note is still a newer navigation intent even
+      // though comparing the route before and after would show no difference.
+      services.navigation.goWsPath(CURRENT_WS_PATH);
+      allowCreate.resolve();
+
+      await vi.waitFor(async () => {
+        expect(
+          getCommandResults().filter((result) => result.type === 'success'),
+        ).toHaveLength(1);
+        await expect(
+          services.fileSystem.readFile(NEW_WS_PATH),
+        ).resolves.toBeDefined();
+      });
+      expect(services.navigation.resolveAtoms().wsPath?.wsPath).toBe(
+        CURRENT_WS_PATH,
+      );
+    });
+
     test('reports duplicate note creation as a command failure', async () => {
       const NOTE_WS_PATH = 'test-ws:existing.md';
       const { dispatch, services, getCommandResults, testEnv } =

--- a/packages/core/command-handlers/src/ws-command-handlers.ts
+++ b/packages/core/command-handlers/src/ws-command-handlers.ts
@@ -145,6 +145,7 @@ export const wsCommandHandlers = [
 
       const filePath = WsPath.assertFile(wsPath);
       const fileNameWithoutExt = filePath.fileNameWithoutExtension;
+      const navigationVersion = navigation.captureNavigationVersion();
 
       try {
         await fileSystem.createFile(
@@ -161,7 +162,12 @@ export const wsCommandHandlers = [
         throw error;
       }
 
-      if (navigate) {
+      // A storage write can outlive the dialog. Do not let its completion
+      // overwrite a navigation made while the write was pending.
+      if (
+        navigate &&
+        navigation.isNavigationVersionCurrent(navigationVersion)
+      ) {
         navigation.goWsPath(wsPath);
       }
     },

--- a/packages/core/service-core/src/navigation-service.ts
+++ b/packages/core/service-core/src/navigation-service.ts
@@ -25,6 +25,8 @@ import { atom } from 'jotai';
 export class NavigationService extends BaseService {
   static deps = ['router'] as const;
 
+  private navigationVersion = 0;
+
   $routeInfo!: WritableAtom<AppRouteInfo, [AppRouteInfo], void>;
   $lifeCycle = atom<{
     current: PageLifeCycleState;
@@ -142,7 +144,20 @@ export class NavigationService extends BaseService {
     to: AppRouteInfo,
     options?: { replace?: boolean; state?: RouterState },
   ) {
+    this.navigationVersion += 1;
     this.routerService.navigate(to, options);
+  }
+
+  /**
+   * Captures the current navigation intent so async work can avoid overwriting
+   * a navigation requested or observed before that work completes.
+   */
+  public captureNavigationVersion(): number {
+    return this.navigationVersion;
+  }
+
+  public isNavigationVersionCurrent(version: number): boolean {
+    return version === this.navigationVersion;
   }
 
   public goWsPath(wsPath: string) {
@@ -226,6 +241,7 @@ export class NavigationService extends BaseService {
   }
 
   private syncRouteInfoAtom() {
+    this.navigationVersion += 1;
     this.store.set(this.$routeInfo, this.routerService.routeInfo);
   }
 }

--- a/packages/tooling/e2e-tests/src/editor-cursor-position.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-cursor-position.e2e.ts
@@ -14,7 +14,13 @@ async function createNote(page: Page, noteName: string) {
   await page.getByRole('menuitem', { name: 'New Note' }).click();
   await page.getByLabel('Note name').fill(noteName);
   await page.getByRole('button', { name: 'Create' }).click();
-  await expect(getEditorLocator(page, {})).toBeVisible();
+  const fileName = `${noteName}.md`;
+  await expect(
+    page.getByLabel('breadcrumb').getByRole('button', { name: fileName }),
+  ).toBeVisible();
+  await expect
+    .poll(() => getEditorLocator(page, {}).getAttribute('data-editor-name'))
+    .toContain(`:${fileName}:`);
   await waitForEditorFocus(page, {});
 }
 


### PR DESCRIPTION
## Summary

- prevent a slow note creation from overwriting navigation requested while its storage write is pending
- make the cursor-restoration workflow wait for the created editor before switching notes

## Reviewer notes

Navigation now exposes a monotonic intent version covering both requested and observed route changes. The create-note handler uses that version only to guard its optional post-write navigation; file creation still completes normally.