### PR TITLE
Editor: scope Cmd/Ctrl-A to the note and add block-format controls to the selection toolbar

### DIFF
--- a/packages/core/context/src/service-types.ts
+++ b/packages/core/context/src/service-types.ts
@@ -52,6 +52,19 @@ export type EditorEngineContract = BaseService & {
   collapseAllHeadings: (level: number) => boolean;
   focusEditor: () => void;
   getSelectionMarkdown: () => string | null;
+  /**
+   * Redirects a global select-all (Cmd/Ctrl-A) into the mounted editor when
+   * the shortcut fires while the editor is not DOM-focused — e.g. the user
+   * clicked the empty padding around the note. Focuses the editor and selects
+   * its whole document, returning true so the caller suppresses the browser's
+   * document-wide select-all (which would otherwise sweep in the sidebar and
+   * the rest of the app chrome).
+   *
+   * Returns false when the editor already has focus (its own keymap owns
+   * select-all) or when no editor is mounted, so the caller leaves the native
+   * behavior intact for the editor's own shortcut and for non-editor pages.
+   */
+  selectAllInActiveEditor: () => boolean;
   hasPendingOrFailedSave: (wsPath?: string) => boolean;
   insertMarkdownAtSelection: (markdownText: string) => boolean;
   /** Reports whether an app-level editor action can run against the current

--- a/packages/core/editor-w/src/editor-w-service.ts
+++ b/packages/core/editor-w/src/editor-w-service.ts
@@ -126,6 +126,12 @@ export class EditorWService
     // Read-only stub: nothing focusable to hand the cursor to.
   }
 
+  selectAllInActiveEditor(): boolean {
+    // Read-only stub: no editable view to focus or select, so a global
+    // select-all falls through to native behavior.
+    return false;
+  }
+
   getSelectionMarkdown(): string | null {
     return null;
   }

--- a/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
+++ b/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import { TextSelection } from '@bangle.io/prosemirror-plugins';
 import { createTestEnvironment, waitForExpect } from '@bangle.io/test-utils';
 import { describe, expect, test } from 'vitest';
 import { PmEditorService } from '../pm-editor-service';
@@ -157,6 +158,73 @@ describe('PmEditorService', () => {
 
     controller.abort();
     domNode.remove();
+  });
+
+  test('selectAllInActiveEditor redirects select-all into an unfocused editor', async () => {
+    const controller = new AbortController();
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+
+    await services.workspaceOps.createWorkspaceInfo({
+      name: TEST_WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.fileSystem.createTextFile(
+      `${TEST_WS_NAME}:note.md`,
+      'Alpha\n\nBeta',
+    );
+
+    if (!(services.editorEngine instanceof PmEditorService)) {
+      throw new Error('Expected the ProseMirror editor engine');
+    }
+    const service = services.editorEngine;
+
+    // With no editor mounted the shortcut declines, so native (document-wide)
+    // select-all still runs on non-editor pages.
+    expect(service.selectAllInActiveEditor()).toBe(false);
+
+    const domNode = document.createElement('div');
+    const outsideInput = document.createElement('input');
+    document.body.append(domNode, outsideInput);
+
+    const unmount = service.mountEditor({
+      domNode,
+      wsPath: `${TEST_WS_NAME}:note.md`,
+      name: 'note-editor',
+    });
+    await waitForExpect(() => {
+      expect(service.getEditor('note-editor')).toBeDefined();
+    });
+    const view = service.getEditor('note-editor');
+    if (!view) {
+      throw new Error('Expected the editor to be ready');
+    }
+
+    // Focus lives outside the editor, mimicking a click on the pane whitespace
+    // that leaves the contenteditable unfocused.
+    outsideInput.focus();
+    expect(view.hasFocus()).toBe(false);
+
+    expect(service.selectAllInActiveEditor()).toBe(true);
+    expect(view.hasFocus()).toBe(true);
+    expect(view.state.selection.from).toBe(0);
+    expect(view.state.selection.to).toBe(view.state.doc.content.size);
+
+    // While the editor already owns focus its own keymap handles select-all,
+    // so the service declines and leaves the live selection untouched.
+    view.dispatch(
+      view.state.tr.setSelection(TextSelection.create(view.state.doc, 1, 1)),
+    );
+    expect(service.selectAllInActiveEditor()).toBe(false);
+    expect(view.state.selection.empty).toBe(true);
+    expect(view.state.selection.from).toBe(1);
+
+    unmount();
+    controller.abort();
+    domNode.remove();
+    outsideInput.remove();
   });
 
   test('keeps the last active editor while another surface owns focus', async () => {

--- a/packages/core/editor/src/components/inline-selection-menu.tsx
+++ b/packages/core/editor/src/components/inline-selection-menu.tsx
@@ -1,6 +1,8 @@
 import {
   $selectionMenu,
   type Command,
+  chainCommands,
+  lift,
   type SelectionMenuState,
 } from '@bangle.io/prosemirror-plugins';
 import {
@@ -120,6 +122,15 @@ function InlineSelectionMenuContent({
     onOutside: dismiss,
   });
 
+  // "Turn into paragraph" for any block: convert a heading/code block, lift a
+  // list item out of its list, or lift out of a blockquote. `convertToParagraph`
+  // alone no-ops inside a list because the list item already wraps a paragraph.
+  const setParagraph = chainCommands(
+    ext.paragraph.command.convertToParagraph,
+    ext.list.command.unwrapList,
+    lift,
+  );
+
   return linkSession ? (
     <FloatingLinkEditor
       anchorEl={anchorEl}
@@ -141,7 +152,10 @@ function InlineSelectionMenuContent({
     >
       <div
         aria-label={t.app.editor.selectionMenu.label}
-        className="flex items-center gap-0.5 rounded-md border bg-popover p-0.5 shadow-xs"
+        // Wrap rather than overflow: on a narrow viewport the max-width clamp
+        // (see the wrapper's `max-w-[calc(100vw-1rem)]`) would otherwise push
+        // the trailing controls off-screen and force horizontal page scroll.
+        className="flex flex-wrap items-center gap-0.5 rounded-md border bg-popover p-0.5 shadow-xs"
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
             event.preventDefault();
@@ -222,11 +236,12 @@ function InlineSelectionMenuContent({
             // matches the paragraph nested inside a list item or blockquote,
             // which would light this up alongside the list/quote control.
             active={ext.paragraph.query.isTopLevelParagraph(editorView.state)}
-            disabled={false}
+            // Disabled only when there is genuinely nothing to convert (already
+            // a plain paragraph), so the control never looks actionable while
+            // no-oping.
+            disabled={!setParagraph(editorView.state)}
             label={t.app.editor.selectionMenu.paragraph}
-            onToggle={() =>
-              runCommand(editorView, ext.paragraph.command.convertToParagraph)
-            }
+            onToggle={() => runCommand(editorView, setParagraph)}
           >
             <Pilcrow />
           </FormatToggle>

--- a/packages/core/editor/src/components/inline-selection-menu.tsx
+++ b/packages/core/editor/src/components/inline-selection-menu.tsx
@@ -5,6 +5,7 @@ import {
 } from '@bangle.io/prosemirror-plugins';
 import {
   Button,
+  Separator,
   Toggle,
   Tooltip,
   TooltipContent,
@@ -15,8 +16,15 @@ import { useAtomValue } from 'jotai';
 import {
   Bold,
   Code,
+  Heading1,
+  Heading2,
+  Heading3,
   Italic,
   Link as LinkIcon,
+  List,
+  ListChecks,
+  ListOrdered,
+  Pilcrow,
   Strikethrough,
 } from 'lucide-react';
 import React, { useRef, useState } from 'react';
@@ -144,15 +152,15 @@ function InlineSelectionMenuContent({
         role="toolbar"
       >
         <TooltipProvider delay={300}>
-          <MarkToggle
+          <FormatToggle
             active={ext.bold.query.isBoldActive(editorView.state)}
             disabled={!ext.bold.command.toggleBold(editorView.state)}
             label={t.app.editor.selectionMenu.bold}
             onToggle={() => runCommand(editorView, ext.bold.command.toggleBold)}
           >
             <Bold />
-          </MarkToggle>
-          <MarkToggle
+          </FormatToggle>
+          <FormatToggle
             active={ext.italic.query.isItalicActive(editorView.state)}
             disabled={!ext.italic.command.toggleItalic(editorView.state)}
             label={t.app.editor.selectionMenu.italic}
@@ -161,8 +169,8 @@ function InlineSelectionMenuContent({
             }
           >
             <Italic />
-          </MarkToggle>
-          <MarkToggle
+          </FormatToggle>
+          <FormatToggle
             active={ext.strike.query.isStrikeActive(editorView.state)}
             disabled={!ext.strike.command.toggleStrike(editorView.state)}
             label={t.app.editor.selectionMenu.strike}
@@ -171,15 +179,15 @@ function InlineSelectionMenuContent({
             }
           >
             <Strikethrough />
-          </MarkToggle>
-          <MarkToggle
+          </FormatToggle>
+          <FormatToggle
             active={ext.code.query.isCodeActive(editorView.state)}
             disabled={!ext.code.command.toggleCode(editorView.state)}
             label={t.app.editor.selectionMenu.inlineCode}
             onToggle={() => runCommand(editorView, ext.code.command.toggleCode)}
           >
             <Code />
-          </MarkToggle>
+          </FormatToggle>
           <ToolbarButton
             disabled={
               !ext.link.query.linkAllowedInRange(
@@ -208,6 +216,80 @@ function InlineSelectionMenuContent({
           >
             <LinkIcon />
           </ToolbarButton>
+          <Separator className="mx-0.5 h-6" orientation="vertical" />
+          <FormatToggle
+            // Highlight only a plain top-level paragraph. `isParagraph` also
+            // matches the paragraph nested inside a list item or blockquote,
+            // which would light this up alongside the list/quote control.
+            active={ext.paragraph.query.isTopLevelParagraph(editorView.state)}
+            disabled={false}
+            label={t.app.editor.selectionMenu.paragraph}
+            onToggle={() =>
+              runCommand(editorView, ext.paragraph.command.convertToParagraph)
+            }
+          >
+            <Pilcrow />
+          </FormatToggle>
+          <FormatToggle
+            active={ext.heading.query.isHeadingActive(editorView.state, 1)}
+            disabled={!ext.heading.command.toggleHeading(1)(editorView.state)}
+            label={t.app.editor.selectionMenu.heading1}
+            onToggle={() =>
+              runCommand(editorView, ext.heading.command.toggleHeading(1))
+            }
+          >
+            <Heading1 />
+          </FormatToggle>
+          <FormatToggle
+            active={ext.heading.query.isHeadingActive(editorView.state, 2)}
+            disabled={!ext.heading.command.toggleHeading(2)(editorView.state)}
+            label={t.app.editor.selectionMenu.heading2}
+            onToggle={() =>
+              runCommand(editorView, ext.heading.command.toggleHeading(2))
+            }
+          >
+            <Heading2 />
+          </FormatToggle>
+          <FormatToggle
+            active={ext.heading.query.isHeadingActive(editorView.state, 3)}
+            disabled={!ext.heading.command.toggleHeading(3)(editorView.state)}
+            label={t.app.editor.selectionMenu.heading3}
+            onToggle={() =>
+              runCommand(editorView, ext.heading.command.toggleHeading(3))
+            }
+          >
+            <Heading3 />
+          </FormatToggle>
+          <FormatToggle
+            active={ext.list.query.isBulletListActive(editorView.state)}
+            disabled={!ext.list.command.toggleBulletList(editorView.state)}
+            label={t.app.editor.selectionMenu.bulletList}
+            onToggle={() =>
+              runCommand(editorView, ext.list.command.toggleBulletList)
+            }
+          >
+            <List />
+          </FormatToggle>
+          <FormatToggle
+            active={ext.list.query.isOrderedListActive(editorView.state)}
+            disabled={!ext.list.command.toggleOrderedList(editorView.state)}
+            label={t.app.editor.selectionMenu.orderedList}
+            onToggle={() =>
+              runCommand(editorView, ext.list.command.toggleOrderedList)
+            }
+          >
+            <ListOrdered />
+          </FormatToggle>
+          <FormatToggle
+            active={ext.list.query.isTaskListActive(editorView.state)}
+            disabled={!ext.list.command.toggleTaskList(editorView.state)}
+            label={t.app.editor.selectionMenu.taskList}
+            onToggle={() =>
+              runCommand(editorView, ext.list.command.toggleTaskList)
+            }
+          >
+            <ListChecks />
+          </FormatToggle>
         </TooltipProvider>
       </div>
     </div>
@@ -219,7 +301,7 @@ function runCommand(editorView: EditorView, command: Command) {
   editorView.focus();
 }
 
-function MarkToggle({
+function FormatToggle({
   active,
   children,
   disabled,

--- a/packages/core/editor/src/components/inline-selection-menu.tsx
+++ b/packages/core/editor/src/components/inline-selection-menu.tsx
@@ -4,6 +4,7 @@ import {
   chainCommands,
   lift,
   type SelectionMenuState,
+  setBlockType,
 } from '@bangle.io/prosemirror-plugins';
 import {
   Button,
@@ -44,10 +45,45 @@ import { useOutsidePointer } from './use-outside-pointer';
 
 type Extensions = PmEditorService['extensions'];
 type EditorView = NonNullable<ReturnType<PmEditorService['getEditor']>>;
+type EditorState = EditorView['state'];
 type LinkSession = {
   editingLink: boolean;
   initialHref: string;
 };
+
+// A single "turn into paragraph" click may need to peel off several nesting
+// levels (e.g. a list inside a blockquote); this bounds the flatten loop well
+// above any realistic nesting depth.
+const MAX_PARAGRAPH_FLATTEN_STEPS = 8;
+
+/**
+ * Whether every block touched by the selection is a paragraph sitting directly
+ * under the document. This is the goal state of "turn into paragraph", so it
+ * drives both the Paragraph control's active state and its availability. A
+ * mixed selection (e.g. a paragraph plus a following heading) is not all
+ * top-level paragraphs, so the control stays actionable there.
+ */
+function isSelectionAllTopLevelParagraphs(state: EditorState): boolean {
+  const paragraph = state.schema.nodes.paragraph;
+  if (!paragraph) {
+    return false;
+  }
+  const topType = state.schema.topNodeType;
+  const { from, to } = state.selection;
+  let sawTextblock = false;
+  let allTopLevel = true;
+  state.doc.nodesBetween(from, to, (node, _pos, parent) => {
+    if (node.isTextblock) {
+      sawTextblock = true;
+      if (node.type !== paragraph || parent?.type !== topType) {
+        allTopLevel = false;
+      }
+      return false;
+    }
+    return allTopLevel;
+  });
+  return sawTextblock && allTopLevel;
+}
 
 export function InlineSelectionMenu({ editorName }: { editorName: string }) {
   const selectionMenus = useAtomValue($selectionMenu);
@@ -122,14 +158,44 @@ function InlineSelectionMenuContent({
     onOutside: dismiss,
   });
 
-  // "Turn into paragraph" for any block: convert a heading/code block, lift a
-  // list item out of its list, or lift out of a blockquote. `convertToParagraph`
-  // alone no-ops inside a list because the list item already wraps a paragraph.
-  const setParagraph = chainCommands(
-    ext.paragraph.command.convertToParagraph,
-    ext.list.command.unwrapList,
-    lift,
-  );
+  // "Turn into paragraph", whole-selection aware. One flatten step converts
+  // every block in the range to a paragraph (`setBlockType` is range-aware, so
+  // a mixed paragraph+heading selection is handled in one transaction), then
+  // lifts out of an enclosing list or blockquote. Re-running the step against
+  // the live view until the whole selection sits at the top level means a
+  // single click also flattens nested blocks like `> - item`. `dispatch` is
+  // absent for the availability dry-run, where we only report whether anything
+  // is left to convert.
+  const paragraphType = editorView.state.schema.nodes.paragraph;
+  const flattenStep = paragraphType
+    ? chainCommands(
+        setBlockType(paragraphType),
+        ext.list.command.unwrapList,
+        lift,
+      )
+    : undefined;
+  const setParagraph: Command = (state, dispatch, view) => {
+    if (!flattenStep) {
+      return false;
+    }
+    if (!dispatch) {
+      return !isSelectionAllTopLevelParagraphs(state);
+    }
+    if (!view) {
+      return flattenStep(state, dispatch);
+    }
+    let changed = false;
+    for (let step = 0; step < MAX_PARAGRAPH_FLATTEN_STEPS; step += 1) {
+      if (isSelectionAllTopLevelParagraphs(view.state)) {
+        break;
+      }
+      if (!flattenStep(view.state, view.dispatch, view)) {
+        break;
+      }
+      changed = true;
+    }
+    return changed;
+  };
 
   return linkSession ? (
     <FloatingLinkEditor
@@ -232,13 +298,12 @@ function InlineSelectionMenuContent({
           </ToolbarButton>
           <Separator className="mx-0.5 h-6" orientation="vertical" />
           <FormatToggle
-            // Highlight only a plain top-level paragraph. `isParagraph` also
-            // matches the paragraph nested inside a list item or blockquote,
-            // which would light this up alongside the list/quote control.
-            active={ext.paragraph.query.isTopLevelParagraph(editorView.state)}
-            // Disabled only when there is genuinely nothing to convert (already
-            // a plain paragraph), so the control never looks actionable while
-            // no-oping.
+            // Pressed only when the whole selection is already made of
+            // top-level paragraphs; a mixed selection (e.g. a paragraph plus a
+            // following heading) is not, so the control stays actionable.
+            active={isSelectionAllTopLevelParagraphs(editorView.state)}
+            // Disabled only when there is genuinely nothing to convert, so the
+            // control never looks actionable while no-oping.
             disabled={!setParagraph(editorView.state)}
             label={t.app.editor.selectionMenu.paragraph}
             onToggle={() => runCommand(editorView, setParagraph)}

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -11,6 +11,7 @@ import {
   type EditorView,
   markdownLoader,
   type Schema,
+  selectAll,
   TextSelection,
 } from '@bangle.io/prosemirror-plugins';
 import {
@@ -919,6 +920,28 @@ export class PmEditorService
 
   focusEditor() {
     this.getActiveEditorView()?.focus();
+  }
+
+  /**
+   * Redirects a global Cmd/Ctrl-A into the active editor when the editor is
+   * mounted but not DOM-focused (e.g. the user clicked the empty padding
+   * around the note, leaving focus on the page body). Without this a browser
+   * select-all fired from outside the contenteditable selects the whole
+   * document, sweeping the sidebar and app chrome into the selection.
+   *
+   * Defers to the editor's own keymap while it is focused, and to native
+   * behavior when no editor is mounted, by returning false in those cases.
+   */
+  selectAllInActiveEditor(): boolean {
+    const view = this.getActiveEditorView();
+    if (!view || view.isDestroyed || !view.dom.isConnected) {
+      return false;
+    }
+    if (view.hasFocus()) {
+      return false;
+    }
+    view.focus();
+    return selectAll(view.state, view.dispatch);
   }
 
   /** Dry-runs app-level editor actions against the live selection. */

--- a/packages/core/initialize-services/src/service-setup.ts
+++ b/packages/core/initialize-services/src/service-setup.ts
@@ -371,38 +371,57 @@ export function createServiceSetup<
       ShortcutService,
       withOverride('shortcut', () => ({
         target: shortcutTarget,
-        shortcuts: commands
-          .filter(
-            (
-              command,
-            ): command is Extract<
-              BangleAppCommand,
-              { keybindings: string[] }
-            > => 'keybindings' in command && command.keybindings !== undefined,
-          )
-          .map((command): ShortcutServiceConfig => {
-            const keys = command.keybindings.join('-');
-            return {
-              keyBinding: {
-                id: command.id,
-                keys,
-              },
-              handler: (event) => {
-                getCoreInstances().commandDispatcher.dispatch(
-                  command.id,
-                  event,
-                  `keyboard(${keys})`,
-                );
-              },
-              options: {
-                ...('allowShortcutInInputs' in command &&
-                command.allowShortcutInInputs
-                  ? { allowInInput: true }
-                  : {}),
-                unique: true,
-              },
-            };
-          }),
+        shortcuts: [
+          ...commands
+            .filter(
+              (
+                command,
+              ): command is Extract<
+                BangleAppCommand,
+                { keybindings: string[] }
+              > =>
+                'keybindings' in command && command.keybindings !== undefined,
+            )
+            .map((command): ShortcutServiceConfig => {
+              const keys = command.keybindings.join('-');
+              return {
+                keyBinding: {
+                  id: command.id,
+                  keys,
+                },
+                handler: (event) => {
+                  getCoreInstances().commandDispatcher.dispatch(
+                    command.id,
+                    event,
+                    `keyboard(${keys})`,
+                  );
+                },
+                options: {
+                  ...('allowShortcutInInputs' in command &&
+                  command.allowShortcutInInputs
+                    ? { allowInInput: true }
+                    : {}),
+                  unique: true,
+                },
+              };
+            }),
+          // Keep Cmd/Ctrl-A scoped to the note when it is pressed from the
+          // editor pane while the contenteditable is not focused (e.g. the
+          // user clicked the empty padding around the note). Returning the
+          // engine's boolean lets the editor keymap and native page behavior
+          // proceed unchanged whenever it declines to handle the shortcut.
+          // This is deliberately not a command: it must return synchronously so
+          // ShortcutManager can decide whether to suppress the default.
+          {
+            keyBinding: {
+              id: 'app-editor:select-all-in-editor',
+              keys: 'ctrl-a',
+            },
+            handler: () =>
+              getCoreInstances().editorEngine.selectAllInActiveEditor(),
+            options: { unique: true },
+          },
+        ],
       })),
     ),
     editorService: slot(

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -53,6 +53,13 @@ export const t = {
         strike: 'Strikethrough',
         inlineCode: 'Inline code',
         link: 'Link',
+        paragraph: 'Paragraph',
+        heading1: 'Heading 1',
+        heading2: 'Heading 2',
+        heading3: 'Heading 3',
+        bulletList: 'Bullet list',
+        orderedList: 'Numbered list',
+        taskList: 'Task list',
       },
       linkEditor: {
         label: 'Edit link',

--- a/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
@@ -5,6 +5,7 @@ import {
   getEditorLocator,
   readStoredMarkdown,
   selectEditorText,
+  writeStoredMarkdown,
 } from './common';
 
 // The selection toolbar exposes block-type controls (paragraph, headings,
@@ -102,6 +103,55 @@ test('selection toolbar converts block types and reflects the active block', asy
   await expect(toolbar).toBeVisible();
   await expect(bulletList).toHaveAttribute('aria-pressed', 'true');
   await expect(paragraph).toHaveAttribute('aria-pressed', 'false');
+});
+
+// "Turn into paragraph" is whole-selection aware: it converts every block in
+// the selection, not just the one under the caret, and flattens nested blocks
+// in a single click.
+test('Paragraph converts an entire mixed or nested selection in one click', async ({
+  page,
+}) => {
+  const workspaceName = 'format-toolbar-paragraph';
+  const noteName = 'para';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const toolbar = page.getByRole('toolbar', { name: 'Text formatting' });
+  const paragraph = toolbar.getByRole('button', { name: 'Paragraph' });
+
+  // A selection spanning a paragraph and a following heading is not "all
+  // paragraphs", so the control stays actionable and one click converts the
+  // heading too (the caret-block alone would report an already-a-paragraph
+  // no-op).
+  await writeStoredMarkdown(page, workspaceName, noteName, 'alpha\n\n## bravo');
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('alpha\n\n## bravo');
+  await selectEditorText(page, 'alphabravo');
+  await expect(toolbar).toBeVisible();
+  await expect(paragraph).toBeEnabled();
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'false');
+  await paragraph.click();
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('alpha\n\nbravo');
+
+  // A list nested inside a blockquote flattens to a plain paragraph in a single
+  // click (both the list and the blockquote are peeled off).
+  await writeStoredMarkdown(page, workspaceName, noteName, '> - item');
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('> - item');
+  await selectEditorText(page, 'item');
+  await expect(toolbar).toBeVisible();
+  await expect(paragraph).toBeEnabled();
+  await paragraph.click();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('item');
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
 });
 
 // The toolbar now carries enough controls that it can be wider than a phone

--- a/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
   createBrowserWorkspaceAndNote,
+  expectNoPageHorizontalOverflow,
   getEditorLocator,
   readStoredMarkdown,
   selectEditorText,
@@ -33,10 +34,13 @@ test('selection toolbar converts block types and reflects the active block', asy
   const heading1 = toolbar.getByRole('button', { name: 'Heading 1' });
   const bulletList = toolbar.getByRole('button', { name: 'Bullet list' });
 
-  // A plain paragraph reports itself as the active block.
+  // A plain paragraph reports itself as the active block. Paragraph is
+  // disabled here because there is nothing to convert — so it never looks
+  // actionable while no-oping.
   await selectEditorText(page, 'alpha');
   await expect(toolbar).toBeVisible();
   await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
+  await expect(paragraph).toBeDisabled();
   await expect(heading1).toHaveAttribute('aria-pressed', 'false');
 
   // Convert to a heading: the active state moves to Heading 1 and the
@@ -70,6 +74,24 @@ test('selection toolbar converts block types and reflects the active block', asy
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
     .toBe('line alpha\n\n- line bravo\n\nline charlie');
 
+  // Paragraph must be actionable inside a list and lift the item back out to a
+  // plain paragraph — `convertToParagraph` alone no-ops there because the list
+  // item already wraps a paragraph.
+  await expect(paragraph).toBeEnabled();
+  await paragraph.click();
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
+  await expect(bulletList).toHaveAttribute('aria-pressed', 'false');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('line alpha\n\nline bravo\n\nline charlie');
+
+  // Re-apply the list so the reload below exercises list persistence.
+  await bulletList.click();
+  await expect(bulletList).toHaveAttribute('aria-pressed', 'true');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('line alpha\n\n- line bravo\n\nline charlie');
+
   // The block conversions survive a reload: the stored Markdown is unchanged
   // and the reloaded editor still reports the list as the active block.
   await page.reload({ waitUntil: 'networkidle' });
@@ -80,4 +102,33 @@ test('selection toolbar converts block types and reflects the active block', asy
   await expect(toolbar).toBeVisible();
   await expect(bulletList).toHaveAttribute('aria-pressed', 'true');
   await expect(paragraph).toHaveAttribute('aria-pressed', 'false');
+});
+
+// The toolbar now carries enough controls that it can be wider than a phone
+// viewport. It must wrap within the viewport rather than overflow the page.
+test('selection toolbar wraps instead of overflowing a narrow viewport', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 720 });
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName: 'format-toolbar-narrow',
+    noteName: 'narrow',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await page.keyboard.insertText('some selectable body text');
+
+  const toolbar = page.getByRole('toolbar', { name: 'Text formatting' });
+  await selectEditorText(page, 'selectable');
+  await expect(toolbar).toBeVisible();
+
+  // Every control stays reachable (the row wraps, nothing is clipped away).
+  await expect(toolbar.getByRole('button', { name: 'Bold' })).toBeVisible();
+  await expect(
+    toolbar.getByRole('button', { name: 'Task list' }),
+  ).toBeVisible();
+
+  // The page itself must not gain horizontal scroll from the wide toolbar.
+  await expectNoPageHorizontalOverflow(page);
 });

--- a/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspaceAndNote,
+  getEditorLocator,
+  readStoredMarkdown,
+  selectEditorText,
+} from './common';
+
+// The selection toolbar exposes block-type controls (paragraph, headings,
+// lists) alongside the inline mark toggles. Each reflects the selection's
+// current block as an active (aria-pressed) state and toggles it on click.
+//
+// Each line leads with a filler word so the selected word sits mid-block: the
+// text-selection helper concatenates block text without separators, so a word
+// at a block's start would resolve to a cross-block range.
+test('selection toolbar converts block types and reflects the active block', async ({
+  page,
+}) => {
+  const workspaceName = 'format-toolbar';
+  const noteName = 'blocks';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await page.keyboard.insertText('line alpha');
+  await page.keyboard.press('Enter');
+  await page.keyboard.insertText('line bravo');
+  await page.keyboard.press('Enter');
+  await page.keyboard.insertText('line charlie');
+
+  const toolbar = page.getByRole('toolbar', { name: 'Text formatting' });
+  const paragraph = toolbar.getByRole('button', { name: 'Paragraph' });
+  const heading1 = toolbar.getByRole('button', { name: 'Heading 1' });
+  const bulletList = toolbar.getByRole('button', { name: 'Bullet list' });
+
+  // A plain paragraph reports itself as the active block.
+  await selectEditorText(page, 'alpha');
+  await expect(toolbar).toBeVisible();
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
+  await expect(heading1).toHaveAttribute('aria-pressed', 'false');
+
+  // Convert to a heading: the active state moves to Heading 1 and the
+  // document (and its Markdown) reflect the new block.
+  await heading1.click();
+  await expect(heading1).toHaveAttribute('aria-pressed', 'true');
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'false');
+  await expect(
+    editor.getByRole('heading', { level: 1, name: 'line alpha' }),
+  ).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('# line alpha\n\nline bravo\n\nline charlie');
+
+  // Clicking the active heading toggles the block back to a paragraph.
+  await heading1.click();
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
+  await expect(heading1).toHaveAttribute('aria-pressed', 'false');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('line alpha\n\nline bravo\n\nline charlie');
+
+  // Convert a different paragraph to a bullet list. The list becomes active
+  // and Paragraph does NOT stay lit, even though a list item still wraps a
+  // paragraph — the toolbar reports the outer block, not the nested one.
+  await selectEditorText(page, 'bravo');
+  await bulletList.click();
+  await expect(bulletList).toHaveAttribute('aria-pressed', 'true');
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'false');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('line alpha\n\n- line bravo\n\nline charlie');
+
+  // The block conversions survive a reload: the stored Markdown is unchanged
+  // and the reloaded editor still reports the list as the active block.
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('line alpha\n\n- line bravo\n\nline charlie');
+  await selectEditorText(page, 'bravo');
+  await expect(toolbar).toBeVisible();
+  await expect(bulletList).toHaveAttribute('aria-pressed', 'true');
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'false');
+});

