### PR TITLE
fix(nativefs): avoid structural watcher rename races

### DIFF
--- a/packages/core/initialize-services/src/initialize-services.ts
+++ b/packages/core/initialize-services/src/initialize-services.ts
@@ -29,7 +29,6 @@ import {
 import type {
   BaseServiceCommonOptions,
   CommandHandler,
-  FileStorageExternalChangeEvent,
   RootEmitter,
 } from '@bangle.io/types';
 import { createServiceSetup } from './service-setup';
@@ -42,20 +41,6 @@ export function readEditorEngineFromUrl(
   );
   return isEditorEngineId(engineId) ? engineId : DEFAULT_EDITOR_ENGINE;
 }
-
-/**
- * Per-path watcher changes carry the same meaning as the app's own file
- * mutations; only the event names differ. The `Record` key type keeps this
- * exhaustive over the non-`refresh` cases.
- */
-const EXTERNAL_CHANGE_TO_FILE_EVENT = {
-  create: 'file-create',
-  update: 'file-content-update',
-  delete: 'file-delete',
-} as const satisfies Record<
-  Exclude<FileStorageExternalChangeEvent['type'], 'refresh'>,
-  string
->;
 
 export function initializeServices(
   commonOpts: BaseServiceCommonOptions,
@@ -117,7 +102,7 @@ export function initializeServices(
           return;
         }
         rootEmitter.emit('event::file:update', {
-          type: EXTERNAL_CHANGE_TO_FILE_EVENT[change.type],
+          type: 'file-content-update',
           wsPath: change.wsPath,
           sender,
         });

--- a/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
+++ b/packages/platform/service-platform/src/__tests__/file-storage-nativefs.spec.ts
@@ -442,7 +442,7 @@ describe('external change watching', () => {
     });
   });
 
-  it('maps visible file records and degrades ambiguous moves to a refresh', async () => {
+  it('maps possible content writes without applying structural records live', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     await observer.emitRecords([
@@ -465,9 +465,8 @@ describe('external change watching', () => {
     ]);
 
     expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'create', wsPath: 'myWorkspace:sub/new.md' },
+      { type: 'update', wsPath: 'myWorkspace:sub/new.md' },
       { type: 'update', wsPath: 'myWorkspace:existing.md' },
-      { type: 'delete', wsPath: 'myWorkspace:gone.md' },
     ]);
 
     onExternalChange.mockClear();
@@ -479,13 +478,10 @@ describe('external change watching', () => {
         changedHandle: { kind: 'file' },
       },
     ]);
-    expect(onExternalChange).toHaveBeenCalledWith({
-      type: 'refresh',
-      wsName: 'myWorkspace',
-    });
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 
-  it('coalesces one observer burst: duplicates collapse, a coarse record wins alone', async () => {
+  it('coalesces content updates without letting structural hints hide them', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     // Duplicate records for the same path collapse into one event.
@@ -511,9 +507,8 @@ describe('external change watching', () => {
       { type: 'update', wsPath: 'myWorkspace:b.md' },
     ]);
 
-    // Once any record in the batch demands a coarse refresh, the refresh is
-    // emitted alone — it re-lists the workspace and revalidates open notes,
-    // so per-path events in the same batch would only duplicate that work.
+    // A structural hint in the same burst waits for page-return revalidation;
+    // it must not suppress an independent live content update.
     onExternalChange.mockClear();
     await observer.emitRecords([
       {
@@ -528,7 +523,7 @@ describe('external change watching', () => {
       },
     ]);
     expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'refresh', wsName: 'myWorkspace' },
+      { type: 'update', wsPath: 'myWorkspace:a.md' },
     ]);
   });
 
@@ -569,7 +564,7 @@ describe('external change watching', () => {
     ]);
   });
 
