### PR TITLE
docs(plans): re-verify pending plans against main

### DIFF
--- a/plans/004-vite-plus-migration.md
+++ b/plans/004-vite-plus-migration.md
@@ -4,7 +4,7 @@ status: planned
 type: plan
 archived: false
 created: 2026-06-14
-updated: 2026-06-14
+updated: 2026-07-24
 owner: mixed
 related_prs: []
 related_issues: []
@@ -26,6 +26,12 @@ such as Playwright E2E/component testing, Storybook, Chromatic, Sentry's Vite
 plugin, Tailwind's Vite plugin, and React's Vite plugin if still required.
 
 ## Current Status
+
+Not started. Vite+ reached beta in June 2026 (MIT, open source), a real
+de-risk versus the alpha this plan was written against — but still pre-1.0.
+The Known Risks below stand, in particular Oxlint/Oxfmt-versus-Biome rule
+parity, which decides whether this is a net win. Re-evaluate at 1.0; no
+forcing function today.
 
 - [ ] Create a dedicated migration branch.
 - [ ] Capture baseline results for the current toolchain.

--- a/plans/005-tech-debt-cleanup-audit.md
+++ b/plans/005-tech-debt-cleanup-audit.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-15
-updated: 2026-07-21
+updated: 2026-07-24
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/631
@@ -24,7 +24,8 @@ related_prs:
   - https://github.com/bangle-io/bangle-io/pull/649
   - https://github.com/bangle-io/bangle-io/pull/658
   - https://github.com/bangle-io/bangle-io/pull/667
-related_issues: []
+related_issues:
+  - https://github.com/bangle-io/bangle-io/issues/563
 ---
 
 # Tech Debt Cleanup Audit

--- a/plans/006-image-embeds-and-paste-assets.md
+++ b/plans/006-image-embeds-and-paste-assets.md
@@ -4,13 +4,14 @@ status: active
 type: plan
 archived: false
 created: 2026-06-30
-updated: 2026-07-19
+updated: 2026-07-24
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/587
   - https://github.com/bangle-io/bangle-io/pull/610
   - https://github.com/bangle-io/bangle-io/pull/661
-related_issues: []
+related_issues:
+  - https://github.com/bangle-io/bangle-io/issues/679
 ---
 
 # Image Embeds And Paste Assets

--- a/plans/007-workspace-index-cache.md
+++ b/plans/007-workspace-index-cache.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-06-30
-updated: 2026-07-12
+updated: 2026-07-24
 owner: mixed
 related_prs: []
 related_issues: []
@@ -32,13 +32,24 @@ clearing, and eventual persisted snapshots.
 
 ## Current Status
 
-- `WorkspaceStateService.$backlinkIndex` currently builds an in-memory reverse
-  link map for the active workspace. A content-update counter triggers a
-  debounced full rebuild, files are read serially, and the atom aborts stale
-  generations. On failure it exposes an error state with an empty map rather
-  than retaining last-good data. Bounded concurrency, typed incremental event
-  updates, and stale-while-error behavior remain target work (also tracked as
-  A8 in plan 005).
+Verified against `main` 2026-07-24. No `WorkspaceIndexService` exists; Phase 1
+has not started.
+
+- `WorkspaceStateService.$backlinkIndex` builds an in-memory reverse link map
+  for the active workspace. A content-update counter triggers a debounced full
+  rebuild, files are read serially, and the atom aborts stale generations.
+  `buildBacklinkIndex` throws on the *first* unreadable source and the catch
+  returns an empty map, so one unreadable note collapses every backlink in the
+  workspace and Linked Mentions shows its error copy. The stale-while-*loading*
+  path is fine; only the error path drops data. **Retaining last-good data on
+  error is the highest-value item here and is worth doing on its own, even if
+  the service extraction stays deferred.** Bounded concurrency and typed
+  incremental updates remain target work (also A8 in plan 005).
+- The note file stats scan is a second workspace-wide lifecycle in the same
+  service, and a better one: bounded concurrency, a cache that survives
+  failures instead of flashing consumers back to empty, and incremental
+  single-path patching. Treat it as the reference template and migration
+  target for `WorkspaceIndexService`, not just the backlink index.
 - `packages/core/app/src/components/backlinks/linked-mentions.tsx` now renders
   backlinks from `WorkspaceStateService.$backlinkIndex` instead of reading or
   parsing Markdown in React.
@@ -258,7 +269,7 @@ Completed in the release branch as a scoped cleanup:
   map for the active workspace.
 - `LinkedMentions` renders the service state and no longer reads files from
   React.
-- Failed rebuilds keep previous backlink data and expose an error state.
+- Failed rebuilds expose an error state, but do **not** retain last-good data.
 - Extensionless Markdown backlink extraction now resolves through the known
   note index instead of guessing `.md` before `.markdown`.
 

--- a/plans/007-workspace-index-cache.md
+++ b/plans/007-workspace-index-cache.md
@@ -46,10 +46,13 @@ has not started.
   the service extraction stays deferred.** Bounded concurrency and typed
   incremental updates remain target work (also A8 in plan 005).
 - The note file stats scan is a second workspace-wide lifecycle in the same
-  service, and a better one: bounded concurrency, a cache that survives
-  failures instead of flashing consumers back to empty, and incremental
-  single-path patching. Treat it as the reference template and migration
-  target for `WorkspaceIndexService`, not just the backlink index.
+  service, and a better one: bounded concurrency, a published map that is not
+  reset wholesale on failure, and incremental single-path patching. It is not
+  fully failure-retaining either — a per-path stat failure deletes that path's
+  cache entry, and only the targeted patch path keeps last-known values — but
+  it degrades per file instead of collapsing the workspace. Treat it as the
+  reference template and migration target for `WorkspaceIndexService`, not
+  just the backlink index.
 - `packages/core/app/src/components/backlinks/linked-mentions.tsx` now renders
   backlinks from `WorkspaceStateService.$backlinkIndex` instead of reading or
   parsing Markdown in React.

