### PR TITLE
docs: refresh plans after project grooming

### DIFF
--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-15
-updated: 2026-07-19
+updated: 2026-07-21
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
@@ -23,6 +23,7 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/648
   - https://github.com/bangle-io/bangle-io/pull/649
   - https://github.com/bangle-io/bangle-io/pull/658
+  - https://github.com/bangle-io/bangle-io/pull/667
 related_issues: []
 ---
 
@@ -216,12 +217,20 @@ workflows, recovery gaps, and the open package-boundary items below.
     facade and proves the current graph performs the write. Browser E2E forces
     a save failure, emits the real `event::app:reload-ui`, retries through the
     disposed graph, and verifies the edit is durable after a full page reload.
-- 2026-07-19 list-fidelity cleanup (PR #658, open):
-  - The pending implementation preserves tight/loose list semantics, ordered
+- 2026-07-19 list-fidelity cleanup (PR #658):
+  - The merged implementation preserves tight/loose list semantics, ordered
     task-list container kind, and structural nested-list indentation across
     both editor engines.
-  - P1.3 remains in progress until the PR merges; its shared corpus, command,
-    codec, DOM, and persistence coverage are already part of the PR.
+  - P1.3 is complete. Shared corpus, command, codec, DOM, persistence, and
+    reload coverage protect the cross-engine behavior.
+- 2026-07-21 broad cleanup continuation (PR #667, open):
+  - The review-ready sweep removes dead code and obsolete tooling, consolidates
+    repeated editor/router/service/script behavior behind existing owners, and
+    hardens Native FS rename, sync-value, malformed-state, and mobile-origin
+    boundaries.
+  - The plan remains active after this sweep because the command-completion,
+    asset-recovery, package-boundary, and workspace-index items below are still
+    separate follow-ups.
 - Findings are grouped by priority and theme below.
 
 ## Scope
@@ -467,10 +476,9 @@ Current status:
 - ProseMirror explicitly ignores wrapper `bullet_list`/`ordered_list` tokens
   and derives flat list items from the configured kind/checked attributes.
 - The original general task-list coverage gap is resolved.
-- PR #658 is open with the remaining implementation: preserve tight/loose
-  list semantics, keep ordered task lists ordered, and use structural marker
-  widths for stable nested indentation. This section is not complete until
-  that PR merges.
+- PR #658 merged with the remaining implementation: tight/loose list semantics,
+  ordered task-list containers, and structural marker widths for stable nested
+  indentation across both editor engines.
 
 Evidence:
 
@@ -483,7 +491,7 @@ Plan:
 - [x] Derive task-list state from standard Markdown tokens or configure the parser
   explicitly to emit the required attrs.
 - [x] Document task-list normalization rules in tests.
-- [ ] Merge PR #658, including nested ordered-list indentation in the golden
+- [x] Merge PR #658, including nested ordered-list indentation in the golden
   corpus and fixed-point coverage.
 
 Verification:

--- a/plans/011-wordgard-editor-w-migration.md
+++ b/plans/011-wordgard-editor-w-migration.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-05
-updated: 2026-07-19
+updated: 2026-07-21
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/609
@@ -53,13 +53,14 @@ Key upstream facts (as of 2026-07-05):
 
 ## Current status
 
-2026-07-19 update:
+2026-07-21 update:
 
 - PR #655 fixed nested multiline code serialization inside block delimiters in
   the Wordgard Markdown codec.
-- PR #658 is open with shared list-syntax and codec work that preserves list
+- PR #658 merged with shared list-syntax and codec work that preserves list
   kind, task state, tightness, and structural indentation across both editor
-  engines. The migration remains in progress while that parity work is pending.
+  engines. The migration remains active; M2 real-editor wiring is the next
+  documented milestone.
 
 Active. Landed so far (PR #609):
 

--- a/plans/012-markdown-feature-parity.md
+++ b/plans/012-markdown-feature-parity.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-07
-updated: 2026-07-18
+updated: 2026-07-21
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/615
@@ -51,7 +51,7 @@ Active and partially implemented:
   tokenization, editable inline/display nodes, KaTeX rendering, exact-source
   safeguards, and Playwright persistence coverage. That PR also added a
   separate Plan 016 for lazy-loading the renderer after the first release.
-- PR #658 is open with a cross-engine list-fidelity slice: tight/loose list
+- PR #658 merged with a cross-engine list-fidelity slice: tight/loose list
   semantics, ordered task-list kind, split/input-rule transitions, and stable
   structural indentation. It strengthens the parity baseline but does not
   complete one of the numbered milestones below.

--- a/plans/archived/017-pwa-install-open-in-app.md
+++ b/plans/archived/017-pwa-install-open-in-app.md
@@ -5,16 +5,18 @@ type: plan
 archived: true
 archived_on: 2026-07-19
 created: 2026-07-18
-updated: 2026-07-19
+updated: 2026-07-21
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/657
+  - https://github.com/bangle-io/bangle-io/pull/665
 related_issues: []
 ---
 
 > DONE (2026-07-19): PR #657 delivered the install/open-in-app surfaces,
 > deployment-aware manifest, protocol deep links, focus-existing launches, and
-> app shortcuts. Native in-place Markdown file handling was deliberately
+> app shortcuts. PR #665 then fixed installed-state detection for standalone
+> overlay windows. Native in-place Markdown file handling was deliberately
 > removed from this scope and remains a separate storage initiative. Automated
 > coverage and local browser smoke testing were completed with the
 > implementation; the real installed-PWA check remains part of release-time
@@ -43,10 +45,11 @@ Three user-visible surfaces, all driven by one install-state snapshot:
 
 ## Completion status
 
-Completed in PR #657. Phase 1 and the retained phase 2 scope shipped. The
-file-handler import experiment was removed before completion because native
-in-place editing needs a separate single-file storage and save-lifecycle
-design. That follow-up is explicitly out of scope for this completed plan.
+Completed in PR #657, with installed overlay-window detection corrected in PR
+#665. Phase 1 and the retained phase 2 scope shipped. The file-handler import
+experiment was removed before completion because native in-place editing needs
+a separate single-file storage and save-lifecycle design. That follow-up is
+explicitly out of scope for this completed plan.
 
 ## Browser API basis (verified July 2026)
 


### PR DESCRIPTION
## Overview

- reconcile merged list-fidelity work across active plans
- record the current cleanup continuation and next milestones
- include the installed-PWA detection follow-up in the completed plan