### PR TITLE
fix: keep note snapshot history through renames and retry lost-writer preservation

### DIFF
--- a/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/note-snapshot-service.spec.ts
@@ -460,6 +460,86 @@ describe('NoteSnapshotService', () => {
     controller.abort();
   });
 
+  it('retries preserving outgoing content after a transient storage failure', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-07-21T00:00:00Z'));
+    const { controller, services, testEnv } = await setup();
+    await services.fileSystem.createTextFile(NOTE_WS_PATH, 'v1');
+    await writeNote(services, NOTE_WS_PATH, 'v2 from this tab');
+    // Different retention bucket, so the preserved snapshot adds a row.
+    vi.advanceTimersByTime(11 * 60_000);
+
+    const originalUpdateEntry = services.database.updateEntry.bind(
+      services.database,
+    );
+    const failingUpdateEntry = vi
+      .spyOn(services.database, 'updateEntry')
+      .mockImplementation(async (key, callback, options) => {
+        if (options.tableName === DATABASE_TABLE_NAME.noteSnapshotsContent) {
+          throw new Error('database exploded');
+        }
+        return originalUpdateEntry(key, callback, options);
+      });
+
+    const emitForeignUpdate = () => {
+      testEnv.rootEmitter.emit('event::file:update', {
+        type: 'file-content-update',
+        wsPath: NOTE_WS_PATH,
+        sender: { id: 'some-other-tab', tag: 'file-system-service' },
+      });
+    };
+    // This preservation attempt fails in storage; the capture below shares
+    // the workspace lock, so once it finishes the failure has completed.
+    emitForeignUpdate();
+    await services.noteSnapshot.captureBeforeOverwrite(
+      `${TEST_WS_NAME}:barrier.md`,
+      async () => new File(['barrier content'], 'barrier.md'),
+    );
+    failingUpdateEntry.mockRestore();
+
+    // Storage works again: a later foreign event must retry the preservation
+    // instead of treating the lost content as already handled.
+    await vi.waitFor(async () => {
+      emitForeignUpdate();
+      const snapshots = await services.noteSnapshot.listSnapshots();
+      const contents = await Promise.all(
+        snapshots.map(
+          async ({ id }) =>
+            (await services.noteSnapshot.getSnapshot(id))?.content,
+        ),
+      );
+      expect(contents).toContain('v2 from this tab');
+    });
+    controller.abort();
+  });
+
+  it('keeps snapshot history attached to a note across a rename', async () => {
+    const { controller, services } = await setup();
+    await services.fileSystem.createTextFile(NOTE_WS_PATH, 'original');
+    await writeNote(services, NOTE_WS_PATH, 'edited');
+    expect(await services.noteSnapshot.listSnapshots()).toHaveLength(1);
+
+    const renamedWsPath = `${TEST_WS_NAME}:renamed.md`;
+    await services.fileSystem.renameFile({
+      oldWsPath: NOTE_WS_PATH,
+      newWsPath: renamedWsPath,
+    });
+
+    await vi.waitFor(async () => {
+      const snapshots = await services.noteSnapshot.listSnapshots();
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0]?.wsPath).toBe(renamedWsPath);
+    });
+    // The re-keyed row still resolves to its content.
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    const full = await services.noteSnapshot.getSnapshot(
+      snapshots[0]?.id ?? '',
+    );
+    expect(full?.content).toBe('original');
+    expect(full?.wsName).toBe(TEST_WS_NAME);
+    controller.abort();
+  });
+
   it('lists snapshots per workspace, newest first', async () => {
     const OTHER_WS = 'other-ws';
     const { controller, services } = await setup();

--- a/packages/core/service-core/src/note-snapshot-service.ts
+++ b/packages/core/service-core/src/note-snapshot-service.ts
@@ -148,6 +148,9 @@ export class NoteSnapshotService extends BaseService {
           this.clearPathState(event.wsPath);
         } else if (event.type === 'file-rename') {
           this.relocatePathState(event.oldWsPath, event.wsPath);
+          if (event.oldWsPath) {
+            void this.migratePersistedSnapshots(event.oldWsPath, event.wsPath);
+          }
         } else if (event.sender.id !== this.config.selfSenderId) {
           // Another tab changed this note. Drop the local throttle so this
           // tab's next save re-captures the content it is about to overwrite.
@@ -156,8 +159,17 @@ export class NoteSnapshotService extends BaseService {
           // race, its content only exists in this map now.
           const outgoing = this.lastWrittenContent.get(event.wsPath);
           if (outgoing && !outgoing.preserved) {
+            // Marked eagerly so overlapping foreign events do not preserve
+            // twice; reset on storage failure so a later foreign event
+            // retries instead of silently dropping the only copy.
             outgoing.preserved = true;
-            void this.preserveContent(event.wsPath, outgoing.content);
+            void this.preserveContent(event.wsPath, outgoing.content).then(
+              (preserved) => {
+                if (!preserved) {
+                  outgoing.preserved = false;
+                }
+              },
+            );
           }
         }
       },
@@ -184,6 +196,43 @@ export class NoteSnapshotService extends BaseService {
     }
     if (lastWrittenContent !== undefined) {
       this.lastWrittenContent.set(wsPath, lastWrittenContent);
+    }
+  }
+
+  /**
+   * Re-keys persisted snapshot metadata after a rename so the note keeps its
+   * history and a new note later created at the old path does not inherit it.
+   * Renames never cross workspaces, so only wsPath changes. Best-effort and
+   * idempotent: every tab observes the rename event, but under the workspace
+   * lock later runs find nothing left to migrate. Never throws.
+   */
+  private async migratePersistedSnapshots(
+    oldWsPath: string,
+    wsPath: string,
+  ): Promise<void> {
+    try {
+      const oldFilePath = WsPath.fromString(oldWsPath).asFile();
+      if (!oldFilePath || !WsPath.fromString(wsPath).asFile()) {
+        return;
+      }
+      await this.withWorkspaceSnapshotLock(oldFilePath.wsName, async () => {
+        const metas = await this.getWorkspaceMetas(oldFilePath.wsName);
+        for (const meta of metas) {
+          if (meta.wsPath !== oldWsPath) {
+            continue;
+          }
+          await this.dependencies.database.updateEntry(
+            meta.id,
+            () => ({ value: { ...meta, wsPath } }),
+            META_TABLE,
+          );
+        }
+      });
+    } catch (error) {
+      this.logger.warn(
+        `could not migrate snapshots of ${oldWsPath} to ${wsPath}`,
+        error,
+      );
     }
   }
 
@@ -322,21 +371,27 @@ export class NoteSnapshotService extends BaseService {
     }
   }
 
