### PR TITLE
Fix keyboard movement of collapsed heading sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,10 @@ recovery path over convenience.
 
 - Before adding functionality, inspect the owning package and lower layers for
   existing behavior that should be extended or shared.
+- Before writing ProseMirror position, range, or transaction math, inspect
+  `packages/js-lib/banger-editor/src/pm-utils` and official ProseMirror
+  utilities. Prefer an existing helper; otherwise keep unavoidable math behind
+  a typed helper, promoting it to `pm-utils` when its semantics are reusable.
 - Put behavior where the concept is owned, not where the first caller happens
   to need it. Keep local mechanism close to its owner, and move reusable policy
   or meaning behind a typed API at the lowest appropriate layer.

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -16,13 +16,14 @@ import { NodeSelection, redo, TextSelection, undo } from '../pm';
 import { createBangerEditorTestSetup } from '../test-helpers';
 
 const collapsible = setupCollapsibleHeading();
+const heading = setupHeading();
 
 const editorTest = createBangerEditorTestSetup({
   extensions: [
     setupBase(),
     setupParagraph(),
     setupCodeBlock(),
-    setupHeading(),
+    heading,
     setupHistory(),
     setupList(),
     collapsible,
@@ -350,6 +351,35 @@ describe('document edits around folds', () => {
 
     expect(hiddenTexts(view)).toEqual([]);
     expect(view.state.doc.textContent).toContain('a');
+  });
+
+  it('keeps the fold when heading markup changes through undo and redo', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One<cursor>'), p('a'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+
+    expect(heading.command.toggleHeading(2)(view.state, view.dispatch)).toBe(
+      true,
+    );
+    expect(view.state.doc.nodeAt(pos)?.attrs.level).toBe(2);
+    expect(collapsible.query.isHeadingCollapsed(view.state, pos)).toBe(true);
+    expect(hiddenTexts(view)).toEqual(['a']);
+
+    expect(undo(view.state, view.dispatch)).toBe(true);
+    expect(view.state.doc.nodeAt(pos)?.attrs.level).toBe(1);
+    expect(collapsible.query.isHeadingCollapsed(view.state, pos)).toBe(true);
+    expect(hiddenTexts(view)).toEqual(['a']);
+
+    expect(redo(view.state, view.dispatch)).toBe(true);
+    expect(view.state.doc.nodeAt(pos)?.attrs.level).toBe(2);
+    expect(collapsible.query.isHeadingCollapsed(view.state, pos)).toBe(true);
+    expect(hiddenTexts(view)).toEqual(['a']);
   });
 
   it('auto-unfolds when an edit lands inside the hidden region', () => {
@@ -766,6 +796,60 @@ describe('moving folded sections', () => {
     expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b', 'c']);
   });
 
+  it('moves folded headings within the same nested parent', () => {
+    const downOriginal = doc(
+      bullet(h1('One<cursor>'), p('a'), h1('Two'), p('b')),
+    );
+    const downMoved = doc(bullet(h1('Two'), h1('One<cursor>'), p('a'), p('b')));
+    const downEditor = editorTest.createEditor(downOriginal);
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(downEditor.view.state.doc, 'One'),
+    )(downEditor.view.state, downEditor.view.dispatch);
+
+    expect(downEditor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    downEditor.expectDoc(downMoved);
+    expect(hiddenTexts(downEditor.view)).toEqual(['a', 'b']);
+    expect(undo(downEditor.view.state, downEditor.view.dispatch)).toBe(true);
+    downEditor.expectDoc(downOriginal);
+    expect(hiddenTexts(downEditor.view)).toEqual(['a']);
+    expect(redo(downEditor.view.state, downEditor.view.dispatch)).toBe(true);
+    downEditor.expectDoc(downMoved);
+    expect(hiddenTexts(downEditor.view)).toEqual(['a', 'b']);
+
+    const upEditor = editorTest.createEditor(
+      doc(bullet(h1('One'), p('a'), h1('Two<cursor>'), p('b'))),
+    );
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(upEditor.view.state.doc, 'Two'),
+    )(upEditor.view.state, upEditor.view.dispatch);
+
+    expect(upEditor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    upEditor.expectDoc(
+      doc(bullet(h1('One'), h1('Two<cursor>'), p('b'), p('a'))),
+    );
+    expect(hiddenTexts(upEditor.view)).toEqual(['b', 'a']);
+  });
+
+  it('preserves a heading node selection across a keyboard move', () => {
+    const editor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h1('Two'), p('b')),
+    );
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+    view.dispatch(
+      view.state.tr.setSelection(NodeSelection.create(view.state.doc, pos)),
+    );
+
+    expect(editor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    expect(view.state.selection).toBeInstanceOf(NodeSelection);
+    expect(view.state.selection.from).toBe(headingPos(view.state.doc, 'One'));
+    expect(hiddenTexts(view)).toEqual(['a', 'b']);
+  });
+
   it('does not move a folded section when heading text is selected', () => {
     const original = doc(h1('<start>One<end>'), p('a'), h1('Two'), p('b'));
     const editor = editorTest.createEditor(original);
@@ -820,7 +904,8 @@ describe('moving folded sections', () => {
     ).toBe(true);
 
     editor.expectDoc(doc(h1('Two'), p('c'), h1('One'), p('a'), p('b')));
-    // The section arrives still folded, with a NodeSelection on the heading.
+    // The section arrives still folded, retaining the text cursor that was
+    // inside its heading.
     expect(hiddenTexts(view)).toEqual(['a', 'b']);
     expect(
       collapsible.query.isHeadingCollapsed(
@@ -828,7 +913,8 @@ describe('moving folded sections', () => {
         headingPos(view.state.doc, 'One'),
       ),
     ).toBe(true);
-    expect(view.state.selection).toBeInstanceOf(NodeSelection);
+    expect(view.state.selection).toBeInstanceOf(TextSelection);
+    expect(view.state.selection.$head.parent.textContent).toBe('One');
   });
 
   it('moves a folded section upwards', () => {
@@ -909,6 +995,26 @@ describe('moving folded sections', () => {
     ).toBe(false);
     editor.expectDoc(original);
     expect(hiddenTexts(view)).toEqual(['a', 'b']);
+  });
+
+  it('refuses to move a nested section into a different parent', () => {
+    const original = doc(bullet(h1('One'), p('a')), h1('Two'), p('b'));
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+    const pos = headingPos(view.state.doc, 'One');
+    collapsible.command.toggleHeadingCollapseAtPos(pos)(
+      view.state,
+      view.dispatch,
+    );
+
+    expect(
+      collapsible.command.moveFoldedHeadingSection(
+        pos,
+        view.state.doc.content.size,
+      )(view.state, view.dispatch),
+    ).toBe(false);
+    editor.expectDoc(original);
+    expect(hiddenTexts(view)).toEqual(['a']);
   });
 
   it('does nothing for a heading that is not folded', () => {

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -618,6 +618,49 @@ describe('nested folds', () => {
 });
 
 describe('moving folded sections', () => {
+  it('moves a folded section down and up with Alt Arrow shortcuts', () => {
+    const original = doc(
+      h1('One<cursor>'),
+      p('a'),
+      h2('Sub'),
+      p('b'),
+      h1('Two'),
+      p('c'),
+    );
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+
+    expect(editor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    editor.expectDoc(
+      doc(h1('Two'), p('c'), h1('One<cursor>'), p('a'), h2('Sub'), p('b')),
+    );
+    expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b']);
+
+    expect(editor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    editor.expectDoc(original);
+    expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b']);
+  });
+
+  it('keeps a folded section intact when there is no adjacent section', () => {
+    const original = doc(p('intro'), h1('One<cursor>'), p('a'));
+    const editor = editorTest.createEditor(original);
+    const { view } = editor;
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(view.state.doc, 'One'),
+    )(view.state, view.dispatch);
+
+    expect(editor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    editor.expectDoc(original);
+    expect(hiddenTexts(view)).toEqual(['a']);
+
+    expect(editor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    editor.expectDoc(original);
+    expect(hiddenTexts(view)).toEqual(['a']);
+  });
+
   it('moves the heading together with its hidden section to the end', () => {
     const editor = editorTest.createEditor(
       doc(h1('One'), p('a'), p('b'), h1('Two'), p('c')),

--- a/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/collapsible-heading.spec.ts
@@ -8,10 +8,11 @@ import {
   setupCollapsibleHeading,
 } from '../collapsible-heading';
 import { setupHeading } from '../heading';
+import { setupHistory } from '../history';
 import { setupList } from '../list';
 import { setupParagraph } from '../paragraph';
 import type { PMNode } from '../pm';
-import { NodeSelection, TextSelection } from '../pm';
+import { NodeSelection, redo, TextSelection, undo } from '../pm';
 import { createBangerEditorTestSetup } from '../test-helpers';
 
 const collapsible = setupCollapsibleHeading();
@@ -22,6 +23,7 @@ const editorTest = createBangerEditorTestSetup({
     setupParagraph(),
     setupCodeBlock(),
     setupHeading(),
+    setupHistory(),
     setupList(),
     collapsible,
   ],
@@ -618,13 +620,131 @@ describe('nested folds', () => {
 });
 
 describe('moving folded sections', () => {
-  it('moves a folded section down and up with Alt Arrow shortcuts', () => {
+  it('moves a folded section by one visible block with Alt Arrow shortcuts', () => {
+    const downEditor = editorTest.createEditor(
+      doc(h1('One<cursor>'), p('a'), h2('Sub'), p('b'), h1('Two'), p('c')),
+    );
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(downEditor.view.state.doc, 'One'),
+    )(downEditor.view.state, downEditor.view.dispatch);
+
+    expect(downEditor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    downEditor.expectDoc(
+      doc(h1('Two'), h1('One<cursor>'), p('a'), h2('Sub'), p('b'), p('c')),
+    );
+    expect(hiddenTexts(downEditor.view)).toEqual(['a', 'Sub', 'b', 'c']);
+
+    const upEditor = editorTest.createEditor(
+      doc(h1('One'), p('a'), h2('Sub'), p('b'), h1('Two<cursor>'), p('c')),
+    );
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(upEditor.view.state.doc, 'Two'),
+    )(upEditor.view.state, upEditor.view.dispatch);
+
+    expect(upEditor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    upEditor.expectDoc(
+      doc(h1('One'), p('a'), h2('Sub'), h1('Two<cursor>'), p('c'), p('b')),
+    );
+    expect(hiddenTexts(upEditor.view)).toEqual(['c', 'b']);
+  });
+
+  it('treats an adjacent folded section as one visible block', () => {
+    const downOriginal = doc(
+      h1('One<cursor>'),
+      p('a'),
+      h1('Two'),
+      p('b'),
+      h1('Three'),
+      p('c'),
+    );
+    const downMoved = doc(
+      h1('Two'),
+      p('b'),
+      h1('One<cursor>'),
+      p('a'),
+      h1('Three'),
+      p('c'),
+    );
+    const downEditor = editorTest.createEditor(downOriginal);
+    for (const text of ['One', 'Two']) {
+      collapsible.command.toggleHeadingCollapseAtPos(
+        headingPos(downEditor.view.state.doc, text),
+      )(downEditor.view.state, downEditor.view.dispatch);
+    }
+
+    expect(downEditor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    downEditor.expectDoc(downMoved);
+    expect(hiddenTexts(downEditor.view)).toEqual(['b', 'a']);
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(downEditor.view.state.doc, 'One'),
+    )(downEditor.view.state, downEditor.view.dispatch);
+    expect(hiddenTexts(downEditor.view)).toEqual(['b']);
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(downEditor.view.state.doc, 'One'),
+    )(downEditor.view.state, downEditor.view.dispatch);
+    expect(undo(downEditor.view.state, downEditor.view.dispatch)).toBe(true);
+    downEditor.expectDoc(downOriginal);
+    expect(hiddenTexts(downEditor.view)).toEqual(['a', 'b']);
+    expect(redo(downEditor.view.state, downEditor.view.dispatch)).toBe(true);
+    downEditor.expectDoc(downMoved);
+    expect(hiddenTexts(downEditor.view)).toEqual(['b', 'a']);
+
+    const upOriginal = doc(
+      h1('One'),
+      p('a'),
+      h1('Two'),
+      p('b'),
+      h1('Three<cursor>'),
+      p('c'),
+    );
+    const upMoved = doc(
+      h1('One'),
+      p('a'),
+      h1('Three<cursor>'),
+      p('c'),
+      h1('Two'),
+      p('b'),
+    );
+    const upEditor = editorTest.createEditor(upOriginal);
+    for (const text of ['Two', 'Three']) {
+      collapsible.command.toggleHeadingCollapseAtPos(
+        headingPos(upEditor.view.state.doc, text),
+      )(upEditor.view.state, upEditor.view.dispatch);
+    }
+
+    expect(upEditor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    upEditor.expectDoc(upMoved);
+    expect(hiddenTexts(upEditor.view)).toEqual(['c', 'b']);
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(upEditor.view.state.doc, 'Three'),
+    )(upEditor.view.state, upEditor.view.dispatch);
+    expect(hiddenTexts(upEditor.view)).toEqual(['b']);
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(upEditor.view.state.doc, 'Three'),
+    )(upEditor.view.state, upEditor.view.dispatch);
+    expect(undo(upEditor.view.state, upEditor.view.dispatch)).toBe(true);
+    upEditor.expectDoc(upOriginal);
+    expect(hiddenTexts(upEditor.view)).toEqual(['b', 'c']);
+    expect(redo(upEditor.view.state, upEditor.view.dispatch)).toBe(true);
+    upEditor.expectDoc(upMoved);
+    expect(hiddenTexts(upEditor.view)).toEqual(['c', 'b']);
+  });
+
+  it('keeps a moved section folded through undo and redo', () => {
     const original = doc(
       h1('One<cursor>'),
       p('a'),
       h2('Sub'),
       p('b'),
       h1('Two'),
+      p('c'),
+    );
+    const moved = doc(
+      h1('Two'),
+      h1('One<cursor>'),
+      p('a'),
+      h2('Sub'),
+      p('b'),
       p('c'),
     );
     const editor = editorTest.createEditor(original);
@@ -634,31 +754,51 @@ describe('moving folded sections', () => {
     )(view.state, view.dispatch);
 
     expect(editor.pressKey('ArrowDown', { altKey: true })).toBe(true);
-    editor.expectDoc(
-      doc(h1('Two'), p('c'), h1('One<cursor>'), p('a'), h2('Sub'), p('b')),
-    );
-    expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b']);
+    editor.expectDoc(moved);
+    expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b', 'c']);
 
-    expect(editor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    expect(undo(view.state, view.dispatch)).toBe(true);
     editor.expectDoc(original);
     expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b']);
+
+    expect(redo(view.state, view.dispatch)).toBe(true);
+    editor.expectDoc(moved);
+    expect(hiddenTexts(view)).toEqual(['a', 'Sub', 'b', 'c']);
   });
 
-  it('keeps a folded section intact when there is no adjacent section', () => {
-    const original = doc(p('intro'), h1('One<cursor>'), p('a'));
+  it('does not move a folded section when heading text is selected', () => {
+    const original = doc(h1('<start>One<end>'), p('a'), h1('Two'), p('b'));
     const editor = editorTest.createEditor(original);
     const { view } = editor;
     collapsible.command.toggleHeadingCollapseAtPos(
       headingPos(view.state.doc, 'One'),
     )(view.state, view.dispatch);
 
-    expect(editor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    expect(editor.pressKey('ArrowDown', { altKey: true })).toBe(false);
     editor.expectDoc(original);
     expect(hiddenTexts(view)).toEqual(['a']);
+  });
 
-    expect(editor.pressKey('ArrowDown', { altKey: true })).toBe(true);
-    editor.expectDoc(original);
-    expect(hiddenTexts(view)).toEqual(['a']);
+  it('keeps a folded section intact when there is no adjacent section', () => {
+    const downOriginal = doc(p('intro'), h1('One<cursor>'), p('a'));
+    const downEditor = editorTest.createEditor(downOriginal);
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(downEditor.view.state.doc, 'One'),
+    )(downEditor.view.state, downEditor.view.dispatch);
+
+    expect(downEditor.pressKey('ArrowDown', { altKey: true })).toBe(true);
+    downEditor.expectDoc(downOriginal);
+    expect(hiddenTexts(downEditor.view)).toEqual(['a']);
+
+    const upOriginal = doc(h1('One<cursor>'), p('a'));
+    const upEditor = editorTest.createEditor(upOriginal);
+    collapsible.command.toggleHeadingCollapseAtPos(
+      headingPos(upEditor.view.state.doc, 'One'),
+    )(upEditor.view.state, upEditor.view.dispatch);
+
+    expect(upEditor.pressKey('ArrowUp', { altKey: true })).toBe(true);
+    upEditor.expectDoc(upOriginal);
+    expect(hiddenTexts(upEditor.view)).toEqual(['a']);
   });
 
   it('moves the heading together with its hidden section to the end', () => {

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -6,12 +6,10 @@ import {
   dropPoint,
   type EditorState,
   type EditorView,
-  NodeSelection,
   Plugin,
   PluginKey,
   type PMNode,
   Selection,
-  TextSelection,
   type Transaction,
 } from './pm';
 import {
@@ -130,11 +128,7 @@ function findAdjacentSectionDropPos(
 ): number | null {
   const { headingPos } = currentRange;
   const heading = doc.nodeAt(headingPos);
-  if (
-    !heading ||
-    heading.type.name !== headingName ||
-    doc.resolve(headingPos).depth !== 0
-  ) {
+  if (!heading || heading.type.name !== headingName) {
     return null;
   }
 
@@ -179,15 +173,29 @@ function remapFoldedHeadingPos(
     return mapped.pos;
   }
 
-  // Moving a section is represented as delete + insert, so its old anchor is
-  // reported as deleted. ProseMirror nodes are immutable and the inserted
-  // slice retains the heading object; recovering that identity also keeps the
-  // fold anchored through history's inverse undo/redo transactions, which do
-  // not carry this plugin's forward transaction metadata.
   const heading = oldDoc.nodeAt(pos);
   if (!heading || heading.type.name !== headingName) {
     return null;
   }
+
+  // Changing a heading's markup replaces its boundary tokens and creates a
+  // new node object even though its content is unchanged. Preserve the fold
+  // only when the mapped position still contains the same heading type and
+  // exact immutable content fragment; this avoids transferring a deleted
+  // heading's fold to an unrelated neighbor.
+  const replacement = newDoc.nodeAt(mapped.pos);
+  if (
+    replacement?.type === heading.type &&
+    replacement.content === heading.content
+  ) {
+    return mapped.pos;
+  }
+
+  // Reordering sibling ranges is represented as delete + insert, so a folded
+  // heading inside the moved range can be reported as deleted. ProseMirror
+  // nodes are immutable and the inserted slice retains the heading object;
+  // recovering that identity also keeps the fold anchored through history's
+  // inverse undo/redo transactions.
   let recovered: number | null = null;
   let duplicate = false;
   newDoc.descendants((node, nodePos) => {
@@ -287,16 +295,15 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
   /**
    * Moves a folded heading together with its hidden section to `dropPos`.
    * Nested fold state inside the section is preserved by re-anchoring it
-   * relative to the heading's new position. Fails (returns false) for drops
-   * inside the section itself and for non-top-level headings.
+   * relative to the heading's new position. The source and resolved drop
+   * position must share a parent, so a move cannot silently change the
+   * section's nesting. Fails (returns false) for drops inside the section
+   * itself.
    */
   const moveFoldedSection = (headingPos: number, dropPos: number): Command => {
     return (state, dispatch) => {
       const pluginState = key.getState(state);
       if (!pluginState?.folded.includes(headingPos)) {
-        return false;
-      }
-      if (state.doc.resolve(headingPos).depth !== 0) {
         return false;
       }
       const range = getHeadingFoldRange(
@@ -318,12 +325,44 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
       ) {
         return false;
       }
+      if (
+        !state.doc.resolve(headingPos).sameParent(state.doc.resolve(insertPos))
+      ) {
+        return false;
+      }
+
+      const movingDown = insertPos > range.to;
+      const neighborFrom = movingDown ? range.to : insertPos;
+      const neighborTo = movingDown ? insertPos : headingPos;
+      const neighbor = state.doc.slice(neighborFrom, neighborTo);
+      if (neighbor.content.size === 0) {
+        return false;
+      }
+
+      const swapFrom = Math.min(headingPos, insertPos);
+      const swapTo = Math.max(range.to, insertPos);
+      const $swapFrom = state.doc.resolve(swapFrom);
+      const $swapTo = state.doc.resolve(swapTo);
+      const swappedContent = movingDown
+        ? neighbor.content.append(slice.content)
+        : slice.content.append(neighbor.content);
+      if (
+        !$swapFrom.parent.canReplace(
+          $swapFrom.index(),
+          $swapTo.index(),
+          swappedContent,
+        )
+      ) {
+        return false;
+      }
+
       if (dispatch) {
         const tr = state.tr;
-        tr.delete(headingPos, range.to);
-        const mapped = tr.mapping.map(insertPos);
-        tr.insert(mapped, slice.content);
-        tr.setSelection(NodeSelection.create(tr.doc, mapped));
+        tr.delete(neighborFrom, neighborTo);
+        const neighborInsertPos = movingDown
+          ? headingPos
+          : tr.mapping.map(range.to);
+        tr.insert(neighborInsertPos, neighbor.content);
         tr.scrollIntoView();
         dispatch(tr);
       }
@@ -375,29 +414,12 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
         return true;
       }
 
-      const cursorOffset = isNodeSelection(state.selection)
-        ? 0
-        : Math.max(0, state.selection.head - found.pos - 1);
       const move = moveFoldedSection(found.pos, dropPos);
       if (!dispatch) {
         move(state);
         return true;
       }
-      move(state, (tr) => {
-        const movedHeadingPos = tr.selection.from;
-        const movedHeading = tr.doc.nodeAt(movedHeadingPos);
-        if (movedHeading?.type === headingType) {
-          tr.setSelection(
-            TextSelection.create(
-              tr.doc,
-              movedHeadingPos +
-                1 +
-                Math.min(cursorOffset, movedHeading.content.size),
-            ),
-          );
-        }
-        dispatch(tr);
-      });
+      move(state, dispatch);
       return true;
     };
   };

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -1,4 +1,4 @@
-import { collection, keybinding } from './common';
+import { collection, keybinding, PRIORITY } from './common';
 import {
   type Command,
   Decoration,
@@ -11,9 +11,11 @@ import {
   PluginKey,
   type PMNode,
   Selection,
+  TextSelection,
 } from './pm';
 import {
   findParentNodeOfType,
+  findSelectedNodeOfType,
   getNodeType,
   isNodeSelection,
   type KeyCode,
@@ -34,6 +36,8 @@ export type CollapsibleHeadingConfig = {
   /** Node name of the heading this plugin folds. Defaults to `heading`. */
   headingName?: string;
   keyToggleCollapse?: KeyCode;
+  keyMoveDown?: KeyCode;
+  keyMoveUp?: KeyCode;
   /** Accessible label for the fold toggle when the section is expanded. */
   collapseLabel?: string;
   /** Accessible label for the fold toggle when the section is folded. */
@@ -45,6 +49,8 @@ type RequiredConfig = Required<CollapsibleHeadingConfig>;
 const DEFAULT_CONFIG: RequiredConfig = {
   headingName: 'heading',
   keyToggleCollapse: false,
+  keyMoveDown: 'Alt-ArrowDown',
+  keyMoveUp: 'Alt-ArrowUp',
   collapseLabel: 'Collapse section',
   expandLabel: 'Expand section',
 };
@@ -112,6 +118,49 @@ export function getHeadingFoldRange(
   }
 
   return to === from ? null : { headingPos, from, to };
+}
+
+function findAdjacentSectionDropPos(
+  doc: PMNode,
+  headingPos: number,
+  headingName: string,
+  direction: 'up' | 'down',
+): number | null {
+  const heading = doc.nodeAt(headingPos);
+  const range = getHeadingFoldRange(doc, headingPos, headingName);
+  if (
+    !heading ||
+    heading.type.name !== headingName ||
+    !range ||
+    doc.resolve(headingPos).depth !== 0
+  ) {
+    return null;
+  }
+
+  if (direction === 'down') {
+    const nextHeading = doc.nodeAt(range.to);
+    if (!nextHeading || nextHeading.type.name !== headingName) {
+      return null;
+    }
+    return (
+      getHeadingFoldRange(doc, range.to, headingName)?.to ??
+      range.to + nextHeading.nodeSize
+    );
+  }
+
+  const $heading = doc.resolve(headingPos);
+  let siblingPos = headingPos;
+  for (let index = $heading.index() - 1; index >= 0; index--) {
+    const sibling = $heading.parent.child(index);
+    siblingPos -= sibling.nodeSize;
+    if (
+      sibling.type.name === headingName &&
+      sibling.attrs.level <= heading.attrs.level
+    ) {
+      return siblingPos;
+    }
+  }
+  return null;
 }
 
 export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
@@ -258,6 +307,56 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
     return true;
   };
 
+  const moveFoldedSectionByDirection = (direction: 'up' | 'down'): Command => {
+    return (state, dispatch) => {
+      const headingType = getNodeType(state.schema, config.headingName);
+      const found =
+        findSelectedNodeOfType(headingType)(state.selection) ??
+        findParentNodeOfType(headingType)(state.selection);
+      const pluginState = key.getState(state);
+      if (!found || !pluginState?.folded.includes(found.pos)) {
+        return false;
+      }
+
+      const dropPos = findAdjacentSectionDropPos(
+        state.doc,
+        found.pos,
+        config.headingName,
+        direction,
+      );
+      // Do not fall through to the ordinary heading keymap: it would move
+      // only the heading and tear apart the folded section at the boundary.
+      if (dropPos == null) {
+        return true;
+      }
+
+      const cursorOffset = isNodeSelection(state.selection)
+        ? 0
+        : Math.max(0, state.selection.head - found.pos - 1);
+      const move = moveFoldedSection(found.pos, dropPos);
+      if (!dispatch) {
+        move(state);
+        return true;
+      }
+      move(state, (tr) => {
+        const movedHeadingPos = tr.selection.from;
+        const movedHeading = tr.doc.nodeAt(movedHeadingPos);
+        if (movedHeading?.type === headingType) {
+          tr.setSelection(
+            TextSelection.create(
+              tr.doc,
+              movedHeadingPos +
+                1 +
+                Math.min(cursorOffset, movedHeading.content.size),
+            ),
+          );
+        }
+        dispatch(tr);
+      });
+      return true;
+    };
+  };
+
   const listCollapsedHeadings = (state: EditorState) => {
     const pluginState = key.getState(state);
     if (!pluginState) {
@@ -288,7 +387,12 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
 
   const plugin = {
     fold: pluginFold(config, key, toggleAtPos, moveFoldedSection),
-    keybindings: pluginKeybindings(config, toggleAtSelection),
+    keybindings: pluginKeybindings(
+      config,
+      toggleAtSelection,
+      moveFoldedSectionByDirection('up'),
+      moveFoldedSectionByDirection('down'),
+    ),
   };
 
   return collection({
@@ -308,11 +412,21 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
   });
 }
 
-function pluginKeybindings(config: RequiredConfig, toggleAtSelection: Command) {
+function pluginKeybindings(
+  config: RequiredConfig,
+  toggleAtSelection: Command,
+  moveUp: Command,
+  moveDown: Command,
+) {
   return () => {
     return keybinding(
-      [[config.keyToggleCollapse, toggleAtSelection]],
+      [
+        [config.keyToggleCollapse, toggleAtSelection],
+        [config.keyMoveUp, moveUp],
+        [config.keyMoveDown, moveDown],
+      ],
       'collapsible-heading',
+      PRIORITY.high,
     );
   };
 }

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -161,6 +161,73 @@ function findAdjacentSectionDropPos(
   return headingPos - $heading.parent.child(previousIndex).nodeSize;
 }
 
+type SiblingRange = {
+  from: number;
+  to: number;
+};
+
+/**
+ * Moves a closed range of siblings to a raw drop position without deleting
+ * the source range. Instead, the intervening siblings move around it, which
+ * lets ProseMirror map selections and plugin anchors inside the source.
+ */
+function moveSiblingRange(
+  tr: Transaction,
+  source: SiblingRange,
+  rawDropPos: number,
+): Transaction | null {
+  const { from, to } = source;
+  if (
+    from < 0 ||
+    from >= to ||
+    to > tr.doc.content.size ||
+    rawDropPos < 0 ||
+    rawDropPos > tr.doc.content.size ||
+    (rawDropPos >= from && rawDropPos <= to)
+  ) {
+    return null;
+  }
+
+  const sourceSlice = tr.doc.slice(from, to);
+  const dropPos = dropPoint(tr.doc, rawDropPos, sourceSlice);
+  if (
+    dropPos == null ||
+    (dropPos >= from && dropPos <= to) ||
+    !tr.doc.resolve(from).sameParent(tr.doc.resolve(dropPos))
+  ) {
+    return null;
+  }
+
+  const movingDown = dropPos > to;
+  const neighborFrom = movingDown ? to : dropPos;
+  const neighborTo = movingDown ? dropPos : from;
+  const neighbor = tr.doc.slice(neighborFrom, neighborTo);
+  if (neighbor.content.size === 0) {
+    return null;
+  }
+
+  const swapFrom = Math.min(from, dropPos);
+  const swapTo = Math.max(to, dropPos);
+  const $swapFrom = tr.doc.resolve(swapFrom);
+  const $swapTo = tr.doc.resolve(swapTo);
+  const swappedContent = movingDown
+    ? neighbor.content.append(sourceSlice.content)
+    : sourceSlice.content.append(neighbor.content);
+  if (
+    !$swapFrom.parent.canReplace(
+      $swapFrom.index(),
+      $swapTo.index(),
+      swappedContent,
+    )
+  ) {
+    return null;
+  }
+
+  tr.delete(neighborFrom, neighborTo);
+  tr.insert(movingDown ? from : tr.mapping.map(to), neighbor.content);
+  return tr;
+}
+
 function remapFoldedHeadingPos(
   tr: Transaction,
   pos: number,
@@ -314,55 +381,16 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
       if (!range) {
         return false;
       }
-      if (dropPos >= headingPos && dropPos <= range.to) {
-        return false;
-      }
-      const slice = state.doc.slice(headingPos, range.to);
-      const insertPos = dropPoint(state.doc, dropPos, slice);
-      if (
-        insertPos == null ||
-        (insertPos >= headingPos && insertPos <= range.to)
-      ) {
-        return false;
-      }
-      if (
-        !state.doc.resolve(headingPos).sameParent(state.doc.resolve(insertPos))
-      ) {
-        return false;
-      }
-
-      const movingDown = insertPos > range.to;
-      const neighborFrom = movingDown ? range.to : insertPos;
-      const neighborTo = movingDown ? insertPos : headingPos;
-      const neighbor = state.doc.slice(neighborFrom, neighborTo);
-      if (neighbor.content.size === 0) {
-        return false;
-      }
-
-      const swapFrom = Math.min(headingPos, insertPos);
-      const swapTo = Math.max(range.to, insertPos);
-      const $swapFrom = state.doc.resolve(swapFrom);
-      const $swapTo = state.doc.resolve(swapTo);
-      const swappedContent = movingDown
-        ? neighbor.content.append(slice.content)
-        : slice.content.append(neighbor.content);
-      if (
-        !$swapFrom.parent.canReplace(
-          $swapFrom.index(),
-          $swapTo.index(),
-          swappedContent,
-        )
-      ) {
+      const tr = moveSiblingRange(
+        state.tr,
+        { from: headingPos, to: range.to },
+        dropPos,
+      );
+      if (!tr) {
         return false;
       }
 
       if (dispatch) {
-        const tr = state.tr;
-        tr.delete(neighborFrom, neighborTo);
-        const neighborInsertPos = movingDown
-          ? headingPos
-          : tr.mapping.map(range.to);
-        tr.insert(neighborInsertPos, neighbor.content);
         tr.scrollIntoView();
         dispatch(tr);
       }

--- a/packages/js-lib/banger-editor/src/collapsible-heading.ts
+++ b/packages/js-lib/banger-editor/src/collapsible-heading.ts
@@ -12,6 +12,7 @@ import {
   type PMNode,
   Selection,
   TextSelection,
+  type Transaction,
 } from './pm';
 import {
   findParentNodeOfType,
@@ -122,45 +123,85 @@ export function getHeadingFoldRange(
 
 function findAdjacentSectionDropPos(
   doc: PMNode,
-  headingPos: number,
+  currentRange: HeadingFoldRange,
   headingName: string,
   direction: 'up' | 'down',
+  foldedRanges: readonly HeadingFoldRange[],
 ): number | null {
+  const { headingPos } = currentRange;
   const heading = doc.nodeAt(headingPos);
-  const range = getHeadingFoldRange(doc, headingPos, headingName);
   if (
     !heading ||
     heading.type.name !== headingName ||
-    !range ||
     doc.resolve(headingPos).depth !== 0
   ) {
     return null;
   }
 
   if (direction === 'down') {
-    const nextHeading = doc.nodeAt(range.to);
-    if (!nextHeading || nextHeading.type.name !== headingName) {
+    const nextFoldedSection = foldedRanges.find(
+      (range) => range.headingPos === currentRange.to,
+    );
+    if (nextFoldedSection) {
+      return nextFoldedSection.to;
+    }
+    const nextSibling = doc.nodeAt(currentRange.to);
+    if (!nextSibling) {
       return null;
     }
-    return (
-      getHeadingFoldRange(doc, range.to, headingName)?.to ??
-      range.to + nextHeading.nodeSize
-    );
+    return currentRange.to + nextSibling.nodeSize;
+  }
+
+  const previousFoldedSection = foldedRanges.find(
+    (range) => range.to === headingPos,
+  );
+  if (previousFoldedSection) {
+    return previousFoldedSection.headingPos;
   }
 
   const $heading = doc.resolve(headingPos);
-  let siblingPos = headingPos;
-  for (let index = $heading.index() - 1; index >= 0; index--) {
-    const sibling = $heading.parent.child(index);
-    siblingPos -= sibling.nodeSize;
-    if (
-      sibling.type.name === headingName &&
-      sibling.attrs.level <= heading.attrs.level
-    ) {
-      return siblingPos;
-    }
+  const previousIndex = $heading.index() - 1;
+  if (previousIndex < 0) {
+    return null;
   }
-  return null;
+  return headingPos - $heading.parent.child(previousIndex).nodeSize;
+}
+
+function remapFoldedHeadingPos(
+  tr: Transaction,
+  pos: number,
+  oldDoc: PMNode,
+  newDoc: PMNode,
+  headingName: string,
+): number | null {
+  const mapped = tr.mapping.mapResult(pos);
+  if (!mapped.deleted) {
+    return mapped.pos;
+  }
+
+  // Moving a section is represented as delete + insert, so its old anchor is
+  // reported as deleted. ProseMirror nodes are immutable and the inserted
+  // slice retains the heading object; recovering that identity also keeps the
+  // fold anchored through history's inverse undo/redo transactions, which do
+  // not carry this plugin's forward transaction metadata.
+  const heading = oldDoc.nodeAt(pos);
+  if (!heading || heading.type.name !== headingName) {
+    return null;
+  }
+  let recovered: number | null = null;
+  let duplicate = false;
+  newDoc.descendants((node, nodePos) => {
+    if (node !== heading) {
+      return true;
+    }
+    if (recovered != null) {
+      duplicate = true;
+      return false;
+    }
+    recovered = nodePos;
+    return false;
+  });
+  return duplicate ? null : recovered;
 }
 
 export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
@@ -282,12 +323,6 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
         tr.delete(headingPos, range.to);
         const mapped = tr.mapping.map(insertPos);
         tr.insert(mapped, slice.content);
-        tr.setMeta(key, {
-          type: 'fold',
-          positions: pluginState.folded
-            .filter((pos) => pos >= headingPos && pos < range.to)
-            .map((pos) => mapped + (pos - headingPos)),
-        } satisfies FoldMeta);
         tr.setSelection(NodeSelection.create(tr.doc, mapped));
         tr.scrollIntoView();
         dispatch(tr);
@@ -317,12 +352,22 @@ export function setupCollapsibleHeading(userConfig?: CollapsibleHeadingConfig) {
       if (!found || !pluginState?.folded.includes(found.pos)) {
         return false;
       }
+      if (!isNodeSelection(state.selection) && !state.selection.empty) {
+        return false;
+      }
 
+      const currentRange = pluginState.ranges.find(
+        (range) => range.headingPos === found.pos,
+      );
+      if (!currentRange) {
+        return true;
+      }
       const dropPos = findAdjacentSectionDropPos(
         state.doc,
-        found.pos,
+        currentRange,
         config.headingName,
         direction,
+        pluginState.ranges,
       );
       // Do not fall through to the ordinary heading keymap: it would move
       // only the heading and tear apart the folded section at the boundary.
@@ -447,14 +492,20 @@ function pluginFold(
         init: (_, state) => {
           return buildPluginState(state.doc, [], config, toggleAtPos);
         },
-        apply: (tr, prev, _oldState, newState) => {
+        apply: (tr, prev, oldState, newState) => {
           const meta = tr.getMeta(key) as FoldMeta | undefined;
 
           let folded = prev.folded;
           if (tr.docChanged) {
             folded = folded.flatMap((pos) => {
-              const result = tr.mapping.mapResult(pos);
-              return result.deleted ? [] : [result.pos];
+              const mapped = remapFoldedHeadingPos(
+                tr,
+                pos,
+                oldState.doc,
+                newState.doc,
+                config.headingName,
+              );
+              return mapped == null ? [] : [mapped];
             });
           }
 

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -27,8 +27,6 @@ const SOURCE = [
 const MOVED_SOURCE = [
   '# Two',
   '',
-  'gamma',
-  '',
   '# One',
   '',
   'alpha',
@@ -38,6 +36,8 @@ const MOVED_SOURCE = [
   '## Sub',
   '',
   'nested content',
+  '',
+  'gamma',
 ].join('\n');
 
 async function openSeededNote(page: Page) {
@@ -229,21 +229,11 @@ test('moving a folded heading with option arrow moves the whole folded section',
   await waitForEditorFocus(page, {});
   await page.keyboard.press('Alt+ArrowDown');
 
-  // The full section moves past "Two" and remains folded at its new location.
+  // The full section moves down by one visible block ("Two"), rather than
+  // jumping over that heading's content, and remains folded at its new home.
   await expect(editor.getByText('alpha')).toBeHidden();
   await expect(editor.getByText('nested content')).toBeHidden();
-  await expect
-    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
-    .toBe(MOVED_SOURCE);
-
-  // The reverse shortcut treats the folded section as the same complete unit.
-  await page.keyboard.press('Alt+ArrowUp');
-  await expect(editor.getByText('alpha')).toBeHidden();
-  await expect
-    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
-    .toBe(SOURCE);
-
-  await page.keyboard.press('Alt+ArrowDown');
+  await expect(editor.getByText('gamma')).toBeHidden();
   await expect
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
     .toBe(MOVED_SOURCE);
@@ -251,6 +241,7 @@ test('moving a folded heading with option arrow moves the whole folded section',
   await editor.getByRole('button', { name: 'Expand section' }).click();
   await expect(editor.getByText('alpha')).toBeVisible();
   await expect(editor.getByText('nested content')).toBeVisible();
+  await expect(editor.getByText('gamma')).toBeVisible();
 });
 
 test('nested folds survive folding and unfolding the outer section', async ({

--- a/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
+++ b/packages/tooling/e2e-tests/src/collapsible-headings.e2e.ts
@@ -24,6 +24,22 @@ const SOURCE = [
   'gamma',
 ].join('\n');
 
+const MOVED_SOURCE = [
+  '# Two',
+  '',
+  'gamma',
+  '',
+  '# One',
+  '',
+  'alpha',
+  '',
+  'beta',
+  '',
+  '## Sub',
+  '',
+  'nested content',
+].join('\n');
+
 async function openSeededNote(page: Page) {
   const workspaceName = 'collapsible-headings';
   const noteName = 'Home';
@@ -192,6 +208,45 @@ test('dragging a folded heading moves the whole section without losing content',
   for (const line of ['alpha', 'beta', '## Sub', 'nested content', 'gamma']) {
     expect(movedMarkdown).toContain(line);
   }
+
+  await editor.getByRole('button', { name: 'Expand section' }).click();
+  await expect(editor.getByText('alpha')).toBeVisible();
+  await expect(editor.getByText('nested content')).toBeVisible();
+});
+
+test('moving a folded heading with option arrow moves the whole folded section', async ({
+  page,
+}) => {
+  const { editor, noteName, workspaceName } = await openSeededNote(page);
+
+  await editor
+    .getByRole('button', { name: 'Collapse section' })
+    .first()
+    .click();
+  await expect(editor.getByText('alpha')).toBeHidden();
+
+  await editor.getByText('One').click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.press('Alt+ArrowDown');
+
+  // The full section moves past "Two" and remains folded at its new location.
+  await expect(editor.getByText('alpha')).toBeHidden();
+  await expect(editor.getByText('nested content')).toBeHidden();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(MOVED_SOURCE);
+
+  // The reverse shortcut treats the folded section as the same complete unit.
+  await page.keyboard.press('Alt+ArrowUp');
+  await expect(editor.getByText('alpha')).toBeHidden();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(SOURCE);
+
+  await page.keyboard.press('Alt+ArrowDown');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(MOVED_SOURCE);
 
   await editor.getByRole('button', { name: 'Expand section' }).click();
   await expect(editor.getByText('alpha')).toBeVisible();


### PR DESCRIPTION
## Summary
- Move collapsed headings one visible block at a time with Option/Alt + Arrow Up/Down while carrying hidden content and preserving cursor and fold state.
- Reorder the adjacent visible range around the folded section, including safe same-parent movement for nested headings and collapsed neighbors.
- Preserve folds through heading-level changes, undo/redo, expansion, and exact Markdown storage.

The generic heading keymap previously moved only the heading node, separating it from hidden content.