--- a/plans/010-editor-route-file-scan-loading.md
+++ b/plans/010-editor-route-file-scan-loading.md
@@ -42,10 +42,21 @@ plan assumed — the error half already landed, only the pending half remains.
   first scan the app asserts the listing is fine while `$rawWsPaths` is empty.
 - `page-editor.tsx` renders `NoteNotFoundView` from the final `else` of its
   three-way ternary, consulting neither a loading state nor
-  `$fileTreeListState` — so a scan *error* also shows "Note Not Found" today,
-  even though `app/src/index.tsx` and `app-sidebar.tsx` both handle that state.
-- There are no `PageEditor` tests, and no test blocks a scan to assert an
-  in-flight state.
+  `$fileTreeListState`. A *first* scan that fails therefore shows "Note Not
+  Found"; a failed rescan does not, because `$rawWsPaths` is preserved for the
+  same workspace. The `native-fs-directory-not-found` variant never reaches
+  `PageEditor` at all — `app/src/index.tsx` preempts it with
+  `PageNativeFsRecovery` — and `app-sidebar.tsx` handles only plain `error`.
+- **The `WorkspaceNotFoundView` branch has the same premature-verdict bug, and
+  it fires first.** `!currentWsName` renders workspace-not-found, but
+  `$currentWsName` derives from `$workspaceListState`, which *already* has a
+  `loading` member that `PageEditor` ignores. So on a cold load the first false
+  verdict is "Workspace Not Found", not "Note Not Found". Fixing only the file
+  scan leaves the earlier flash in place — this belongs in Scope.
+- There are no `PageEditor` unit tests. Note that
+  `e2e-tests/src/delete-note-dialog.e2e.ts` asserts the `Note Not Found`
+  heading twice, including after a reload, so it is pinned to the exact branch
+  steps 6-7 replace and will need updating.
 
 ## Scope
 
@@ -53,6 +64,8 @@ plan assumed — the error half already landed, only the pending half remains.
   `packages/core/service-core/src/workspace-state-service.ts`.
 - Add a derived current-route file resolution atom, likely shaped like:
   `none | loading | found | missing | error`.
+- Make `PageEditor` respect `$workspaceListState`'s existing `loading` status
+  so the workspace-not-found branch stops firing before the list resolves.
 - Keep the existing `$currentWsPath` API as the "found file only" compatibility
   surface so existing note-only callers do not accidentally start acting on
   unresolved routes.

--- a/plans/010-editor-route-file-scan-loading.md
+++ b/plans/010-editor-route-file-scan-loading.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-03
-updated: 2026-07-03
+updated: 2026-07-24
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/587
@@ -29,11 +29,23 @@ a missing note.
 
 ## Current Status
 
+Verified against `main` 2026-07-24: bug still present, and smaller than this
+plan assumed — the error half already landed, only the pending half remains.
+
 - The issue is reproducible in a large real Native FS workspace.
 - A worker prototype confirmed the likely root cause and proved that a
   dedicated route-resolution state can address it.
 - That prototype was intentionally not kept in the working tree because the
   state model and UI semantics need careful review before implementation.
+- `$fileTreeListState` (`ok | native-fs-directory-not-found | error`) now
+  exists but has no pending member and initializes to `ok`, so before the
+  first scan the app asserts the listing is fine while `$rawWsPaths` is empty.
+- `page-editor.tsx` renders `NoteNotFoundView` from the final `else` of its
+  three-way ternary, consulting neither a loading state nor
+  `$fileTreeListState` — so a scan *error* also shows "Note Not Found" today,
+  even though `app/src/index.tsx` and `app-sidebar.tsx` both handle that state.
+- There are no `PageEditor` tests, and no test blocks a scan to assert an
+  in-flight state.
 
 ## Scope
 
@@ -79,11 +91,15 @@ a missing note.
 
 ## Implementation Steps
 
-1. Add a private workspace scan atom in `WorkspaceStateService`, for example:
-   `idle`, `loading`, `ready`, and `error`, with `wsName` on non-idle states.
-2. Replace the `wrapPromiseInAppErrorHandler(..., EMPTY_STRING_ARRAY, ...)`
-   scan path with explicit success/error handling so errors can be represented
-   separately from an empty workspace.
+1. Add a `wsName`-keyed scan state to `WorkspaceStateService`: `idle`,
+   `loading`, `ready`, `error`. Prefer extending `$fileTreeListState` with a
+   pending member over a parallel atom, but note `app/src/index.tsx` and
+   `app-sidebar.tsx` both read it and each need a branch. The only current
+   workspace keying is `lastListedWsName`, a mutable field no atom can read.
+   `WorkspaceListState` is the in-repo precedent for the shape.
+2. ~~Replace the `wrapPromiseInAppErrorHandler` scan path with explicit
+   success/error handling.~~ Done: the scan uses explicit success/error
+   callbacks and a failed rescan preserves the last known tree.
 3. Add a public `$currentWsPathResolution` atom:
    - `none` when there is no editor file route;
    - `found` when the route wsPath is present in `$rawWsPaths`;

--- a/plans/014-block-handle-slash-menu-hardening.md
+++ b/plans/014-block-handle-slash-menu-hardening.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-12
-updated: 2026-07-19
+updated: 2026-07-24
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/633
@@ -33,11 +33,12 @@ Large / Editor).
 
 ## Current status
 
