### PR TITLE
fix(editor): open nested assets on mobile

### DIFF
--- a/packages/core/app/src/components/navigation/note-breadcrumb.tsx
+++ b/packages/core/app/src/components/navigation/note-breadcrumb.tsx
@@ -34,8 +34,8 @@ export function NoteBreadcrumb({
   const showEllipsisFlag = shouldShowEllipsis(segments);
 
   return (
-    <Breadcrumb.Breadcrumb>
-      <Breadcrumb.BreadcrumbList>
+    <Breadcrumb.Breadcrumb className="min-w-0 flex-1 overflow-hidden">
+      <Breadcrumb.BreadcrumbList className="min-w-0 flex-nowrap overflow-hidden">
         {visibleSegments.map((segment, idx) => (
           <BreadcrumbItem
             key={segment.wsPath ?? segment.label}
@@ -74,7 +74,7 @@ function BreadcrumbItem({
 }: BreadcrumbItemProps) {
   return (
     <React.Fragment>
-      <Breadcrumb.BreadcrumbItem>
+      <Breadcrumb.BreadcrumbItem className={isFirst ? 'shrink-0' : 'min-w-0'}>
         {isFirst ? (
           <HomeFolderLink />
         ) : (
@@ -86,11 +86,11 @@ function BreadcrumbItem({
           />
         )}
       </Breadcrumb.BreadcrumbItem>
-      {!isLast && <Breadcrumb.BreadcrumbSeparator />}
+      {!isLast && <Breadcrumb.BreadcrumbSeparator className="shrink-0" />}
       {showEllipsis && (
         <>
           <Breadcrumb.BreadcrumbEllipsis />
-          <Breadcrumb.BreadcrumbSeparator />
+          <Breadcrumb.BreadcrumbSeparator className="shrink-0" />
         </>
       )}
     </React.Fragment>
@@ -148,7 +148,7 @@ function DirectoryDropdown({
         render={
           <Button
             variant="ghost"
-            className="h-auto cursor-pointer px-1 py-0 text-sm hover:underline"
+            className="h-auto min-w-0 cursor-pointer truncate px-1 py-0 text-sm hover:underline"
           >
             {segment.label}
           </Button>

--- a/packages/core/app/src/layout/app-header.tsx
+++ b/packages/core/app/src/layout/app-header.tsx
@@ -45,7 +45,7 @@ export function AppHeader({ children }: AppHeaderProps) {
         aria-hidden="true"
         className="desktop-titlebar-main-spacer shrink-0"
       />
-      <div className="flex h-full flex-1 items-center justify-between">
+      <div className="flex h-full min-w-0 flex-1 items-center gap-2">
         <ToolbarLeftSection
           showEditorToolbar={showEditorToolbar}
           currentWsPath={currentWsPath?.wsPath}
@@ -84,7 +84,7 @@ function ToolbarLeftSection({
   const coreServices = useCoreServices();
 
   return (
-    <div className="desktop-titlebar-no-drag flex min-w-0 items-center gap-2">
+    <div className="desktop-titlebar-no-drag flex min-w-0 flex-1 items-center gap-2">
       <Sidebar.SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="h-4" />
       {showEditorToolbar && currentWsPath ? (
@@ -105,7 +105,9 @@ function ToolbarLeftSection({
               );
             }}
           />
-          <MarkdownFidelityNotice wsPath={currentWsPath} />
+          <div className="shrink-0">
+            <MarkdownFidelityNotice wsPath={currentWsPath} />
+          </div>
         </>
       ) : currentWsName ? (
         <WsNameBreadcrumb wsName={currentWsName} />
@@ -171,7 +173,7 @@ function ToolbarRightSection({
   };
 
   return (
-    <div className="desktop-titlebar-no-drag flex items-center">
+    <div className="desktop-titlebar-no-drag flex shrink-0 items-center">
       <StarButton
         isStarred={isCurrentWsPathStarred}
         onClick={handleStarClick}

--- a/packages/core/editor/src/components/floating-link-editor.tsx
+++ b/packages/core/editor/src/components/floating-link-editor.tsx
@@ -190,7 +190,7 @@ function LinkEditor({
               <LinkEditorButton
                 disabled={!valid}
                 label={t.app.editor.linkEditor.open}
-                onClick={() => normalizedValue && onOpen(normalizedValue)}
+                onClick={() => normalizedValue && onOpen(value.trim())}
                 onPointerDown={preserveSelection}
                 type="button"
               >

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -29,13 +29,14 @@ import {
   createWikiLinkIndex,
   getEmbeddableWorkspaceAssetKind,
   getInternalLinkHeading,
+  normalizeLinkTarget,
   normalizeStoredMarkdownLinkTarget,
   relativeMarkdownAssetHref,
   resolveInternalLink,
-  resolveLocalMarkdownAsset,
   resolveWikiLinkTarget,
   resolveWorkspaceMarkdownAssetReferenceCandidates,
   type WikiLinkIndex,
+  type WsFilePath,
   WsPath,
   workspaceRootMarkdownAssetHref,
 } from '@bangle.io/ws-path';
@@ -738,15 +739,7 @@ export class PmEditorService
       return undefined;
     }
 
-    const existingWsPaths = new Set(
-      this.store
-        .get(this.dependencies.workspaceState.$wsPaths)
-        .map((path) => path.wsPath),
-    );
-    const assetWsPath = resolveWorkspaceMarkdownAssetReferenceCandidates(
-      currentWsPath,
-      target,
-    ).find((candidate) => existingWsPaths.has(candidate.wsPath));
+    const assetWsPath = this.resolveExistingAssetWsPath(currentWsPath, target);
     if (!assetWsPath) {
       return undefined;
     }
@@ -763,6 +756,21 @@ export class PmEditorService
       isImage: getEmbeddableWorkspaceAssetKind(assetWsPath) === 'image',
       label: assetWsPath.fileName,
     };
+  }
+
+  private resolveExistingAssetWsPath(
+    currentWsPath: WsFilePath,
+    target: string,
+  ): WsFilePath | undefined {
+    const existingWsPaths = new Set(
+      this.store
+        .get(this.dependencies.workspaceState.$wsPaths)
+        .map((path) => path.wsPath),
+    );
+    return resolveWorkspaceMarkdownAssetReferenceCandidates(
+      currentWsPath,
+      target,
+    ).find((candidate) => existingWsPaths.has(candidate.wsPath));
   }
 
   /** Opens a web link externally or routes a relative Markdown link in-app. */
@@ -793,8 +801,10 @@ export class PmEditorService
       return;
     }
 
-    if (target?.kind === 'external') {
-      window.open(target.href, '_blank', 'noopener,noreferrer');
+    const externalTarget =
+      target?.kind === 'external' ? target : normalizeLinkTarget(href);
+    if (externalTarget?.kind === 'external') {
+      window.open(externalTarget.href, '_blank', 'noopener,noreferrer');
     }
   }
 
@@ -808,7 +818,12 @@ export class PmEditorService
       return false;
     }
 
-    const assetWsPath = resolveLocalMarkdownAsset(editor.wsPath, href);
+    const currentWsPath = WsPath.safeParse(editor.wsPath).data?.asFile();
+    if (!currentWsPath) {
+      return false;
+    }
+
+    const assetWsPath = this.resolveExistingAssetWsPath(currentWsPath, href);
     if (!assetWsPath) {
       return false;
     }

--- a/packages/tooling/e2e-tests/src/app-shell-layout.e2e.ts
+++ b/packages/tooling/e2e-tests/src/app-shell-layout.e2e.ts
@@ -58,6 +58,37 @@ test('app shell: full-height flush sidebar, thin titlebar, collapse/expand', asy
     .toBeGreaterThanOrEqual(0);
 });
 
+test('app shell: keeps a nested note breadcrumb on one mobile titlebar line', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const noteName =
+    'Novo folder de teste/Com anexo generico com um nome muito longo';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'mobile-titlebar-ws',
+    noteName,
+  });
+
+  const titlebar = page.locator('header.desktop-titlebar-surface').first();
+  const breadcrumb = titlebar.getByRole('navigation', { name: 'breadcrumb' });
+  await expect(breadcrumb).toBeVisible();
+  await expectNoPageHorizontalOverflow(page);
+  await expect
+    .poll(async () => {
+      const titlebarBox = await titlebar.boundingBox();
+      const breadcrumbBox = await breadcrumb.boundingBox();
+      if (!titlebarBox || !breadcrumbBox) {
+        return false;
+      }
+      return (
+        breadcrumbBox.y >= titlebarBox.y &&
+        breadcrumbBox.y + breadcrumbBox.height <=
+          titlebarBox.y + titlebarBox.height
+      );
+    })
+    .toBe(true);
+});
+
 test('app shell: resize the sidebar with pointer or keyboard and persist its width', async ({
   page,
 }) => {

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -180,7 +180,7 @@ test('pastes workspace-backed image and PDF assets, reloads, and opens asset pag
   page,
 }, testInfo) => {
   const workspaceName = `asset-workflow-${testInfo.workerIndex}-${Date.now()}`;
-  const noteName = 'source';
+  const noteName = 'nested/source';
   await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
 
   const editor = getEditorLocator(page, {});
@@ -221,11 +221,7 @@ test('pastes workspace-backed image and PDF assets, reloads, and opens asset pag
   await expect(page.getByRole('textbox', { name: 'Link URL' })).toHaveValue(
     /assets\/spec-sheet-.*\.pdf/,
   );
-  await page.getByRole('textbox', { name: 'Link URL' }).press('Escape');
-
-  await page.keyboard.down(ctrlKey);
-  await assetLink.click();
-  await page.keyboard.up(ctrlKey);
+  await page.getByRole('button', { name: 'Open link' }).click();
   await expect(
     page.getByRole('heading', { name: /spec-sheet-.*\.pdf/i }),
   ).toBeVisible();


### PR DESCRIPTION
Follow-up to #659.

- preserve relative attachment paths when the mobile link menu opens a generic file
- resolve only existing workspace assets before falling back to web URLs
- keep long nested-note breadcrumbs on one clipped titlebar line
- cover the nested attachment flow and narrow titlebar layout with browser tests