### PR TITLE
Change only the marker when converting a same-level list run

### DIFF
--- a/packages/core/editor/src/__tests__/list-insert-item-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-insert-item-markdown.spec.ts
@@ -1,54 +1,13 @@
-import {
-  type Command,
-  EditorState,
-  setupList,
-  TextSelection,
-} from '@bangle.io/prosemirror-plugins';
+import { setupList } from '@bangle.io/prosemirror-plugins';
 import { describe, expect, it } from 'vitest';
-import { createProductionMarkdown } from './production-markdown-test-helpers';
+import { createMarkdownHarness } from './production-markdown-test-helpers';
 
 // The insert-item shortcuts leave an *empty* item behind until the user types,
 // and autosave serializes that transient state. These assertions pin what it
 // writes to disk and that reading it back is a fixpoint, so a serializer change
 // cannot quietly turn the empty item into a different construct.
-function setup() {
-  const markdown = createProductionMarkdown();
-  const list = setupList();
-
-  const caretAfter = (source: string, text: string) => {
-    const doc = markdown.parser.parse(source);
-    let pos = -1;
-    doc.descendants((node, nodePos) => {
-      if (pos === -1 && node.isText && node.text?.includes(text)) {
-        pos = nodePos + node.text.indexOf(text) + text.length;
-      }
-    });
-    if (pos === -1) throw new Error(`No text "${text}" in ${source}`);
-    return EditorState.create({
-      doc,
-      schema: markdown.schema,
-      selection: TextSelection.create(doc, pos),
-    });
-  };
-  const apply = (state: EditorState, command: Command) => {
-    let next = state;
-    command(state, (tr) => {
-      next = state.apply(tr);
-    });
-    return next;
-  };
-  const serialize = (state: EditorState) =>
-    markdown.serializer.serialize(state.doc);
-
-  return {
-    caretAfter,
-    apply,
-    serialize,
-    list,
-    reserialize: (source: string) =>
-      markdown.serializer.serialize(markdown.parser.parse(source)),
-  };
-}
+const { caretAfter, apply, serialize, reserialize } = createMarkdownHarness();
+const list = setupList();
 
 describe('inserting a list item writes stable Markdown', () => {
   // The empty item serializes as its marker plus the separating space, so these
@@ -78,8 +37,6 @@ describe('inserting a list item writes stable Markdown', () => {
     below,
     above,
   }) => {
-    const { caretAfter, apply, serialize, list, reserialize } = setup();
-
     const withBelow = serialize(
       apply(caretAfter(source, 'alpha'), list.command.insertEmptyListBelow),
     );
@@ -95,8 +52,6 @@ describe('inserting a list item writes stable Markdown', () => {
   });
 
   it('keeps a new task item unchecked and leaves the source item checked', () => {
-    const { caretAfter, apply, serialize, list } = setup();
-
     const next = apply(
       caretAfter('- [x] alpha', 'alpha'),
       list.command.insertEmptyListBelow,
@@ -106,8 +61,6 @@ describe('inserting a list item writes stable Markdown', () => {
   });
 
   it('adds the nested sibling at its own depth', () => {
-    const { caretAfter, apply, serialize, list, reserialize } = setup();
-
     const next = serialize(
       apply(
         caretAfter('- parent\n  - child\n- sibling', 'child'),

--- a/packages/core/editor/src/__tests__/list-kind-toggle-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-kind-toggle-markdown.spec.ts
@@ -61,18 +61,20 @@ describe('list kind toggles', () => {
     expect(serialize(back)).toBe('- [x] alpha\n- [x] bravo');
   });
 
-  it('keeps checked state when a task list detours through an ordered list', () => {
+  it('keeps checked state when a task list takes an ordered marker', () => {
     const { stateFrom, apply, serialize, list } = setup();
     const checked = stateFrom('- [x] alpha\n- [x] bravo');
 
+    // Asking for a number does not ask for the checkboxes to go: the marker is
+    // a whole-list property, task-ness is per item. This used to detour through
+    // `1. alpha`, so saving in between lost the boxes for good.
     const ordered = apply(checked, list.command.toggleOrderedList);
-    expect(serialize(ordered)).toBe('1. alpha\n1. bravo');
+    expect(serialize(ordered)).toBe('1. [x] alpha\n1. [x] bravo');
 
-    const back = apply(ordered, list.command.toggleTaskList);
-
-    // The container stays ordered because that is what the user asked for;
-    // only the checkbox state has to survive the detour.
-    expect(serialize(back)).toBe('1. [x] alpha\n1. [x] bravo');
+    // Pressing the task toggle when every item is already a task turns the list
+    // off, rather than clearing boxes the user had ticked.
+    const off = apply(ordered, list.command.toggleTaskList);
+    expect(serialize(off)).toBe('alpha\n\nbravo');
   });
 
   it('round-trips a bullet list through task and back', () => {

--- a/packages/core/editor/src/__tests__/list-kind-toggle-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-kind-toggle-markdown.spec.ts
@@ -1,46 +1,16 @@
-import {
-  AllSelection,
-  type Command,
-  EditorState,
-  setupList,
-} from '@bangle.io/prosemirror-plugins';
+import { setupList } from '@bangle.io/prosemirror-plugins';
 import { describe, expect, it } from 'vitest';
-import { createProductionMarkdown } from './production-markdown-test-helpers';
+import { createMarkdownHarness } from './production-markdown-test-helpers';
 
 // Switching a list between kinds from the selection toolbar must round-trip
 // through Markdown: the container marker follows the kind, and a task item's
 // checked state is not silently cleared by a detour through another kind.
-function setup() {
-  const markdown = createProductionMarkdown();
-  const list = setupList();
-
-  const stateFrom = (source: string) => {
-    const doc = markdown.parser.parse(source);
-    return EditorState.create({
-      doc,
-      schema: markdown.schema,
-      selection: new AllSelection(doc),
-    });
-  };
-  const apply = (state: EditorState, command: Command) => {
-    let next = state;
-    command(state, (tr) => {
-      next = state.apply(tr);
-    });
-    return next;
-  };
-  return {
-    stateFrom,
-    apply,
-    serialize: (state: EditorState) => markdown.serializer.serialize(state.doc),
-    list,
-  };
-}
+const { selectAll, apply, serialize } = createMarkdownHarness();
+const list = setupList();
 
 describe('list kind toggles', () => {
   it('starts a new task item unchecked', () => {
-    const { stateFrom, apply, serialize, list } = setup();
-    const bullet = stateFrom('- alpha\n- bravo');
+    const bullet = selectAll('- alpha\n- bravo');
 
     const task = apply(bullet, list.command.toggleTaskList);
 
@@ -48,8 +18,7 @@ describe('list kind toggles', () => {
   });
 
   it('keeps checked state when a task list detours through a bullet list', () => {
-    const { stateFrom, apply, serialize, list } = setup();
-    const checked = stateFrom('- [x] alpha\n- [x] bravo');
+    const checked = selectAll('- [x] alpha\n- [x] bravo');
 
     const bullet = apply(checked, list.command.toggleBulletList);
     expect(serialize(bullet)).toBe('- alpha\n- bravo');
@@ -62,8 +31,7 @@ describe('list kind toggles', () => {
   });
 
   it('keeps checked state when a task list takes an ordered marker', () => {
-    const { stateFrom, apply, serialize, list } = setup();
-    const checked = stateFrom('- [x] alpha\n- [x] bravo');
+    const checked = selectAll('- [x] alpha\n- [x] bravo');
 
     // Asking for a number does not ask for the checkboxes to go: the marker is
     // a whole-list property, task-ness is per item. This used to detour through
@@ -78,8 +46,7 @@ describe('list kind toggles', () => {
   });
 
   it('round-trips a bullet list through task and back', () => {
-    const { stateFrom, apply, serialize, list } = setup();
-    const bullet = stateFrom('- alpha\n- bravo');
+    const bullet = selectAll('- alpha\n- bravo');
 
     const task = apply(bullet, list.command.toggleTaskList);
     expect(serialize(task)).toBe('- [ ] alpha\n- [ ] bravo');

--- a/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
@@ -83,14 +83,45 @@ describe('changing a list run marker', () => {
   });
 
   it('stops at a neighbour that already has the target marker', () => {
+    // The neighbour is a task so over-expansion is visible: rewriting it too
+    // would strip its checkbox instead of leaving the item untouched.
     const out = serialize(
       apply(
-        stateAt('- alpha\n\n1. beta', 'alpha'),
+        stateAt('- alpha\n\n1. [ ] beta', 'alpha'),
         list.command.toggleOrderedList,
       ),
     );
 
-    expect(out).toBe('1. alpha\n1. beta');
+    expect(out).toBe('1. alpha\n1. [ ] beta');
+    expect(reserialize(out)).toBe(out);
+  });
+
+  it('converts the whole run when the selection ends inside a nested item', () => {
+    const out = serialize(
+      apply(
+        stateAt('- [x] alpha\n- beta\n  - sub\n- gamma', 'alpha', 'sub'),
+        list.command.toggleOrderedList,
+      ),
+    );
+
+    // Endpoints at different depths used to fall back to the library command,
+    // which stripped alpha's checkbox and left `- gamma` as a second list.
+    expect(out).toBe('1. [x] alpha\n1. beta\n   - sub\n1. gamma');
+    expect(reserialize(out)).toBe(out);
+  });
+
+  it('converts a mixed-marker selection to one uniform run', () => {
+    const out = serialize(
+      apply(
+        stateAt('- alpha\n\n1. [x] beta', 'alpha', 'beta'),
+        list.command.toggleBulletList,
+      ),
+    );
+
+    // The first item already has the target marker, so keying the decision off
+    // it alone used to defer to the library and drop beta's checkbox.
+    expect(out).toBe('- alpha\n- [x] beta');
+    expect(reserialize(out)).toBe(out);
   });
 
   it('leaves task-ness alone when toggling the task kind', () => {

--- a/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
@@ -1,0 +1,146 @@
+import {
+  type Command,
+  EditorState,
+  setupList,
+  TextSelection,
+} from '@bangle.io/prosemirror-plugins';
+import { describe, expect, it } from 'vitest';
+import { createProductionMarkdown } from './production-markdown-test-helpers';
+
+// Markdown decides list membership by the marker, so a marker change has to
+// cover the whole contiguous run and must not rewrite anything else about an
+// item. These assertions go through the production serializer because the bugs
+// they cover were only visible in the saved Markdown.
+const markdown = createProductionMarkdown();
+const list = setupList();
+
+function stateAt(source: string, from: string, to = from) {
+  const doc = markdown.parser.parse(source);
+  const find = (text: string, offset: number) => {
+    let pos = -1;
+    doc.descendants((node, nodePos) => {
+      if (pos === -1 && node.isText && node.text?.includes(text)) {
+        pos = nodePos + node.text.indexOf(text) + offset;
+      }
+    });
+    if (pos === -1) throw new Error(`no "${text}" in ${source}`);
+    return pos;
+  };
+  return EditorState.create({
+    doc,
+    schema: markdown.schema,
+    selection: TextSelection.create(doc, find(from, 0), find(to, to.length)),
+  });
+}
+
+function apply(state: EditorState, command: Command) {
+  let next = state;
+  command(state, (tr) => {
+    next = state.apply(tr);
+  });
+  return next;
+}
+
+const serialize = (state: EditorState) =>
+  markdown.serializer.serialize(state.doc);
+const reserialize = (source: string) =>
+  markdown.serializer.serialize(markdown.parser.parse(source));
+
+describe('changing a list run marker', () => {
+  it('keeps the checkbox when a task changes marker', () => {
+    const out = serialize(
+      apply(stateAt('- [x] alpha', 'alpha'), list.command.toggleOrderedList),
+    );
+
+    expect(out).toBe('1. [x] alpha');
+    expect(reserialize(out)).toBe(out);
+  });
+
+  it('converts the whole run from a caret, tasks included', () => {
+    const out = serialize(
+      apply(
+        stateAt('- alpha\n- [x] beta\n- gamma', 'beta'),
+        list.command.toggleOrderedList,
+      ),
+    );
+
+    expect(out).toBe('1. alpha\n1. [x] beta\n1. gamma');
+    expect(reserialize(out)).toBe(out);
+  });
+
+  it('converts the whole run from a selection that covers part of it', () => {
+    const out = serialize(
+      apply(
+        stateAt('- alpha\n- beta\n- gamma', 'alpha', 'beta'),
+        list.command.toggleOrderedList,
+      ),
+    );
+
+    // Selecting two of three items used to leave `- gamma` behind, which
+    // Markdown reads as a second list.
+    expect(out).toBe('1. alpha\n1. beta\n1. gamma');
+    expect(reserialize(out)).toBe(out);
+  });
+
+  it('stops at a neighbour that already has the target marker', () => {
+    const out = serialize(
+      apply(
+        stateAt('- alpha\n\n1. beta', 'alpha'),
+        list.command.toggleOrderedList,
+      ),
+    );
+
+    expect(out).toBe('1. alpha\n1. beta');
+  });
+
+  it('leaves task-ness alone when toggling the task kind', () => {
+    const out = serialize(
+      apply(
+        stateAt('- alpha\n- beta\n- gamma', 'beta'),
+        list.command.toggleTaskList,
+      ),
+    );
+
+    // Task-ness is per item in Markdown, so this must not spread to the run.
+    expect(out).toBe('- alpha\n- [ ] beta\n- gamma');
+    expect(reserialize(out)).toBe(out);
+  });
+});
+
+describe('dedenting a list item', () => {
+  it('adopts the destination marker without dropping a checkbox', () => {
+    const out = serialize(
+      apply(
+        stateAt('- one\n  - [x] task\n- two', 'task'),
+        list.command.dedentList,
+      ),
+    );
+
+    expect(out).toBe('- one\n- [x] task\n- two');
+    expect(reserialize(out)).toBe(out);
+  });
+
+  it('does not add a checkbox to a plain item', () => {
+    const out = serialize(
+      apply(
+        stateAt('- [x] one\n  - nested\n- [x] two', 'nested'),
+        list.command.dedentList,
+      ),
+    );
+
+    expect(out).toBe('- [x] one\n- nested\n- [x] two');
+    expect(reserialize(out)).toBe(out);
+  });
+
+  it('adopts an ordered destination marker', () => {
+    const out = serialize(
+      apply(
+        stateAt('1. one\n   - nested\n1. two', 'nested'),
+        list.command.dedentList,
+      ),
+    );
+
+    expect(out).toBe('1. one\n1. nested\n1. two');
+    expect(reserialize(out)).toBe(out);
+  });
+});

--- a/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
@@ -138,4 +138,16 @@ describe('dedenting a list item', () => {
     expect(out).toBe('1. one\n1. nested\n1. two');
     expect(reserialize(out)).toBe(out);
   });
+
+  it('joins a loose destination without closing it up', () => {
+    const out = serialize(
+      apply(
+        caretAfter('- one\n\n  - nested\n\n- two', 'nested'),
+        list.command.dedentList,
+      ),
+    );
+
+    expect(out).toBe('- one\n\n- nested\n\n- two');
+    expect(reserialize(out)).toBe(out);
+  });
 });

--- a/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-run-marker-markdown.spec.ts
@@ -1,55 +1,19 @@
-import {
-  type Command,
-  EditorState,
-  setupList,
-  TextSelection,
-} from '@bangle.io/prosemirror-plugins';
+import { setupList } from '@bangle.io/prosemirror-plugins';
 import { describe, expect, it } from 'vitest';
-import { createProductionMarkdown } from './production-markdown-test-helpers';
+import { createMarkdownHarness } from './production-markdown-test-helpers';
 
 // Markdown decides list membership by the marker, so a marker change has to
 // cover the whole contiguous run and must not rewrite anything else about an
 // item. These assertions go through the production serializer because the bugs
 // they cover were only visible in the saved Markdown.
-const markdown = createProductionMarkdown();
+const { caretAfter, rangeOver, apply, serialize, reserialize } =
+  createMarkdownHarness();
 const list = setupList();
-
-function stateAt(source: string, from: string, to = from) {
-  const doc = markdown.parser.parse(source);
-  const find = (text: string, offset: number) => {
-    let pos = -1;
-    doc.descendants((node, nodePos) => {
-      if (pos === -1 && node.isText && node.text?.includes(text)) {
-        pos = nodePos + node.text.indexOf(text) + offset;
-      }
-    });
-    if (pos === -1) throw new Error(`no "${text}" in ${source}`);
-    return pos;
-  };
-  return EditorState.create({
-    doc,
-    schema: markdown.schema,
-    selection: TextSelection.create(doc, find(from, 0), find(to, to.length)),
-  });
-}
-
-function apply(state: EditorState, command: Command) {
-  let next = state;
-  command(state, (tr) => {
-    next = state.apply(tr);
-  });
-  return next;
-}
-
-const serialize = (state: EditorState) =>
-  markdown.serializer.serialize(state.doc);
-const reserialize = (source: string) =>
-  markdown.serializer.serialize(markdown.parser.parse(source));
 
 describe('changing a list run marker', () => {
   it('keeps the checkbox when a task changes marker', () => {
     const out = serialize(
-      apply(stateAt('- [x] alpha', 'alpha'), list.command.toggleOrderedList),
+      apply(caretAfter('- [x] alpha', 'alpha'), list.command.toggleOrderedList),
     );
 
     expect(out).toBe('1. [x] alpha');
@@ -59,7 +23,7 @@ describe('changing a list run marker', () => {
   it('converts the whole run from a caret, tasks included', () => {
     const out = serialize(
       apply(
-        stateAt('- alpha\n- [x] beta\n- gamma', 'beta'),
+        caretAfter('- alpha\n- [x] beta\n- gamma', 'beta'),
         list.command.toggleOrderedList,
       ),
     );
@@ -71,7 +35,7 @@ describe('changing a list run marker', () => {
   it('converts the whole run from a selection that covers part of it', () => {
     const out = serialize(
       apply(
-        stateAt('- alpha\n- beta\n- gamma', 'alpha', 'beta'),
+        rangeOver('- alpha\n- beta\n- gamma', 'alpha', 'beta'),
         list.command.toggleOrderedList,
       ),
     );
@@ -87,7 +51,7 @@ describe('changing a list run marker', () => {
     // would strip its checkbox instead of leaving the item untouched.
     const out = serialize(
       apply(
-        stateAt('- alpha\n\n1. [ ] beta', 'alpha'),
+        caretAfter('- alpha\n\n1. [ ] beta', 'alpha'),
         list.command.toggleOrderedList,
       ),
     );
@@ -99,7 +63,7 @@ describe('changing a list run marker', () => {
   it('converts the whole run when the selection ends inside a nested item', () => {
     const out = serialize(
       apply(
-        stateAt('- [x] alpha\n- beta\n  - sub\n- gamma', 'alpha', 'sub'),
+        rangeOver('- [x] alpha\n- beta\n  - sub\n- gamma', 'alpha', 'sub'),
         list.command.toggleOrderedList,
       ),
     );
@@ -113,7 +77,7 @@ describe('changing a list run marker', () => {
   it('converts a mixed-marker selection to one uniform run', () => {
     const out = serialize(
       apply(
-        stateAt('- alpha\n\n1. [x] beta', 'alpha', 'beta'),
+        rangeOver('- alpha\n\n1. [x] beta', 'alpha', 'beta'),
         list.command.toggleBulletList,
       ),
     );
@@ -127,7 +91,7 @@ describe('changing a list run marker', () => {
   it('leaves task-ness alone when toggling the task kind', () => {
     const out = serialize(
       apply(
-        stateAt('- alpha\n- beta\n- gamma', 'beta'),
+        caretAfter('- alpha\n- beta\n- gamma', 'beta'),
         list.command.toggleTaskList,
       ),
     );
@@ -142,7 +106,7 @@ describe('dedenting a list item', () => {
   it('adopts the destination marker without dropping a checkbox', () => {
     const out = serialize(
       apply(
-        stateAt('- one\n  - [x] task\n- two', 'task'),
+        caretAfter('- one\n  - [x] task\n- two', 'task'),
         list.command.dedentList,
       ),
     );
@@ -154,7 +118,7 @@ describe('dedenting a list item', () => {
   it('does not add a checkbox to a plain item', () => {
     const out = serialize(
       apply(
-        stateAt('- [x] one\n  - nested\n- [x] two', 'nested'),
+        caretAfter('- [x] one\n  - nested\n- [x] two', 'nested'),
         list.command.dedentList,
       ),
     );
@@ -166,7 +130,7 @@ describe('dedenting a list item', () => {
   it('adopts an ordered destination marker', () => {
     const out = serialize(
       apply(
-        stateAt('1. one\n   - nested\n1. two', 'nested'),
+        caretAfter('1. one\n   - nested\n1. two', 'nested'),
         list.command.dedentList,
       ),
     );

--- a/packages/core/editor/src/__tests__/production-markdown-test-helpers.ts
+++ b/packages/core/editor/src/__tests__/production-markdown-test-helpers.ts
@@ -1,5 +1,10 @@
 import {
+  AllSelection,
+  type Command,
+  EditorState,
   markdownLoader,
+  type PMNode,
+  type PMSelection,
   resolve,
   Schema,
   setupBase,
@@ -20,6 +25,7 @@ import {
   setupStrike,
   setupTable,
   setupWikiLink,
+  TextSelection,
 } from '@bangle.io/prosemirror-plugins';
 
 /**
@@ -51,4 +57,81 @@ export function createProductionMarkdown() {
   const resolved = resolve(extensions);
   const schema = new Schema({ nodes: resolved.nodes, marks: resolved.marks });
   return { schema, ...markdownLoader(extensions, schema) };
+}
+
+/**
+ * Runs editor commands against the production Markdown pipeline: parse a
+ * document, place a selection in it by naming the text, run the command, and
+ * read the Markdown back out.
+ *
+ * Selections are addressed by text rather than by position so a test reads as
+ * the edit a user would make, and stays put when surrounding content changes.
+ */
+export function createMarkdownHarness() {
+  const markdown = createProductionMarkdown();
+
+  const parse = (source: string) => markdown.parser.parse(source);
+
+  /** Offset of `text` within the document, or throws if it is not there. */
+  const findText = (doc: PMNode, text: string, offset: number) => {
+    let pos = -1;
+    doc.descendants((node, nodePos) => {
+      if (pos === -1 && node.isText && node.text?.includes(text)) {
+        pos = nodePos + node.text.indexOf(text) + offset;
+      }
+    });
+    if (pos === -1) {
+      throw new Error(`No text "${text}" in the parsed document`);
+    }
+    return pos;
+  };
+
+  const stateWith = (doc: PMNode, selection: PMSelection) =>
+    EditorState.create({ doc, schema: markdown.schema, selection });
+
+  return {
+    markdown,
+
+    /** Caret immediately after the first occurrence of `text`. */
+    caretAfter(source: string, text: string) {
+      const doc = parse(source);
+      return stateWith(
+        doc,
+        TextSelection.create(doc, findText(doc, text, text.length)),
+      );
+    },
+
+    /** Selection running from the start of `from` to the end of `to`. */
+    rangeOver(source: string, from: string, to: string) {
+      const doc = parse(source);
+      return stateWith(
+        doc,
+        TextSelection.create(
+          doc,
+          findText(doc, from, 0),
+          findText(doc, to, to.length),
+        ),
+      );
+    },
+
+    /** The whole document selected, as a toolbar action on a full selection. */
+    selectAll(source: string) {
+      const doc = parse(source);
+      return stateWith(doc, new AllSelection(doc));
+    },
+
+    apply(state: EditorState, command: Command) {
+      let next = state;
+      command(state, (tr) => {
+        next = state.apply(tr);
+      });
+      return next;
+    },
+
+    serialize: (state: EditorState) => markdown.serializer.serialize(state.doc),
+
+    /** Markdown of `source` after a parse/serialize round trip. */
+    reserialize: (source: string) =>
+      markdown.serializer.serialize(parse(source)),
+  };
 }

--- a/packages/js-lib/banger-editor/src/__tests__/list.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/list.spec.ts
@@ -721,6 +721,37 @@ describe('list Markdown metadata through editing commands', () => {
     expect(editor.view.state.doc.child(1).textContent).toBe('child');
   });
 
+  // Looseness is a property of the run the item lands in, so the lifted item
+  // has to stop carrying the tightness of the run it came from. The Markdown
+  // serializer arbitrates the run's spacing on its own, which is why this is
+  // asserted on the node rather than on the serialized output.
+  it('adopts the destination looseness when dedenting', () => {
+    const looseBullet = {
+      kind: 'bullet',
+      listKind: 'bullet',
+      tight: false,
+    } as const;
+    const tightBullet = {
+      kind: 'bullet',
+      listKind: 'bullet',
+      tight: true,
+    } as const;
+    const editor = editorTest.createEditor(
+      doc(
+        list(looseBullet, p('one'), list(tightBullet, p('nested<cursor>'))),
+        list(looseBullet, p('two')),
+      ),
+    );
+
+    run(lists.command.dedentList, editor);
+
+    expectListShapes(editor.view.state.doc, [
+      looseBullet,
+      looseBullet,
+      looseBullet,
+    ]);
+  });
+
   it('adopts the destination list kind when dedenting into a parent run', () => {
     const bullet = {
       kind: 'bullet',

--- a/packages/js-lib/banger-editor/src/__tests__/list.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/list.spec.ts
@@ -396,9 +396,17 @@ describe('list Markdown metadata through editing commands', () => {
       name: 'ordered to ordered task',
       source: { kind: 'ordered', listKind: 'ordered', tight: false },
     },
+    // Changing the marker of a task keeps the task: the container becomes
+    // ordered/bullet while the checkbox survives, which Markdown writes as
+    // `1. [x] item`. Rewriting `kind` here used to drop the checkbox outright.
     {
       command: lists.command.toggleOrderedList,
-      expected: { kind: 'ordered', listKind: 'ordered', tight: false },
+      expected: {
+        checked: true,
+        kind: 'task',
+        listKind: 'ordered',
+        tight: false,
+      },
       name: 'bullet task to ordered',
       source: {
         checked: true,
@@ -409,7 +417,12 @@ describe('list Markdown metadata through editing commands', () => {
     },
     {
       command: lists.command.toggleBulletList,
-      expected: { kind: 'bullet', listKind: 'bullet', tight: false },
+      expected: {
+        checked: true,
+        kind: 'task',
+        listKind: 'bullet',
+        tight: false,
+      },
       name: 'ordered task to bullet',
       source: {
         checked: true,
@@ -475,7 +488,10 @@ describe('list Markdown metadata through editing commands', () => {
     expect(editor.view.state.doc.child(3).attrs).toMatchObject(ordered);
   });
 
-  it('does not cross a different list item kind when converting a run', () => {
+  // A task sharing the run's marker is still part of the same Markdown list, so
+  // the conversion has to carry it along. Stopping at it would leave
+  // `1. one` beside `- [x] task`, splitting one list into two.
+  it('carries a task that shares the marker along with the run', () => {
     const bullet = {
       kind: 'bullet',
       listKind: 'bullet',
@@ -502,7 +518,12 @@ describe('list Markdown metadata through editing commands', () => {
 
     run(lists.command.toggleOrderedList, editor);
 
-    expectListShapes(editor.view.state.doc, [ordered, task, bullet]);
+    expectListShapes(editor.view.state.doc, [
+      ordered,
+      // The container becomes ordered but the checkbox stays.
+      { ...task, listKind: 'ordered' },
+      ordered,
+    ]);
   });
 
   it('unwraps only the selected item when toggling the active list kind', () => {
@@ -633,7 +654,8 @@ describe('list Markdown metadata through editing commands', () => {
 
     run(lists.command.toggleBulletList, editor);
     expect(editor.view.state.doc.firstChild?.attrs).toMatchObject({
-      kind: 'bullet',
+      checked: true,
+      kind: 'task',
       listKind: 'bullet',
       tight: false,
     });

--- a/packages/js-lib/banger-editor/src/__tests__/list.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/list.spec.ts
@@ -427,7 +427,7 @@ describe('list Markdown metadata through editing commands', () => {
     expectListShapes(editor.view.state.doc, [expected, expected]);
   });
 
-  it('converts only the selected item in a longer list run', () => {
+  it('converts the whole same-level list run from the selected item', () => {
     const bullet = {
       kind: 'bullet',
       listKind: 'bullet',
@@ -447,10 +447,10 @@ describe('list Markdown metadata through editing commands', () => {
     );
 
     run(lists.command.toggleOrderedList, editor);
-    expectListShapes(editor.view.state.doc, [bullet, ordered, bullet]);
+    expectListShapes(editor.view.state.doc, [ordered, ordered, ordered]);
   });
 
-  it('leaves surrounding paragraphs and list items outside the selection unchanged', () => {
+  it('converts a whole list run without changing surrounding paragraphs', () => {
     const bullet = { kind: 'bullet', listKind: 'bullet', tight: true } as const;
     const ordered = {
       kind: 'ordered',
@@ -470,9 +470,62 @@ describe('list Markdown metadata through editing commands', () => {
     run(lists.command.toggleOrderedList, editor);
     expect(editor.view.state.doc.child(0).textContent).toBe('before');
     expect(editor.view.state.doc.child(4).textContent).toBe('after');
-    expect(editor.view.state.doc.child(1).attrs).toMatchObject(bullet);
+    expect(editor.view.state.doc.child(1).attrs).toMatchObject(ordered);
     expect(editor.view.state.doc.child(2).attrs).toMatchObject(ordered);
-    expect(editor.view.state.doc.child(3).attrs).toMatchObject(bullet);
+    expect(editor.view.state.doc.child(3).attrs).toMatchObject(ordered);
+  });
+
+  it('does not cross a different list item kind when converting a run', () => {
+    const bullet = {
+      kind: 'bullet',
+      listKind: 'bullet',
+      tight: true,
+    } as const;
+    const task = {
+      checked: true,
+      kind: 'task',
+      listKind: 'bullet',
+      tight: true,
+    } as const;
+    const ordered = {
+      kind: 'ordered',
+      listKind: 'ordered',
+      tight: true,
+    } as const;
+    const editor = editorTest.createEditor(
+      doc(
+        list(bullet, p('one<cursor>')),
+        list(task, p('task')),
+        list(bullet, p('two')),
+      ),
+    );
+
+    run(lists.command.toggleOrderedList, editor);
+
+    expectListShapes(editor.view.state.doc, [ordered, task, bullet]);
+  });
+
+  it('unwraps only the selected item when toggling the active list kind', () => {
+    const bullet = {
+      kind: 'bullet',
+      listKind: 'bullet',
+      tight: true,
+    } as const;
+    const editor = editorTest.createEditor(
+      doc(
+        list(bullet, p('one')),
+        list(bullet, p('two<cursor>')),
+        list(bullet, p('three')),
+      ),
+    );
+
+    run(lists.command.toggleBulletList, editor);
+
+    expect(editor.view.state.doc.childCount).toBe(3);
+    expect(editor.view.state.doc.child(0).attrs).toMatchObject(bullet);
+    expect(editor.view.state.doc.child(1).type.name).toBe('paragraph');
+    expect(editor.view.state.doc.child(1).textContent).toBe('two');
+    expect(editor.view.state.doc.child(2).attrs).toMatchObject(bullet);
   });
 
   it('keeps each container kind when a mixed selection becomes tasks', () => {
@@ -589,6 +642,33 @@ describe('list Markdown metadata through editing commands', () => {
     );
   });
 
+  it('preserves a continuation paragraph when converting its list run', () => {
+    const bullet = {
+      kind: 'bullet',
+      listKind: 'bullet',
+      tight: false,
+    } as const;
+    const ordered = {
+      kind: 'ordered',
+      listKind: 'ordered',
+      tight: false,
+    } as const;
+    const editor = editorTest.createEditor(
+      doc(
+        list(bullet, p('first'), p('continuation<cursor>')),
+        list(bullet, p('sibling')),
+      ),
+    );
+    const contentBefore = editor.view.state.doc.firstChild?.content.toJSON();
+
+    run(lists.command.toggleOrderedList, editor);
+
+    expectListShapes(editor.view.state.doc, [ordered, ordered]);
+    expect(editor.view.state.doc.firstChild?.content.toJSON()).toEqual(
+      contentBefore,
+    );
+  });
+
   it('preserves loose ordered task attrs while indenting and dedenting', () => {
     const parent = {
       checked: true,
@@ -617,6 +697,35 @@ describe('list Markdown metadata through editing commands', () => {
     expectListShapes(editor.view.state.doc, [parent, child]);
     expect(editor.view.state.doc.child(0).textContent).toBe('parent');
     expect(editor.view.state.doc.child(1).textContent).toBe('child');
+  });
+
+  it('adopts the destination list kind when dedenting into a parent run', () => {
+    const bullet = {
+      kind: 'bullet',
+      listKind: 'bullet',
+      tight: true,
+    } as const;
+    const ordered = {
+      kind: 'ordered',
+      listKind: 'ordered',
+      tight: true,
+    } as const;
+    const editor = editorTest.createEditor(
+      doc(
+        list(bullet, p('one'), list(ordered, p('nested<cursor>'))),
+        list(bullet, p('two')),
+      ),
+    );
+
+    run(lists.command.dedentList, editor);
+
+    expectListShapes(editor.view.state.doc, [bullet, bullet, bullet]);
+    expect(
+      Array.from(
+        { length: editor.view.state.doc.childCount },
+        (_, index) => editor.view.state.doc.child(index).textContent,
+      ),
+    ).toEqual(['one', 'nested', 'two']);
   });
 
   it.each([

--- a/packages/js-lib/banger-editor/src/list-attrs.ts
+++ b/packages/js-lib/banger-editor/src/list-attrs.ts
@@ -1,0 +1,50 @@
+import {
+  isListNode,
+  type ListAttributes,
+  type ListKind,
+  type PMNode,
+} from './pm';
+
+/**
+ * The list attributes shared by the editor commands and the Markdown codec.
+ *
+ * Lives apart from both so neither has to import the other: `list.ts` owns the
+ * schema, plugins and commands, `list-markdown.ts` owns parse and serialize.
+ */
+export const LIST_KIND = {
+  BULLET: 'bullet',
+  ORDERED: 'ordered',
+  TASK: 'task',
+  TOGGLE: 'toggle',
+} as const satisfies Record<string, ListKind>;
+
+export type ListKindType = (typeof LIST_KIND)[keyof typeof LIST_KIND];
+
+export type MarkdownListKind = 'bullet' | 'ordered';
+export type MarkdownListAttrs = ListAttributes & {
+  kind: ListKindType;
+  listKind: MarkdownListKind;
+  tight: boolean;
+};
+
+/**
+ * Helper to read typed list attributes from a node
+ * Returns null if the node is not a list node
+ */
+export function readListAttrs(node?: PMNode): MarkdownListAttrs | null {
+  if (!node || !isListNode(node)) {
+    return null;
+  }
+  const { kind, checked, collapsed, order, listKind, tight } = node.attrs;
+  return {
+    kind,
+    listKind:
+      listKind === LIST_KIND.ORDERED || kind === LIST_KIND.ORDERED
+        ? LIST_KIND.ORDERED
+        : LIST_KIND.BULLET,
+    tight: tight !== false,
+    ...(kind === LIST_KIND.TASK ? { checked } : {}),
+    ...(kind === LIST_KIND.TOGGLE ? { collapsed } : {}),
+    ...(kind === LIST_KIND.ORDERED ? { order } : {}),
+  };
+}

--- a/packages/js-lib/banger-editor/src/list-markdown.ts
+++ b/packages/js-lib/banger-editor/src/list-markdown.ts
@@ -1,0 +1,242 @@
+import {
+  listItemCanRenderTight,
+  readListTokenMetadata,
+  resolveListRunTightness,
+  type TightListItemBlockKind,
+} from '@bangle.io/markdown-syntax';
+import type { MarkdownSerializerState } from 'prosemirror-markdown';
+import type { CollectionType } from './common';
+import {
+  LIST_KIND,
+  type MarkdownListAttrs,
+  type MarkdownListKind,
+  readListAttrs,
+} from './list-attrs';
+import { isListNode, type PMNode } from './pm';
+
+type ListMarkdownSerializerState = MarkdownSerializerState & {
+  [LIST_TIGHTNESS_CACHE]?: WeakMap<PMNode, readonly boolean[]>;
+  flushClose(size?: number): void;
+  inTightList: boolean;
+};
+
+const LIST_TIGHTNESS_CACHE = Symbol('listTightnessCache');
+
+function isListMarkdownSerializerState(
+  state: MarkdownSerializerState,
+): state is ListMarkdownSerializerState {
+  return (
+    'inTightList' in state &&
+    typeof state.inTightList === 'boolean' &&
+    'flushClose' in state &&
+    typeof state.flushClose === 'function'
+  );
+}
+
+/**
+ * Provides ProseMirror's parse and serialize handling for bullet, ordered,
+ * and task lists. Toggle list is ignored in the parse/serialize logic.
+ */
+export function listMarkdown(listNodeName: string): CollectionType['markdown'] {
+  return {
+    nodes: {
+      [listNodeName]: {
+        // For serialization:
+        toMarkdown: (state, node, parent, index) => {
+          flatListToMarkdown(state, node, parent ?? null, index ?? 0);
+        },
+        // For parsing:
+        parseMarkdown: {
+          bullet_list: {
+            ignore: true,
+          },
+          ordered_list: {
+            ignore: true,
+          },
+          list_item: {
+            block: listNodeName,
+            getAttrs: (tok) => {
+              const { kind, taskChecked, tight } = readListTokenMetadata(tok);
+              if (taskChecked !== null) {
+                return {
+                  kind: LIST_KIND.TASK,
+                  listKind: kind,
+                  checked: taskChecked,
+                  tight,
+                };
+              }
+              return { kind, listKind: kind, tight };
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function flatListToMarkdown(
+  state: MarkdownSerializerState,
+  node: PMNode,
+  parent: PMNode | null,
+  index: number,
+) {
+  if (!isListMarkdownSerializerState(state)) {
+    throw new Error('Markdown serializer does not support list tightness');
+  }
+  const attrs = readListAttrs(node);
+  if (!attrs) return;
+  const tight = listRunIsTight(state, node, parent, index);
+  const sameList = previousSiblingIsSameList(parent, index, attrs.listKind);
+  if ((state.inTightList && !sameList) || (tight && sameList)) {
+    state.flushClose(1);
+  }
+
+  const containerMarker = attrs.listKind === LIST_KIND.ORDERED ? '1.' : '-';
+  const marker =
+    attrs.kind === LIST_KIND.TASK
+      ? `${containerMarker} [${attrs.checked ? 'x' : ' '}]`
+      : containerMarker;
+  const firstDelim = `${marker} `;
+  const continuationDelim = ' '.repeat(containerMarker.length + 1);
+  const previousTight = state.inTightList;
+  state.inTightList = tight;
+  state.wrapBlock(continuationDelim, firstDelim, node, () => {
+    const firstChildIndex = firstRenderedListItemChild(node, attrs);
+    const firstChild = node.maybeChild(firstChildIndex);
+    const firstKind = firstChild ? listItemBlockKind(firstChild) : null;
+    const taskStartsWithBlock =
+      attrs.kind === LIST_KIND.TASK &&
+      firstKind !== null &&
+      firstKind !== 'paragraph';
+    if (taskStartsWithBlock) {
+      // The checkbox is an implicit empty paragraph before the actual block.
+      state.closeBlock(node);
+      state.flushClose(tight ? 1 : 2);
+    } else if (isListNode(firstChild) || firstKind === 'thematic-break') {
+      state.ensureNewLine();
+    }
+    let renderedChildCount = 0;
+    node.forEach((child, _offset, childIndex) => {
+      if (childIndex < firstChildIndex) return;
+      // Nested list serializers own their run's tightness independently.
+      if (renderedChildCount > 0 && tight && !isListNode(child)) {
+        state.flushClose(1);
+      }
+      state.render(child, node, childIndex);
+      renderedChildCount++;
+    });
+  });
+  state.inTightList = previousTight;
+}
+
+function previousSiblingIsSameList(
+  parent: PMNode | null,
+  index: number,
+  kind: MarkdownListKind,
+): boolean {
+  if (!parent || index === 0) return false;
+  return readListAttrs(parent.child(index - 1))?.listKind === kind;
+}
+
+function listRunIsTight(
+  state: ListMarkdownSerializerState,
+  node: PMNode,
+  parent: PMNode | null,
+  index: number,
+): boolean {
+  if (!parent) {
+    const attrs = readListAttrs(node);
+    return attrs ? attrs.tight && flatListItemCanRenderTight(node) : true;
+  }
+  let cache = state[LIST_TIGHTNESS_CACHE];
+  if (!cache) {
+    cache = new WeakMap();
+    state[LIST_TIGHTNESS_CACHE] = cache;
+  }
+  let tightness = cache.get(parent);
+  if (!tightness) {
+    tightness = listTightnessByChild(parent);
+    cache.set(parent, tightness);
+  }
+  return tightness[index] ?? true;
+}
+
+function listTightnessByChild(parent: PMNode): readonly boolean[] {
+  return resolveListRunTightness(
+    Array.from({ length: parent.childCount }, (_, index) => {
+      const child = parent.child(index);
+      const attrs = readListAttrs(child);
+      return attrs
+        ? {
+            kind: attrs.listKind,
+            tight: attrs.tight && flatListItemCanRenderTight(child),
+          }
+        : null;
+    }),
+  );
+}
+
+function flatListItemCanRenderTight(node: PMNode): boolean {
+  const attrs = readListAttrs(node);
+  const firstChildIndex = attrs ? firstRenderedListItemChild(node, attrs) : 0;
+  for (let index = firstChildIndex + 1; index < node.childCount; index++) {
+    const child = node.child(index);
+    if (isListNode(child) && listMarkerIsHidden(child)) return false;
+  }
+  const blocks = listItemBlockKinds(node, firstChildIndex);
+  if (attrs?.kind === LIST_KIND.TASK && blocks[0] !== 'paragraph') {
+    blocks.unshift('paragraph');
+  }
+  return listItemCanRenderTight(blocks);
+}
+
+function listMarkerIsHidden(node: PMNode): boolean {
+  return isListNode(node.firstChild);
+}
+
+function firstRenderedListItemChild(
+  node: PMNode,
+  attrs: MarkdownListAttrs,
+): number {
+  if (attrs.kind === LIST_KIND.TASK) return 0;
+  let index = 0;
+  while (
+    index < node.childCount - 1 &&
+    node.child(index).type.name === 'paragraph' &&
+    node.child(index).content.size === 0
+  ) {
+    index++;
+  }
+  return index;
+}
+
+function listItemBlockKinds(
+  node: PMNode,
+  startIndex: number,
+): TightListItemBlockKind[] {
+  const blocks: TightListItemBlockKind[] = [];
+  node.forEach((child, _offset, index) => {
+    if (index >= startIndex) blocks.push(listItemBlockKind(child));
+  });
+  return blocks;
+}
+
+function listItemBlockKind(node: PMNode): TightListItemBlockKind {
+  if (isListNode(node)) return 'list';
+  switch (node.type.name) {
+    case 'paragraph':
+      return 'paragraph';
+    case 'blockquote':
+      return 'blockquote';
+    case 'horizontalRule':
+      return 'thematic-break';
+    case 'table':
+      return 'table';
+    case 'code_block':
+    case 'heading':
+    case 'math_display':
+      return 'self-terminating';
+    default:
+      return 'unknown';
+  }
+}

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -12,6 +12,14 @@ import {
   PRIORITY,
   setPriority,
 } from './common';
+import {
+  LIST_KIND,
+  type ListKindType,
+  type MarkdownListAttrs,
+  type MarkdownListKind,
+  readListAttrs,
+} from './list-attrs';
+import { listMarkdown } from './list-markdown';
 import type {
   Command,
   DOMOutputSpec,
@@ -60,63 +68,7 @@ import {
   type PluginContext,
 } from './pm-utils';
 
-const LIST_KIND = {
-  BULLET: 'bullet',
-  ORDERED: 'ordered',
-  TASK: 'task',
-  TOGGLE: 'toggle',
-} as const satisfies Record<string, ListKind>;
-
-// Export the type for external use
-export type ListKindType = (typeof LIST_KIND)[keyof typeof LIST_KIND];
-
-type MarkdownListKind = 'bullet' | 'ordered';
-type MarkdownListAttrs = ListAttributes & {
-  kind: ListKindType;
-  listKind: MarkdownListKind;
-  tight: boolean;
-};
-
-type ListMarkdownSerializerState = MarkdownSerializerState & {
-  [LIST_TIGHTNESS_CACHE]?: WeakMap<PMNode, readonly boolean[]>;
-  flushClose(size?: number): void;
-  inTightList: boolean;
-};
-
-const LIST_TIGHTNESS_CACHE = Symbol('listTightnessCache');
-
-function isListMarkdownSerializerState(
-  state: MarkdownSerializerState,
-): state is ListMarkdownSerializerState {
-  return (
-    'inTightList' in state &&
-    typeof state.inTightList === 'boolean' &&
-    'flushClose' in state &&
-    typeof state.flushClose === 'function'
-  );
-}
-
-/**
- * Helper to read typed list attributes from a node
- * Returns null if the node is not a list node
- */
-function readListAttrs(node?: PMNode): MarkdownListAttrs | null {
-  if (!node || !isListNode(node)) {
-    return null;
-  }
-  const { kind, checked, collapsed, order, listKind, tight } = node.attrs;
-  return {
-    kind,
-    listKind:
-      listKind === LIST_KIND.ORDERED || kind === LIST_KIND.ORDERED
-        ? LIST_KIND.ORDERED
-        : LIST_KIND.BULLET,
-    tight: tight !== false,
-    ...(kind === LIST_KIND.TASK ? { checked } : {}),
-    ...(kind === LIST_KIND.TOGGLE ? { collapsed } : {}),
-    ...(kind === LIST_KIND.ORDERED ? { order } : {}),
-  };
-}
+export type { ListKindType } from './list-attrs';
 
 function markdownListDomAttributes(
   node: PMNode,
@@ -308,7 +260,7 @@ export function setupList(userConfig: Partial<ListConfig> = {}) {
       isTaskListActive: isTaskListActive(config),
       isToggleListActive: isToggleListActive(config),
     },
-    markdown: markdown(config),
+    markdown: listMarkdown(listNodeName),
   });
 }
 
@@ -821,213 +773,4 @@ function isInsideList(config: RequiredConfig) {
     const type = getNodeType(state.schema, listNodeName);
     return isListType(type);
   };
-}
-
-/**
- * Provides ProseMirror's parse and serialize handling for bullet, ordered,
- * and task lists. Toggle list is ignored in the parse/serialize logic.
- */
-function markdown(config: RequiredConfig): CollectionType['markdown'] {
-  const { listNodeName } = config;
-  return {
-    nodes: {
-      [listNodeName]: {
-        // For serialization:
-        toMarkdown: (state, node, parent, index) => {
-          flatListToMarkdown(state, node, parent ?? null, index ?? 0);
-        },
-        // For parsing:
-        parseMarkdown: {
-          bullet_list: {
-            ignore: true,
-          },
-          ordered_list: {
-            ignore: true,
-          },
-          list_item: {
-            block: listNodeName,
-            getAttrs: (tok) => {
-              const { kind, taskChecked, tight } = readListTokenMetadata(tok);
-              if (taskChecked !== null) {
-                return {
-                  kind: LIST_KIND.TASK,
-                  listKind: kind,
-                  checked: taskChecked,
-                  tight,
-                };
-              }
-              return { kind, listKind: kind, tight };
-            },
-          },
-        },
-      },
-    },
-  };
-}
-
-function flatListToMarkdown(
-  state: MarkdownSerializerState,
-  node: PMNode,
-  parent: PMNode | null,
-  index: number,
-) {
-  if (!isListMarkdownSerializerState(state)) {
-    throw new Error('Markdown serializer does not support list tightness');
-  }
-  const attrs = readListAttrs(node);
-  if (!attrs) return;
-  const tight = listRunIsTight(state, node, parent, index);
-  const sameList = previousSiblingIsSameList(parent, index, attrs.listKind);
-  if ((state.inTightList && !sameList) || (tight && sameList)) {
-    state.flushClose(1);
-  }
-
-  const containerMarker = attrs.listKind === LIST_KIND.ORDERED ? '1.' : '-';
-  const marker =
-    attrs.kind === LIST_KIND.TASK
-      ? `${containerMarker} [${attrs.checked ? 'x' : ' '}]`
-      : containerMarker;
-  const firstDelim = `${marker} `;
-  const continuationDelim = ' '.repeat(containerMarker.length + 1);
-  const previousTight = state.inTightList;
-  state.inTightList = tight;
-  state.wrapBlock(continuationDelim, firstDelim, node, () => {
-    const firstChildIndex = firstRenderedListItemChild(node, attrs);
-    const firstChild = node.maybeChild(firstChildIndex);
-    const firstKind = firstChild ? listItemBlockKind(firstChild) : null;
-    const taskStartsWithBlock =
-      attrs.kind === LIST_KIND.TASK &&
-      firstKind !== null &&
-      firstKind !== 'paragraph';
-    if (taskStartsWithBlock) {
-      // The checkbox is an implicit empty paragraph before the actual block.
-      state.closeBlock(node);
-      state.flushClose(tight ? 1 : 2);
-    } else if (isListNode(firstChild) || firstKind === 'thematic-break') {
-      state.ensureNewLine();
-    }
-    let renderedChildCount = 0;
-    node.forEach((child, _offset, childIndex) => {
-      if (childIndex < firstChildIndex) return;
-      // Nested list serializers own their run's tightness independently.
-      if (renderedChildCount > 0 && tight && !isListNode(child)) {
-        state.flushClose(1);
-      }
-      state.render(child, node, childIndex);
-      renderedChildCount++;
-    });
-  });
-  state.inTightList = previousTight;
-}
-
-function previousSiblingIsSameList(
-  parent: PMNode | null,
-  index: number,
-  kind: MarkdownListKind,
-): boolean {
-  if (!parent || index === 0) return false;
-  return readListAttrs(parent.child(index - 1))?.listKind === kind;
-}
-
-function listRunIsTight(
-  state: ListMarkdownSerializerState,
-  node: PMNode,
-  parent: PMNode | null,
-  index: number,
-): boolean {
-  if (!parent) {
-    const attrs = readListAttrs(node);
-    return attrs ? attrs.tight && flatListItemCanRenderTight(node) : true;
-  }
-  let cache = state[LIST_TIGHTNESS_CACHE];
-  if (!cache) {
-    cache = new WeakMap();
-    state[LIST_TIGHTNESS_CACHE] = cache;
-  }
-  let tightness = cache.get(parent);
-  if (!tightness) {
-    tightness = listTightnessByChild(parent);
-    cache.set(parent, tightness);
-  }
-  return tightness[index] ?? true;
-}
-
-function listTightnessByChild(parent: PMNode): readonly boolean[] {
-  return resolveListRunTightness(
-    Array.from({ length: parent.childCount }, (_, index) => {
-      const child = parent.child(index);
-      const attrs = readListAttrs(child);
-      return attrs
-        ? {
-            kind: attrs.listKind,
-            tight: attrs.tight && flatListItemCanRenderTight(child),
-          }
-        : null;
-    }),
-  );
-}
-
-function flatListItemCanRenderTight(node: PMNode): boolean {
-  const attrs = readListAttrs(node);
-  const firstChildIndex = attrs ? firstRenderedListItemChild(node, attrs) : 0;
-  for (let index = firstChildIndex + 1; index < node.childCount; index++) {
-    const child = node.child(index);
-    if (isListNode(child) && listMarkerIsHidden(child)) return false;
-  }
-  const blocks = listItemBlockKinds(node, firstChildIndex);
-  if (attrs?.kind === LIST_KIND.TASK && blocks[0] !== 'paragraph') {
-    blocks.unshift('paragraph');
-  }
-  return listItemCanRenderTight(blocks);
-}
-
-function listMarkerIsHidden(node: PMNode): boolean {
-  return isListNode(node.firstChild);
-}
-
-function firstRenderedListItemChild(
-  node: PMNode,
-  attrs: MarkdownListAttrs,
-): number {
-  if (attrs.kind === LIST_KIND.TASK) return 0;
-  let index = 0;
-  while (
-    index < node.childCount - 1 &&
-    node.child(index).type.name === 'paragraph' &&
-    node.child(index).content.size === 0
-  ) {
-    index++;
-  }
-  return index;
-}
-
-function listItemBlockKinds(
-  node: PMNode,
-  startIndex: number,
-): TightListItemBlockKind[] {
-  const blocks: TightListItemBlockKind[] = [];
-  node.forEach((child, _offset, index) => {
-    if (index >= startIndex) blocks.push(listItemBlockKind(child));
-  });
-  return blocks;
-}
-
-function listItemBlockKind(node: PMNode): TightListItemBlockKind {
-  if (isListNode(node)) return 'list';
-  switch (node.type.name) {
-    case 'paragraph':
-      return 'paragraph';
-    case 'blockquote':
-      return 'blockquote';
-    case 'horizontalRule':
-      return 'thematic-break';
-    case 'table':
-      return 'table';
-    case 'code_block':
-    case 'heading':
-    case 'math_display':
-      return 'self-terminating';
-    default:
-      return 'unknown';
-  }
 }

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -17,7 +17,10 @@ import type {
   DOMOutputSpec,
   EditorState,
   NodeSpec,
+  NodeType,
   PMNode,
+  PMSelection,
+  ResolvedPos,
   Transaction,
 } from './pm';
 import {
@@ -50,6 +53,7 @@ import {
 } from './pm';
 import {
   findParentNode,
+  findParentNodeClosestToPos,
   getNodeType,
   insertNodeAdjacentToNode,
   type PluginContext,
@@ -376,38 +380,58 @@ function pluginInsertKeybindings(config: RequiredConfig) {
 }
 
 // COMMANDS
-function toggleBulletList(_config: RequiredConfig): Command {
-  return (state, dispatch) => {
-    return createToggleListCommand({
-      kind: LIST_KIND.BULLET,
-      listKind: LIST_KIND.BULLET,
-    })(state, dispatch);
-  };
+function toggleBulletList(config: RequiredConfig): Command {
+  return toggleList(config, {
+    kind: LIST_KIND.BULLET,
+    listKind: LIST_KIND.BULLET,
+  });
 }
 
-function toggleOrderedList(_config: RequiredConfig): Command {
-  return (state, dispatch) => {
-    return createToggleListCommand({
-      kind: LIST_KIND.ORDERED,
-      listKind: LIST_KIND.ORDERED,
-      order: 1,
-    })(state, dispatch);
-  };
+function toggleOrderedList(config: RequiredConfig): Command {
+  return toggleList(config, {
+    kind: LIST_KIND.ORDERED,
+    listKind: LIST_KIND.ORDERED,
+    order: 1,
+  });
 }
 
-function toggleTaskList(_config: RequiredConfig): Command {
-  return (state, dispatch) => {
-    return createToggleListCommand({
-      kind: LIST_KIND.TASK,
-      // `checked` is deliberately not set here. Forcing it to false cleared the
-      // boxes of items that were already checked whenever a task list was
-      // converted to another kind and back, so correcting a mis-click lost
-      // state that undo would have kept. New task items still start unchecked
-      // via the node spec's default.
-      //
-      // `listKind` is likewise left alone: an ordered container that becomes a
-      // task list stays ordered, which Markdown writes as `1. [ ] item`.
-    })(state, dispatch);
+function toggleTaskList(config: RequiredConfig): Command {
+  return toggleList(config, {
+    kind: LIST_KIND.TASK,
+    // `checked` is deliberately not set here. Forcing it to false cleared the
+    // boxes of items that were already checked whenever a task list was
+    // converted to another kind and back, so correcting a mis-click lost
+    // state that undo would have kept. New task items still start unchecked
+    // via the node spec's default.
+    //
+    // `listKind` is likewise left alone: an ordered container that becomes a
+    // task list stays ordered, which Markdown writes as `1. [ ] item`.
+  });
+}
+
+type ToggleListAttrs = ListAttributes & {
+  kind: ListKindType;
+  listKind?: MarkdownListKind;
+};
+
+function toggleList(
+  config: RequiredConfig,
+  targetAttrs: ToggleListAttrs,
+): Command {
+  const command = createToggleListCommand(targetAttrs);
+  return (state, dispatch, view) => {
+    const type = getNodeType(state.schema, config.listNodeName);
+    const sourceRun = findSelectedListRun(state.selection, type);
+    if (sourceRun && sourceRun.attrs.kind !== targetAttrs.kind) {
+      if (dispatch) {
+        const tr = state.tr;
+        setListAttrs(tr, sourceRun.positions, targetAttrs);
+        dispatch(tr);
+      }
+      return true;
+    }
+
+    return command(state, dispatch, view);
   };
 }
 
@@ -512,8 +536,135 @@ function normalizeNewIndentationPlaceholders(
   }
 }
 
-function dedentList(_config: RequiredConfig): Command {
-  return createDedentListCommand();
+function dedentList(config: RequiredConfig): Command {
+  const command = createDedentListCommand();
+  return (state, dispatch, view) => {
+    if (!dispatch) return command(state, undefined, view);
+
+    const type = getNodeType(state.schema, config.listNodeName);
+    const destinationAttrs = findDedentDestinationAttrs(state.selection, type);
+
+    return command(
+      state,
+      destinationAttrs
+        ? (tr) => {
+            const positions = findSelectedSiblingLists(tr.selection, type);
+            setListAttrs(tr, positions, {
+              kind: destinationAttrs.kind,
+              listKind: destinationAttrs.listKind,
+              order: null,
+              tight: destinationAttrs.tight,
+            });
+            dispatch(tr);
+          }
+        : dispatch,
+      view,
+    );
+  };
+}
+
+function findSelectedListRun(
+  selection: PMSelection,
+  type: NodeType,
+): { attrs: MarkdownListAttrs; positions: number[] } | null {
+  const from = findListAtPos(selection.$from, type);
+  const to = findListAtPos(selection.$to, type);
+  if (!from || !to || from.node !== to.node) return null;
+
+  const attrs = readListAttrs(from.node);
+  if (!attrs) return null;
+
+  const parentDepth = from.depth - 1;
+  const parent = selection.$from.node(parentDepth);
+  const selectedIndex = selection.$from.index(parentDepth);
+  let startIndex = selectedIndex;
+  let endIndex = selectedIndex + 1;
+
+  while (startIndex > 0 && isSameListRun(parent.child(startIndex - 1), attrs)) {
+    startIndex--;
+  }
+  while (
+    endIndex < parent.childCount &&
+    isSameListRun(parent.child(endIndex), attrs)
+  ) {
+    endIndex++;
+  }
+
+  return {
+    attrs,
+    positions: Array.from({ length: endIndex - startIndex }, (_, offset) =>
+      selection.$from.posAtIndex(startIndex + offset, parentDepth),
+    ),
+  };
+}
+
+function findDedentDestinationAttrs(
+  selection: PMSelection,
+  type: NodeType,
+): MarkdownListAttrs | null {
+  const source = findListAtPos(selection.$from, type);
+  const endSource = findListAtPos(selection.$to, type);
+  // A range can lift items to different destination depths, each with its own
+  // list kind. The single-item caret workflow has one unambiguous destination.
+  if (!source || source.node !== endSource?.node) return null;
+
+  for (let depth = source.depth - 1; depth > 0; depth--) {
+    const node = selection.$from.node(depth);
+    if (node.type === type) return readListAttrs(node);
+  }
+  return null;
+}
+
+function findSelectedSiblingLists(
+  selection: PMSelection,
+  type: NodeType,
+): number[] {
+  const from = findListAtPos(selection.$from, type);
+  const to = findListAtPos(selection.$to, type);
+  if (!from || !to || from.depth !== to.depth) return [];
+
+  const parentDepth = from.depth - 1;
+  if (selection.$from.node(parentDepth) !== selection.$to.node(parentDepth)) {
+    return [];
+  }
+
+  const startIndex = selection.$from.index(parentDepth);
+  const endIndex = selection.$to.index(parentDepth);
+  const parent = selection.$from.node(parentDepth);
+  const positions: number[] = [];
+  for (let index = startIndex; index <= endIndex; index++) {
+    const node = parent.maybeChild(index);
+    if (node?.type === type && isListNode(node)) {
+      positions.push(selection.$from.posAtIndex(index, parentDepth));
+    }
+  }
+  return positions;
+}
+
+function findListAtPos($pos: ResolvedPos, type: NodeType) {
+  return findParentNodeClosestToPos(
+    $pos,
+    (node: PMNode) => node.type === type && isListNode(node),
+  );
+}
+
+function isSameListRun(node: PMNode, attrs: MarkdownListAttrs): boolean {
+  const candidate = readListAttrs(node);
+  return (
+    candidate?.kind === attrs.kind && candidate.listKind === attrs.listKind
+  );
+}
+
+function setListAttrs(
+  tr: Transaction,
+  positions: readonly number[],
+  attrs: Partial<MarkdownListAttrs>,
+) {
+  for (const pos of positions) {
+    const node = tr.doc.nodeAt(pos);
+    if (!node || !isListNode(node)) continue;
+    tr.setNodeMarkup(pos, null, { ...node.attrs, ...attrs });
+  }
 }
 
 function insertEmptyListAbove(config: RequiredConfig): Command {

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -419,14 +419,23 @@ function toggleList(
   targetAttrs: ToggleListAttrs,
 ): Command {
   const command = createToggleListCommand(targetAttrs);
+  const targetListKind = targetAttrs.listKind;
   return (state, dispatch, view) => {
     const type = getNodeType(state.schema, config.listNodeName);
-    const sourceRun = findSelectedListRun(state.selection, type);
-    if (sourceRun && sourceRun.attrs.kind !== targetAttrs.kind) {
+    // Only the marker is a whole-list property in Markdown, so only a marker
+    // change converts the run. Task-ness is per item, which is why the task
+    // toggle has no `listKind` and always defers to the library command.
+    const sourceRun = targetListKind
+      ? findSelectedListRun(state.selection, type)
+      : null;
+    if (targetListKind && sourceRun && sourceRun.listKind !== targetListKind) {
       if (dispatch) {
         const tr = state.tr;
-        setListAttrs(tr, sourceRun.positions, targetAttrs);
-        dispatch(tr);
+        setRunMarker(tr, sourceRun.positions, {
+          listKind: targetListKind,
+          order: targetAttrs.order ?? null,
+        });
+        dispatch(tr.scrollIntoView());
       }
       return true;
     }
@@ -548,13 +557,16 @@ function dedentList(config: RequiredConfig): Command {
       state,
       destinationAttrs
         ? (tr) => {
-            const positions = findSelectedSiblingLists(tr.selection, type);
-            setListAttrs(tr, positions, {
-              kind: destinationAttrs.kind,
-              listKind: destinationAttrs.listKind,
-              order: null,
-              tight: destinationAttrs.tight,
-            });
+            // Adopt the destination run's marker only. Taking its `kind` too
+            // would rewrite a dedented task into a plain bullet and drop the
+            // checkbox from the Markdown.
+            const lifted = findListAtPos(tr.selection.$from, type);
+            if (lifted) {
+              setRunMarker(tr, [lifted.pos], {
+                listKind: destinationAttrs.listKind,
+                tight: destinationAttrs.tight,
+              });
+            }
             dispatch(tr);
           }
         : dispatch,
@@ -563,35 +575,40 @@ function dedentList(config: RequiredConfig): Command {
   };
 }
 
+/**
+ * The contiguous items the selection sits in that Markdown writes as one list,
+ * which is every neighbour sharing the same marker. A range selection expands to
+ * the whole run too, so selecting part of a list cannot leave it half converted.
+ */
 function findSelectedListRun(
   selection: PMSelection,
   type: NodeType,
-): { attrs: MarkdownListAttrs; positions: number[] } | null {
+): { listKind: MarkdownListKind; positions: number[] } | null {
   const from = findListAtPos(selection.$from, type);
   const to = findListAtPos(selection.$to, type);
-  if (!from || !to || from.node !== to.node) return null;
-
-  const attrs = readListAttrs(from.node);
-  if (!attrs) return null;
+  if (!from || !to || from.depth !== to.depth) return null;
 
   const parentDepth = from.depth - 1;
   const parent = selection.$from.node(parentDepth);
-  const selectedIndex = selection.$from.index(parentDepth);
-  let startIndex = selectedIndex;
-  let endIndex = selectedIndex + 1;
+  if (parent !== selection.$to.node(parentDepth)) return null;
 
-  while (startIndex > 0 && isSameListRun(parent.child(startIndex - 1), attrs)) {
+  const listKind = readListAttrs(from.node)?.listKind;
+  if (!listKind) return null;
+
+  let startIndex = selection.$from.index(parentDepth);
+  let endIndex = selection.$to.index(parentDepth) + 1;
+  while (startIndex > 0 && hasMarker(parent.child(startIndex - 1), listKind)) {
     startIndex--;
   }
   while (
     endIndex < parent.childCount &&
-    isSameListRun(parent.child(endIndex), attrs)
+    hasMarker(parent.child(endIndex), listKind)
   ) {
     endIndex++;
   }
 
   return {
-    attrs,
+    listKind,
     positions: Array.from({ length: endIndex - startIndex }, (_, offset) =>
       selection.$from.posAtIndex(startIndex + offset, parentDepth),
     ),
@@ -615,32 +632,6 @@ function findDedentDestinationAttrs(
   return null;
 }
 
-function findSelectedSiblingLists(
-  selection: PMSelection,
-  type: NodeType,
-): number[] {
-  const from = findListAtPos(selection.$from, type);
-  const to = findListAtPos(selection.$to, type);
-  if (!from || !to || from.depth !== to.depth) return [];
-
-  const parentDepth = from.depth - 1;
-  if (selection.$from.node(parentDepth) !== selection.$to.node(parentDepth)) {
-    return [];
-  }
-
-  const startIndex = selection.$from.index(parentDepth);
-  const endIndex = selection.$to.index(parentDepth);
-  const parent = selection.$from.node(parentDepth);
-  const positions: number[] = [];
-  for (let index = startIndex; index <= endIndex; index++) {
-    const node = parent.maybeChild(index);
-    if (node?.type === type && isListNode(node)) {
-      positions.push(selection.$from.posAtIndex(index, parentDepth));
-    }
-  }
-  return positions;
-}
-
 function findListAtPos($pos: ResolvedPos, type: NodeType) {
   return findParentNodeClosestToPos(
     $pos,
@@ -648,24 +639,44 @@ function findListAtPos($pos: ResolvedPos, type: NodeType) {
   );
 }
 
-function isSameListRun(node: PMNode, attrs: MarkdownListAttrs): boolean {
-  const candidate = readListAttrs(node);
-  return (
-    candidate?.kind === attrs.kind && candidate.listKind === attrs.listKind
-  );
+function hasMarker(node: PMNode, listKind: MarkdownListKind): boolean {
+  return readListAttrs(node)?.listKind === listKind;
 }
 
-function setListAttrs(
+/**
+ * Rewrites only the container marker of the given items.
+ *
+ * `kind` follows the marker for plain bullet/ordered items, because
+ * `readListAttrs` derives the marker from it. A task or toggle item keeps its
+ * own `kind`, so its checkbox survives the change and Markdown writes the
+ * combination the user asked for, such as `1. [x] item`.
+ */
+function setRunMarker(
   tr: Transaction,
   positions: readonly number[],
-  attrs: Partial<MarkdownListAttrs>,
+  { listKind, order = null, tight }: MarkerChange,
 ) {
   for (const pos of positions) {
     const node = tr.doc.nodeAt(pos);
-    if (!node || !isListNode(node)) continue;
-    tr.setNodeMarkup(pos, null, { ...node.attrs, ...attrs });
+    const attrs = readListAttrs(node ?? undefined);
+    if (!node || !attrs) continue;
+    const isPlainMarker =
+      attrs.kind === LIST_KIND.BULLET || attrs.kind === LIST_KIND.ORDERED;
+    tr.setNodeMarkup(pos, null, {
+      ...node.attrs,
+      listKind,
+      ...(isPlainMarker ? { kind: listKind } : {}),
+      order: listKind === LIST_KIND.ORDERED ? order : null,
+      ...(tight === undefined ? {} : { tight }),
+    });
   }
 }
+
+type MarkerChange = {
+  listKind: MarkdownListKind;
+  order?: number | null;
+  tight?: boolean;
+};
 
 function insertEmptyListAbove(config: RequiredConfig): Command {
   return insertEmptySiblingList(config, 'above');

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -39,6 +39,7 @@ import {
   deleteCommand,
   enterCommand,
   findCheckboxInListItem,
+  findListsRange,
   inputRules,
   isListNode,
   isListType,
@@ -380,23 +381,23 @@ function pluginInsertKeybindings(config: RequiredConfig) {
 }
 
 // COMMANDS
-function toggleBulletList(config: RequiredConfig): Command {
-  return toggleList(config, {
+function toggleBulletList(_config: RequiredConfig): Command {
+  return toggleList({
     kind: LIST_KIND.BULLET,
     listKind: LIST_KIND.BULLET,
   });
 }
 
-function toggleOrderedList(config: RequiredConfig): Command {
-  return toggleList(config, {
+function toggleOrderedList(_config: RequiredConfig): Command {
+  return toggleList({
     kind: LIST_KIND.ORDERED,
     listKind: LIST_KIND.ORDERED,
     order: 1,
   });
 }
 
-function toggleTaskList(config: RequiredConfig): Command {
-  return toggleList(config, {
+function toggleTaskList(_config: RequiredConfig): Command {
+  return toggleList({
     kind: LIST_KIND.TASK,
     // `checked` is deliberately not set here. Forcing it to false cleared the
     // boxes of items that were already checked whenever a task list was
@@ -414,30 +415,28 @@ type ToggleListAttrs = ListAttributes & {
   listKind?: MarkdownListKind;
 };
 
-function toggleList(
-  config: RequiredConfig,
-  targetAttrs: ToggleListAttrs,
-): Command {
+function toggleList(targetAttrs: ToggleListAttrs): Command {
   const command = createToggleListCommand(targetAttrs);
   const targetListKind = targetAttrs.listKind;
   return (state, dispatch, view) => {
-    const type = getNodeType(state.schema, config.listNodeName);
     // Only the marker is a whole-list property in Markdown, so only a marker
     // change converts the run. Task-ness is per item, which is why the task
-    // toggle has no `listKind` and always defers to the library command.
-    const sourceRun = targetListKind
-      ? findSelectedListRun(state.selection, type)
-      : null;
-    if (targetListKind && sourceRun && sourceRun.listKind !== targetListKind) {
-      if (dispatch) {
-        const tr = state.tr;
-        setRunMarker(tr, sourceRun.positions, {
-          listKind: targetListKind,
-          order: targetAttrs.order ?? null,
-        });
-        dispatch(tr.scrollIntoView());
+    // toggle carries no `listKind` and always defers to the library command.
+    if (targetListKind) {
+      const positions = findSelectedListRun(state.selection);
+      // Keep converting while any item still lacks the target marker. Once the
+      // whole run matches, defer so a second press toggles the list off.
+      const needsMarker = positions.some(
+        (pos) => !hasMarker(state.doc.nodeAt(pos), targetListKind),
+      );
+      if (needsMarker) {
+        if (dispatch) {
+          const tr = state.tr;
+          setRunMarker(tr, positions, targetListKind);
+          dispatch(tr.scrollIntoView());
+        }
+        return true;
       }
-      return true;
     }
 
     return command(state, dispatch, view);
@@ -562,10 +561,12 @@ function dedentList(config: RequiredConfig): Command {
             // checkbox from the Markdown.
             const lifted = findListAtPos(tr.selection.$from, type);
             if (lifted) {
-              setRunMarker(tr, [lifted.pos], {
-                listKind: destinationAttrs.listKind,
-                tight: destinationAttrs.tight,
-              });
+              setRunMarker(
+                tr,
+                [lifted.pos],
+                destinationAttrs.listKind,
+                destinationAttrs.tight,
+              );
             }
             dispatch(tr);
           }
@@ -576,27 +577,24 @@ function dedentList(config: RequiredConfig): Command {
 }
 
 /**
- * The contiguous items the selection sits in that Markdown writes as one list,
- * which is every neighbour sharing the same marker. A range selection expands to
- * the whole run too, so selecting part of a list cannot leave it half converted.
+ * The sibling items a marker change has to cover: every item the selection
+ * touches, widened to the neighbours that already share the selection's marker,
+ * because Markdown writes those as a single list.
+ *
+ * The range itself comes from the list library, so a selection that starts and
+ * ends at different nesting depths, runs backwards, or selects a whole node all
+ * resolve to the same set of siblings.
  */
-function findSelectedListRun(
-  selection: PMSelection,
-  type: NodeType,
-): { listKind: MarkdownListKind; positions: number[] } | null {
-  const from = findListAtPos(selection.$from, type);
-  const to = findListAtPos(selection.$to, type);
-  if (!from || !to || from.depth !== to.depth) return null;
+function findSelectedListRun(selection: PMSelection): number[] {
+  const range = findListsRange(selection.$from, selection.$to);
+  if (!range) return [];
 
-  const parentDepth = from.depth - 1;
-  const parent = selection.$from.node(parentDepth);
-  if (parent !== selection.$to.node(parentDepth)) return null;
+  const { parent, depth } = range;
+  const listKind = readListAttrs(parent.child(range.startIndex))?.listKind;
+  if (!listKind) return [];
 
-  const listKind = readListAttrs(from.node)?.listKind;
-  if (!listKind) return null;
-
-  let startIndex = selection.$from.index(parentDepth);
-  let endIndex = selection.$to.index(parentDepth) + 1;
+  let startIndex = range.startIndex;
+  let endIndex = range.endIndex;
   while (startIndex > 0 && hasMarker(parent.child(startIndex - 1), listKind)) {
     startIndex--;
   }
@@ -607,12 +605,9 @@ function findSelectedListRun(
     endIndex++;
   }
 
-  return {
-    listKind,
-    positions: Array.from({ length: endIndex - startIndex }, (_, offset) =>
-      selection.$from.posAtIndex(startIndex + offset, parentDepth),
-    ),
-  };
+  return Array.from({ length: endIndex - startIndex }, (_, offset) =>
+    range.$from.posAtIndex(startIndex + offset, depth),
+  );
 }
 
 function findDedentDestinationAttrs(
@@ -625,11 +620,11 @@ function findDedentDestinationAttrs(
   // list kind. The single-item caret workflow has one unambiguous destination.
   if (!source || source.node !== endSource?.node) return null;
 
-  for (let depth = source.depth - 1; depth > 0; depth--) {
-    const node = selection.$from.node(depth);
-    if (node.type === type) return readListAttrs(node);
-  }
-  return null;
+  // Only the item's own parent, never a further ancestor. Nesting always puts a
+  // list directly inside a list, so anything else in between (a blockquote, say)
+  // means the lift lands somewhere this marker does not describe.
+  const parent = selection.$from.node(source.depth - 1);
+  return parent.type === type ? readListAttrs(parent) : null;
 }
 
 function findListAtPos($pos: ResolvedPos, type: NodeType) {
@@ -639,22 +634,31 @@ function findListAtPos($pos: ResolvedPos, type: NodeType) {
   );
 }
 
-function hasMarker(node: PMNode, listKind: MarkdownListKind): boolean {
-  return readListAttrs(node)?.listKind === listKind;
+function hasMarker(
+  node: PMNode | null | undefined,
+  listKind: MarkdownListKind,
+): boolean {
+  return readListAttrs(node ?? undefined)?.listKind === listKind;
 }
 
 /**
  * Rewrites only the container marker of the given items.
  *
- * `kind` follows the marker for plain bullet/ordered items, because
- * `readListAttrs` derives the marker from it. A task or toggle item keeps its
- * own `kind`, so its checkbox survives the change and Markdown writes the
- * combination the user asked for, such as `1. [x] item`.
+ * `kind` has to follow the marker for plain bullet/ordered items. It is what
+ * `readListAttrs` derives the marker from, and what the list library renders
+ * from, so leaving it behind would show a bullet while serializing `1.`.
+ *
+ * A task or toggle item keeps its own `kind`, so its checkbox survives the
+ * change and Markdown writes the combination the user asked for, `1. [x] item`.
+ *
+ * `order` is always cleared: the run renumbers itself, Markdown always emits
+ * `1.`, and only a run's first item can carry an explicit start.
  */
 function setRunMarker(
   tr: Transaction,
   positions: readonly number[],
-  { listKind, order = null, tight }: MarkerChange,
+  listKind: MarkdownListKind,
+  tight?: boolean,
 ) {
   for (const pos of positions) {
     const node = tr.doc.nodeAt(pos);
@@ -666,17 +670,11 @@ function setRunMarker(
       ...node.attrs,
       listKind,
       ...(isPlainMarker ? { kind: listKind } : {}),
-      order: listKind === LIST_KIND.ORDERED ? order : null,
+      order: null,
       ...(tight === undefined ? {} : { tight }),
     });
   }
 }
-
-type MarkerChange = {
-  listKind: MarkdownListKind;
-  order?: number | null;
-  tight?: boolean;
-};
 
 function insertEmptyListAbove(config: RequiredConfig): Command {
   return insertEmptySiblingList(config, 'above');

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -1,17 +1,4 @@
-import {
-  listItemCanRenderTight,
-  readListTokenMetadata,
-  resolveListRunTightness,
-  type TightListItemBlockKind,
-} from '@bangle.io/markdown-syntax';
-import type { MarkdownSerializerState } from 'prosemirror-markdown';
-import {
-  type CollectionType,
-  collection,
-  keybinding,
-  PRIORITY,
-  setPriority,
-} from './common';
+import { collection, keybinding, PRIORITY, setPriority } from './common';
 import {
   LIST_KIND,
   type ListKindType,
@@ -53,7 +40,6 @@ import {
   isListType,
   type ListAttributes,
   ListDOMSerializer,
-  type ListKind,
   listToDOM,
   Plugin,
   type Schema,

--- a/packages/js-lib/banger-editor/src/pm/index.ts
+++ b/packages/js-lib/banger-editor/src/pm/index.ts
@@ -52,6 +52,7 @@ export {
   deleteCommand,
   enterCommand,
   findCheckboxInListItem,
+  findListsRange,
   isListNode,
   isListType,
   ListDOMSerializer,

--- a/packages/tooling/e2e-tests/src/markdown-lists.e2e.ts
+++ b/packages/tooling/e2e-tests/src/markdown-lists.e2e.ts
@@ -221,6 +221,59 @@ test('typing a bullet marker inside an ordered item persists as a bullet', async
   );
 });
 
+test('list type changes follow the same-level run', async ({ page }) => {
+  const workspaceName = 'same-level-list-formatting';
+  const noteName = 'list-runs';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  const bulletRun = '- alpha\n- beta\n- gamma';
+  await writeStoredMarkdown(page, workspaceName, noteName, bulletRun);
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  await collapseEditorSelectionAfterText(page, 'beta');
+  await page.keyboard.insertText(' /');
+  const slashMenu = page.getByTestId('slash-command-menu');
+  await expect(slashMenu).toBeVisible();
+  await slashMenu.getByText('Numbered list', { exact: true }).click();
+  await page.keyboard.press('Backspace');
+
+  const orderedRun = '1. alpha\n1. beta\n1. gamma';
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(orderedRun);
+  await expect(
+    editor.locator(
+      '.prosemirror-flat-list[data-list-container-kind="ordered"]',
+    ),
+  ).toHaveCount(3);
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(readStoredMarkdown(page, workspaceName, noteName)).resolves.toBe(
+    orderedRun,
+  );
+
+  const nestedRun = '- parent\n  1. nested\n- sibling';
+  await writeStoredMarkdown(page, workspaceName, noteName, nestedRun);
+  await page.reload({ waitUntil: 'networkidle' });
+  await editor.getByText('nested', { exact: true }).click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.press('Shift+Tab');
+
+  const dedentedRun = '- parent\n- nested\n- sibling';
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(dedentedRun);
+  await expect(
+    editor.locator('.prosemirror-flat-list[data-list-container-kind="bullet"]'),
+  ).toHaveCount(3);
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(readStoredMarkdown(page, workspaceName, noteName)).resolves.toBe(
+    dedentedRun,
+  );
+});
+
 test('replacing task text with a thematic break preserves both structures', async ({
   page,
 }) => {


### PR DESCRIPTION
Flat-list stores each visual item as an independent node, so a caret-level list operation could split one Markdown list into two: changing a single item's marker leaves its neighbours behind, and a dedent could keep the nested marker.

Markdown decides list membership by the marker, so this settles on one rule: **the container marker (`listKind`) is a whole-list property; task-ness (`kind`) is per item.**

- A run is the items the selection touches, widened to the neighbours already sharing their marker. The range comes from the list library's own `findListsRange`, so a selection whose endpoints sit at different depths, runs backwards, or covers a whole node all resolve to the same siblings.
- Conversion continues while any item in that set still lacks the target marker, and defers once they all match so a second press turns the list off.
- `kind` follows the marker only for plain bullet/ordered items. A task keeps its own `kind`, so its checkbox survives and Markdown writes `1. [x] item`.
- Dedent adopts the destination's marker and looseness only, read from the item's own parent.
- The task toggle carries no marker and defers to the upstream command, since Markdown allows task and non-task siblings in one list.

The last three commits are cleanup with no behaviour change: a shared harness for the production-Markdown specs, the list Markdown codec moved into `list-markdown.ts` (`list.ts` 1033 → 776 lines, with the shared vocabulary in `list-attrs.ts` so neither half imports the other), and the imports that move left behind.

Reviewer callouts:

- **Six pre-existing expectations changed**, across the second and third commits. Each asserted the behaviour this fixes — a checked task losing its checkbox when its marker changed, and a run stopping at the first task, which splits `- one` / `- [x] task` into separate lists. Worth checking those independently rather than taking my word for it.
- **`setRunMarker` writes `kind` conditionally**, which is load-bearing rather than incidental: `kind` is what `readListAttrs` derives the marker from *and* what the list library renders from, so leaving it behind would show a bullet while serializing `1.`. Documented at the function.
- `list-run-marker-markdown.spec.ts` asserts through the **production serializer** with a parse→serialize fixpoint per case, because the original bug was only visible in the saved file rather than in the document. The one property that cannot be asserted there is the dedent's looseness adoption — the serializer arbitrates a run's spacing itself — so that is pinned on the node in `list.spec.ts` instead.
- Pressing "Bullet list" on a bullet-marker task list still flattens it to plain bullets, since the marker is unchanged and the press reads as "make these plain". `list-kind-toggle-markdown.spec.ts` pins that, including that the boxes come back on the next press.
- Cross-depth *dedents* remain on the upstream library's semantics: one selection can lift items to several destination depths, each with its own marker.

Rebased onto main after #687, which touched the same file. The only conflict was an import list.