-Partially complete. PR #656 completed item 6 by adding a typed editor-engine
-availability contract, hiding unavailable omni editor commands, retaining the
-last-focused live editor across external-focus handoffs, and revalidating at
-execution. Items 1-5 and 7-8 remain in Backlog; none block release of the
-merged PR #633 behavior.
+Partially complete. Item 6 shipped in PR #656; items 1-5 and 7-8 remain, and
+none block release of the merged PR #633 behavior.
+
+Verified against `main` 2026-07-24: items 1-5, 7, and 8 all still open,
+verbatim. Nothing has touched `banger-editor/src/drag/` since PR #633.
+Item 4 now goes first — see below.
 
 ## Scope
 
@@ -85,6 +86,14 @@ while `view.composing`, and keep the existing `view.editable` gate.
 Scroll-hiding already exists via the `mousewheel` handler; further scroll
 polish is optional.
 
+**Do this one first.** PR #680's inline selection toolbar shows on
+`!selection.empty`, the exact inverse of the handle's only gate
+(`view.editable`), so both floating surfaces are live during any drag-select.
+That is no longer hypothetical. The fix is a few lines in the `mousemove`
+guard and is independent of item 1's state container. No test asserts the
+handle hides during a selection; new coverage belongs beside the toolbar
+tests rather than in `block-handle.e2e.ts`.
+
 ### 5. Explicit nested-block handle policy
 
 List items (`prosemirror-flat-list`) are excluded from handles via
@@ -95,11 +104,8 @@ and encode it in tests before enabling handles on nested structures.
 
 ### 6. Omni editor-command availability
 
-Completed in PR #656. A narrow typed editor-engine availability contract now
-hides unavailable heading and table commands in omni search while handlers
-still revalidate at execution. The implementation also retains the
-last-focused live editor across omni/external focus handoffs and covers the
-multi-editor edge case without adding a generic dynamic command registry.
+Done — see Completed since first draft. Number retained so items 7-8 keep
+their identities.
 
 ### 7. Intentional undo grouping
 
@@ -110,6 +116,11 @@ state is the Atlaskit/tiptap convention), implement via `addToHistory` /
 `appendTransaction` grouping if needed, and add e2e coverage for typed-select
 undo and plus-select undo before changing anything.
 
+Try the cheap fix first: the item-select dismissal deletes the query text
+without `addToHistory: false`, while the Escape path sets it on every branch.
+Adding that meta may collapse typed-select to one undo step outright. The
+`+` path is genuinely three transactions and needs its own answer.
+
 ### 8. Outside-click and scrollbar interaction tests
 
 The slash menu dismisses via selection movement and Escape; outside clicks
@@ -117,6 +128,13 @@ move the selection and dismiss indirectly. Add explicit Playwright coverage:
 outside click closes the menu without inserting; dragging the menu's
 scrollbar (the `[cmdk-list]` mousedown exemption in `slash-command.tsx`)
 neither blurs the editor nor selects an item.
+
+A reusable `useOutsidePointer` hook now exists (used by the floating link
+editor and selection menu); the slash menu still dismisses indirectly via
+selection movement. Adopting it is a behavior change beyond this item — decide
+explicitly. Its effect has no dependency array, so it reattaches its capture
+listener every render; harmless today, but the slash menu re-renders per
+keystroke.
 
 ## Completed since first draft
 
@@ -126,8 +144,10 @@ neither blurs the editor nor selects an item.
   synthetic-marked text on every deactivation path, and the save path
   serializes through `stripSyntheticSuggestionText`, so a "+"-opened `/`
   can never reach storage (navigate-away e2e covers the repro).
-- Omni editor-command availability: PR #656 hides invalid heading/table
-  actions from omni search and retains execution-time validation.
+- Item 6, omni editor-command availability (PR #656): a typed editor-engine
+  availability contract hides unavailable heading/table commands in omni
+  search, handlers still revalidate at execution, and the last-focused live
+  editor is retained across external focus handoffs.
 
 ## Out of scope
 
@@ -159,8 +179,13 @@ None.
 
 ## Next steps
 
-1. Item 1 (mapped positions) first — items 2 and 4 want the same per-view
-   state container it introduces.
-2. Items 3 and 4 are small and independent; good warm-ups.
-3. Items 7–8 are behavior decisions; confirm the intended UX (one-line answer
-   each) before implementing.
+1. Item 4 first — small, independent, fixes a live overlap.
+2. Item 3 next; small and independent.
+3. Item 1 (mapped positions), then item 2 which reuses its state container.
+   Expect design friction on item 1: the drag plugin is `view`-only with no
+   `state`/`apply`, and the deliberate `WeakMap<EditorView>` keying rules out
+   plugin state, so mapping likely goes in a `view.update` hook.
+4. Items 5 and 7–8 are behavior decisions; confirm the intended UX (one-line
+   answer each) first. Item 5 may need no code change if the current matrix is
+   ratified, though the handle also hardcodes `ol`/`ul` beyond the configured
+   exclusions — a third undocumented rule to fold into config.

--- a/plans/014-block-handle-slash-menu-hardening.md
+++ b/plans/014-block-handle-slash-menu-hardening.md
@@ -36,13 +36,14 @@ Large / Editor).
 Partially complete. Item 6 shipped in PR #656; items 1-5 and 7-8 remain, and
 none block release of the merged PR #633 behavior.
 
-Verified against `main` 2026-07-24: items 1-5, 7, and 8 all still open,
-verbatim. Nothing has touched `banger-editor/src/drag/` since PR #633.
+Verified against `main` 2026-07-24: items 1-5, 7, and 8 all still open as
+described. Nothing has touched `banger-editor/src/drag/` since PR #633.
 Item 4 now goes first — see below.
 
 ## Scope
 