--- a/packages/tooling/e2e-tests/src/editor-select-all-scope.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-select-all-scope.e2e.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+import {
+  createBrowserWorkspaceAndNote,
+  EDITOR_FOCUSED_SELECTOR,
+  getEditorLocator,
+  pressAppShortcut,
+  waitForEditorFocus,
+} from './common';
+
+const workspaceName = 'select-all-scope';
+const noteBody = 'alpha bravo charlie';
+
+// Regression: clicking the empty padding around a short note left focus on the
+// page body, so Cmd/Ctrl-A ran the browser's document-wide select-all and swept
+// the sidebar and app chrome into the selection. The shortcut must instead stay
+// scoped to the note.
+test('Cmd/Ctrl-A from the editor pane whitespace selects only the note', async ({
+  page,
+}) => {
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'note-a',
+  });
+  const editor = getEditorLocator(page, {});
+  await waitForEditorFocus(page, {});
+  await editor.fill(noteBody);
+  await expect(editor).toHaveText(noteBody);
+
+  // Click the empty pane whitespace just below the note (the flex gap before
+  // "Linked mentions"), the region a user clicks when the note is short.
+  const box = await editor.boundingBox();
+  if (!box) {
+    throw new Error('Expected the editor to expose a bounding box');
+  }
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height + 8);
+
+  // Guard: the click must actually leave the contenteditable, otherwise the
+  // test would pass vacuously by never reproducing the unfocused state.
+  await expect(page.locator(EDITOR_FOCUSED_SELECTOR)).toBeHidden();
+
+  // Cmd/Ctrl-A is an app-level shortcut (ShortcutManager), so press the
+  // modifier the app itself bound. See pressAppShortcut for why this differs
+  // from the editor's own Mod-a under headless Chromium.
+  await pressAppShortcut(page, 'a');
+
+  // The fix re-homes the shortcut into the note: the editor regains focus and
+  // the selection is scoped to it rather than the whole document.
+  await waitForEditorFocus(page, {});
+  const selection = await page.evaluate(() => {
+    const pm = document.querySelector('.ProseMirror');
+    const sel = window.getSelection();
+    const text = sel ? sel.toString() : '';
+    const range = sel && sel.rangeCount ? sel.getRangeAt(0) : null;
+    const container = range ? range.commonAncestorContainer : null;
+    const ancestor =
+      container && container.nodeType === Node.TEXT_NODE
+        ? container.parentElement
+        : (container as Element | null);
+    return {
+      text,
+      withinEditor: Boolean(
+        ancestor && pm && (pm === ancestor || pm.contains(ancestor)),
+      ),
+    };
+  });
+
+  expect(selection.text).toContain(noteBody);
+  expect(selection.withinEditor).toBe(true);
+  // The sidebar's workspace name must never land in the selection.
+  expect(selection.text).not.toContain(workspaceName);
+});


### PR DESCRIPTION
Two related editor improvements to the selection experience.

- **Cmd/Ctrl-A scope** — clicking the empty padding around a note left focus on the page body, so select-all ran the browser's document-wide select-all and swept the sidebar and app chrome into the selection. It now routes through the global shortcut service to a new editor-engine method that focuses the note and selects its content when an editor is mounted but unfocused. It defers to the editor's own keymap while the editor is focused, and to native behavior when no editor is mounted.
- **Block-format toolbar** — the inline selection menu gains Paragraph, Heading 1–3, and bullet / numbered / task-list toggles alongside the existing mark buttons. Each reflects the selection's current block as an `aria-pressed` active state and toggles it on click, reusing the same block commands and active queries the slash menu already uses. Paragraph highlights only for a plain top-level paragraph, so it does not light up alongside the list control inside a list item.

Reviewer callout: the Cmd/Ctrl-A handler is registered as an app-level shortcut rather than a command because it must return synchronously so the shortcut manager can decide whether to suppress the default — letting the editor keymap and native page behavior proceed unchanged when it declines. Playwright coverage is added for both changes; the existing selection-menu and editor suites remain green.