-  it('ignores hidden paths and coalesces unmappable records into one refresh', async () => {
+  it('ignores hidden, unmappable, and errored structural records live', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     await observer.emitRecords([
@@ -579,8 +574,8 @@ describe('external change watching', () => {
         relativePathComponents: ['.obsidian', 'config.json'],
         changedHandle: { kind: 'file' },
       },
-      // Directory records and unknown/errored records only say "something
-      // changed": they collapse into a single coarse refresh.
+      // Directory and unknown records only say that workspace structure may
+      // have changed. The next page return owns that revalidation.
       {
         type: 'appeared',
         relativePathComponents: ['new-dir'],
@@ -590,34 +585,31 @@ describe('external change watching', () => {
       { type: 'errored', relativePathComponents: [] },
     ]);
 
-    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'refresh', wsName: 'myWorkspace' },
-    ]);
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 
-  it('coarse-refreshes a deleted directory, whose record has no handle to say so', async () => {
+  it('defers a deleted directory whose record has no handle to say so', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     // Real Chrome delivers `disappeared` with changedHandle: null, so a
     // deleted DIRECTORY is indistinguishable from a file by `kind`. Its
     // extensionless path is directory-shaped, and its descendants get no
-    // records of their own — only a re-list reconciles the tree.
+    // records of their own. Page-return/manual revalidation reconciles it
+    // without letting an app mutation's intermediate state reach the tree.
     await observer.emitRecords([
       { type: 'disappeared', relativePathComponents: ['archive'] },
     ]);
-    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'refresh', wsName: 'myWorkspace' },
-    ]);
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 
-  it('keeps invisible-to-visible atomic writes targeted but refreshes ambiguous visible moves', async () => {
+  it('keeps atomic replacement content live but defers visible moves', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     await observer.emitRecords([
       // Chromium's own createWritable commit / sync tools' write-to-temp:
       // the visible file materialized from a transient path. A workspace
-      // refresh here would re-list on EVERY local save (self-writes are
-      // deliberately unfiltered).
+      // tree update here would run on EVERY local save (self-writes are
+      // deliberately unfiltered). Only the destination bytes are relevant.
       {
         type: 'moved',
         relativePathComponents: ['note.md'],
@@ -626,14 +618,14 @@ describe('external change watching', () => {
       },
     ]);
     expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'create', wsPath: 'myWorkspace:note.md' },
+      { type: 'update', wsPath: 'myWorkspace:note.md' },
     ]);
 
     onExternalChange.mockClear();
     await observer.emitRecords([
       // `.tmp` is visible workspace content. A visible-to-visible watcher
-      // move can be either a rename or an atomic target replacement, so the
-      // safe interpretation is a workspace refresh.
+      // move can be either a rename or an atomic target replacement, so it is
+      // deferred to page-return/manual structural revalidation.
       {
         type: 'moved',
         relativePathComponents: ['trash.md.tmp'],
@@ -648,12 +640,10 @@ describe('external change watching', () => {
       },
     ]);
 
-    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'refresh', wsName: 'myWorkspace' },
-    ]);
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 
-  it('coarse-refreshes a moved directory whose dot-named path looks like a file', async () => {
+  it('defers a moved directory whose dot-named path looks like a file', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
     // A directory materializing from an invisible path matches the atomic-write
@@ -669,9 +659,7 @@ describe('external change watching', () => {
       },
     ]);
 
-    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'refresh', wsName: 'myWorkspace' },
-    ]);
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 
   it('ignores churn inside locations the listing never shows', async () => {
@@ -718,11 +706,12 @@ describe('external change watching', () => {
     expect(onExternalChange).not.toHaveBeenCalled();
   });
 
-  it('still refreshes when a visible directory changes', async () => {
+  it('defers visible directory changes until page return', async () => {
     const { observer, onExternalChange } = await setupExternalChangeWatching();
 
-    // The ignore check must not swallow real directory changes: adding or
-    // removing a visible folder does change the listing.
+    // The observer record is still real, but applying it immediately can
+    // expose an app operation's intermediate disk state. Page return performs
+    // the eventual full listing instead.
     await observer.emitRecords([
       {
         type: 'appeared',
@@ -731,9 +720,7 @@ describe('external change watching', () => {
       },
     ]);
 
-    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'refresh', wsName: 'myWorkspace' },
-    ]);
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 
   it('reports changes to visible temp-suffix files', async () => {
@@ -761,9 +748,40 @@ describe('external change watching', () => {
 
     expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
       { type: 'update', wsPath: 'myWorkspace:export.tmp' },
-      { type: 'create', wsPath: 'myWorkspace:recovered.swp' },
+      { type: 'update', wsPath: 'myWorkspace:recovered.swp' },
       { type: 'update', wsPath: 'myWorkspace:real-note.md' },
     ]);
+  });
+
+  it('reconciles deferred structural records on the next plain refocus', async () => {
+    const { observer, onExternalChange, triggerPageReturn } =
+      await setupExternalChangeWatching();
+
+    await observer.emitRecords([
+      {
+        type: 'disappeared',
+        relativePathComponents: ['removed.md'],
+      },
+      {
+        type: 'moved',
+        relativePathComponents: ['renamed.md'],
+        relativePathMovedFrom: ['original.md'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
+    expect(onExternalChange).not.toHaveBeenCalled();
+
+    triggerPageReturn({ returnedFromHidden: false });
+    expect(onExternalChange).toHaveBeenCalledWith({
+      type: 'refresh',
+      wsName: 'myWorkspace',
+    });
+
+    // The pending bit is consumed by that reconciliation. A later ordinary
+    // refocus can stay cheap until another structural record arrives.
+    onExternalChange.mockClear();
+    triggerPageReturn({ returnedFromHidden: false });
+    expect(onExternalChange).not.toHaveBeenCalled();
   });
 
   it('revalidates opened workspaces on every page return when no observer exists', async () => {
@@ -804,13 +822,22 @@ describe('external change watching', () => {
     ]);
   });
 
-  it('skips the refresh on plain refocus while a watcher is armed and healthy', async () => {
-    const { onExternalChange, triggerPageReturn } =
+  it('skips the refresh on plain refocus while a watcher is armed and clean', async () => {
+    const { observer, onExternalChange, triggerPageReturn } =
       await setupExternalChangeWatching();
 
-    // The page stayed visible the whole time and the observer was armed:
-    // nothing was missed, so refreshing would re-list the workspace and
-    // re-read every open note on every alt-tab for no reason.
+    // Ignored tool metadata does not dirty the visible workspace.
+    await observer.emitRecords([
+      {
+        type: 'appeared',
+        relativePathComponents: ['.git', 'index.lock'],
+        changedHandle: { kind: 'file' },
+      },
+    ]);
+
+    // The page stayed visible, the observer was armed, and it saw no relevant
+    // structure, so refreshing would re-list the workspace and re-read every
+    // open note on every alt-tab for no reason.
     triggerPageReturn({ returnedFromHidden: false });
     expect(onExternalChange).not.toHaveBeenCalled();
 
@@ -920,13 +947,12 @@ describe('external change watching', () => {
     const { observer, onExternalChange, triggerPageReturn } =
       await setupExternalChangeWatching();
 
-    // Observation broke (e.g. permission loss): one coarse refresh goes out.
+    // Observation broke (e.g. permission loss). Do not scan immediately from
+    // the error record; page return owns re-arming and reconciliation.
     await observer.emitRecords([
       { type: 'errored', relativePathComponents: [] },
     ]);
-    expect(onExternalChange.mock.calls.map(([event]) => event)).toEqual([
-      { type: 'refresh', wsName: 'myWorkspace' },
-    ]);
+    expect(onExternalChange).not.toHaveBeenCalled();
 
     // Even a plain refocus re-establishes the observer AND refreshes: with
     // the watcher dead, anything could have been missed meanwhile.

--- a/packages/platform/service-platform/src/file-storage-nativefs.ts
+++ b/packages/platform/service-platform/src/file-storage-nativefs.ts
@@ -39,7 +39,8 @@ type Config = {
   /**
    * External watcher events. Self-write records intentionally flow through;
    * downstream content comparison coalesces echoes without hiding a real
-   * overwrite that happened just after a local save.
+   * overwrite that happened just after a local save. Live observer delivery
+   * is content-only; structural changes reconcile on page return.
    */
   onExternalChange?: (event: FileStorageExternalChangeEvent) => void;
   /**
@@ -60,6 +61,8 @@ type WatchPathClass =
 
 type FsCacheEntry = {
   fs: NativeFs;
+  /** A watcher saw structure that must be reconciled on the next return. */
+  pendingStructuralRefresh: boolean;
   /** `starting` deduplicates setup; only `armed` may skip revalidation. */
   watchState: 'idle' | 'starting' | 'armed';
   /** Disconnects the current observer, so re-arming cannot stack a second. */
@@ -144,7 +147,11 @@ export class FileStorageNativeFs
         // The lock scope is the workspace name (not the folder basename) so
         // cross-tab write serialization stays keyed to the workspace identity.
         const fs = new NativeFs({ rootHandle: handle, lockScope: wsName });
-        const entry: FsCacheEntry = { fs, watchState: 'idle' };
+        const entry: FsCacheEntry = {
+          fs,
+          pendingStructuralRefresh: false,
+          watchState: 'idle',
+        };
         if (!this.abortSignal.aborted) {
           // A load that outlived teardown must not refill the cache the
           // cleanup just cleared.
@@ -202,9 +209,10 @@ export class FileStorageNativeFs
 
   /**
    * Re-arms unhealthy watchers. Hidden returns always refresh because the
-   * browser may have starved observers; plain refocus refreshes only when a
-   * watcher is unavailable. Refreshes are scoped to the workspaces this
-   * provider actually holds, so unrelated workspaces are left alone.
+   * browser may have starved observers; plain refocus refreshes when a watcher
+   * is unavailable or reported deferred structure. Refreshes are scoped to
+   * the workspaces this provider actually holds, so unrelated workspaces are
+   * left alone.
    */
   private revalidateOnPageReturn(info: PageReturnInfo): void {
     const onExternalChange = this.config.onExternalChange;
@@ -214,7 +222,12 @@ export class FileStorageNativeFs
     for (const [wsName, entry] of this.fsCache) {
       const wasArmed = entry.watchState === 'armed';
       this.startWatching(wsName, entry);
-      if (info.returnedFromHidden || !wasArmed) {
+      if (
+        info.returnedFromHidden ||
+        !wasArmed ||
+        entry.pendingStructuralRefresh
+      ) {
+        entry.pendingStructuralRefresh = false;
         onExternalChange({ type: 'refresh', wsName });
       }
     }
@@ -222,7 +235,7 @@ export class FileStorageNativeFs
 
   /**
    * Classifies a record as a targeted visible file, an ignored hidden path,
-   * or a coarse refresh when path shape is ambiguous.
+   * or an ambiguous structural path.
    */
   private classifyWatchPath(
     wsName: string,
@@ -251,104 +264,84 @@ export class FileStorageNativeFs
   }
 
   /**
-   * Whether a record is too coarse to translate into a targeted event, so the
-   * whole workspace has to be re-read.
+   * Content updates that are safe to apply live, deduplicated in arrival
+   * order. FileSystemObserver does not identify the writer or describe a
+   * multi-step operation as one transaction. Applying structural records
+   * immediately can therefore expose an app rename's copy/delete fallback as
+   * a real deletion in this or another tab. App mutations already publish
+   * typed logical events; external structural changes reconcile through the
+   * page-return/manual refresh path.
+   *
+   * `appeared` and invisible-to-visible moves may be atomic replacements of
+   * an existing file. Treating their destination as a content update keeps
+   * common editor/sync-tool saves live without adding or removing tree paths.
    */
-  private needsCoarseRefresh(wsName: string, change: NativeFsChange): boolean {
-    if (change.type === 'unknown') {
-      return true;
-    }
-    if (change.type === 'moved') {
-      if (change.movedFromPath === undefined) {
-        // The origin is required to determine visibility.
-        return true;
-      }
-      const from = this.classifyWatchPath(wsName, change.movedFromPath);
-      const to = this.classifyWatchPath(wsName, change.path);
-      if (from.kind === 'ignored' && to.kind === 'ignored') {
-        return false;
-      }
-      // Same as the plain branch below: a visible directory moving changes
-      // the listing wholesale, and a dot-named directory would otherwise pass
-      // for a file on path shape alone.
-      if (change.kind === 'directory') {
-        return true;
-      }
-      return (
-        from.kind === 'coarse' ||
-        to.kind === 'coarse' ||
-        // Visible moves may be renames or atomic replacements.
-        (from.kind === 'file' && to.kind === 'file')
-      );
-    }
-    const classified = this.classifyWatchPath(wsName, change.path);
-    if (classified.kind === 'ignored') {
-      return false;
-    }
-    // A visible directory appearing or vanishing changes the listing.
-    return change.kind === 'directory' || classified.kind === 'coarse';
-  }
-
-  /** Targeted events for a burst, deduplicated and in arrival order. */
-  private toTargetedEvents(
+  private translateWatchChanges(
     wsName: string,
     changes: NativeFsChange[],
-  ): Map<string, FileStorageExternalChangeEvent> {
-    const events = new Map<string, FileStorageExternalChangeEvent>();
-    const add = (
-      event: FileStorageExternalChangeEvent & { wsPath: string },
-    ) => {
-      events.set(`${event.type}:${event.wsPath}`, event);
-    };
+  ): {
+    contentUpdates: Array<
+      Extract<FileStorageExternalChangeEvent, { type: 'update' }>
+    >;
+    hasDeferredStructure: boolean;
+  } {
+    const wsPaths = new Set<string>();
+    let hasDeferredStructure = false;
 
     for (const change of changes) {
       if (change.type === 'errored' || change.type === 'unknown') {
-        // Both force a coarse refresh, so this pass never runs for them.
+        hasDeferredStructure = true;
         continue;
       }
       if (change.type === 'moved') {
-        if (change.movedFromPath === undefined) {
-          // Unknown origin already forced a coarse refresh.
-          continue;
-        }
-        // Only one side can be visible here; a visible-to-visible move was
-        // already classified as needing a coarse refresh.
-        const from = this.classifyWatchPath(wsName, change.movedFromPath);
+        const from = change.movedFromPath
+          ? this.classifyWatchPath(wsName, change.movedFromPath)
+          : ({ kind: 'coarse' } as const);
         const to = this.classifyWatchPath(wsName, change.path);
-        if (to.kind === 'file') {
-          // Atomic write from an invisible temporary path.
-          add({ type: 'create', wsPath: to.wsPath });
-        } else if (from.kind === 'file') {
-          // A visible file moved out of the app's listing.
-          add({ type: 'delete', wsPath: from.wsPath });
+        if (from.kind !== 'ignored' || to.kind !== 'ignored') {
+          hasDeferredStructure = true;
+        }
+        if (
+          change.kind !== 'directory' &&
+          to.kind === 'file' &&
+          from.kind !== 'file'
+        ) {
+          wsPaths.add(to.wsPath);
         }
         continue;
       }
 
       const classified = this.classifyWatchPath(wsName, change.path);
-      if (classified.kind !== 'file') {
+      if (
+        change.type === 'disappeared' ||
+        change.kind === 'directory' ||
+        change.type === 'appeared'
+      ) {
+        if (classified.kind !== 'ignored') {
+          hasDeferredStructure = true;
+        }
+      }
+      if (change.type === 'disappeared' || change.kind === 'directory') {
         continue;
       }
-      const wsPath = classified.wsPath;
-      switch (change.type) {
-        case 'appeared': {
-          add({ type: 'create', wsPath });
-          break;
+      if (classified.kind !== 'file') {
+        if (change.type === 'modified' && classified.kind === 'coarse') {
+          hasDeferredStructure = true;
         }
-        case 'modified': {
-          add({ type: 'update', wsPath });
-          break;
-        }
-        case 'disappeared': {
-          add({ type: 'delete', wsPath });
-          break;
-        }
-        default: {
-          const _exhaustiveCheck: never = change.type;
-        }
+        continue;
+      }
+      if (change.type === 'appeared' || change.type === 'modified') {
+        wsPaths.add(classified.wsPath);
       }
     }
-    return events;
+
+    return {
+      contentUpdates: [...wsPaths].map((wsPath) => ({
+        type: 'update',
+        wsPath,
+      })),
+      hasDeferredStructure,
+    };
   }
 
   private handleWatchChanges(wsName: string, changes: NativeFsChange[]): void {
@@ -357,20 +350,22 @@ export class FileStorageNativeFs
       return;
     }
 
+    const entry = this.fsCache.get(wsName);
+    const { contentUpdates, hasDeferredStructure } = this.translateWatchChanges(
+      wsName,
+      changes,
+    );
+    if (entry && hasDeferredStructure) {
+      entry.pendingStructuralRefresh = true;
+    }
+
     if (changes.some((change) => change.type === 'errored')) {
       // Observation broke; re-arm on the next page return.
-      const entry = this.fsCache.get(wsName);
       if (entry) {
         entry.watchState = 'idle';
       }
-      onExternalChange({ type: 'refresh', wsName });
-      return;
     }
-    if (changes.some((change) => this.needsCoarseRefresh(wsName, change))) {
-      onExternalChange({ type: 'refresh', wsName });
-      return;
-    }
-    for (const event of this.toTargetedEvents(wsName, changes).values()) {
+    for (const event of contentUpdates) {
       onExternalChange(event);
     }
   }

--- a/packages/shared/types/base-file-storage.ts
+++ b/packages/shared/types/base-file-storage.ts
@@ -33,15 +33,18 @@ export type FileStorageChangeEvent =
     };
 
 /**
- * A change made to workspace files by something other than this app instance
- * (a sync tool, another editor, a shell command), detected by a storage
- * provider's watcher. Per-path changes reuse the mutation event shape;
- * `refresh` is the coarse fallback when the watcher only knows "something
+ * A storage-provider hint that workspace files changed. Watchers may also
+ * report this app's own writes because platform records do not carry writer
+ * identity. `update` invalidates content at an existing path; `refresh` is the
+ * structural revalidation boundary when the provider only knows "something
  * changed". A workspace name scopes the refresh when known; absent means
  * app-wide.
  */
 export type FileStorageExternalChangeEvent =
-  | Exclude<FileStorageChangeEvent, { type: 'rename' }>
+  | {
+      type: 'update';
+      wsPath: string;
+    }
   | {
       type: 'refresh';
       wsName?: string;

--- a/packages/tooling/e2e-tests/src/native-fs-rename-fallback.e2e.ts
+++ b/packages/tooling/e2e-tests/src/native-fs-rename-fallback.e2e.ts
@@ -5,6 +5,30 @@ const WORKSPACE_NAME = 'native-rename-fallback-workspace';
 const PARENT_DIR = 'native-rename-fallback-parent';
 const NOTE_CONTENT = '# Source note\n\nContent that must survive the rename.';
 
+type TestFileSystemObserver = {
+  observe: () => Promise<void>;
+  disconnect: () => void;
+};
+
+type TestFileSystemObserverCallback = (
+  records: readonly {
+    type: string;
+    relativePathComponents: readonly string[];
+    relativePathMovedFrom: readonly string[] | null;
+    changedHandle?: FileSystemHandle;
+  }[],
+  observer: TestFileSystemObserver,
+) => void;
+
+type NativeRenameWatcherTestState = {
+  callback?: TestFileSystemObserverCallback;
+  deliverMove: (oldFileName: string, newFileName: string) => void;
+  deliveries: number;
+  observer?: TestFileSystemObserver;
+  pendingRename?: { oldFileName: string; newFileName: string };
+  releaseRename?: () => void;
+};
+
 /**
  * Exercises the Native FS rename fallback (copy -> verify destination ->
  * delete source) against a real browser file system (OPFS-backed handles).
@@ -12,19 +36,87 @@ const NOTE_CONTENT = '# Source note\n\nContent that must survive the rename.';
  * the rename cannot take the native single-call move path — exactly the
  * engines the fallback exists for.
  */
-test('native-fs rename falls back to copy+verify+delete and preserves content', async ({
+test('structural watcher records cannot expose rename intermediates in any tab', async ({
+  context,
   page,
 }) => {
-  await page.addInitScript(() => {
+  await context.addInitScript(() => {
     // Force the copy->verify->delete fallback: without `move` on the handle
     // prototype, NativeFs.moveFile cannot use the native move path.
-    // biome-ignore lint/performance/noDelete: intentionally removing a
-    // platform method so the fallback path is what this test exercises.
     delete (
       FileSystemFileHandle.prototype as FileSystemFileHandle & {
         move?: unknown;
       }
     ).move;
+
+    const watcherState = {
+      deliveries: 0,
+    } as NativeRenameWatcherTestState;
+    class DeterministicFileSystemObserver implements TestFileSystemObserver {
+      constructor(callback: TestFileSystemObserverCallback) {
+        watcherState.callback = callback;
+        watcherState.observer = this;
+      }
+
+      async observe(): Promise<void> {}
+
+      disconnect(): void {}
+    }
+    Object.defineProperty(globalThis, 'FileSystemObserver', {
+      configurable: true,
+      value: DeterministicFileSystemObserver,
+    });
+
+    watcherState.deliverMove = (oldFileName, newFileName) => {
+      if (!watcherState.callback || !watcherState.observer) {
+        throw new Error('FileSystemObserver is not armed');
+      }
+      watcherState.deliveries += 1;
+      watcherState.callback(
+        [
+          {
+            type: 'moved',
+            relativePathComponents: [newFileName],
+            relativePathMovedFrom: [oldFileName],
+            changedHandle: { kind: 'file' } as FileSystemHandle,
+          },
+        ],
+        watcherState.observer,
+      );
+    };
+
+    const removeEntry = FileSystemDirectoryHandle.prototype.removeEntry;
+    FileSystemDirectoryHandle.prototype.removeEntry = async function (
+      name,
+      options,
+    ) {
+      await removeEntry.call(this, name, options);
+      const pendingRename = watcherState.pendingRename;
+      if (
+        pendingRename?.oldFileName !== name ||
+        !watcherState.callback ||
+        !watcherState.observer
+      ) {
+        return;
+      }
+
+      watcherState.pendingRename = undefined;
+      watcherState.deliverMove(
+        pendingRename.oldFileName,
+        pendingRename.newFileName,
+      );
+      // Hold the physical operation after the observer record but before the
+      // app can publish its typed logical rename event.
+      await new Promise<void>((resolve) => {
+        watcherState.releaseRename = resolve;
+      });
+    };
+
+    (
+      window as typeof window & {
+        __nativeRenameWatcherTest: NativeRenameWatcherTestState;
+      }
+    ).__nativeRenameWatcherTest = watcherState;
   });
 
   await page.goto('/');
@@ -98,6 +190,29 @@ test('native-fs rename falls back to copy+verify+delete and preserves content', 
   const editor = getEditorLocator(page, {});
   await expect(editor).toContainText('Content that must survive the rename.');
 
+  // A second tab receives both BroadcastChannel events from this tab and its
+  // own filesystem observer records. Neither source may turn the physical
+  // fallback's intermediate state into a missing active note.
+  const secondPage = await context.newPage();
+  await secondPage.goto(
+    `/ws#route=editor&wsPath=${encodeURIComponent(`${WORKSPACE_NAME}:source.md`)}`,
+  );
+  const secondEditor = getEditorLocator(secondPage, {});
+  await expect(secondEditor).toContainText(
+    'Content that must survive the rename.',
+  );
+
+  await page.evaluate(() => {
+    (
+      window as typeof window & {
+        __nativeRenameWatcherTest: NativeRenameWatcherTestState;
+      }
+    ).__nativeRenameWatcherTest.pendingRename = {
+      oldFileName: 'source.md',
+      newFileName: 'renamed.md',
+    };
+  });
+
   const explorer = page.getByTestId('bangle-file-explorer');
   await explorer
     .getByRole('treeitem', { name: 'source.md', exact: true })
@@ -110,7 +225,69 @@ test('native-fs rename falls back to copy+verify+delete and preserves content', 
   await renameDialog.getByRole('textbox', { name: 'New name' }).fill('renamed');
   await renameDialog.getByRole('textbox', { name: 'New name' }).press('Enter');
 
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __nativeRenameWatcherTest: NativeRenameWatcherTestState;
+            }
+          ).__nativeRenameWatcherTest.deliveries,
+      ),
+    )
+    .toBe(1);
+
+  // Each page owns an independent FileSystemObserver. Deliver the same
+  // pre-logical record to the second tab while the initiating tab still holds
+  // the physical rename promise, then prove both observers saw the race.
+  await secondPage.evaluate(() => {
+    (
+      window as typeof window & {
+        __nativeRenameWatcherTest: NativeRenameWatcherTestState;
+      }
+    ).__nativeRenameWatcherTest.deliverMove('source.md', 'renamed.md');
+  });
+  await expect
+    .poll(() =>
+      secondPage.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              __nativeRenameWatcherTest: NativeRenameWatcherTestState;
+            }
+          ).__nativeRenameWatcherTest.deliveries,
+      ),
+    )
+    .toBe(1);
+
+  try {
+    await expect(editor).toContainText('Content that must survive the rename.');
+    await expect(secondEditor).toContainText(
+      'Content that must survive the rename.',
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Note Not Found' }),
+    ).toBeHidden();
+    await expect(
+      secondPage.getByRole('heading', { name: 'Note Not Found' }),
+    ).toBeHidden();
+  } finally {
+    await page.evaluate(() => {
+      const state = (
+        window as typeof window & {
+          __nativeRenameWatcherTest: NativeRenameWatcherTestState;
+        }
+      ).__nativeRenameWatcherTest;
+      state.releaseRename?.();
+      state.releaseRename = undefined;
+    });
+  }
+
   await expect(page).toHaveURL(
+    `/ws#route=editor&wsPath=${encodeURIComponent(`${WORKSPACE_NAME}:renamed.md`)}`,
+  );
+  await expect(secondPage).toHaveURL(
     `/ws#route=editor&wsPath=${encodeURIComponent(`${WORKSPACE_NAME}:renamed.md`)}`,
   );
   await expect(editor).toContainText('Content that must survive the rename.');

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -3,8 +3,8 @@ import { getEditorLocator } from './common';
 
 /**
  * Exercises the NativeFS external-change refresh pipeline end to end:
- * FileSystemObserver → storage watcher → typed file events → file tree and
- * open-editor refresh.
+ * FileSystemObserver → safe live content updates, plus page-return
+ * revalidation for structural file-tree changes.
  *
  * The directory picker is stubbed to return an OPFS-backed directory, which
  * behaves like a picked local directory (granted permissions, observer
@@ -70,6 +70,28 @@ async function externallyDeleteFile(page: Page, relativePath: string) {
       await dir.removeEntry(fileName);
     },
     { workspaceDir: WORKSPACE_DIR, relativePath },
+  );
+}
+
+/** Models the durable copy-then-delete rename used by sync tools and fallbacks. */
+async function externallyRenameFile(
+  page: Page,
+  oldFileName: string,
+  newFileName: string,
+) {
+  await page.evaluate(
+    async ({ workspaceDir, oldFileName, newFileName }) => {
+      const root = await navigator.storage.getDirectory();
+      const dir = await root.getDirectoryHandle(workspaceDir);
+      const oldHandle = await dir.getFileHandle(oldFileName);
+      const oldFile = await oldHandle.getFile();
+      const newHandle = await dir.getFileHandle(newFileName, { create: true });
+      const writable = await newHandle.createWritable();
+      await writable.write(oldFile);
+      await writable.close();
+      await dir.removeEntry(oldFileName);
+    },
+    { workspaceDir: WORKSPACE_DIR, oldFileName, newFileName },
   );
 }
 
@@ -157,7 +179,26 @@ async function simulateLeaveAndReturn(page: Page) {
   });
 }
 
-test('externally created and edited files refresh the tree and the open note', async ({
+/** Simulates switching to another app window and focusing Bangle again. */
+async function simulateWindowRefocus(page: Page) {
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: () => false,
+    });
+    window.dispatchEvent(new Event('blur'));
+  });
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hasFocus', {
+      configurable: true,
+      value: () => true,
+    });
+    window.dispatchEvent(new Event('focus'));
+    Reflect.deleteProperty(document, 'hasFocus');
+  });
+}
+
+test('external content stays live while structural changes reconcile on ordinary refocus', async ({
   page,
   browserName,
 }) => {
@@ -178,27 +219,73 @@ test('externally created and edited files refresh the tree and the open note', a
     'FileSystemObserver is unavailable in this Chromium build',
   );
 
-  // Sanity: the normal app flow works against the OPFS-backed directory.
+  // Seed one app-owned note so a later byte update can prove that the live
+  // observer pipeline is running independently of structural tree refreshes.
   await page.getByRole('button', { name: 'New Note' }).click();
   await page.getByLabel('Note name').fill('local-note');
   await page.getByRole('button', { name: 'Create' }).click();
-  await expect(getEditorLocator(page, {})).toBeVisible();
+  const editor = getEditorLocator(page, {});
+  await expect(editor).toBeVisible();
 
   const explorer = page.getByTestId('bangle-file-explorer');
 
-  // A file created outside the app appears in the file tree without any
-  // manual reload.
+  // A new external path is a structural change. The experimental observer
+  // cannot distinguish it from an intermediate app rename, so it must not
+  // mutate the tree immediately.
   await externallyWriteFile(
     page,
     'external-note.md',
     '# External Note\n\nsynced from another device\n',
   );
+
+  // An update to an existing path remains live. Waiting for it gives us a
+  // deterministic observer barrier before asserting that the earlier create
+  // was deliberately deferred rather than merely slow.
+  await externallyWriteFile(
+    page,
+    'local-note.md',
+    '# Local Note\n\nupdated outside the app\n',
+  );
+  await expect(editor).toContainText('updated outside the app');
+  await expect(
+    explorer.getByRole('treeitem', { name: /external-note/ }),
+  ).toHaveCount(0);
+
+  // Switching back from another app window performs the authoritative
+  // structural re-list even though the Bangle tab stayed visible throughout.
+  await simulateWindowRefocus(page);
   await expect(
     explorer.getByRole('treeitem', { name: /external-note/ }),
   ).toBeVisible();
 
-  // Open the externally created note...
-  await explorer.getByRole('treeitem', { name: /external-note/ }).click();
+  // A rename-like copy/delete is also structural. Updating the still-open
+  // local note afterwards is an observer barrier: once its new bytes are in
+  // the editor, the earlier structural records have reached the app but must
+  // not have exposed either half of the rename in the tree.
+  await externallyRenameFile(page, 'external-note.md', 'renamed-note.md');
+  await externallyWriteFile(
+    page,
+    'local-note.md',
+    '# Local Note\n\nrename observer barrier\n',
+  );
+  await expect(editor).toContainText('rename observer barrier');
+  await expect(
+    explorer.getByRole('treeitem', { name: /external-note/ }),
+  ).toBeVisible();
+  await expect(
+    explorer.getByRole('treeitem', { name: /renamed-note/ }),
+  ).toHaveCount(0);
+
+  await simulateWindowRefocus(page);
+  await expect(
+    explorer.getByRole('treeitem', { name: /external-note/ }),
+  ).toHaveCount(0);
+  await expect(
+    explorer.getByRole('treeitem', { name: /renamed-note/ }),
+  ).toBeVisible();
+
+  // Open the externally renamed note...
+  await explorer.getByRole('treeitem', { name: /renamed-note/ }).click();
   await expect(getEditorLocator(page, {})).toContainText(
     'synced from another device',
   );
@@ -207,16 +294,34 @@ test('externally created and edited files refresh the tree and the open note', a
   // to the new disk content instead of showing a stale note.
   await externallyWriteFile(
     page,
-    'external-note.md',
+    'renamed-note.md',
     '# External Note\n\nupdated by the sync tool\n',
   );
   await expect(getEditorLocator(page, {})).toContainText(
     'updated by the sync tool',
   );
 
-  // The refresh pipeline must not have clobbered the other note.
+  // Return to the local note, then delete the renamed note externally. A
+  // second content barrier proves the disappeared record was observed while
+  // the stale tree entry remains deliberately mounted.
   await explorer.getByRole('treeitem', { name: /local-note/ }).click();
-  await expect(getEditorLocator(page, {})).toBeVisible();
+  await expect(editor).toContainText('rename observer barrier');
+  await externallyDeleteFile(page, 'renamed-note.md');
+  await externallyWriteFile(
+    page,
+    'local-note.md',
+    '# Local Note\n\ndelete observer barrier\n',
+  );
+  await expect(editor).toContainText('delete observer barrier');
+  await expect(
+    explorer.getByRole('treeitem', { name: /renamed-note/ }),
+  ).toBeVisible();
+
+  await simulateWindowRefocus(page);
+  await expect(
+    explorer.getByRole('treeitem', { name: /renamed-note/ }),
+  ).toHaveCount(0);
+  await expect(editor).toContainText('delete observer barrier');
 });
 
 test('a byte-identical watcher update cannot normalize a locally saved note', async ({
@@ -494,16 +599,17 @@ test('an external write never clobbers unsaved local edits in the open editor', 
   // writes only reopens the disk for the sync tool simulated below.
   await restoreAppWrites(page);
 
-  // A sync tool overwrites the dirty note, then creates a sentinel file. The
-  // sentinel's appearance in the tree proves the watcher pipeline processed
-  // the burst, so "the editor did not change" below is a real refusal rather
-  // than the sync simply not having run yet.
+  // A sync tool overwrites the dirty note, then creates a sentinel file.
+  // Structural records wait for page return; the sentinel's later appearance
+  // proves the authoritative refresh processed both disk changes, so "the
+  // editor did not change" below is a real refusal rather than a race.
   await externallyWriteFile(
     page,
     'conflict-dirty.md',
     '# External\n\noverwritten by the sync tool\n',
   );
   await externallyWriteFile(page, 'sentinel.md', 'marker\n');
+  await simulateLeaveAndReturn(page);
   await expect(
     page
       .getByTestId('bangle-file-explorer')
@@ -563,6 +669,15 @@ test('an externally deleted note stays mounted while its local save is failed', 
   await expect(page.getByText(/Changes could not be saved/)).toBeVisible();
 
   await externallyDeleteFile(page, 'dirty-note.md');
+  await expect(
+    page
+      .getByTestId('bangle-file-explorer')
+      .getByRole('treeitem', { name: /dirty-note/ }),
+  ).toBeVisible();
+
+  // Destructive structural changes are reconciled only at the explicit
+  // page-return boundary.
+  await simulateLeaveAndReturn(page);
   await expect(
     page
       .getByTestId('bangle-file-explorer')


### PR DESCRIPTION
Fixes #690

- Treat NativeFS watcher records as live content invalidations only, including invisible-temp atomic replacement destinations.
- Remember relevant structural records and reconcile once on the next window or tab return; app-originated logical mutations still update immediately across tabs.
- Narrow the external watcher contract to content update or structural refresh, and cover both the two-tab fallback rename race and external create/rename/delete reconciliation on ordinary refocus.

Reviewer callout: external structural changes no longer update the tree while the page is actively in use. They appear when the user returns to Bangle or manually refreshes; content edits remain live.