-Work areas, roughly in priority order. Each item should land with its own
+Work areas, numbered as identifiers rather than in priority order — see Next
+steps for the current sequencing. Each item should land with its own
 tests and can ship independently.
 
 ### 1. Track the hovered block as a mapped ProseMirror position
@@ -86,13 +87,15 @@ while `view.composing`, and keep the existing `view.editable` gate.
 Scroll-hiding already exists via the `mousewheel` handler; further scroll
 polish is optional.
 
-**Do this one first.** PR #680's inline selection toolbar shows on
-`!selection.empty`, the exact inverse of the handle's only gate
-(`view.editable`), so both floating surfaces are live during any drag-select.
-That is no longer hypothetical. The fix is a few lines in the `mousemove`
-guard and is independent of item 1's state container. No test asserts the
-handle hides during a selection; new coverage belongs beside the toolbar
-tests rather than in `block-handle.e2e.ts`.
+**Do this one first.** The inline selection toolbar requires
+`view.editable && !selection.empty` (plus code-block and eligible-content
+checks) — a strict superset of the handle's only gate, `view.editable`. Both
+floating surfaces are therefore live during a mouse drag-select. This has been
+true since PR #633 shipped the handle, not a recent regression, and the
+selection toolbar predates it. The fix is a few lines in the `mousemove` guard
+and is independent of item 1's state container. No test asserts the handle
+hides during a selection; new coverage belongs beside the selection-menu tests
+rather than in `block-handle.e2e.ts`.
 
 ### 5. Explicit nested-block handle policy
 

--- a/plans/015-file-change-eventing-consolidation.md
+++ b/plans/015-file-change-eventing-consolidation.md
@@ -51,8 +51,9 @@ dialog is local-only and adds no file-event consumer.
    adapter (IndexedDB, Native FS, memory) has an internal
    `emitChange(FileStorageChangeEvent)` feeding a constructor `onChange`
    callback. This seam is currently dead-ended: `initialize-services` wires it
-   to `logger.info` only. No signal flows through it; it exists as reserved
-   plumbing for `FileSystemObserver`.
+   to `logger.info` only, and only for the IndexedDB and Native FS adapters —
+   memory's is not wired at all. No signal flows through it; it exists as
+   reserved plumbing for `FileSystemObserver`.
 
 2. **`RootEmitter` (`shared/root-emitter`).** Hand-rolled typed pub/sub with
    scoped views per service and a BroadcastChannel transport for the
@@ -80,9 +81,10 @@ dialog is local-only and adds no file-event consumer.
    note-stats scan/patch off `$fileForceUpdateCount` and
    `$fileContentUpdateEvent`. `PmEditorService` follows renames via
    `$fileRenameEvent` (no longer with a handled-sequence field — it relies on
-   an idempotent handler). `EditorService` bypasses atoms and uses the emitter
-   directly, and emits `file:force-update` as an "invalidate everything"
-   hammer on Native FS auth recovery. `NoteSnapshotService` also subscribes the
+   an idempotent handler). `EditorService` consumes no file events at all — it
+   subscribes only `event::editor:reload-editor` — but it *emits*
+   `file:force-update` as an "invalidate everything" hammer on Native FS auth
+   recovery. `NoteSnapshotService` also subscribes the
    scoped emitter directly, discriminates its own writes from cross-tab echoes
    via `event.sender`, and keeps its own path-state relocation for
    create/delete/rename.
@@ -134,13 +136,15 @@ function and test vehicle.
 
 The atom fan-out discards `event.sender`, so "was this my own write or another
 tab's" is unanswerable from atoms. `NoteSnapshotService` needs exactly that
-discrimination and therefore subscribes the scoped emitter directly — the
-second service after `EditorService` to bypass atoms, this time for a
-structural reason rather than preference. It also hand-rolls its own
-create/delete/rename path-state relocation, mirroring `WorkspaceStateService`'s
-against a different vocabulary: duplicated *semantics* rather than duplicated
-dedup. It is additionally on the write path via a synchronous pre-write hook in
-`FileSystemService`, so one service now participates through two mechanisms.
+discrimination and therefore subscribes the scoped emitter directly — it is the
+only consumer of `event::file:update` outside the translating service itself,
+and it bypassed atoms for a structural reason rather than preference. It also
+hand-rolls its own create/delete/rename path-state relocation, mirroring
+`WorkspaceStateService`'s against a different vocabulary: duplicated *semantics*
+rather than duplicated dedup. It is additionally on the write path via two
+`async` hooks that `FileSystemService` awaits before `writeFile`, so one
+service now participates through two mechanisms — and a snapshot failure or
+delay sits in front of the user's own write.
 
 This binds harder once FileSystemObserver adds a third origin — an external
 disk change that is neither self nor a known peer tab.
@@ -178,8 +182,8 @@ producer contracts, not spaghetti.
   with counters derived from it, plus one shared subscription helper that owns
   dedup — deleting the per-consumer copies.
 - Alternatively, reserve atoms strictly for state and have event consumers
-  subscribe the scoped emitter directly (the pattern `EditorService` already
-  uses), so events are never round-tripped through last-value atoms.
+  subscribe the scoped emitter directly (the pattern `NoteSnapshotService`
+  already uses), so events are never round-tripped through last-value atoms.
 
 ## Verification (when picked up)
 

--- a/plans/015-file-change-eventing-consolidation.md
+++ b/plans/015-file-change-eventing-consolidation.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-18
-updated: 2026-07-19
+updated: 2026-07-24
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/652
@@ -38,6 +38,11 @@ refresh stats). PR #626 is still open and activates Native FS external-change
 observation, making this consolidation more important, but the consolidation
 itself has not started.
 
