### PR TITLE
fix(editor): tighten heading spacing

### DIFF
--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -216,12 +216,12 @@ div.ProseMirror {
   }
 
   & h2 {
-    margin: 1.75em 0 0.5em;
+    margin: 1.5rem 0 0.5rem;
     font-size: 1.75em;
   }
 
   & h3 {
-    margin: 1.5em 0 0.5em;
+    margin: 1.25rem 0 0.5rem;
     font-size: 1.375em;
   }
 

--- a/packages/tooling/e2e-tests/src/editor-typography.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-typography.e2e.ts
@@ -1,0 +1,62 @@
+import { expect, type Locator, test } from '@playwright/test';
+import {
+  createBrowserWorkspaceAndNote,
+  getEditorLocator,
+  writeStoredMarkdown,
+} from './common';
+
+async function expectVerticalGap(
+  previousBlock: Locator,
+  heading: Locator,
+  expectedGap: number,
+) {
+  await expect
+    .poll(async () => {
+      const previousBox = await previousBlock.boundingBox();
+      const headingBox = await heading.boundingBox();
+
+      if (!previousBox || !headingBox) {
+        return undefined;
+      }
+
+      return headingBox.y - (previousBox.y + previousBox.height);
+    })
+    .toBe(expectedGap);
+}
+
+test('uses compact, predictable spacing above section headings', async ({
+  page,
+}) => {
+  const workspaceName = 'editor-heading-spacing';
+  const noteName = 'Home';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    [
+      '# Page title',
+      '',
+      'Paragraph before H2.',
+      '',
+      '## Section',
+      '',
+      'Paragraph before H3.',
+      '',
+      '### Subsection',
+    ].join('\n'),
+  );
+  await page.reload();
+
+  const editor = getEditorLocator(page, {});
+  await expectVerticalGap(
+    editor.getByText('Paragraph before H2.'),
+    editor.getByRole('heading', { level: 2, name: 'Section' }),
+    24,
+  );
+  await expectVerticalGap(
+    editor.getByText('Paragraph before H3.'),
+    editor.getByRole('heading', { level: 3, name: 'Subsection' }),
+    20,
+  );
+});


### PR DESCRIPTION
## Summary

- Use fixed typographic rhythm for H2 and H3 spacing so heading font size no longer compounds their top margins.
- Add browser regression coverage for paragraph-to-heading visual gaps.