### PR TITLE
fix(editor): prevent cross-surface data loss

### DIFF
--- a/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
+++ b/packages/core/command-handlers/src/ui-handlers/basic-operations.ts
@@ -196,6 +196,11 @@ export const basicOperationsHandlers = [
   }),
 
   c('command::ui:paste-from-markdown', async ({ editorEngine }) => {
+    const insertMarkdown = editorEngine.captureMarkdownInsertion();
+    if (!insertMarkdown) {
+      toast.error(t.app.toasts.pasteMarkdownFailed);
+      return;
+    }
     let text: string;
     try {
       text = await readTextFromClipboard();
@@ -207,7 +212,7 @@ export const basicOperationsHandlers = [
       toast.error(t.app.toasts.pasteMarkdownEmpty);
       return;
     }
-    if (!editorEngine.insertMarkdownAtSelection(text)) {
+    if (!insertMarkdown(text)) {
       toast.error(t.app.toasts.pasteMarkdownFailed);
     }
   }),

--- a/packages/core/context/src/service-types.ts
+++ b/packages/core/context/src/service-types.ts
@@ -49,6 +49,13 @@ export type EditorEngineContract = BaseService & {
    * note. An engine that always preserves Markdown exposes an always-empty set.
    */
   readonly $roundTripWarnings: Atom<ReadonlySet<string>>;
+  /**
+   * Captures the active editor and selection for a later Markdown insertion.
+   * The returned function refuses to insert if the editor, document, or
+   * selection changes before it runs, so asynchronous clipboard access cannot
+   * retarget content into another note or range.
+   */
+  captureMarkdownInsertion: () => ((markdownText: string) => boolean) | null;
   collapseAllHeadings: (level: number) => boolean;
   focusEditor: () => void;
   getSelectionMarkdown: () => string | null;
@@ -66,6 +73,10 @@ export type EditorEngineContract = BaseService & {
    */
   selectAllInActiveEditor: () => boolean;
   hasPendingOrFailedSave: (wsPath?: string) => boolean;
+  /**
+   * Parses and inserts Markdown at the current selection. Returns false when
+   * the source cannot round-trip without loss or normalization.
+   */
   insertMarkdownAtSelection: (markdownText: string) => boolean;
   /** Reports whether an app-level editor action can run against the current
    * active editor and selection. Callers must still revalidate on execution. */

--- a/packages/core/editor-w/src/editor-w-service.ts
+++ b/packages/core/editor-w/src/editor-w-service.ts
@@ -136,6 +136,10 @@ export class EditorWService
     return null;
   }
 
+  captureMarkdownInsertion(): null {
+    return null;
+  }
+
   insertMarkdownAtSelection(_markdownText: string): boolean {
     return false;
   }

--- a/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
+++ b/packages/core/editor/src/__tests__/pm-editor-service.spec.ts
@@ -74,6 +74,31 @@ describe('PmEditorService', () => {
     ).toBe(true);
     expect(firstEditor.state.doc.textContent).toBe('First note');
 
+    const secondDocAfterSafePaste = secondEditor.state.doc;
+    secondEditor.dispatch(
+      secondEditor.state.tr.setSelection(
+        TextSelection.create(
+          secondEditor.state.doc,
+          1,
+          secondEditor.state.doc.content.size - 1,
+        ),
+      ),
+    );
+    expect(
+      service.insertMarkdownAtSelection(
+        '[visible][missing]\n\n[unused]: https://example.com',
+      ),
+    ).toBe(false);
+    expect(secondEditor.state.doc).toBe(secondDocAfterSafePaste);
+
+    secondEditor.focus();
+    const capturedInsertion = service.captureMarkdownInsertion();
+    expect(capturedInsertion).not.toBeNull();
+    firstEditor.focus();
+    expect(capturedInsertion?.('wrong editor')).toBe(false);
+    expect(firstEditor.state.doc.textContent).toBe('First note');
+    expect(secondEditor.state.doc.textContent).toBe('from Markdown');
+
     unmountSecond();
     unmountFirst();
     controller.abort();
@@ -202,15 +227,27 @@ describe('PmEditorService', () => {
       throw new Error('Expected the editor to be ready');
     }
 
-    // Focus lives outside the editor, mimicking a click on the pane whitespace
-    // that leaves the contenteditable unfocused.
-    outsideInput.focus();
+    // With no meaningful focus owner, the app-level shortcut redirects
+    // select-all into the last active editor.
+    view.dom.blur();
     expect(view.hasFocus()).toBe(false);
 
     expect(service.selectAllInActiveEditor()).toBe(true);
     expect(view.hasFocus()).toBe(true);
     expect(view.state.selection.from).toBe(0);
     expect(view.state.selection.to).toBe(view.state.doc.content.size);
+
+    const nestedEditor = document.createElement('div');
+    nestedEditor.contentEditable = 'true';
+    view.dom.append(nestedEditor);
+    nestedEditor.focus();
+    expect(view.hasFocus()).toBe(false);
+    expect(service.selectAllInActiveEditor()).toBe(false);
+    expect(document.activeElement).toBe(nestedEditor);
+
+    outsideInput.focus();
+    expect(service.selectAllInActiveEditor()).toBe(false);
+    expect(document.activeElement).toBe(outsideInput);
 
     // While the editor already owns focus its own keymap handles select-all,
     // so the service declines and leaves the live selection untouched.
@@ -223,6 +260,7 @@ describe('PmEditorService', () => {
 
     unmount();
     controller.abort();
+    nestedEditor.remove();
     domNode.remove();
     outsideInput.remove();
   });

--- a/packages/core/editor/src/components/date-picker-menu.tsx
+++ b/packages/core/editor/src/components/date-picker-menu.tsx
@@ -37,6 +37,8 @@ export function DatePickerMenu({
   const suggestions = useAtomValue($suggestions);
   const [selectedDate, setSelectedDate] = useState(() => new Date());
   const selectedDateRef = useRef(selectedDate);
+  const calendarRef = useRef<HTMLDivElement | null>(null);
+  const didAutoFocusRef = useRef(false);
   selectedDateRef.current = selectedDate;
   const { editorEngine } = useEditorCoreServices();
   const editorView = editorEngine.getEditor(editorName);
@@ -71,6 +73,7 @@ export function DatePickerMenu({
   useEffect(() => {
     if (!active?.show) {
       setSelectedDate(new Date());
+      didAutoFocusRef.current = false;
     }
   }, [active?.show]);
 
@@ -91,13 +94,29 @@ export function DatePickerMenu({
     markName: DATE_SUGGESTION.markName,
   });
 
+  const focusCalendarAfterPosition = useCallback(() => {
+    const selectedDay = calendarRef.current?.querySelector<HTMLElement>(
+      '[data-selected-single="true"]',
+    );
+    if (!active?.synthetic || didAutoFocusRef.current || !selectedDay) {
+      return;
+    }
+    didAutoFocusRef.current = true;
+    selectedDay.focus({ preventScroll: true });
+  }, [active?.synthetic]);
+
   const floatingRef = useFloatingPosition({
     show: Boolean(active?.show),
     anchorEl: () => active?.anchorEl() ?? null,
     // Constrain to the owning editor: a global selector would pick the
     // first editable ProseMirror on the page and leak across editors.
     boundaryElement: editorView?.dom ?? null,
+    onPositioned: focusCalendarAfterPosition,
   });
+  const setFloatingRef = (node: HTMLDivElement | null) => {
+    calendarRef.current = node;
+    floatingRef.current = node;
+  };
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -124,7 +143,7 @@ export function DatePickerMenu({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: Escape handling for a floating popover, not an interactive control.
     <div
-      ref={floatingRef}
+      ref={setFloatingRef}
       style={FLOATING_INITIAL_STYLE}
       className="w-fit overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
       onKeyDown={handleKeyDown}

--- a/packages/core/editor/src/components/date-picker-menu.tsx
+++ b/packages/core/editor/src/components/date-picker-menu.tsx
@@ -135,9 +135,6 @@ export function DatePickerMenu({
         // that already-selected day toggles the selection to `undefined`, so
         // the trigger is left behind instead of committing today's date.
         required
-        // Move focus to the selected day so arrow keys navigate the grid and
-        // Enter commits, without any editor-side key forwarding.
-        autoFocus
         captionLayout="dropdown"
         // Hide adjacent-month days so only the visible month is selectable
         // (avoids ambiguous day cells near month boundaries).

--- a/packages/core/editor/src/components/inline-selection-menu.tsx
+++ b/packages/core/editor/src/components/inline-selection-menu.tsx
@@ -51,11 +51,6 @@ type LinkSession = {
   initialHref: string;
 };
 
-// A single "turn into paragraph" click may need to peel off several nesting
-// levels (e.g. a list inside a blockquote); this bounds the flatten loop well
-// above any realistic nesting depth.
-const MAX_PARAGRAPH_FLATTEN_STEPS = 8;
-
 /**
  * Whether every block touched by the selection is a paragraph sitting directly
  * under the document. This is the goal state of "turn into paragraph", so it
@@ -185,14 +180,24 @@ function InlineSelectionMenuContent({
       return flattenStep(state, dispatch);
     }
     let changed = false;
-    for (let step = 0; step < MAX_PARAGRAPH_FLATTEN_STEPS; step += 1) {
+    // Each successful step must remove or convert document structure. The
+    // initial node size is therefore a natural upper bound that supports valid
+    // deeply nested Markdown while still guarding against a misbehaving
+    // command that reports success without making progress.
+    let remainingSteps = view.state.doc.nodeSize;
+    while (remainingSteps > 0) {
       if (isSelectionAllTopLevelParagraphs(view.state)) {
         break;
       }
+      const before = view.state.doc;
       if (!flattenStep(view.state, view.dispatch, view)) {
         break;
       }
+      if (view.state.doc.eq(before)) {
+        break;
+      }
       changed = true;
+      remainingSteps -= 1;
     }
     return changed;
   };

--- a/packages/core/editor/src/components/slash-command.tsx
+++ b/packages/core/editor/src/components/slash-command.tsx
@@ -119,12 +119,13 @@ export function SlashCommand({
       return;
     }
 
-    // Swap the slash mark for the date trigger text carrying the
-    // `date_suggestion` mark — the same document state as if the user had
-    // typed the trigger — so the DatePickerMenu surface takes over.
+    // Swap the slash mark for a synthetic date trigger. DatePickerMenu uses
+    // that existing distinction to focus the calendar for keyboard navigation;
+    // a directly typed `$date` keeps focus in the editor so typing can continue.
     const { schema } = editorView.state;
     const mark = schema.mark(DATE_SUGGESTION.markName, {
       trigger: DATE_SUGGESTION.trigger,
+      synthetic: true,
     });
     ext.suggestions.command.replaceSuggestMarkWith({
       content: Fragment.from(schema.text(DATE_SUGGESTION.trigger, [mark])),

--- a/packages/core/editor/src/extensions.ts
+++ b/packages/core/editor/src/extensions.ts
@@ -141,6 +141,9 @@ export function setupExtensions(
       markName: DATE_SUGGESTION.markName,
       trigger: DATE_SUGGESTION.trigger,
       markClassName: 'text-pop',
+      // This provider has no query: typing past the exact trigger means the
+      // user is entering literal text, so close without consuming the suffix.
+      endOnQuery: true,
       // The suggestion keymap is installed once by the slash-command
       // provider and dispatches by mark name, same as wikiSuggestions.
       installKeymap: false,

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -937,7 +937,12 @@ export class PmEditorService
     if (!view || view.isDestroyed || !view.dom.isConnected) {
       return false;
     }
-    if (view.hasFocus()) {
+    const activeElement = view.dom.ownerDocument.activeElement;
+    const pageOwnsFocus =
+      !activeElement ||
+      activeElement === view.dom.ownerDocument.body ||
+      activeElement === view.dom.ownerDocument.documentElement;
+    if (view.hasFocus() || !pageOwnsFocus) {
       return false;
     }
     view.focus();
@@ -1066,9 +1071,51 @@ export class PmEditorService
     if (!view) {
       return false;
     }
-    const parsed = this.getMarkdown(view.state.schema).parser.parse(
-      markdownText,
-    );
+    return this.insertMarkdownIntoView(view, markdownText);
+  }
+
+  /**
+   * Binds a future Markdown insertion to the current editor state. Clipboard
+   * reads may wait on a permission prompt; during that wait the user can switch
+   * notes or move the selection, and the pending operation must not follow.
+   */
+  captureMarkdownInsertion(): ((markdownText: string) => boolean) | null {
+    const view = this.getActiveEditorView();
+    if (!view) {
+      return null;
+    }
+    const capturedDoc = view.state.doc;
+    const capturedSelection = view.state.selection;
+
+    return (markdownText) => {
+      if (
+        view.isDestroyed ||
+        !this.getEditorEntryByView(view) ||
+        this.getActiveEditorView() !== view ||
+        !view.state.doc.eq(capturedDoc) ||
+        !view.state.selection.eq(capturedSelection)
+      ) {
+        return false;
+      }
+      return this.insertMarkdownIntoView(view, markdownText);
+    };
+  }
+
+  private insertMarkdownIntoView(
+    view: ReturnType<typeof createEditor>,
+    markdownText: string,
+  ): boolean {
+    const markdown = this.getMarkdown(view.state.schema);
+    let parsed: ReturnType<typeof markdown.parser.parse>;
+    try {
+      parsed = markdown.parser.parse(markdownText);
+      const serialized = markdown.serializer.serialize(parsed);
+      if (!isMarkdownRoundTripPreserved(markdownText, serialized)) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
     const inline =
       parsed.childCount === 1 && parsed.firstChild?.type.name === 'paragraph';
     const slice = inline

--- a/packages/js-lib/banger-editor/src/__tests__/math.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/math.spec.ts
@@ -4,8 +4,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { setupBase } from '../base';
 import { setupBold } from '../bold';
 import { setupCodeBlock } from '../code-block';
-import { collection } from '../common';
+import { collection, isMac } from '../common';
 import { setupHardBreak } from '../hard-break';
+import { setupHistory } from '../history';
 import { setupImage } from '../image';
 import { serializeMathClipboardText, setupMath } from '../math';
 import { setupParagraph } from '../paragraph';
@@ -37,6 +38,7 @@ const editorTest = createBangerEditorTestSetup({
     setupBold(),
     setupCodeBlock(),
     setupHardBreak(),
+    setupHistory(),
     setupImage(),
     setupWikiLink(),
     math,
@@ -372,6 +374,63 @@ describe('math interaction', () => {
 
     expect(event.defaultPrevented).toBe(true);
     editor.expectDoc(doc(p('before ', mathInline('alpha '))));
+  });
+
+  it('keeps select-all scoped to the nested math source', () => {
+    const editor = editorTest.createEditor(doc(p(mathInline('abc'))));
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(
+        NodeSelection.create(editor.view.state.doc, 1),
+      ),
+    );
+    const sourceEditor = editor.view.dom.querySelector<HTMLElement>(
+      'math-inline .math-src .ProseMirror',
+    );
+    expect(sourceEditor).not.toBeNull();
+    sourceEditor?.focus();
+    const event = new KeyboardEvent('keydown', {
+      key: 'a',
+      metaKey: isMac,
+      ctrlKey: !isMac,
+      bubbles: true,
+      cancelable: true,
+    });
+    sourceEditor?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(document.getSelection()?.toString()).toBe('abc');
+    expect(editor.view.state.selection).toBeInstanceOf(NodeSelection);
+  });
+
+  it('undoes outer document history while the math source editor is focused', () => {
+    const editor = editorTest.createEditor(doc(p(), mathDisplay('abc'), p()));
+    const mathPos = 2;
+    editor.view.dispatch(
+      editor.view.state.tr.setSelection(
+        NodeSelection.create(editor.view.state.doc, mathPos),
+      ),
+    );
+    const sourceEditor = editor.view.dom.querySelector<HTMLElement>(
+      'math-display .math-src .ProseMirror',
+    );
+    expect(sourceEditor).not.toBeNull();
+
+    editor.view.dispatch(
+      editor.view.state.tr.insertText('d', mathPos + 4, mathPos + 4),
+    );
+    editor.expectDoc(doc(p(), mathDisplay('abcd'), p()));
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: isMac,
+      ctrlKey: !isMac,
+      bubbles: true,
+      cancelable: true,
+    });
+    sourceEditor?.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    editor.expectDoc(doc(p(), mathDisplay('abc'), p()));
   });
 
   it('keeps multiline plain-text paste inside display math source', () => {

--- a/packages/js-lib/banger-editor/src/math.ts
+++ b/packages/js-lib/banger-editor/src/math.ts
@@ -12,6 +12,7 @@ import type { PluginSimple } from 'markdown-it';
 import {
   type CollectionType,
   collection,
+  isMac,
   keybinding,
   PRIORITY,
   setPluginPriority,
@@ -39,8 +40,10 @@ import {
   NodeSelection,
   Plugin,
   PluginKey,
+  redo,
   Selection,
   TextSelection,
+  undo,
 } from './pm';
 import { getNodeType } from './pm-utils';
 
@@ -195,6 +198,8 @@ function installMathViewSafeguards(
   displayMode: boolean,
 ): void {
   const handleKeyDown = (event: KeyboardEvent) => {
+    if (handleNestedSelectAll(event, mathView)) return;
+    if (handleHistoryShortcut(event, outerView)) return;
     if (handleCtrlBackspace(event, mathView, outerView, getPos)) return;
     if (!displayMode) return;
     const direction = displayExitDirection(event, mathView.dom);
@@ -281,6 +286,75 @@ function installMathViewSafeguards(
     mathView.dom.removeEventListener('paste', handlePaste, true);
     upstreamDestroy();
   };
+}
+
+function handleNestedSelectAll(
+  event: KeyboardEvent,
+  mathView: MathView,
+): boolean {
+  if (event.isComposing || event.altKey || event.shiftKey) {
+    return false;
+  }
+  const primaryModifier = isMac
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+  if (!primaryModifier || event.key.toLowerCase() !== 'a') {
+    return false;
+  }
+  const source = mathView.dom.querySelector<HTMLElement>(
+    '.math-src .ProseMirror',
+  );
+  if (
+    !source ||
+    !(event.target instanceof Node) ||
+    !source.contains(event.target)
+  ) {
+    return false;
+  }
+
+  const selection = source.ownerDocument.getSelection();
+  if (!selection) {
+    return false;
+  }
+  const range = source.ownerDocument.createRange();
+  range.selectNodeContents(source);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  return true;
+}
+
+function handleHistoryShortcut(
+  event: KeyboardEvent,
+  outerView: Parameters<NodeViewConstructor>[1],
+): boolean {
+  if (event.isComposing || event.altKey) {
+    return false;
+  }
+  const primaryModifier = isMac
+    ? event.metaKey && !event.ctrlKey
+    : event.ctrlKey && !event.metaKey;
+  if (!primaryModifier) {
+    return false;
+  }
+
+  const key = event.key.toLowerCase();
+  const command =
+    key === 'z'
+      ? event.shiftKey
+        ? redo
+        : undo
+      : !isMac && key === 'y' && !event.shiftKey
+        ? redo
+        : undefined;
+  if (!command || !command(outerView.state, outerView.dispatch)) {
+    return false;
+  }
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  return true;
 }
 
 function handleCtrlBackspace(

--- a/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
@@ -42,6 +42,7 @@ const dateSuggestions = setupSuggestions({
   trigger: '$date',
   markClassName: 'date',
   installKeymap: false,
+  endOnQuery: true,
 });
 const resolved = resolve([
   collection({ id: 'test-store' }),
@@ -275,6 +276,35 @@ describe('suggestions provider state', () => {
       text: '$date',
       show: true,
     });
+  });
+
+  it('ends a trigger-only suggestion when literal text follows it', () => {
+    const store = createStore();
+    const view = createPlainEditor({ text: '$dat', store });
+
+    expect(handleTextInput(view, 5, 5, 'e')).toBe(true);
+    expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
+      markName: 'date_suggestion',
+      text: '$date',
+    });
+
+    view.dispatch(view.state.tr.insertText('f'));
+    view.dispatch(view.state.tr.insertText('oo'));
+
+    expect(view.state.doc.textContent).toBe('$datefoo');
+    expect(editorStore.get(view.state, $suggestions).get(view)).toBeUndefined();
+    const dateSuggestionMark = schema.marks.date_suggestion;
+    expect(dateSuggestionMark).toBeDefined();
+    if (!dateSuggestionMark) {
+      throw new Error('Expected the date suggestion mark');
+    }
+    expect(
+      view.state.doc.rangeHasMark(
+        0,
+        view.state.doc.content.size,
+        dateSuggestionMark,
+      ),
+    ).toBe(false);
   });
 
   it('activates a provider when its trigger arrives as a single inserted chunk', () => {

--- a/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/__tests__/suggestions.spec.ts
@@ -355,7 +355,10 @@ describe('suggestions provider state', () => {
     // This is the contract the slash menu's "Date" item relies on: replacing
     // the slash mark with another provider's trigger text (carrying that
     // provider's mark) activates the other provider's suggestion.
-    const mark = schema.mark('date_suggestion', { trigger: '$date' });
+    const mark = schema.mark('date_suggestion', {
+      trigger: '$date',
+      synthetic: true,
+    });
     slashSuggestions.command.replaceSuggestMarkWith({
       content: Fragment.from(schema.text('$date', [mark])),
     })(view.state, view.dispatch, view);
@@ -364,6 +367,7 @@ describe('suggestions provider state', () => {
     expect(editorStore.get(view.state, $suggestions).get(view)).toMatchObject({
       markName: 'date_suggestion',
       text: '$date',
+      synthetic: true,
       show: true,
     });
 
@@ -399,6 +403,7 @@ describe('suggestions provider state', () => {
           {
             markName: 'slash_command',
             trigger: '/',
+            synthetic: false,
             show: true,
             text: '/',
             position: 1,
@@ -412,6 +417,7 @@ describe('suggestions provider state', () => {
           {
             markName: 'wiki_link_suggestion',
             trigger: '[[',
+            synthetic: false,
             show: true,
             text: '[[Tar',
             position: 1,

--- a/packages/js-lib/banger-editor/src/suggestions/index.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/index.ts
@@ -29,6 +29,9 @@ export type SuggestionConfig = {
   /** End the suggestion when the query contains whitespace (slash menu
    * behavior); providers with multi-word queries (wiki links) leave it off. */
   endOnWhitespace?: boolean;
+  /** End the suggestion as soon as text follows the trigger. Use for
+   * trigger-only providers that have no query. */
+  endOnQuery?: boolean;
 };
 
 export function setupSuggestions(config: SuggestionConfig) {

--- a/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
@@ -198,11 +198,13 @@ export function pluginSuggestion({
   trigger,
   logger,
   endOnWhitespace = false,
+  endOnQuery = false,
 }: {
   markName: string;
   trigger: string;
   logger?: Logger;
   endOnWhitespace?: boolean;
+  endOnQuery?: boolean;
 }) {
   return new Plugin({
     key: new PluginKey(`suggestion-${markName}`),
@@ -284,6 +286,15 @@ export function pluginSuggestion({
               return;
             }
             logger?.debug('querytext', result?.text);
+
+            if (endOnQuery && result.text !== trigger) {
+              logger?.debug('suggestion:text after trigger ended the query');
+              removeSuggestMark({
+                markName,
+                selection: state.selection,
+              })(state, view.dispatch, view);
+              return;
+            }
 
             // Whitespace ends the query for providers that opt in (the
             // slash menu): the typed text stays in the document, the menu

--- a/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
+++ b/packages/js-lib/banger-editor/src/suggestions/plugin-suggestion.ts
@@ -27,6 +27,7 @@ import { store } from '../store';
 export type Suggestion = {
   markName: string;
   trigger: string;
+  synthetic: boolean;
   show: boolean;
   text: string;
   position: number;
@@ -319,6 +320,9 @@ export function pluginSuggestion({
               return;
             }
 
+            const activeMark = state.doc
+              .nodeAt(result.start)
+              ?.marks.find((mark) => mark.type === markType);
             setSuggestionForView(state, view, markName, {
               selectedIndex:
                 suggestion?.markName === markName &&
@@ -327,6 +331,7 @@ export function pluginSuggestion({
                   : 0,
               markName,
               trigger,
+              synthetic: activeMark?.attrs.synthetic === true,
               show: true,
               text: result.text ?? '',
               position: result.start,

--- a/packages/tooling/e2e-tests/src/clipboard-markdown.e2e.ts
+++ b/packages/tooling/e2e-tests/src/clipboard-markdown.e2e.ts
@@ -6,6 +6,7 @@ import {
   pressAppShortcut,
   readStoredMarkdown,
   selectEditorText,
+  waitForEditorFocus,
   writeStoredMarkdown,
 } from './common';
 
@@ -148,4 +149,122 @@ test('multi-block Markdown pasted into a tight list keeps its paragraph boundari
   await expect(readStoredMarkdown(page, workspaceName, noteName)).resolves.toBe(
     expected,
   );
+});
+
+test('refuses Markdown paste when parsing would silently discard source', async ({
+  context,
+  page,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  const workspaceName = 'paste-markdown-fidelity';
+  const noteName = 'fidelity';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  const editor = getEditorLocator(page, {});
+  await waitForEditorFocus(page, {});
+  await editor.fill('KEEP');
+  await selectEditorText(page, 'KEEP');
+  await page.evaluate(() =>
+    navigator.clipboard.writeText(
+      '[visible][missing]\n\n[unused]: https://example.com',
+    ),
+  );
+
+  await runCommand(page, 'Paste from Markdown');
+
+  await expect(page.getByText('Could not paste Markdown')).toBeVisible();
+  await expect(editor).toHaveText('KEEP');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('KEEP');
+});
+
+test('async Markdown paste cannot land in a different note', async ({
+  context,
+  page,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  const workspaceName = 'paste-markdown-target';
+  const firstNote = 'first';
+  const secondNote = 'second';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: firstNote,
+  });
+  const editor = getEditorLocator(page, {});
+  await waitForEditorFocus(page, {});
+  await editor.fill('FIRST');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, firstNote))
+    .toBe('FIRST');
+
+  await page.getByRole('button', { name: 'Bangle.io' }).click();
+  await page.getByRole('menuitem', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill(secondNote);
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect
+    .poll(() => editor.getAttribute('data-editor-name'))
+    .toContain(`${workspaceName}:${secondNote}.md`);
+  await waitForEditorFocus(page, {});
+  await editor.fill('SECOND');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, secondNote))
+    .toBe('SECOND');
+  await page.getByRole('treeitem', { name: `${firstNote}.md` }).click();
+  await expect
+    .poll(() => editor.getAttribute('data-editor-name'))
+    .toContain(`${workspaceName}:${firstNote}.md`);
+  await waitForEditorFocus(page, {});
+  await selectEditorText(page, 'FIRST');
+
+  await page.evaluate(() => {
+    const testWindow = window as typeof window & {
+      clipboardReadStarted?: boolean;
+      resolveClipboardRead?: (value: string) => void;
+    };
+    const pendingRead = new Promise<string>((resolve) => {
+      testWindow.resolveClipboardRead = resolve;
+    });
+    Object.defineProperty(navigator.clipboard, 'readText', {
+      configurable: true,
+      value: () => {
+        testWindow.clipboardReadStarted = true;
+        return pendingRead;
+      },
+    });
+  });
+  await runCommand(page, 'Paste from Markdown');
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              clipboardReadStarted?: boolean;
+            }
+          ).clipboardReadStarted,
+      ),
+    )
+    .toBe(true);
+
+  await page.getByRole('treeitem', { name: `${secondNote}.md` }).click();
+  await expect
+    .poll(() => editor.getAttribute('data-editor-name'))
+    .toContain(`${workspaceName}:${secondNote}.md`);
+  await waitForEditorFocus(page, {});
+  await selectEditorText(page, 'SECOND');
+  await page.evaluate(() =>
+    (
+      window as typeof window & {
+        resolveClipboardRead?: (value: string) => void;
+      }
+    ).resolveClipboardRead?.('WRONG NOTE'),
+  );
+
+  await expect(page.getByText('Could not paste Markdown')).toBeVisible();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, firstNote))
+    .toBe('FIRST');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, secondNote))
+    .toBe('SECOND');
 });

--- a/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-format-toolbar.e2e.ts
@@ -152,6 +152,19 @@ test('Paragraph converts an entire mixed or nested selection in one click', asyn
     .poll(() => readStoredMarkdown(page, workspaceName, noteName))
     .toBe('item');
   await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
+
+  // The flattening loop must be driven by document progress, not an arbitrary
+  // nesting cap. Ten blockquote levels previously stopped halfway through.
+  const deeplyNested = `${'> '.repeat(10)}- deep item`;
+  await writeStoredMarkdown(page, workspaceName, noteName, deeplyNested);
+  await page.reload({ waitUntil: 'networkidle' });
+  await selectEditorText(page, 'deep item');
+  await expect(paragraph).toBeEnabled();
+  await paragraph.click();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('deep item');
+  await expect(paragraph).toHaveAttribute('aria-pressed', 'true');
 });
 
 // The toolbar now carries enough controls that it can be wider than a phone

--- a/packages/tooling/e2e-tests/src/editor-math.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-math.e2e.ts
@@ -7,6 +7,7 @@ import {
   getEditorLocator,
   readStoredMarkdown,
   waitForEditorFocus,
+  writeStoredMarkdown,
 } from './common';
 
 test('authors, edits, copies, and persists inline and display math', async ({
@@ -162,6 +163,42 @@ $$`;
   });
 
   expect(invalidSelectionWarnings).toEqual([]);
+});
+
+test('undo from a focused math source restores the outer note history', async ({
+  page,
+}) => {
+  const workspaceName = 'editor-math-undo';
+  const noteName = 'Math';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    'KEEP\n\n$$\nabc\n$$',
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const displayMath = getEditorLocator(page, {})
+    .first()
+    .locator('math-display');
+  await displayMath.locator('.math-render').click();
+  const sourceEditor = displayMath.locator('.math-src .ProseMirror');
+  await expect(sourceEditor).toBeVisible();
+  await sourceEditor.press('End');
+  await page.keyboard.insertText('d');
+  await expect(sourceEditor).toHaveText('abcd');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toContain('abcd');
+
+  await sourceEditor.press(`${ctrlKey}+z`);
+
+  await expect(sourceEditor).toBeFocused();
+  await expect(sourceEditor).toHaveText('abc');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('KEEP\n\n$$\nabc\n$$');
 });
 
 test('unsafe edited math cannot consume following note content', async ({

--- a/packages/tooling/e2e-tests/src/editor-select-all-scope.e2e.ts
+++ b/packages/tooling/e2e-tests/src/editor-select-all-scope.e2e.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test';
 import {
   createBrowserWorkspaceAndNote,
+  ctrlKey,
   EDITOR_FOCUSED_SELECTOR,
   getEditorLocator,
   pressAppShortcut,
+  readStoredMarkdown,
   waitForEditorFocus,
 } from './common';
 
@@ -68,4 +70,38 @@ test('Cmd/Ctrl-A from the editor pane whitespace selects only the note', async (
   expect(selection.withinEditor).toBe(true);
   // The sidebar's workspace name must never land in the selection.
   expect(selection.text).not.toContain(workspaceName);
+});
+
+test('Cmd/Ctrl-A inside math cannot replace the outer note', async ({
+  page,
+}) => {
+  const noteName = 'math-selection';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName,
+  });
+  const editor = getEditorLocator(page, {}).first();
+  await waitForEditorFocus(page, {});
+  await editor.fill('KEEP THIS LINE');
+  await editor.press('End');
+  await editor.press('Enter');
+  await page.keyboard.insertText('/');
+  await page.getByText('Math block', { exact: true }).click();
+
+  const sourceEditor = editor.locator('math-display .math-src .ProseMirror');
+  await expect(sourceEditor).toBeVisible();
+  await sourceEditor.fill(String.raw`\frac{a}{b}`);
+  await expect(sourceEditor).toBeFocused();
+
+  // Exercise the application shortcut manager as well as the browser-native
+  // nested editor selection. Neither may redirect focus to the outer editor.
+  await pressAppShortcut(page, 'a');
+  await expect(sourceEditor).toBeFocused();
+  await sourceEditor.press(`${ctrlKey}+a`);
+  await page.keyboard.insertText('x');
+
+  await expect(editor).toContainText('KEEP THIS LINE');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('KEEP THIS LINE\n\n$$\nx\n$$');
 });

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -448,6 +448,28 @@ test('typing the $date trigger directly opens the calendar and inserts a day', a
     .toBe(targetLabel);
 });
 
+test('typing after the $date trigger keeps every character in the note', async ({
+  page,
+}) => {
+  const workspaceName = 'date-trigger-literal-text';
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await editor.pressSequentially('$datefoo', { delay: 100 });
+
+  await expect(page.locator('[data-slot="calendar"]')).toBeHidden();
+  await waitForEditorFocus(page, {});
+  await expect(editor).toHaveText('$datefoo');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe('$datefoo');
+});
+
 test('an abandoned $date trigger persists as plain text across reload', async ({
   page,
 }) => {

--- a/packages/tooling/e2e-tests/src/slash-command.e2e.ts
+++ b/packages/tooling/e2e-tests/src/slash-command.e2e.ts
@@ -384,6 +384,42 @@ test('slash date command inserts a day picked from the current month', async ({
     .toBe(`${targetLabel} meeting`);
 });
 
+test('slash date command supports keyboard day navigation', async ({
+  page,
+}) => {
+  const workspaceName = 'slash-command-date-keyboard';
+  await page.clock.setFixedTime(FIXED_CALENDAR_DATE);
+  const target = new Date(
+    FIXED_CALENDAR_DATE.getFullYear(),
+    FIXED_CALENDAR_DATE.getMonth(),
+    FIXED_CALENDAR_DATE.getDate() + 1,
+  );
+  const targetLabel = formatDateLabel(target);
+
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: 'Home',
+  });
+
+  const editor = getEditorLocator(page, {});
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.insertText('/');
+  await expect(page.getByText('Date', { exact: true })).toBeVisible();
+  await page.keyboard.insertText('date');
+  await page.keyboard.press('Enter');
+
+  await expect(page.locator('[data-slot="calendar"]')).toBeVisible();
+  await expect(page.locator(daySelector(FIXED_CALENDAR_DATE))).toBeFocused();
+  await page.keyboard.press('ArrowRight');
+  await page.keyboard.press('Enter');
+
+  await expect(editor).toBeFocused();
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, 'Home'))
+    .toBe(targetLabel);
+});
+
 test('slash date command inserts a day after navigating months', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- contain nested math selection and history shortcuts within the correct editor
- bind asynchronous Markdown paste to its original selection and reject lossy parsing
- preserve literal date-trigger suffixes and fully flatten deeply nested block selections

## Reviewer callout

The browser regression reproduces the original `Cmd/Ctrl-A` plus typing data-loss path and verifies the persisted outer Markdown remains intact.