+Inventory verified against `main` 2026-07-24; the ten atoms, the force-update
+side-channel, and the dead `onChange` seam are unchanged. `NoteSnapshotService`
+has since joined as a consumer — see mechanism 5 and Cost 4. The stale-tab
+dialog is local-only and adds no file-event consumer.
+
 ## The problem
 
 ### Inventory: five stacked mechanisms
@@ -52,7 +57,8 @@ itself has not started.
 2. **`RootEmitter` (`shared/root-emitter`).** Hand-rolled typed pub/sub with
    scoped views per service and a BroadcastChannel transport for the
    `CROSS_TAB_EVENTS` allowlist (`event::file:update`,
-   `event::file:force-update`, `event::app:reload-ui`).
+   `event::file:force-update`, `event::app:reload-ui`, and — added since this
+   inventory was written — `event::app:build-presence`).
 
 3. **Command-side emission in `FileSystemService`.** Change detection is not
    observation of storage: the service emits `event::file:update`
@@ -73,9 +79,13 @@ itself has not started.
    rebuilds the backlink index off `$fileContentUpdateCount`, and runs the
    note-stats scan/patch off `$fileForceUpdateCount` and
    `$fileContentUpdateEvent`. `PmEditorService` follows renames via
-   `$fileRenameEvent`. `EditorService` bypasses atoms and uses the emitter
+   `$fileRenameEvent` (no longer with a handled-sequence field — it relies on
+   an idempotent handler). `EditorService` bypasses atoms and uses the emitter
    directly, and emits `file:force-update` as an "invalidate everything"
-   hammer on Native FS auth recovery.
+   hammer on Native FS auth recovery. `NoteSnapshotService` also subscribes the
+   scoped emitter directly, discriminates its own writes from cross-tab echoes
+   via `event.sender`, and keeps its own path-state relocation for
+   create/delete/rename.
 
 ### Cost 1: atoms used as event channels
 
@@ -83,10 +93,13 @@ Jotai atoms are last-value-wins state containers; file changes are a stream.
 Forcing the stream through atoms required sequence numbers on the producer
 side — and every consumer independently re-implements "have I already handled
 this event" with its own handled-sequence field. That pattern currently exists
-in at least four places (create merge, rename relocation, editor rename
-follow, stats patch). Each future consumer must write another copy, and each
-copy is an opportunity for a subtle bug (missed gating, wrong reset on
-remount, double-handling).
+in **three** places, all inside `WorkspaceStateService`: the stats patch, the
+create merge, and the rename relocation. (Corrected 2026-07-24 from "at least
+four": `PmEditorService` no longer keeps a handled-sequence field — it
+subscribes `$fileRenameEvent` and re-reads it, relying on an idempotent
+handler.) Each future consumer must write another copy, and each copy is an
+opportunity for a subtle bug (missed gating, wrong reset on remount,
+double-handling).
 
 A second-order effect: because an atom only holds the latest event, a consumer
 that processes events asynchronously can drop a superseded predecessor (two
@@ -117,6 +130,21 @@ it has never seen. Consolidating after that lands means debugging two problems
 at once; consolidating immediately before it lands has a natural forcing
 function and test vehicle.
 
+### Cost 4: the atom layer is lossy, and silently pushes consumers off it
+
+The atom fan-out discards `event.sender`, so "was this my own write or another
+tab's" is unanswerable from atoms. `NoteSnapshotService` needs exactly that
+discrimination and therefore subscribes the scoped emitter directly — the
+second service after `EditorService` to bypass atoms, this time for a
+structural reason rather than preference. It also hand-rolls its own
+create/delete/rename path-state relocation, mirroring `WorkspaceStateService`'s
+against a different vocabulary: duplicated *semantics* rather than duplicated
+dedup. It is additionally on the write path via a synchronous pre-write hook in
+`FileSystemService`, so one service now participates through two mechanisms.
+
+This binds harder once FileSystemObserver adds a third origin — an external
+disk change that is neither self nor a known peer tab.
+
 ### What is *not* the problem
 
 The layering itself is sound: providers → emitter → one translating service →
@@ -135,6 +163,7 @@ producer contracts, not spaghetti.
 - Force-update must not be a side-channel that event-consumers can miss.
 - The design must accommodate observation-side events (FileSystemObserver,
   cross-tab) with the same guarantees as command-side echoes.
+- Sender identity must survive to consumers (Cost 4).
 
 ## Out of scope
 

--- a/plans/015-heading-toc-rail.md
+++ b/plans/015-heading-toc-rail.md
@@ -5,7 +5,7 @@ type: plan
 archived: false
 archived_on:
 created: 2026-07-13
-updated: 2026-07-18
+updated: 2026-07-24
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/642
@@ -32,6 +32,8 @@ editor engine is ProseMirror (`packages/core/editor` /
 `@bangle.io/banger-editor`); wordgard (`editor-w`) is URL-flag gated and its
 heading APIs are stubs, so this plan targets the ProseMirror stack with a
 seam that wordgard can adopt later.
+
+Verified against `main` 2026-07-24.
 
 ## UX behavior
 
@@ -66,11 +68,15 @@ seam that wordgard can adopt later.
 
 ### 1. Heading data: ProseMirror plugin → jotai atom
 
-Follow the `$suggestions` idiom (plugin publishes derived state to an atom;
-React reads it with `useAtomValue`):
+Follow the `link-menu` idiom (plugin publishes derived state to a view-keyed
+atom; React reads it with `useAtomValue`). `link-menu` is the minimal form —
+internal atom plus read-only public atom, a copy-on-write `setXForView` that
+deletes the key on `undefined`, cleanup in `destroy`. `$suggestions` is the
+same shape with an extra by-mark inner map a TOC does not need.
 
-- New plugin in `@bangle.io/prosemirror-plugins` (js-lib layer):
-  `headingWatch` (name TBD). On `docChanged` transactions it walks
+- New plugin in `@bangle.io/banger-editor` (js-lib layer), re-exported through
+  the `@bangle.io/prosemirror-plugins` barrel — see the placement correction in
+  Current Status: `headingWatch` (name TBD). On `docChanged` transactions it walks
   `doc.descendants`, collecting `{ pos, level, text }` for nodes of type
   `heading` (same walk `PmEditorService.navigateToHeading` already does).
   Publishes to a `$headings: Map<EditorView, HeadingItem[]>` atom, with a
@@ -92,18 +98,14 @@ React reads it with `useAtomValue`):
   `useEditorCoreServices().editorEngine.getEditor(editorName)`.
 - Reads `useAtomValue($headings)` and picks the entry for its view. Returns
   `null` under the visibility rules above.
