### PR TITLE
fix(assets): open workspace files in Android apps

### DIFF
--- a/packages/core/app/src/pages/page-asset.tsx
+++ b/packages/core/app/src/pages/page-asset.tsx
@@ -6,7 +6,7 @@ import {
   WsPath,
 } from '@bangle.io/ws-path';
 import { useAtomValue } from 'jotai';
-import { Download } from 'lucide-react';
+import { Download, ExternalLink } from 'lucide-react';
 import React from 'react';
 import { AssetPreview } from '../components/common/asset-preview';
 import { ContentSection } from '../components/common/content-section';
@@ -26,6 +26,7 @@ type AssetState =
       fileName: string;
       objectUrl: string;
       kind: AssetPreviewKind | undefined;
+      shareFile?: File;
       textContent?: string;
     }
   | { status: 'missing'; fileName: string }
@@ -47,8 +48,10 @@ export function PageAsset() {
     routeFilePath?.fileName ??
     t.app.common.unknown;
   const [state, setState] = React.useState<AssetState>({ status: 'loading' });
+  const [shareFailed, setShareFailed] = React.useState(false);
 
   React.useEffect(() => {
+    setShareFailed(false);
     if (!wsPath) {
       setState({ status: 'error', fileName });
       return;
@@ -103,7 +106,18 @@ export function PageAsset() {
         const previewSource =
           kind === 'pdf' ? new Blob([file], { type: 'application/pdf' }) : file;
         objectUrl = URL.createObjectURL(previewSource);
-        setState({ status: 'ready', fileName, objectUrl, kind, textContent });
+        const candidateShareFile = createShareFile(file, fileName, kind);
+        const shareFile = canShareFile(candidateShareFile)
+          ? candidateShareFile
+          : undefined;
+        setState({
+          status: 'ready',
+          fileName,
+          objectUrl,
+          kind,
+          shareFile,
+          textContent,
+        });
       } catch {
         if (!disposed) {
           setState({ status: 'error', fileName });
@@ -119,6 +133,28 @@ export function PageAsset() {
       }
     };
   }, [fileName, fileSystem, wsPath]);
+
+  const handleShare = () => {
+    if (
+      state.status !== 'ready' ||
+      !state.shareFile ||
+      typeof navigator.share !== 'function'
+    ) {
+      return;
+    }
+
+    setShareFailed(false);
+    void navigator
+      .share({
+        files: [state.shareFile],
+        title: state.fileName,
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) {
+          setShareFailed(true);
+        }
+      });
+  };
 
   if (!currentWsName) {
     return (
@@ -150,30 +186,83 @@ export function PageAsset() {
     <>
       <AppHeader />
       <PageContentContainer>
-        <div className="flex w-full flex-wrap items-center justify-between gap-2">
+        <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <h1
-            className="wrap-anywhere min-w-0 flex-1 font-semibold text-lg"
+            className="wrap-anywhere min-w-0 font-semibold text-lg sm:flex-1"
             title={fileName}
           >
             {fileName}
           </h1>
           {state.status === 'ready' ? (
-            <a
-              className={buttonVariants({ variant: 'outline', size: 'sm' })}
-              download={state.fileName}
-              href={state.objectUrl}
-            >
-              <Download />
-              {t.app.pageAsset.downloadButton}
-            </a>
+            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
+              {state.shareFile ? (
+                <button
+                  className={buttonVariants({
+                    variant: 'outline',
+                    size: 'sm',
+                  })}
+                  onClick={handleShare}
+                  type="button"
+                >
+                  <ExternalLink />
+                  {t.app.pageAsset.openExternallyButton}
+                </button>
+              ) : null}
+              <a
+                className={buttonVariants({ variant: 'outline', size: 'sm' })}
+                download={state.fileName}
+                href={state.objectUrl}
+              >
+                <Download />
+                {t.app.pageAsset.downloadButton}
+              </a>
+            </div>
           ) : null}
         </div>
+        {shareFailed ? (
+          <p className="text-destructive text-sm" role="alert">
+            {t.app.pageAsset.openExternallyFailed}
+          </p>
+        ) : null}
         <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center gap-4">
           <AssetBody state={state} />
         </div>
       </PageContentContainer>
     </>
   );
+}
+
+function createShareFile(
+  file: File,
+  fileName: string,
+  kind: AssetPreviewKind | undefined,
+): File {
+  // Android chooses receiving apps from the MIME type. Stored PDFs can carry a
+  // missing or untrusted type, so match the safe type used by the PDF preview.
+  const type = kind === 'pdf' ? 'application/pdf' : file.type;
+  if (file.name === fileName && file.type === type) {
+    return file;
+  }
+
+  return new File([file], fileName, {
+    lastModified: file.lastModified,
+    type,
+  });
+}
+
+function canShareFile(file: File): boolean {
+  if (
+    typeof navigator.share !== 'function' ||
+    typeof navigator.canShare !== 'function'
+  ) {
+    return false;
+  }
+
+  try {
+    return navigator.canShare({ files: [file] });
+  } catch {
+    return false;
+  }
 }
 
 function AssetBody({ state }: { state: AssetState }) {

--- a/packages/shared/translations/src/languages/de.ts
+++ b/packages/shared/translations/src/languages/de.ts
@@ -250,6 +250,9 @@ export const t = {
     },
     pageAsset: {
       downloadButton: 'Download',
+      openExternallyButton: 'In einer anderen App öffnen',
+      openExternallyFailed:
+        'Die App-Auswahl konnte nicht geöffnet werden. Laden Sie die Datei stattdessen herunter.',
       loading: 'Asset wird geladen...',
       unavailable: 'Dieses Asset kann nicht geladen werden.',
       noPreview:

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -298,6 +298,9 @@ export const t = {
     },
     pageAsset: {
       downloadButton: 'Download',
+      openExternallyButton: 'Open in another app',
+      openExternallyFailed:
+        "Couldn't open the system app chooser. Download the file instead.",
       loading: 'Loading asset...',
       unavailable: 'Unable to load this asset.',
       noPreview:

--- a/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
+++ b/packages/tooling/e2e-tests/src/asset-workflow.e2e.ts
@@ -686,6 +686,105 @@ test('renders an image asset inline when the asset URL is opened directly', asyn
   );
 });
 
+test('hands a generic asset to Android through the native app chooser', async ({
+  page,
+}, testInfo) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'canShare', {
+      configurable: true,
+      value: (data: ShareData) =>
+        data.files?.length === 1 && data.files[0]?.type === 'application/pdf',
+    });
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: async (data: ShareData) => {
+        const file = data.files?.[0];
+        if (!file) {
+          throw new Error('Expected one shared file');
+        }
+        (
+          window as typeof window & {
+            __sharedAsset?: {
+              bytes: number[];
+              name: string;
+              title: string | undefined;
+              type: string;
+            };
+          }
+        ).__sharedAsset = {
+          bytes: [...new Uint8Array(await file.arrayBuffer())],
+          name: file.name,
+          title: data.title,
+          type: file.type,
+        };
+      },
+    });
+  });
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  const workspaceName = `asset-native-open-${testInfo.workerIndex}-${Date.now()}`;
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'nested/source',
+  });
+  await writeStoredFile(
+    page,
+    workspaceName,
+    'assets/portal-da-nota-fiscal.pdf',
+    [37, 80, 68, 70, 45, 49, 46, 52, 10],
+    'application/pdf',
+  );
+
+  await page.goto(
+    `/ws#route=asset&wsPath=${encodeURIComponent(
+      `${workspaceName}:assets/portal-da-nota-fiscal.pdf`,
+    )}`,
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const heading = page.getByRole('heading', {
+    name: 'portal-da-nota-fiscal.pdf',
+  });
+  const openExternallyButton = page.getByRole('button', {
+    name: 'Open in another app',
+  });
+  await expect
+    .poll(async () => {
+      const headingBox = await heading.boundingBox();
+      const buttonBox = await openExternallyButton.boundingBox();
+      if (!headingBox || !buttonBox) {
+        return false;
+      }
+      return buttonBox.y >= headingBox.y + headingBox.height;
+    })
+    .toBe(true);
+
+  await openExternallyButton.click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __sharedAsset?: {
+                bytes: number[];
+                name: string;
+                title: string | undefined;
+                type: string;
+              };
+            }
+          ).__sharedAsset,
+      ),
+    )
+    .toEqual({
+      bytes: [37, 80, 68, 70, 45, 49, 46, 52, 10],
+      name: 'portal-da-nota-fiscal.pdf',
+      title: 'portal-da-nota-fiscal.pdf',
+      type: 'application/pdf',
+    });
+  await expect(page.getByRole('link', { name: 'Download' })).toBeVisible();
+});
+
 test('renders a text asset inline when the asset URL is opened directly', async ({
   page,
 }, testInfo) => {


### PR DESCRIPTION
Follow-up to #673 and #659. The earlier fix now resolves the correct workspace asset, but the asset page still left Android with only an in-browser preview or download.

- hand supported files to Android’s native app chooser through Web Share
- preserve the original filename and a safe PDF MIME type for app matching
- keep Download as the fallback when the browser cannot share that file
- keep the filename and actions readable at mobile widths

The regression coverage verifies the exact file bytes passed to the chooser and the phone-width layout.