-  /** Best-effort preservation of this tab's outgoing content. Never throws. */
+  /**
+   * Best-effort preservation of this tab's outgoing content. Never throws.
+   * Returns false only for a storage failure worth retrying; empty content
+   * and invalid paths count as done.
+   */
   private async preserveContent(
     wsPath: string,
     content: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       if (content.trim() === '') {
-        return;
+        return true;
       }
       await this.storeSnapshot(wsPath, content);
+      return true;
     } catch (error) {
       this.logger.warn(
         `could not preserve outgoing content for ${wsPath}`,
         error,
       );
+      return false;
     }
   }
 


### PR DESCRIPTION
Two follow-ups to the recoverable note snapshots feature (#669), from post-merge review:

- **Rename re-keys persisted snapshots.** Previously only the in-memory throttle/cache moved on rename; the stored metadata kept the old `wsPath`, so the note-scoped Recover command showed no history for a renamed note, and a new note created at the old path inherited unrelated versions. Rename events now migrate the metadata rows under the existing workspace snapshot lock — best-effort and idempotent, so concurrent tabs observing the same rename are safe.

- **Losing-writer preservation retries on transient failure.** The `preserved` flag was set before the snapshot write completed, so a storage failure permanently dropped the only remaining copy of the losing tab's content. The flag is still set eagerly (to avoid double-preserving on overlapping foreign events) but resets on storage failure so a later foreign update retries.

Reviewer note: the migration and preservation remain fire-and-forget by design — snapshot work must never block or fail file operations. Both paths are covered by new unit tests using the cross-tab event bridge.