-- Positioning: `position: fixed` is wrong here (sidebar width varies);
-  instead absolutely position within the editor's `relative` wrapper —
-  `right` pinned near the container edge, `top: 50%` with
-  `translateY(-50%)`, `sticky`-like behavior achieved by using `position:
-  fixed` **derived from the wrapper's client rect** is unnecessary: the
-  simplest correct approach is a `position: sticky; top: 50%` child inside a
-  full-height, zero-width absolutely-positioned column at the wrapper's
-  right edge, with a small inset so it does not sit under the scroll
-  container's scrollbar. Verify against the real scroll container (the
-  `SidebarInset` main region) during M2 and fall back to
-  `useFloatingPosition` + `@floating-ui/dom` `autoUpdate` if sticky proves
-  fragile.
+- Positioning: the editor page scrolls the **window**, not a nested container
+  — neither `SidebarInset` nor `PageContentContainer` sets `overflow`. So
+  `sticky` has no scrolling ancestor to stick to. Anchor vertically to the
+  viewport and horizontally to the content column: `top: 50%` with
+  `translateY(-50%)`, right edge measured against `PageContentContainer`,
+  whose width flips between centered and full-bleed via `$wideEditor`. Fall
+  back to `useFloatingPosition` + `@floating-ui/dom` `autoUpdate` if manual
+  measurement proves fragile.
 - Expanded panel renders adjacent to the rail (opens leftward). Reuse
   `FLOATING_INITIAL_STYLE` z-index conventions and `bg-popover
   text-popover-foreground ring-foreground/10` styling to match existing
@@ -111,12 +113,17 @@ React reads it with `useAtomValue`):
 
 ### 3. Active-section tracking
 
-- On scroll (rAF-throttled listener on the scroll container) find the last
-  heading whose DOM element (`editorView.domAtPos(pos)`) sits above a
-  viewport threshold (~1/3 height). Store as local state; drives both dash
-  and panel highlight. IntersectionObserver is an alternative, but heading
-  positions shift as the doc edits, so a cheap rAF scan over ≤100 cached
-  rects re-derived on `$headings` change is simpler and adequate.
+- On scroll find the last heading whose DOM element
+  (`editorView.domAtPos(pos)`) sits above a viewport threshold (~1/3 height).
+  Store as local state; drives both dash and panel highlight.
+  IntersectionObserver is an alternative, but heading positions shift as the
+  doc edits, so a cheap rAF scan over ≤100 cached rects re-derived on
+  `$headings` change is simpler and adequate.
+- Reuse `setupScrollAndResizeHandlers` from `banger-editor`'s
+  `pm-utils/position` — it is the existing rAF-throttled `window`
+  scroll/resize helper. Skip zero-sized rects: headings inside a collapsed
+  section stay mounted under `display: none` and report all-zero rects, which
+  would otherwise poison the scan.
 
 ### 4. Scroll-to-heading
 
@@ -135,18 +142,21 @@ React reads it with `useAtomValue`):
 
 ## Design considerations / known risks
 
-- **Right-edge overlaps**: the rail must not sit under the scroll
-  container's scrollbar, and in wide-editor mode text runs close to the
-  right edge, so the collapsed rail must stay slim (≤ 12px of dashes plus a
-  wider invisible hover hit-area) with a small inset. The left-gutter
-  block/drag handle from plan 014 is a non-issue on this side. Validate
-  visually in M2 in both wide and centered modes and with the sidebar open
-  and closed.
-- **Collapsed heading sections** (existing collapsible-headings feature): a
-  TOC target inside a collapsed region has no visible DOM to scroll to.
-  M3 must handle this: either expand ancestor collapsed sections before
-  scrolling (preferred, matches user intent) or visually mark unreachable
-  entries. Decide against the actual DOM behavior once measured.
+- **Right-edge overlaps**: in wide-editor mode text runs close to the right
+  edge, so the collapsed rail must stay slim (≤ 12px of dashes plus a wider
+  invisible hover hit-area) with a small inset. The left-gutter block/drag
+  handle from plan 014 is a non-issue on this side. `LinkedMentions` renders
+  below the editor in the same window scroll flow, so a viewport-centered
+  rail can overlap it on short notes. Validate visually in M2 in wide and
+  centered modes, sidebar open and closed, and on a short note.
+- **Collapsed heading sections**: folded sections stay mounted under
+  `display: none` node decorations, so a TOC target inside one has a live
+  element that cannot be scrolled to. Expand ancestors before scrolling
+  (matches user intent) using `query.listCollapsedHeadings` +
+  `getHeadingFoldRange` for the containment check and
+  `command.toggleHeadingCollapseAtPos` to open them. Note this dispatches a
+  transaction, which conflicts with the no-dispatch rule in §4 — resolve that
+  tension explicitly in M3.
 - **Focus discipline**: per the established rule for editor popups, the
   panel must never steal focus from the editor — `preventDefault` on
   `mousedown` for every interactive element.
@@ -156,7 +166,8 @@ React reads it with `useAtomValue`):
 
 ## Scope
 
