### PR TITLE
Make insert-block shortcuts work inside list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1. Inside a list, `Mod-Enter` and `Mod-Shift-Enter` now add an empty item below and above the current one. They previously did nothing once the cursor was in a list.
+
+1. Toggling a task checkbox moved from `Mod-Enter` to `Alt-Enter`, so `Mod-Enter` inserts an item consistently in every kind of list.
+
 1. sdsd
 
 1. \~\~sdsds\~\~

--- a/packages/core/app/src/layout/sidebar-footer-menu.tsx
+++ b/packages/core/app/src/layout/sidebar-footer-menu.tsx
@@ -16,6 +16,7 @@ import {
   PlusIcon,
   Search,
   Settings2,
+  Sparkles,
 } from 'lucide-react';
 import React from 'react';
 
@@ -105,6 +106,17 @@ export function SidebarFooterMenu({
           className="mr-2 h-4 w-4 grayscale"
         />
         <span>{t.app.sidebar.homepage}</span>
+      </DropdownMenu.DropdownMenuItem>
+      <DropdownMenu.DropdownMenuItem
+        onClick={() =>
+          window.open(
+            'https://github.com/bangle-io/bangle-io/blob/main/CHANGELOG.md',
+            '_blank',
+          )
+        }
+      >
+        <Sparkles className="mr-2 h-4 w-4" />
+        <span>{t.app.sidebar.whatsNew}</span>
       </DropdownMenu.DropdownMenuItem>
       <DropdownMenu.DropdownMenuItem
         onClick={() =>

--- a/packages/core/editor/src/__tests__/list-insert-item-markdown.spec.ts
+++ b/packages/core/editor/src/__tests__/list-insert-item-markdown.spec.ts
@@ -1,0 +1,123 @@
+import {
+  type Command,
+  EditorState,
+  setupList,
+  TextSelection,
+} from '@bangle.io/prosemirror-plugins';
+import { describe, expect, it } from 'vitest';
+import { createProductionMarkdown } from './production-markdown-test-helpers';
+
+// The insert-item shortcuts leave an *empty* item behind until the user types,
+// and autosave serializes that transient state. These assertions pin what it
+// writes to disk and that reading it back is a fixpoint, so a serializer change
+// cannot quietly turn the empty item into a different construct.
+function setup() {
+  const markdown = createProductionMarkdown();
+  const list = setupList();
+
+  const caretAfter = (source: string, text: string) => {
+    const doc = markdown.parser.parse(source);
+    let pos = -1;
+    doc.descendants((node, nodePos) => {
+      if (pos === -1 && node.isText && node.text?.includes(text)) {
+        pos = nodePos + node.text.indexOf(text) + text.length;
+      }
+    });
+    if (pos === -1) throw new Error(`No text "${text}" in ${source}`);
+    return EditorState.create({
+      doc,
+      schema: markdown.schema,
+      selection: TextSelection.create(doc, pos),
+    });
+  };
+  const apply = (state: EditorState, command: Command) => {
+    let next = state;
+    command(state, (tr) => {
+      next = state.apply(tr);
+    });
+    return next;
+  };
+  const serialize = (state: EditorState) =>
+    markdown.serializer.serialize(state.doc);
+
+  return {
+    caretAfter,
+    apply,
+    serialize,
+    list,
+    reserialize: (source: string) =>
+      markdown.serializer.serialize(markdown.parser.parse(source)),
+  };
+}
+
+describe('inserting a list item writes stable Markdown', () => {
+  // The empty item serializes as its marker plus the separating space, so these
+  // expectations are built from parts rather than written as literals with an
+  // invisible trailing space.
+  it.each([
+    {
+      name: 'bullet',
+      source: '- alpha\n- bravo',
+      below: ['- alpha', '- ', '- bravo'].join('\n'),
+      above: ['- ', '- alpha', '- bravo'].join('\n'),
+    },
+    {
+      name: 'ordered',
+      source: '1. alpha\n1. bravo',
+      below: ['1. alpha', '1. ', '1. bravo'].join('\n'),
+      above: ['1. ', '1. alpha', '1. bravo'].join('\n'),
+    },
+    {
+      name: 'task',
+      source: '- [x] alpha\n- [x] bravo',
+      below: ['- [x] alpha', '- [ ] ', '- [x] bravo'].join('\n'),
+      above: ['- [ ] ', '- [x] alpha', '- [x] bravo'].join('\n'),
+    },
+  ])('$name run keeps one list either side of the new item', ({
+    source,
+    below,
+    above,
+  }) => {
+    const { caretAfter, apply, serialize, list, reserialize } = setup();
+
+    const withBelow = serialize(
+      apply(caretAfter(source, 'alpha'), list.command.insertEmptyListBelow),
+    );
+    expect(withBelow).toBe(below);
+    // A marker change here would split the run into two Markdown lists.
+    expect(reserialize(withBelow)).toBe(withBelow);
+
+    const withAbove = serialize(
+      apply(caretAfter(source, 'alpha'), list.command.insertEmptyListAbove),
+    );
+    expect(withAbove).toBe(above);
+    expect(reserialize(withAbove)).toBe(withAbove);
+  });
+
+  it('keeps a new task item unchecked and leaves the source item checked', () => {
+    const { caretAfter, apply, serialize, list } = setup();
+
+    const next = apply(
+      caretAfter('- [x] alpha', 'alpha'),
+      list.command.insertEmptyListBelow,
+    );
+
+    expect(serialize(next)).toBe(['- [x] alpha', '- [ ] '].join('\n'));
+  });
+
+  it('adds the nested sibling at its own depth', () => {
+    const { caretAfter, apply, serialize, list, reserialize } = setup();
+
+    const next = serialize(
+      apply(
+        caretAfter('- parent\n  - child\n- sibling', 'child'),
+        list.command.insertEmptyListBelow,
+      ),
+    );
+
+    expect(next).toBe(
+      ['- parent', '  - child', '  - ', '- sibling'].join('\n'),
+    );
+    expect(reserialize(next)).toBe(next);
+  });
+});

--- a/packages/js-lib/banger-editor/src/__tests__/insert-block-shortcuts.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/insert-block-shortcuts.spec.ts
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { setupBase } from '../base';
+import { setupBlockquote } from '../blockquote';
+import { setupCodeBlock } from '../code-block';
+import { keybinding } from '../common';
+import { setupHeading } from '../heading';
+import { setupList } from '../list';
+import { setupParagraph } from '../paragraph';
+import type { PMNode } from '../pm';
+import { createBangerEditorTestSetup } from '../test-helpers';
+
+const editorTest = createBangerEditorTestSetup({
+  extensions: [
+    setupBase(),
+    setupParagraph(),
+    setupCodeBlock(),
+    setupHeading(),
+    setupBlockquote(),
+    setupList(),
+  ],
+  builderAliases: {
+    blockquote: { nodeType: 'blockquote' },
+    codeBlock: { nodeType: 'code_block', language: '' },
+    doc: { nodeType: 'doc' },
+    h1: { nodeType: 'heading', level: 1 },
+    list: { nodeType: 'list' },
+    p: { nodeType: 'paragraph' },
+  },
+});
+
+const { doc, p, codeBlock } = editorTest.builders;
+const list = editorTest.nodeBuilder('list');
+const h1 = editorTest.nodeBuilder('h1');
+const blockquote = editorTest.nodeBuilder('blockquote');
+
+afterEach(() => editorTest.cleanup());
+
+// `Mod-` resolves to Meta on Apple platforms and Ctrl everywhere else. Mirror
+// prosemirror-keymap's own check so the test follows the environment instead of
+// hard-coding a modifier that only matches one of them.
+const IS_APPLE =
+  typeof navigator !== 'undefined' &&
+  /Mac|iP(hone|[oa]d)/.test(navigator.platform);
+const MOD = IS_APPLE ? { metaKey: true } : { ctrlKey: true };
+const INSERT_BELOW = MOD;
+const INSERT_ABOVE = { ...MOD, shiftKey: true };
+const TOGGLE_TASK_CHECKED = { altKey: true };
+
+const bullet = { kind: 'bullet', listKind: 'bullet', tight: true } as const;
+const ordered = { kind: 'ordered', listKind: 'ordered', tight: true } as const;
+const uncheckedTask = {
+  checked: false,
+  kind: 'task',
+  listKind: 'bullet',
+  tight: true,
+} as const;
+const checkedTask = { ...uncheckedTask, checked: true } as const;
+
+type Editor = ReturnType<typeof editorTest.createEditor>;
+
+function caretPath(editor: Editor) {
+  const { $from } = editor.view.state.selection;
+  const path: string[] = [];
+  for (let depth = 1; depth <= $from.depth; depth++) {
+    path.push($from.node(depth).type.name);
+  }
+  return path.join('>');
+}
+
+function caretIsInEmptyBlock(editor: Editor) {
+  return editor.view.state.selection.$from.parent.content.size === 0;
+}
+
+function childTexts(node: PMNode) {
+  return Array.from(
+    { length: node.childCount },
+    (_, index) => node.child(index).textContent,
+  );
+}
+
+describe('insert empty block above/below shortcuts', () => {
+  // Guards the whole keymap surface at once: before this fix, a caret inside a
+  // list item left both shortcuts completely unhandled because paragraph.ts
+  // filtered them to top level and list.ts bound neither.
+  describe.each([
+    { name: 'paragraph at top level', build: () => doc(p('one<cursor>')) },
+    { name: 'heading at top level', build: () => doc(h1('one<cursor>')) },
+    {
+      name: 'code block at top level',
+      build: () => doc(codeBlock('one<cursor>')),
+    },
+    {
+      name: 'paragraph in a blockquote',
+      build: () => doc(blockquote(p('one<cursor>'))),
+    },
+    {
+      name: 'bullet list item',
+      build: () => doc(list(bullet, p('one<cursor>'))),
+    },
+    {
+      name: 'ordered list item',
+      build: () => doc(list(ordered, p('one<cursor>'))),
+    },
+    {
+      name: 'task list item',
+      build: () => doc(list(uncheckedTask, p('one<cursor>'))),
+    },
+    {
+      name: 'heading inside a list item',
+      build: () => doc(list(bullet, h1('one<cursor>'))),
+    },
+    {
+      name: 'code block inside a list item',
+      build: () => doc(list(bullet, codeBlock('one<cursor>'))),
+    },
+    {
+      name: 'nested list item',
+      build: () =>
+        doc(list(bullet, p('parent'), list(bullet, p('one<cursor>')))),
+    },
+  ])('$name', ({ build }) => {
+    it('inserts an empty block below and puts the caret in it', () => {
+      const editor = editorTest.createEditor(build());
+
+      expect(editor.pressKey('Enter', INSERT_BELOW)).toBe(true);
+      expect(caretIsInEmptyBlock(editor)).toBe(true);
+    });
+
+    it('inserts an empty block above and puts the caret in it', () => {
+      const editor = editorTest.createEditor(build());
+
+      expect(editor.pressKey('Enter', INSERT_ABOVE)).toBe(true);
+      expect(caretIsInEmptyBlock(editor)).toBe(true);
+    });
+  });
+
+  it('adds a sibling item below that keeps the run marker', () => {
+    const editor = editorTest.createEditor(doc(list(bullet, p('one<cursor>'))));
+
+    editor.pressKey('Enter', INSERT_BELOW);
+
+    const doc_ = editor.view.state.doc;
+    expect(childTexts(doc_)).toEqual(['one', '']);
+    expect(doc_.child(1).attrs).toMatchObject(bullet);
+    expect(caretPath(editor)).toBe('list>paragraph');
+  });
+
+  it('adds a sibling item above that keeps the run marker', () => {
+    const editor = editorTest.createEditor(
+      doc(list(ordered, p('one<cursor>'))),
+    );
+
+    editor.pressKey('Enter', INSERT_ABOVE);
+
+    const doc_ = editor.view.state.doc;
+    expect(childTexts(doc_)).toEqual(['', 'one']);
+    expect(doc_.child(0).attrs).toMatchObject(ordered);
+    expect(caretPath(editor)).toBe('list>paragraph');
+  });
+
+  it('starts a new task item unchecked without touching the source item', () => {
+    const editor = editorTest.createEditor(
+      doc(list(checkedTask, p('one<cursor>'))),
+    );
+
+    editor.pressKey('Enter', INSERT_BELOW);
+
+    const doc_ = editor.view.state.doc;
+    expect(doc_.child(0).attrs).toMatchObject(checkedTask);
+    expect(doc_.child(1).attrs).toMatchObject(uncheckedTask);
+  });
+
+  it('keeps a nested insert at the nested level', () => {
+    const editor = editorTest.createEditor(
+      doc(list(bullet, p('parent'), list(bullet, p('one<cursor>')))),
+    );
+
+    editor.pressKey('Enter', INSERT_BELOW);
+
+    const doc_ = editor.view.state.doc;
+    expect(doc_.childCount).toBe(1);
+    const parent = doc_.child(0);
+    expect(childTexts(parent)).toEqual(['parent', 'one', '']);
+    expect(parent.child(2).attrs).toMatchObject(bullet);
+    expect(caretPath(editor)).toBe('list>list>paragraph');
+  });
+
+  it('adds the sibling after the whole subtree, not between an item and its children', () => {
+    const editor = editorTest.createEditor(
+      doc(list(bullet, p('one<cursor>'), list(bullet, p('child')))),
+    );
+
+    editor.pressKey('Enter', INSERT_BELOW);
+
+    const doc_ = editor.view.state.doc;
+    expect(childTexts(doc_)).toEqual(['onechild', '']);
+    expect(doc_.child(0).childCount).toBe(2);
+  });
+});
+
+describe('task checkbox shortcut', () => {
+  it('toggles the checkbox on its own binding', () => {
+    const editor = editorTest.createEditor(
+      doc(list(uncheckedTask, p('one<cursor>'))),
+    );
+
+    expect(editor.pressKey('Enter', TOGGLE_TASK_CHECKED)).toBe(true);
+    expect(editor.view.state.doc.child(0).attrs).toMatchObject(checkedTask);
+  });
+
+  // Regression guard for the conflict this fix resolved: while the checkbox
+  // owned Mod-Enter, insert-below could never run inside a task item.
+  it('no longer intercepts the insert-below binding', () => {
+    const editor = editorTest.createEditor(
+      doc(list(uncheckedTask, p('one<cursor>'))),
+    );
+
+    editor.pressKey('Enter', INSERT_BELOW);
+
+    const doc_ = editor.view.state.doc;
+    expect(doc_.childCount).toBe(2);
+    expect(doc_.child(0).attrs).toMatchObject(uncheckedTask);
+  });
+});
+
+describe('keybinding', () => {
+  // Object.fromEntries keeps the last entry for a repeated key, so a duplicate
+  // used to silently disable the earlier command instead of failing.
+  it('rejects two commands bound to the same key in one keymap', () => {
+    expect(() =>
+      keybinding(
+        [
+          ['Mod-Enter', () => true],
+          ['Mod-Enter', () => false],
+        ],
+        'test-keymap',
+      ),
+    ).toThrow(/Duplicate keybinding "Mod-Enter" in "test-keymap"/);
+  });
+
+  it('allows disabled bindings to repeat', () => {
+    expect(() =>
+      keybinding(
+        [
+          [false, () => true],
+          [false, () => false],
+        ],
+        'test-keymap',
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/js-lib/banger-editor/src/__tests__/insert-block-shortcuts.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/insert-block-shortcuts.spec.ts
@@ -9,6 +9,7 @@ import { setupHeading } from '../heading';
 import { setupList } from '../list';
 import { setupParagraph } from '../paragraph';
 import type { PMNode } from '../pm';
+import { setupTable } from '../table';
 import { createBangerEditorTestSetup } from '../test-helpers';
 
 const editorTest = createBangerEditorTestSetup({
@@ -23,6 +24,7 @@ const editorTest = createBangerEditorTestSetup({
     setupHeading(),
     setupParagraph(),
     setupCodeBlock(),
+    setupTable(),
   ],
   builderAliases: {
     blockquote: { nodeType: 'blockquote' },
@@ -31,6 +33,9 @@ const editorTest = createBangerEditorTestSetup({
     h1: { nodeType: 'heading', level: 1 },
     list: { nodeType: 'list' },
     p: { nodeType: 'paragraph' },
+    table: { nodeType: 'table' },
+    td: { nodeType: 'table_cell' },
+    tr: { nodeType: 'table_row' },
   },
 });
 
@@ -38,6 +43,9 @@ const { doc, p, codeBlock } = editorTest.builders;
 const list = editorTest.nodeBuilder('list');
 const h1 = editorTest.nodeBuilder('h1');
 const blockquote = editorTest.nodeBuilder('blockquote');
+const table = editorTest.nodeBuilder('table');
+const tableRow = editorTest.nodeBuilder('tr');
+const tableCell = editorTest.nodeBuilder('td');
 
 afterEach(() => editorTest.cleanup());
 
@@ -237,6 +245,32 @@ describe('insert empty block above/below shortcuts', () => {
     expect(childTexts(parent)).toEqual(['parent', 'one', '']);
     expect(parent.child(2).attrs).toMatchObject(bullet);
     expect(caretPath(editor)).toBe('list>list>paragraph');
+  });
+
+  // A table binds only insert-below, so insert-above used to leak through to
+  // the list keymap and replace the caret-in-a-cell with a brand new item.
+  describe('table inside a list item', () => {
+    const build = () =>
+      doc(list(bullet, table(tableRow(tableCell(p('cell<cursor>'))))));
+
+    it('lets the table own insert-below and keeps the caret in the item', () => {
+      const editor = editorTest.createEditor(build());
+
+      expect(editor.pressKey('Enter', INSERT_BELOW)).toBe(true);
+      expect(editor.view.state.doc.childCount).toBe(1);
+      expect(caretPath(editor)).toBe('list>paragraph');
+    });
+
+    it('leaves insert-above unhandled rather than escaping the table', () => {
+      const editor = editorTest.createEditor(build());
+      const before = editor.view.state.doc.toJSON();
+
+      expect(editor.pressKey('Enter', INSERT_ABOVE)).toBe(false);
+      expect(editor.view.state.doc.toJSON()).toEqual(before);
+      expect(caretPath(editor)).toBe(
+        'list>table>table_row>table_cell>paragraph',
+      );
+    });
   });
 
   it('adds the sibling after the whole subtree, not between an item and its children', () => {

--- a/packages/js-lib/banger-editor/src/__tests__/insert-block-shortcuts.spec.ts
+++ b/packages/js-lib/banger-editor/src/__tests__/insert-block-shortcuts.spec.ts
@@ -12,13 +12,17 @@ import type { PMNode } from '../pm';
 import { createBangerEditorTestSetup } from '../test-helpers';
 
 const editorTest = createBangerEditorTestSetup({
+  // Registered in the same relative order as the app (see the `extensions`
+  // object in @bangle.io/editor). Keymaps of equal priority are sorted stably,
+  // so a different order here would exercise a different winner for keys that
+  // more than one extension binds.
   extensions: [
     setupBase(),
-    setupParagraph(),
-    setupCodeBlock(),
-    setupHeading(),
     setupBlockquote(),
     setupList(),
+    setupHeading(),
+    setupParagraph(),
+    setupCodeBlock(),
   ],
   builderAliases: {
     blockquote: { nodeType: 'blockquote' },
@@ -73,6 +77,15 @@ function caretIsInEmptyBlock(editor: Editor) {
   return editor.view.state.selection.$from.parent.content.size === 0;
 }
 
+/** Position of the source text, so above/below can be told apart by direction. */
+function posOfText(editor: Editor, text: string) {
+  let found = -1;
+  editor.view.state.doc.descendants((node, pos) => {
+    if (found === -1 && node.isText && node.text?.includes(text)) found = pos;
+  });
+  return found;
+}
+
 function childTexts(node: PMNode) {
   return Array.from(
     { length: node.childCount },
@@ -84,55 +97,94 @@ describe('insert empty block above/below shortcuts', () => {
   // Guards the whole keymap surface at once: before this fix, a caret inside a
   // list item left both shortcuts completely unhandled because paragraph.ts
   // filtered them to top level and list.ts bound neither.
+  // `docChildren` and `caret` pin *which* extension handled the key: a special
+  // block inside a list item inserts a paragraph into that item (doc stays one
+  // child), while a plain item gets a whole sibling item (doc grows to two).
   describe.each([
-    { name: 'paragraph at top level', build: () => doc(p('one<cursor>')) },
-    { name: 'heading at top level', build: () => doc(h1('one<cursor>')) },
+    {
+      name: 'paragraph at top level',
+      build: () => doc(p('one<cursor>')),
+      docChildren: 2,
+      caret: 'paragraph',
+    },
+    {
+      name: 'heading at top level',
+      build: () => doc(h1('one<cursor>')),
+      docChildren: 2,
+      caret: 'paragraph',
+    },
     {
       name: 'code block at top level',
       build: () => doc(codeBlock('one<cursor>')),
+      docChildren: 2,
+      caret: 'paragraph',
     },
     {
       name: 'paragraph in a blockquote',
       build: () => doc(blockquote(p('one<cursor>'))),
+      docChildren: 2,
+      caret: 'paragraph',
     },
     {
       name: 'bullet list item',
       build: () => doc(list(bullet, p('one<cursor>'))),
+      docChildren: 2,
+      caret: 'list>paragraph',
     },
     {
       name: 'ordered list item',
       build: () => doc(list(ordered, p('one<cursor>'))),
+      docChildren: 2,
+      caret: 'list>paragraph',
     },
     {
       name: 'task list item',
       build: () => doc(list(uncheckedTask, p('one<cursor>'))),
+      docChildren: 2,
+      caret: 'list>paragraph',
     },
     {
       name: 'heading inside a list item',
       build: () => doc(list(bullet, h1('one<cursor>'))),
+      docChildren: 1,
+      caret: 'list>paragraph',
     },
     {
       name: 'code block inside a list item',
       build: () => doc(list(bullet, codeBlock('one<cursor>'))),
+      docChildren: 1,
+      caret: 'list>paragraph',
     },
     {
       name: 'nested list item',
       build: () =>
         doc(list(bullet, p('parent'), list(bullet, p('one<cursor>')))),
+      docChildren: 1,
+      caret: 'list>list>paragraph',
     },
-  ])('$name', ({ build }) => {
-    it('inserts an empty block below and puts the caret in it', () => {
+  ])('$name', ({ build, docChildren, caret }) => {
+    it('inserts an empty block below the source and puts the caret in it', () => {
       const editor = editorTest.createEditor(build());
 
       expect(editor.pressKey('Enter', INSERT_BELOW)).toBe(true);
       expect(caretIsInEmptyBlock(editor)).toBe(true);
+      expect(editor.view.state.doc.childCount).toBe(docChildren);
+      expect(caretPath(editor)).toBe(caret);
+      expect(editor.view.state.selection.from).toBeGreaterThan(
+        posOfText(editor, 'one'),
+      );
     });
 
-    it('inserts an empty block above and puts the caret in it', () => {
+    it('inserts an empty block above the source and puts the caret in it', () => {
       const editor = editorTest.createEditor(build());
 
       expect(editor.pressKey('Enter', INSERT_ABOVE)).toBe(true);
       expect(caretIsInEmptyBlock(editor)).toBe(true);
+      expect(editor.view.state.doc.childCount).toBe(docChildren);
+      expect(caretPath(editor)).toBe(caret);
+      expect(editor.view.state.selection.from).toBeLessThan(
+        posOfText(editor, 'one'),
+      );
     });
   });
 

--- a/packages/js-lib/banger-editor/src/common/collection.ts
+++ b/packages/js-lib/banger-editor/src/common/collection.ts
@@ -411,6 +411,13 @@ export const PRIORITY = {
   // order collections are registered in.
   codeMarkSpec: -100,
 
+  // A list item is the fallback owner of the insert-above/below shortcut: any
+  // special block inside the item (heading, blockquote, code block, table)
+  // keeps handling the key itself, and the list only adds a sibling item when
+  // nothing inner claimed it. Sorting below the default 0 makes that explicit
+  // rather than leaving it to the order collections happen to be registered in.
+  listInsertKeymap: -50,
+
   // -100 to allow default user keymap with 0 priority to run first
   baseKeymap: -100,
 };

--- a/packages/js-lib/banger-editor/src/common/collection.ts
+++ b/packages/js-lib/banger-editor/src/common/collection.ts
@@ -411,11 +411,11 @@ export const PRIORITY = {
   // order collections are registered in.
   codeMarkSpec: -100,
 
-  // A list item is the fallback owner of the insert-above/below shortcut: any
-  // special block inside the item (heading, blockquote, code block, table)
-  // keeps handling the key itself, and the list only adds a sibling item when
-  // nothing inner claimed it. Sorting below the default 0 makes that explicit
-  // rather than leaving it to the order collections happen to be registered in.
+  // A list item is the fallback owner of the insert-above/below shortcut: a
+  // special block inside the item (heading, blockquote, code block) keeps
+  // handling the key itself, and the list only adds a sibling item when nothing
+  // inner claimed it. Sorting below the default 0 makes that explicit rather
+  // than leaving it to the order collections happen to be registered in.
   listInsertKeymap: -50,
 
   // -100 to allow default user keymap with 0 priority to run first

--- a/packages/js-lib/banger-editor/src/common/keybinding.ts
+++ b/packages/js-lib/banger-editor/src/common/keybinding.ts
@@ -11,6 +11,20 @@ export function keybinding(
 ): Plugin {
   const normalizedKeys = Array.isArray(keys) ? keys : Object.entries(keys);
 
+  // `Object.fromEntries` keeps the last entry for a repeated key, which would
+  // silently disable the earlier binding. Fail loudly instead: two commands on
+  // one key inside a single keymap need an explicit `chainCommands`.
+  const seen = new Set<string>();
+  for (const [key] of normalizedKeys) {
+    if (!key) continue;
+    if (seen.has(key)) {
+      throw new Error(
+        `Duplicate keybinding "${key}" in "${name}". Chain the commands instead of binding the key twice.`,
+      );
+    }
+    seen.add(key);
+  }
+
   const object = Object.fromEntries(
     normalizedKeys
       .filter((param): param is [string, Command] => !!param[0])

--- a/packages/js-lib/banger-editor/src/common/keybinding.ts
+++ b/packages/js-lib/banger-editor/src/common/keybinding.ts
@@ -14,6 +14,10 @@ export function keybinding(
   // `Object.fromEntries` keeps the last entry for a repeated key, which would
   // silently disable the earlier binding. Fail loudly instead: two commands on
   // one key inside a single keymap need an explicit `chainCommands`.
+  //
+  // Compares the chord as written, since prosemirror-keymap does not export its
+  // normalizer. Aliases that normalize to the same chord (`Mod-Enter` versus
+  // `Meta-Enter`) are not caught; every call site spells chords the same way.
   const seen = new Set<string>();
   for (const [key] of normalizedKeys) {
     if (!key) continue;

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -356,11 +356,13 @@ function pluginKeybindings(config: RequiredConfig) {
 }
 
 /**
- * Registered below the default priority so a heading, blockquote, code block or
- * table inside a list item keeps handling insert-above/below itself. The list
- * only adds a sibling item when no inner block claimed the key, which keeps the
- * behaviour identical for every special block instead of depending on the order
- * extensions happen to be registered in.
+ * Registered below the default priority so a heading, blockquote or code block
+ * inside a list item keeps handling insert-above/below itself, rather than the
+ * winner depending on the order extensions happen to be registered in.
+ *
+ * A table binds only insert-below (`exitTableBelow`), so insert-above would
+ * otherwise reach this keymap; `insertEmptySiblingList` declines any caret that
+ * is not directly inside the item to keep the two directions consistent.
  */
 function pluginInsertKeybindings(config: RequiredConfig) {
   return keybinding(
@@ -536,7 +538,14 @@ function insertEmptySiblingList(
 ): Command {
   return (state, dispatch, view) => {
     const type = getNodeType(state.schema, config.listNodeName);
-    return insertNodeAdjacentToNode(type, side, (found) => {
+    return insertNodeAdjacentToNode(type, side, (found, { selection }) => {
+      // Only claim the key for a block the item directly contains. A caret
+      // inside a table cell (or any other nested structure) belongs to that
+      // structure, so leaking through to here would yank the caret out of it
+      // into a brand new item. Declining keeps such a caret behaving the same
+      // as it does in a table outside a list.
+      if (selection.$from.depth !== found.depth + 1) return null;
+
       const attrs = readListAttrs(found.node);
       if (!attrs) return null;
       return type.createAndFill({

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -273,6 +273,7 @@ export function setupList(userConfig: Partial<ListConfig> = {}) {
   const plugin = {
     inputRules: pluginInputRules(config),
     keybindings: pluginKeybindings(config),
+    insertKeybindings: pluginInsertKeybindings(config),
     listPlugins: ({ schema }: PluginContext) =>
       createMarkdownListPlugins(schema, listNodeName),
   };
@@ -284,6 +285,8 @@ export function setupList(userConfig: Partial<ListConfig> = {}) {
     command: {
       dedentList: dedentList(config),
       indentList: indentList(config),
+      insertEmptyListAbove: insertEmptyListAbove(config),
+      insertEmptyListBelow: insertEmptyListBelow(config),
       moveListDown: moveListDown(config),
       moveListUp: moveListUp(config),
       toggleBulletList: toggleBulletList(config),
@@ -339,8 +342,6 @@ function pluginKeybindings(config: RequiredConfig) {
       ['Delete', deleteCommand],
       [config.keyDedentList, dedentList(config)],
       [config.keyIndentList, indentList(config)],
-      [config.keyInsertEmptyListAbove, insertEmptyListAbove(config)],
-      [config.keyInsertEmptyListBelow, insertEmptyListBelow(config)],
       [config.keyMoveListDown, moveListDown(config)],
       [config.keyMoveListUp, moveListUp(config)],
       [config.keyToggleBulletList, toggleBulletList(config)],
@@ -351,6 +352,24 @@ function pluginKeybindings(config: RequiredConfig) {
       [config.keyToggleTaskChecked, toggleTaskChecked(config)],
     ],
     'list',
+  );
+}
+
+/**
+ * Registered below the default priority so a heading, blockquote, code block or
+ * table inside a list item keeps handling insert-above/below itself. The list
+ * only adds a sibling item when no inner block claimed the key, which keeps the
+ * behaviour identical for every special block instead of depending on the order
+ * extensions happen to be registered in.
+ */
+function pluginInsertKeybindings(config: RequiredConfig) {
+  return keybinding(
+    [
+      [config.keyInsertEmptyListAbove, insertEmptyListAbove(config)],
+      [config.keyInsertEmptyListBelow, insertEmptyListBelow(config)],
+    ],
+    'list-insert',
+    PRIORITY.listInsertKeymap,
   );
 }
 
@@ -522,6 +541,11 @@ function insertEmptySiblingList(
       if (!attrs) return null;
       return type.createAndFill({
         ...found.node.attrs,
+        // Normalized rather than copied raw: an item that never carried an
+        // explicit `listKind` still hands the sibling the marker it renders
+        // with, the same repair `enterListCommand` applies.
+        listKind: attrs.listKind,
+        tight: attrs.tight,
         checked: false,
         collapsed: false,
         order: null,

--- a/packages/js-lib/banger-editor/src/list.ts
+++ b/packages/js-lib/banger-editor/src/list.ts
@@ -48,7 +48,12 @@ import {
   unwrapListSlice,
   wrappingListInputRule,
 } from './pm';
-import { findParentNode, getNodeType, type PluginContext } from './pm-utils';
+import {
+  findParentNode,
+  getNodeType,
+  insertNodeAdjacentToNode,
+  type PluginContext,
+} from './pm-utils';
 
 const LIST_KIND = {
   BULLET: 'bullet',
@@ -218,6 +223,8 @@ type ListConfig = {
   keyDedentList?: string | false;
   keyDeleteList?: string | false;
   keyIndentList?: string | false;
+  keyInsertEmptyListAbove?: string | false;
+  keyInsertEmptyListBelow?: string | false;
   keyMoveListDown?: string | false;
   keyMoveListUp?: string | false;
   keyToggleBulletList?: string | false;
@@ -236,6 +243,10 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyDedentList: 'Shift-Tab',
   keyDeleteList: 'Delete',
   keyIndentList: 'Tab',
+  // Mirrors the paragraph/heading/blockquote/code-block bindings so the
+  // shortcut keeps working when the caret sits inside a list item.
+  keyInsertEmptyListAbove: 'Mod-Shift-Enter',
+  keyInsertEmptyListBelow: 'Mod-Enter',
   keyMoveListDown: 'Alt-ArrowDown',
   keyMoveListUp: 'Alt-ArrowUp',
   keyToggleBulletList: 'Mod-Shift-8',
@@ -243,7 +254,9 @@ const DEFAULT_CONFIG: RequiredConfig = {
   keyToggleTaskList: 'Mod-Shift-7',
   keyToggleToggleList: 'Mod-Shift-6',
   keyUnwrapList: 'Shift-Mod-0',
-  keyToggleTaskChecked: 'Mod-Enter',
+  // Moved off `Mod-Enter` so insert-below behaves the same in every list item
+  // instead of being swallowed by the checkbox toggle inside task lists.
+  keyToggleTaskChecked: 'Alt-Enter',
 };
 
 export function setupList(userConfig: Partial<ListConfig> = {}) {
@@ -326,6 +339,8 @@ function pluginKeybindings(config: RequiredConfig) {
       ['Delete', deleteCommand],
       [config.keyDedentList, dedentList(config)],
       [config.keyIndentList, indentList(config)],
+      [config.keyInsertEmptyListAbove, insertEmptyListAbove(config)],
+      [config.keyInsertEmptyListBelow, insertEmptyListBelow(config)],
       [config.keyMoveListDown, moveListDown(config)],
       [config.keyMoveListUp, moveListUp(config)],
       [config.keyToggleBulletList, toggleBulletList(config)],
@@ -478,6 +493,41 @@ function normalizeNewIndentationPlaceholders(
 
 function dedentList(_config: RequiredConfig): Command {
   return createDedentListCommand();
+}
+
+function insertEmptyListAbove(config: RequiredConfig): Command {
+  return insertEmptySiblingList(config, 'above');
+}
+
+function insertEmptyListBelow(config: RequiredConfig): Command {
+  return insertEmptySiblingList(config, 'below');
+}
+
+/**
+ * Adds an empty item next to the caret's item, matching the run's marker so the
+ * surrounding Markdown list is not split into two lists.
+ *
+ * Item-specific state is deliberately not inherited: a fresh item starts
+ * unchecked and expanded, and carries no explicit `order` so the run keeps
+ * numbering itself.
+ */
+function insertEmptySiblingList(
+  config: RequiredConfig,
+  side: 'above' | 'below',
+): Command {
+  return (state, dispatch, view) => {
+    const type = getNodeType(state.schema, config.listNodeName);
+    return insertNodeAdjacentToNode(type, side, (found) => {
+      const attrs = readListAttrs(found.node);
+      if (!attrs) return null;
+      return type.createAndFill({
+        ...found.node.attrs,
+        checked: false,
+        collapsed: false,
+        order: null,
+      });
+    })(state, dispatch, view);
+  };
 }
 
 function moveListUp(_config: RequiredConfig): Command {

--- a/packages/js-lib/banger-editor/src/pm-utils/commands.ts
+++ b/packages/js-lib/banger-editor/src/pm-utils/commands.ts
@@ -1,5 +1,5 @@
 import { assertIsDefined } from '../common';
-import type { Command, EditorState, EditorView, Schema } from '../pm';
+import type { Command, EditorState, EditorView, PMNode, Schema } from '../pm';
 import {
   Fragment,
   NodeSelection,
@@ -12,6 +12,7 @@ import {
 import { mapChildren } from './helpers';
 import { findParentNodeOfType } from './selection';
 import { safeInsert } from './transforms';
+import type { ContentNodeWithPos } from './types';
 
 type PredicateFunction = (state: EditorState, view?: EditorView) => boolean;
 export type MoveDirection = 'UP' | 'DOWN';
@@ -142,6 +143,49 @@ export function jumpToEndOfNode(type: NodeType): Command {
 }
 
 /**
+ * Builds the node to insert next to an existing block. Returning `null` aborts
+ * the command, leaving the key free for a lower-priority handler.
+ */
+export type AdjacentNodeBuilder = (
+  found: ContentNodeWithPos,
+  state: EditorState,
+) => PMNode | null;
+
+/**
+ * Insert a node as a sibling of the nearest ancestor of the given node type.
+ *
+ * `side` is resolved against that ancestor, so `'below'` lands after the whole
+ * subtree rather than between the ancestor and its children.
+ *
+ * @param type - The type of the ancestor to anchor against.
+ * @param side - Whether the new node goes before or after the ancestor.
+ * @param buildNode - Builds the node to insert.
+ * @returns A ProseMirror command function.
+ */
+export function insertNodeAdjacentToNode(
+  type: NodeType,
+  side: 'above' | 'below',
+  buildNode: AdjacentNodeBuilder,
+): Command {
+  return (state, dispatch) => {
+    const parent = findParentNodeOfType(type)(state.selection);
+    if (!parent) {
+      return false;
+    }
+
+    const newNode = buildNode(parent, state);
+    if (!newNode) {
+      return false;
+    }
+
+    const insertPos =
+      side === 'above' ? parent.pos : parent.pos + parent.node.nodeSize;
+    dispatch?.(safeInsert(newNode, insertPos)(state.tr));
+    return true;
+  };
+}
+
+/**
  * Insert an empty paragraph above the nearest parent of the given node type.
  *
  * @param type - The type of the parent node to find.
@@ -152,21 +196,9 @@ export function insertEmptyParagraphAboveNode(
   type: NodeType,
   getParagraphNodeType: (schema: Schema) => NodeType,
 ): Command {
-  return (state, dispatch) => {
-    const parent = findParentNodeOfType(type)(state.selection);
-    if (!parent) {
-      return false;
-    }
-
-    const newPara = getParagraphNodeType(state.schema).createAndFill();
-    if (!newPara) {
-      return false;
-    }
-
-    const insertPos = parent.pos;
-    dispatch?.(safeInsert(newPara, insertPos)(state.tr));
-    return true;
-  };
+  return insertNodeAdjacentToNode(type, 'above', (_found, state) =>
+    getParagraphNodeType(state.schema).createAndFill(),
+  );
 }
 
 /**
@@ -180,21 +212,9 @@ export function insertEmptyParagraphBelowNode(
   type: NodeType,
   getParagraphNodeType: (schema: Schema) => NodeType,
 ): Command {
-  return (state, dispatch) => {
-    const parent = findParentNodeOfType(type)(state.selection);
-    if (!parent) {
-      return false;
-    }
-
-    const newPara = getParagraphNodeType(state.schema).createAndFill();
-    if (!newPara) {
-      return false;
-    }
-
-    const insertPos = parent.pos + parent.node.nodeSize;
-    dispatch?.(safeInsert(newPara, insertPos)(state.tr));
-    return true;
-  };
+  return insertNodeAdjacentToNode(type, 'below', (_found, state) =>
+    getParagraphNodeType(state.schema).createAndFill(),
+  );
 }
 
 /**

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -204,6 +204,7 @@ export const t = {
       settings: 'Settings',
       linksLabel: 'Links',
       homepage: 'Homepage',
+      whatsNew: "What's New",
       githubProject: 'GitHub Project',
       reportIssue: 'Report an Issue',
       twitter: 'Twitter',

--- a/packages/tooling/e2e-tests/src/markdown-lists.e2e.ts
+++ b/packages/tooling/e2e-tests/src/markdown-lists.e2e.ts
@@ -403,3 +403,42 @@ test('insert-item shortcut adds an unchecked task without toggling the source', 
     expected,
   );
 });
+
+test('the task checkbox shortcut toggles the item under the caret', async ({
+  page,
+}) => {
+  const workspaceName = 'list-task-shortcut';
+  const noteName = 'toggle-task';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    '- [ ] alpha\n- [ ] bravo',
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  await collapseEditorSelectionAfterText(page, 'bravo');
+  await waitForEditorFocus(page, {});
+  await page.keyboard.press('Alt+Enter');
+
+  const toggled = '- [ ] alpha\n- [x] bravo';
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(toggled);
+  await expect(editor.getByRole('checkbox').first()).not.toBeChecked();
+  await expect(editor.getByRole('checkbox').last()).toBeChecked();
+
+  // Toggling back proves the shortcut is a toggle, not a one-way set.
+  await page.keyboard.press('Alt+Enter');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe('- [ ] alpha\n- [ ] bravo');
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(readStoredMarkdown(page, workspaceName, noteName)).resolves.toBe(
+    '- [ ] alpha\n- [ ] bravo',
+  );
+});

--- a/packages/tooling/e2e-tests/src/markdown-lists.e2e.ts
+++ b/packages/tooling/e2e-tests/src/markdown-lists.e2e.ts
@@ -328,3 +328,78 @@ test('deeply indenting a task does not create another task on reload', async ({
     expected,
   );
 });
+
+test('insert-item shortcuts add siblings that keep the list marker', async ({
+  page,
+}) => {
+  const workspaceName = 'list-insert-shortcuts';
+  const noteName = 'insert-items';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    noteName,
+    '- alpha\n- beta\n- gamma',
+  );
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  await collapseEditorSelectionAfterText(page, 'beta');
+  await waitForEditorFocus(page, {});
+  await page.keyboard.press('ControlOrMeta+Enter');
+  await page.keyboard.insertText('delta');
+
+  const withBelow = '- alpha\n- beta\n- delta\n- gamma';
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(withBelow);
+  await expect(
+    editor.locator('.prosemirror-flat-list[data-list-container-kind="bullet"]'),
+  ).toHaveCount(4);
+
+  await collapseEditorSelectionAfterText(page, 'alpha');
+  await page.keyboard.press('ControlOrMeta+Shift+Enter');
+  await page.keyboard.insertText('start');
+
+  const withAbove = '- start\n- alpha\n- beta\n- delta\n- gamma';
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(withAbove);
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(readStoredMarkdown(page, workspaceName, noteName)).resolves.toBe(
+    withAbove,
+  );
+});
+
+test('insert-item shortcut adds an unchecked task without toggling the source', async ({
+  page,
+}) => {
+  const workspaceName = 'list-insert-task-shortcut';
+  const noteName = 'insert-task';
+  await createBrowserWorkspaceAndNote(page, { workspaceName, noteName });
+
+  await writeStoredMarkdown(page, workspaceName, noteName, '- [x] done');
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  await expect(editor.getByRole('checkbox')).toBeChecked();
+  await collapseEditorSelectionAfterText(page, 'done');
+  await waitForEditorFocus(page, {});
+  await page.keyboard.press('ControlOrMeta+Enter');
+  await page.keyboard.insertText('todo');
+
+  const expected = '- [x] done\n- [ ] todo';
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, noteName))
+    .toBe(expected);
+  await expect(editor.getByRole('checkbox')).toHaveCount(2);
+  await expect(editor.getByRole('checkbox').first()).toBeChecked();
+  await expect(editor.getByRole('checkbox').last()).not.toBeChecked();
+
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(readStoredMarkdown(page, workspaceName, noteName)).resolves.toBe(
+    expected,
+  );
+});

--- a/packages/tooling/e2e-tests/src/sidebar-links.e2e.ts
+++ b/packages/tooling/e2e-tests/src/sidebar-links.e2e.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { createBrowserWorkspace } from './common';
+
+// The footer menu's Links section is the app's only route to the changelog, so
+// assert the entry exists and points at it. The popup URL is checked without
+// letting the tab load, keeping the test off the network.
+test('the sidebar footer links to the changelog', async ({ page }) => {
+  await createBrowserWorkspace(page, { workspaceName: 'sidebar-links-ws' });
+
+  await page.getByRole('button', { name: /Bangle\.io/ }).click();
+
+  const whatsNew = page.getByRole('menuitem', { name: "What's New" });
+  await expect(whatsNew).toBeVisible();
+
+  const popupPromise = page.context().waitForEvent('page');
+  await whatsNew.click();
+  const popup = await popupPromise;
+
+  expect(popup.url()).toBe(
+    'https://github.com/bangle-io/bangle-io/blob/main/CHANGELOG.md',
+  );
+  await popup.close();
+});

--- a/packages/tooling/e2e-tests/src/sidebar-links.e2e.ts
+++ b/packages/tooling/e2e-tests/src/sidebar-links.e2e.ts
@@ -1,10 +1,21 @@
 import { expect, test } from '@playwright/test';
 import { createBrowserWorkspace } from './common';
 
+const CHANGELOG_URL =
+  'https://github.com/bangle-io/bangle-io/blob/main/CHANGELOG.md';
+
 // The footer menu's Links section is the app's only route to the changelog, so
-// assert the entry exists and points at it. The popup URL is checked without
-// letting the tab load, keeping the test off the network.
+// assert the entry exists and points at it. GitHub is stubbed rather than
+// fetched: it keeps the test off the network, and it makes the popup commit its
+// navigation immediately instead of racing `about:blank`.
 test('the sidebar footer links to the changelog', async ({ page }) => {
+  await page.context().route(CHANGELOG_URL, (route) =>
+    route.fulfill({
+      body: '<title>stub changelog</title>',
+      contentType: 'text/html',
+    }),
+  );
+
   await createBrowserWorkspace(page, { workspaceName: 'sidebar-links-ws' });
 
   await page.getByRole('button', { name: /Bangle\.io/ }).click();
@@ -15,9 +26,8 @@ test('the sidebar footer links to the changelog', async ({ page }) => {
   const popupPromise = page.context().waitForEvent('page');
   await whatsNew.click();
   const popup = await popupPromise;
+  await popup.waitForLoadState('domcontentloaded');
 
-  expect(popup.url()).toBe(
-    'https://github.com/bangle-io/bangle-io/blob/main/CHANGELOG.md',
-  );
+  expect(popup.url()).toBe(CHANGELOG_URL);
   await popup.close();
 });


### PR DESCRIPTION
`Mod-Enter` / `Mod-Shift-Enter` ("insert empty block below/above") did nothing when the caret sat inside a list item. `paragraph.ts` filters both commands to top level and `list.ts` bound neither key, so once a paragraph was nested in a list the shortcut reached no handler at all. This has been the behaviour since banger-editor was imported; no test covered it because nothing in the repo exercised a `Mod`-modified keybinding.

- The list extension now owns insert-above/below, adding an empty sibling item that inherits the run's marker so the surrounding Markdown list is not split in two.
- The two near-identical `insertEmptyParagraph{Above,Below}Node` helpers in `pm-utils` collapse into one `insertNodeAdjacentToNode`, which both are rebuilt on.
- The task checkbox toggle moves from `Mod-Enter` to `Alt-Enter`. While it owned `Mod-Enter` it swallowed insert-below in every task item.
- `keybinding()` throws on a duplicate key instead of letting `Object.fromEntries` silently drop the earlier command.
- Both changes are recorded in `CHANGELOG.md`, and a "What's New" entry in the sidebar footer's Links section now points there — the app previously had no route to the changelog at all.

Reviewer callouts:

- **Priority, not registration order, decides the winner.** The insert bindings sit in their own keymap below the default priority (`PRIORITY.listInsertKeymap`), so a heading, blockquote, code block or table inside a list item keeps handling the key itself and the list is only the fallback for a plain paragraph item. Without this the outcome depended on where `setupList()` happened to sit in `extensions.ts`, and a heading inside an item changed behaviour.
- **`Alt-Enter` for the checkbox is a user-visible shortcut change.** Nothing in the repo referenced the old binding, but Obsidian and Notion both use Cmd/Ctrl+Enter to toggle checkboxes.
- The new item serializes as its marker plus the separating space (`- `, `1. `, `- [ ] `). `list-insert-item-markdown.spec.ts` pins that and asserts reparsing is a fixpoint.
- Inserting *above* the head of an ordered run leaves a stale `order` on the demoted item. Cosmetic and transient — Markdown always emits `1.` and parsing drops `order`, so it self-heals on reload.
- The changelog link reads the file on GitHub rather than the `changelogText` build config. `CHANGELOG_TEXT` (and `HELP_DOCS_VERSION`) remain validated-but-unconsumed; rendering Markdown in-app would mean adding a renderer to the `ui` layer, which felt out of proportion here.