### PR TITLE
fix(editor): normalize ProseMirror typography

### DIFF
--- a/packages/core/editor/src/typography.css
+++ b/packages/core/editor/src/typography.css
@@ -25,9 +25,11 @@ div.ProseMirror {
     margin-bottom: 0;
   }
 
-  /* The first heading is typically the page title; give it breathing room
-     from the top of the editor. */
-  & h1:first-child {
+  /* The first top-level heading is typically the page title. Frontmatter may
+     precede it, but nested H1s (for example in lists) are ordinary content. */
+  & > h1:first-child,
+  & > pre[data-frontmatter]:first-child + h1 {
+    margin-top: 0;
     padding-top: 1.5rem;
   }
 
@@ -98,6 +100,7 @@ div.ProseMirror {
     min-height: 1em;
     border-radius: 0.3rem;
     color: hsl(var(--BV-foreground));
+    font-size: 1em;
     font-family: inherit;
   }
 
@@ -110,7 +113,7 @@ div.ProseMirror {
 
   & math-inline .math-render {
     padding: 0 0.1em;
-    font-size: 0.95em;
+    font-size: 1em;
   }
 
   & math-display {
@@ -211,30 +214,33 @@ div.ProseMirror {
   }
 
   & h1 {
-    margin: 1rem 0;
-    font-size: 2.25em;
+    margin: 2rem 0 1rem;
+    font-size: 2.25rem;
   }
 
   & h2 {
     margin: 1.5rem 0 0.5rem;
-    font-size: 1.75em;
+    font-size: 1.5rem;
   }
 
   & h3 {
     margin: 1.25rem 0 0.5rem;
-    font-size: 1.375em;
+    font-size: 1.25rem;
   }
 
   & h4 {
-    margin: 1em 0;
-    font-size: 1.125em;
+    margin: 1rem 0 0.5rem;
+    font-size: 1.125rem;
   }
 
   & h5 {
-    margin: 0.5em 0;
+    margin: 0.75rem 0 0.5rem;
+    font-size: 1rem;
   }
 
   & h6 {
+    margin: 0.75rem 0 0.5rem;
+    font-size: 0.875rem;
     opacity: 0.8;
   }
 
@@ -244,7 +250,7 @@ div.ProseMirror {
      case while preserving the normal spacing when a heading follows body
      text. */
   & :is(h1, h2, h3, h4, h5, h6) + :is(h2, h3, h4, h5, h6) {
-    margin-top: 0.5em;
+    margin-top: 0.5rem;
   }
 
   & img,
@@ -255,7 +261,7 @@ div.ProseMirror {
   }
 
   & code:not(pre code) {
-    font-size: 0.9em;
+    font-size: 0.95em;
     font-weight: 500;
     padding: 0.125em 0.25em;
     border-radius: 0.375rem;
@@ -455,12 +461,12 @@ div.ProseMirror {
   }
 
   & hr {
-    margin: 2em 0;
+    margin: 1rem 0;
   }
 
   & .prosemirror-horizontal-rule {
-    padding: 1em 0;
-    margin: 1em 0;
+    padding: 0;
+    margin: 1rem 0;
 
     & hr {
       margin: 0;
@@ -476,19 +482,19 @@ div.ProseMirror {
     &:has(> div.list-content > h1) {
       &::before,
       & > .list-marker {
-        top: 1em;
+        top: 0.65rem;
       }
     }
     &:has(> div.list-content > h2) {
       &::before,
       & > .list-marker {
-        top: 0.6em;
+        top: 0.2rem;
       }
     }
     &:has(> div.list-content > h3) {
       &::before,
       & > .list-marker {
-        top: 0.25em;
+        top: 0.05rem;
       }
     }
     &:has(> div.list-content > h4) {
@@ -500,13 +506,13 @@ div.ProseMirror {
     &:has(> div.list-content > h5) {
       &::before,
       & > .list-marker {
-        top: -0.1em;
+        top: -0.05rem;
       }
     }
     &:has(> div.list-content > h6) {
       &::before,
       & > .list-marker {
-        top: -0.1em;
+        top: -0.125rem;
       }
     }
   }

--- a/packages/tooling/e2e-tests/src/editor-typography.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-typography.e2e.ts
@@ -5,6 +5,31 @@ import {
   writeStoredMarkdown,
 } from './common';
 
+type TypographyMetrics = {
+  fontSize: string;
+  lineHeight: string;
+  marginBottom: string;
+  marginTop: string;
+  paddingBottom: string;
+  paddingTop: string;
+};
+
+async function getTypographyMetrics(
+  locator: Locator,
+): Promise<TypographyMetrics> {
+  return locator.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      fontSize: style.fontSize,
+      lineHeight: style.lineHeight,
+      marginBottom: style.marginBottom,
+      marginTop: style.marginTop,
+      paddingBottom: style.paddingBottom,
+      paddingTop: style.paddingTop,
+    };
+  });
+}
+
 async function expectVerticalGap(
   previousBlock: Locator,
   heading: Locator,
@@ -24,7 +49,7 @@ async function expectVerticalGap(
     .toBe(expectedGap);
 }
 
-test('uses compact, predictable spacing above section headings', async ({
+test('uses a consistent type scale and spacing rhythm for headings', async ({
   page,
 }) => {
   const workspaceName = 'editor-heading-spacing';
@@ -37,26 +62,350 @@ test('uses compact, predictable spacing above section headings', async ({
     [
       '# Page title',
       '',
+      'Paragraph before H1.',
+      '',
+      '# Section',
+      '',
       'Paragraph before H2.',
       '',
-      '## Section',
+      '## Subsection',
       '',
       'Paragraph before H3.',
       '',
-      '### Subsection',
+      '### Third level',
+      '',
+      'Paragraph before H4.',
+      '',
+      '#### Fourth level',
+      '',
+      'Paragraph before H5.',
+      '',
+      '##### Fifth level',
+      '',
+      'Paragraph before H6.',
+      '',
+      '###### Sixth level',
+      '',
+      'Body after H6.',
     ].join('\n'),
   );
   await page.reload();
 
   const editor = getEditorLocator(page, {});
-  await expectVerticalGap(
-    editor.getByText('Paragraph before H2.'),
-    editor.getByRole('heading', { level: 2, name: 'Section' }),
-    24,
+  const headingExpectations = [
+    {
+      fontSize: '36px',
+      level: 1,
+      marginBottom: '16px',
+      marginTop: '32px',
+      name: 'Section',
+      previous: 'Paragraph before H1.',
+    },
+    {
+      fontSize: '24px',
+      level: 2,
+      marginBottom: '8px',
+      marginTop: '24px',
+      name: 'Subsection',
+      previous: 'Paragraph before H2.',
+    },
+    {
+      fontSize: '20px',
+      level: 3,
+      marginBottom: '8px',
+      marginTop: '20px',
+      name: 'Third level',
+      previous: 'Paragraph before H3.',
+    },
+    {
+      fontSize: '18px',
+      level: 4,
+      marginBottom: '8px',
+      marginTop: '16px',
+      name: 'Fourth level',
+      previous: 'Paragraph before H4.',
+    },
+    {
+      fontSize: '16px',
+      level: 5,
+      marginBottom: '8px',
+      marginTop: '12px',
+      name: 'Fifth level',
+      previous: 'Paragraph before H5.',
+    },
+    {
+      fontSize: '14px',
+      level: 6,
+      marginBottom: '8px',
+      marginTop: '12px',
+      name: 'Sixth level',
+      previous: 'Paragraph before H6.',
+    },
+  ] as const;
+
+  await expect(
+    editor.getByRole('heading', { level: 1, name: 'Page title' }),
+  ).toHaveCSS('padding-top', '24px');
+
+  for (const expectation of headingExpectations) {
+    const heading = editor
+      .locator(`h${expectation.level}`)
+      .filter({ hasText: expectation.name });
+    await expect(heading).toHaveCSS('font-size', expectation.fontSize);
+    await expect(heading).toHaveCSS('margin-top', expectation.marginTop);
+    await expect(heading).toHaveCSS('margin-bottom', expectation.marginBottom);
+    await expectVerticalGap(
+      editor.getByText(expectation.previous, { exact: true }),
+      heading,
+      Number.parseFloat(expectation.marginTop),
+    );
+  }
+});
+
+test('keeps supported block and inline nodes on a coherent typography rhythm', async ({
+  page,
+}) => {
+  const workspaceName = 'editor-node-typography';
+  const noteName = 'All nodes';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    [
+      '---',
+      'title: Typography',
+      '---',
+      '',
+      'Body with `inline code`, [[Wiki Target]], $x + y$, \\$5, and ![alt](missing.png).\\',
+      'After a hard break.',
+      '',
+      '> Quoted paragraph.',
+      '',
+      '- Bullet item',
+      '- [ ] Task item',
+      '',
+      '1. Ordered item',
+      '1. Second ordered item',
+      '',
+      '```ts',
+      'const value = 1;',
+      '```',
+      '',
+      '$$',
+      'x^2 + y^2',
+      '$$',
+      '',
+      '| Column A | Column B |',
+      '| --- | --- |',
+      '| Cell A | Cell B |',
+      '',
+      '---',
+      '',
+      'Final paragraph.',
+      '',
+      '1. # List heading 1',
+      '1. ## List heading 2',
+      '1. ### List heading 3',
+      '1. #### List heading 4',
+      '1. ##### List heading 5',
+      '1. ###### List heading 6',
+    ].join('\n'),
   );
-  await expectVerticalGap(
-    editor.getByText('Paragraph before H3.'),
-    editor.getByRole('heading', { level: 3, name: 'Subsection' }),
-    20,
+  await page.reload();
+
+  const editor = getEditorLocator(page, {});
+  const bodyParagraph = editor.locator('p').filter({ hasText: 'Body with' });
+  const expectedMetrics = [
+    {
+      locator: editor.locator('pre[data-frontmatter]'),
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '8px',
+        marginTop: '8px',
+        paddingBottom: '15.2px',
+        paddingTop: '40.8px',
+      },
+    },
+    {
+      locator: bodyParagraph,
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '0px',
+        marginTop: '0px',
+        paddingBottom: '8px',
+        paddingTop: '8px',
+      },
+    },
+    {
+      locator: editor.locator('blockquote'),
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '0px',
+        marginTop: '0px',
+        paddingBottom: '0px',
+        paddingTop: '0px',
+      },
+    },
+    {
+      locator: editor.locator('.prosemirror-flat-list').filter({
+        hasText: 'Bullet item',
+      }),
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '0px',
+        marginTop: '0px',
+        paddingBottom: '0px',
+        paddingTop: '0px',
+      },
+    },
+    {
+      locator: editor.locator('pre:not([data-frontmatter])'),
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '8px',
+        marginTop: '8px',
+        paddingBottom: '15.2px',
+        paddingTop: '40.8px',
+      },
+    },
+    {
+      locator: editor.locator('math-display'),
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '8px',
+        marginTop: '8px',
+        paddingBottom: '12px',
+        paddingTop: '12px',
+      },
+    },
+    {
+      locator: editor.locator('table'),
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '8px',
+        marginTop: '8px',
+        paddingBottom: '0px',
+        paddingTop: '0px',
+      },
+    },
+    {
+      locator: editor.locator('hr'),
+      metrics: {
+        fontSize: '16px',
+        lineHeight: '24px',
+        marginBottom: '16px',
+        marginTop: '16px',
+        paddingBottom: '0px',
+        paddingTop: '0px',
+      },
+    },
+  ] as const;
+
+  for (const expectation of expectedMetrics) {
+    await expect(expectation.locator).toHaveCount(1);
+    expect(await getTypographyMetrics(expectation.locator)).toEqual(
+      expectation.metrics,
+    );
+  }
+
+  const inlineExpectations = [
+    {
+      fontSize: '15.2px',
+      lineHeight: '22.8px',
+      locator: editor.locator('code:not(pre code)'),
+    },
+    {
+      fontSize: '16px',
+      lineHeight: '24px',
+      locator: editor.locator('math-inline'),
+    },
+    {
+      fontSize: '16px',
+      lineHeight: '24px',
+      locator: editor.locator('math-inline .math-render'),
+    },
+    {
+      fontSize: '16px',
+      lineHeight: '24px',
+      locator: editor.locator('[data-math-escaped-dollar]'),
+    },
+    {
+      fontSize: '16px',
+      lineHeight: '24px',
+      locator: editor.locator('.wiki-link'),
+    },
+    {
+      fontSize: '16px',
+      lineHeight: '24px',
+      locator: editor.getByRole('img', { name: 'alt' }),
+    },
+    {
+      fontSize: '16px',
+      lineHeight: '24px',
+      locator: bodyParagraph.locator('br'),
+    },
+  ] as const;
+
+  for (const expectation of inlineExpectations) {
+    await expect(expectation.locator).toHaveCount(1);
+    await expect(expectation.locator).toHaveCSS(
+      'font-size',
+      expectation.fontSize,
+    );
+    await expect(expectation.locator).toHaveCSS(
+      'line-height',
+      expectation.lineHeight,
+    );
+  }
+
+  const tableHeader = editor.getByRole('columnheader', { name: 'Column A' });
+  const tableCell = editor.getByRole('cell', { name: 'Cell A' });
+  await expect(tableHeader).toHaveCSS('font-size', '16px');
+  await expect(tableHeader).toHaveCSS('line-height', '24px');
+  await expect(tableCell).toHaveCSS('font-size', '16px');
+  await expect(tableCell).toHaveCSS('line-height', '24px');
+  await expect(editor.locator('pre:not([data-frontmatter]) code')).toHaveCSS(
+    'font-size',
+    '15.2px',
   );
+
+  const listHeadingAlignment = await editor
+    .locator('.prosemirror-flat-list')
+    .evaluateAll((items) =>
+      items.flatMap((item) => {
+        const heading = item.querySelector('h1,h2,h3,h4,h5,h6');
+        if (!heading) {
+          return [];
+        }
+        const itemBox = item.getBoundingClientRect();
+        const headingBox = heading.getBoundingClientRect();
+        const markerStyle = getComputedStyle(item, '::before');
+        const markerTop = Number.parseFloat(markerStyle.top);
+        const markerLineHeight = Number.parseFloat(markerStyle.lineHeight);
+        const markerCenter = markerTop + markerLineHeight / 2;
+        const headingCenter =
+          headingBox.top - itemBox.top + headingBox.height / 2;
+
+        return [
+          {
+            alignmentDelta: Math.abs(markerCenter - headingCenter),
+            paddingTop: getComputedStyle(heading).paddingTop,
+          },
+        ];
+      }),
+    );
+
+  expect(listHeadingAlignment).toHaveLength(6);
+  for (const metrics of listHeadingAlignment) {
+    expect(metrics.paddingTop).toBe('0px');
+    expect(metrics.alignmentDelta).toBeLessThanOrEqual(1);
+  }
 });


### PR DESCRIPTION
## Summary

- establish a consistent H1–H6 type and spacing scale, including adjacent headings and list markers
- normalize code, math, horizontal-rule, and page-title spacing across editor nodes
- add schema-wide E2E coverage for block and inline typography

## Reviewer callout

This intentionally reduces H2/H3 from 28/22px to 24/20px and gives H6 a distinct 14px size.