-- Heading-watch plugin + `$headings` atom in `@bangle.io/prosemirror-plugins`.
+- Heading-watch plugin + `$headings` atom in `@bangle.io/banger-editor`,
+  re-exported through the `@bangle.io/prosemirror-plugins` barrel.
 - `HeadingTocRail` component (collapsed rail, hover/focus expansion, click
   to scroll, active tracking) mounted in the ProseMirror editor.
 - Visibility rules, translations, reduced-motion support, a11y pass.

--- a/plans/015-heading-toc-rail.md
+++ b/plans/015-heading-toc-rail.md
@@ -74,9 +74,10 @@ internal atom plus read-only public atom, a copy-on-write `setXForView` that
 deletes the key on `undefined`, cleanup in `destroy`. `$suggestions` is the
 same shape with an extra by-mark inner map a TOC does not need.
 
-- New plugin in `@bangle.io/banger-editor` (js-lib layer), re-exported through
-  the `@bangle.io/prosemirror-plugins` barrel — see the placement correction in
-  Current Status: `headingWatch` (name TBD). On `docChanged` transactions it walks
+- New plugin `headingWatch` (name TBD) in `@bangle.io/banger-editor` (js-lib
+  layer), re-exported through the `@bangle.io/prosemirror-plugins` barrel.
+  That barrel is almost entirely re-exports of `banger-editor`, and
+  `core/editor` imports PM code through it rather than directly. On `docChanged` transactions it walks
   `doc.descendants`, collecting `{ pos, level, text }` for nodes of type
   `heading` (same walk `PmEditorService.navigateToHeading` already does).
   Publishes to a `$headings: Map<EditorView, HeadingItem[]>` atom, with a

--- a/plans/016-editor-math-lazy-loading.md
+++ b/plans/016-editor-math-lazy-loading.md
@@ -1,11 +1,11 @@
 ---
 title: Lazy-load the editor math renderer
-status: planned
+status: blocked
 type: plan
 archived: false
 archived_on:
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-07-24
 owner: mixed
 related_prs:
   - https://github.com/bangle-io/bangle-io/pull/637
@@ -25,17 +25,20 @@ success to parse, edit, save, or recover.
 
 ## Current status
 
+Blocked on upstream, verified 2026-07-24.
+
 - Math support is complete in PR #637 and deliberately loads KaTeX eagerly.
 - The recorded main JavaScript bundle grew from 564.01 kB gzip before the
   feature to about 653.25 kB gzip on the PR head. KaTeX also emits about 1.07 MB
   of font assets that browsers load on demand.
-- `@benrbray/prosemirror-math` currently exposes one JavaScript entry point.
-  That entry statically imports KaTeX and bundles schema, plugins, commands, and
-  `MathView` together. Importing only the synchronous editor primitives still
-  pulls KaTeX into the eager graph.
+- `@benrbray/prosemirror-math` is pinned at `1.0.0` and exposes one JavaScript
+  entry, which statically imports KaTeX and bundles schema, plugins, commands,
+  and `MathView` together. Its `exports` map declares only `"."` and
+  `"./dist/*.css"`; raw `lib/` sources ship but are not exposed, so
+  deep-importing the schema without the nodeview does not resolve.
 - Bangle must not fork or copy the upstream nodeview to create an artificial
-  split. A true lazy boundary therefore needs an upstream package-entry split
-  or another upstream-supported renderer boundary first.
+  split. A true lazy boundary needs an upstream entry split first, so the only
+  actionable step is an upstream issue or PR.
 
 ## Scope
 

--- a/plans/016-editor-math-lazy-loading.md
+++ b/plans/016-editor-math-lazy-loading.md
@@ -37,8 +37,10 @@ Blocked on upstream, verified 2026-07-24.
   `"./dist/*.css"`; raw `lib/` sources ship but are not exposed, so
   deep-importing the schema without the nodeview does not resolve.
 - Bangle must not fork or copy the upstream nodeview to create an artificial
-  split. A true lazy boundary needs an upstream entry split first, so the only
-  actionable step is an upstream issue or PR.
+  split. A true lazy boundary cannot *ship* without an upstream entry split, so
+  the blocking step is an upstream issue or PR. Next steps 1 and 3 (measuring
+  the module graph, prototyping the async nodeview handoff) can still proceed
+  locally and would strengthen that upstream request.
 
 ## Scope
 

--- a/plans/018-note-snapshot-native-fs-backend.md
+++ b/plans/018-note-snapshot-native-fs-backend.md
@@ -41,9 +41,11 @@ Planned; no implementation. This plan exists because the shipped feature had no
 durable record and the follow-up was only captured in conversation.
 
 `NoteSnapshotService` is database-only (`static deps = ['database']`). It sits
-on the write path via a synchronous pre-write hook in `FileSystemService` and
-also subscribes the scoped emitter directly — plan 015 (file change eventing)
-records the constraints that come with that.
+on the write path via two `async` pre-write hooks that `FileSystemService`
+awaits *before* `writeFile`, and also subscribes the scoped emitter directly —
+plan 015 (file change eventing) records the constraints that come with that.
+The awaited-before-write ordering is what makes the write-path question below
+a real one rather than theoretical.
 
 ## Scope
 

--- a/plans/018-note-snapshot-native-fs-backend.md
+++ b/plans/018-note-snapshot-native-fs-backend.md
@@ -1,0 +1,97 @@
+---
+title: Native FS backend for note snapshots
+status: planned
+type: plan
+archived: false
+archived_on:
+created: 2026-07-24
+updated: 2026-07-24
+owner: mixed
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/669
+  - https://github.com/bangle-io/bangle-io/pull/676
+related_issues: []
+---
+
+# Native FS Backend For Note Snapshots
+
+## Summary
+
+Recoverable note snapshots shipped in PR #669, with rename-survival and
+lost-writer retry hardening in PR #676. `NoteSnapshotService` declares
+`static deps = ['database']`, so every snapshot is written to the `database` DI
+slot — IndexedDB in the browser — regardless of which storage backend the
+workspace itself uses.
+
+For Browser workspaces that is coherent: notes and their recovery history share
+one durability domain. For Native FS workspaces it is not. The notes are files
+the user owns on disk, but their recovery history lives in browser storage,
+where it is invisible to the user, unavailable on another machine or profile,
+and destroyed by clearing site data — while the notes it protects survive. The
+agreed direction is a file-backed snapshot store for Native FS workspaces,
+under a workspace-local directory such as `.bangle/backups/`.
+
+The split is by **workspace type, not by snapshot age**: Browser workspaces keep
+the database store, Native FS workspaces write to the workspace directory. This
+is deliberately not a tiering or archival scheme.
+
+## Current status
+
+Planned; no implementation. This plan exists because the shipped feature had no
+durable record and the follow-up was only captured in conversation.
+
+`NoteSnapshotService` is database-only (`static deps = ['database']`). It sits
+on the write path via a synchronous pre-write hook in `FileSystemService` and
+also subscribes the scoped emitter directly — plan 015 (file change eventing)
+records the constraints that come with that.
+
+## Scope
+
+- A snapshot storage seam that can be satisfied by either the database or a
+  file-backed implementation, selected by workspace type.
+- A Native FS implementation writing under a workspace-local directory.
+- Keep the Recovery page and the recover command working unchanged across both
+  backends.
+
+## Out of scope
+
+- Changing snapshot capture policy, retention counts, or the recovery UX.
+- Syncing snapshots between devices, or any remote/cloud backend.
+- Migrating existing database snapshots for Native FS workspaces — decide
+  explicitly at pickup whether they are migrated, left readable in place, or
+  dropped.
+
+## Open questions
+
+These need answers before implementation, and none should be guessed:
+
+- Directory name and layout, and whether it must be hidden from the file tree,
+  search, backlinks, and the notes table.
+- Whether a write failure to the snapshot directory (permission loss, quota,
+  read-only volume) may ever fail or delay the user's own note write. It must
+  not — but the pre-write hook currently sits on the write path, so this needs
+  a deliberate answer.
+- Behavior when the user deletes or edits files inside the snapshot directory
+  by hand, which they can and eventually will.
+- Whether snapshots should be excluded from the Native FS external-change
+  observation work (PR #626 / issue #521) to avoid a feedback loop where
+  writing a snapshot triggers a change event that triggers another snapshot.
+
+## Verification
+
+- Contract-level tests covering both backends with the same behavior, in the
+  style of the existing file-storage contract tests.
+- Recovery E2E extended to a Native FS workspace, including recovery after a
+  reload.
+- Explicit failure-path coverage: snapshot write failure must leave the note
+  write successful and surface a non-destructive error.
+
+## Known blockers
+
+Depends on the open questions above, particularly the interaction with
+FileSystemObserver in PR #626.
+
+## Next steps
+
+1. Answer the open questions, especially the write-path safety one.
+2. Design the storage seam against both backends before writing either.

--- a/plans/AGENTS.md
+++ b/plans/AGENTS.md
@@ -25,6 +25,10 @@ Add `002-*` only when a new plan cannot reasonably live inside an existing plan.
 Do not renumber existing plans after they are referenced by commits, issues, or
 pull requests.
 
+Never reuse a number, including after archiving — pick the next one above every
+plan in both `plans/` and `plans/archived/`. Reuse has already made `003`,
+`010`, `014`, and `015` ambiguous in commit history.
+
 ## Frontmatter
 
 Every plan must start with YAML frontmatter:


### PR DESCRIPTION
Re-checked every pending plan's premises against the current code instead of trusting the plan text, and corrected the stale statements in place. Docs-only.

Reviewer callouts:

- **Plan 007 documented a data-safety property the code does not have.** Its Phase 0 notes claimed failed backlink rebuilds keep previous data. They don't: the build throws on the first unreadable source and the catch returns an empty map, so one unreadable note wipes every backlink in the workspace. Flagged as worth fixing on its own, ahead of the service extraction.
- **Plan 014 item 4 is now a live overlap.** The selection toolbar from #680 shows on `!selection.empty`, while the block handle's only gate is still `view.editable` — both are active during a drag-select, and nothing tests it. Item 4 moves to the front.
- **Plan 015 (TOC rail) had a wrong architectural assumption.** The editor page scrolls the window; neither `SidebarInset` nor `PageContentContainer` sets `overflow`, so the planned `sticky` positioning has no scrolling ancestor. Rewrote the positioning and active-tracking sections rather than annotating them.
- **Plan 010 is smaller than it reads** — step 2 already landed, and a typed scan state exists that just lacks a pending member and defaults to `ok`.
- **Plan 015 (eventing)** gained a constraint worth knowing before the FileSystemObserver work: the atom fan-out drops `event.sender`, so consumers needing self-versus-foreign discrimination must bypass atoms. Recorded as Cost 4.
- **Plan 016 is now `status: blocked`** — upstream still ships no renderer-free entry, and nothing here can move it.

Adds plan 018 for the Native FS note-snapshot backend: snapshots are database-backed for every workspace type, so Native FS users' notes live on disk while their recovery history lives in browser storage. Its open questions are deliberately unanswered — particularly whether a snapshot write failure may ever affect the user's own note write, since the capture hook sits on the write path.

Verification: documentation-only, so per AGENTS.md the code suites don't apply. Every path, symbol, and behavioral claim cited was verified against the working tree.