### PR TITLE
fix(nativefs): ignore byte-identical watcher echoes

### DIFF
--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -781,6 +781,53 @@ describe('editor refresh on external file changes', () => {
     expect(editorText(domNode)).toContain('the original note body');
   });
 
+  it('leaves a locally saved parse-normalized document untouched when its watcher echo arrives', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      'the original note body',
+    );
+    const editor = asPmEditor(services.editorEngine).getEditor(
+      'main-test-editor',
+    );
+    expect(editor).toBeDefined();
+    if (!editor) {
+      return;
+    }
+
+    editor.dispatch(
+      editor.state.tr.insertText(
+        'xyz   ',
+        1,
+        editor.state.doc.content.size - 1,
+      ),
+    );
+    await vi.waitFor(async () => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+      await expect(
+        services.fileSystem.readFileAsText(NOTE_WS_PATH),
+      ).resolves.toBe('xyz   ');
+    });
+
+    const docBefore = editor.state.doc;
+    const selectionBefore = editor.state.selection;
+    expect(editorText(domNode)).toBe('xyz   ');
+
+    // Native FS observers cannot distinguish this app's just-completed write
+    // from a foreign update, so the adapter deliberately forwards the record.
+    testEnv.rootEmitter.emit('event::file:update', {
+      type: 'file-content-update',
+      wsPath: NOTE_WS_PATH,
+      sender: EXTERNAL_SENDER,
+    });
+    await settleReconcile();
+
+    expect(editor.state.doc).toBe(docBefore);
+    expect(editor.state.selection.eq(selectionBefore)).toBe(true);
+    expect(editorText(domNode)).toBe('xyz   ');
+    await expect(
+      services.fileSystem.readFileAsText(NOTE_WS_PATH),
+    ).resolves.toBe('xyz   ');
+  });
+
   it('surfaces a refusal as a per-note warning toast and withdraws it once reconciled', async () => {
     const { testEnv, services, domNode } = await setupEditorWithNote(
       'the original note body',

--- a/packages/core/editor/src/__tests__/external-change-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-change-sync.spec.ts
@@ -4,6 +4,7 @@ import {
   EXTERNAL_FILE_CHANGE_SENDER_TAG,
   WORKSPACE_STORAGE_TYPE,
 } from '@bangle.io/constants';
+import { markdownLoader } from '@bangle.io/prosemirror-plugins';
 import { createTestEnvironment } from '@bangle.io/test-utils';
 import { toast } from '@bangle.io/ui-components';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -544,6 +545,56 @@ describe('editor refresh on external file changes', () => {
     ).resolves.toMatchObject({ content: '- the original note body\n' });
   });
 
+  it('applies a serializer-equal external reformat after a local save', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      '- the original note body\n',
+    );
+    const editorService = asPmEditor(services.editorEngine);
+    const editor = editorService.getEditor('main-test-editor');
+    expect(editor).toBeDefined();
+    if (!editor) {
+      return;
+    }
+
+    editor.dispatch(
+      editor.state.tr.insertText('updated ', editor.state.selection.from),
+    );
+    let locallySaved = '';
+    await vi.waitFor(async () => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+      locallySaved =
+        (await services.fileSystem.readFileAsText(NOTE_WS_PATH)) ?? '';
+      expect(locallySaved).toContain('updated');
+    });
+    expect(locallySaved).toMatch(/^- /);
+
+    // Once the view has changed, it no longer has a retained load baseline.
+    // A byte-different external marker still must be applied: serializer
+    // equality is not writer provenance, and skipping would let the next save
+    // silently restore the locally serialized marker.
+    const externalSource = locallySaved.replace(/^- /, '* ');
+    await simulateExternalEdit(testEnv, services, externalSource);
+
+    await vi.waitFor(
+      () => {
+        expect(testEnv.store.get(editorService.$roundTripWarnings)).toContain(
+          NOTE_WS_PATH,
+        );
+      },
+      { timeout: 3_000 },
+    );
+    expect(editorText(domNode)).toContain('updated');
+    await expect(
+      services.fileSystem.readFileAsText(NOTE_WS_PATH),
+    ).resolves.toBe(externalSource);
+
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    expect(snapshots).toHaveLength(1);
+    await expect(
+      services.noteSnapshot.getSnapshot(snapshots[0]?.id ?? ''),
+    ).resolves.toMatchObject({ content: locallySaved });
+  });
+
   it('refuses dropped content even when it serializes like the open document', async () => {
     const { testEnv, services } = await setupEditorWithNote(
       'the original note body with [the spec](https://example.com/spec)',
@@ -826,6 +877,126 @@ describe('editor refresh on external file changes', () => {
     await expect(
       services.fileSystem.readFileAsText(NOTE_WS_PATH),
     ).resolves.toBe('xyz   ');
+  });
+
+  it('does not mistake a byte-different external reformat for an echo while a synthetic suggestion is open', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      '- the original note body\n',
+    );
+    const editorService = asPmEditor(services.editorEngine);
+    const editor = editorService.getEditor('main-test-editor');
+    expect(editor).toBeDefined();
+    if (!editor) {
+      return;
+    }
+
+    // jsdom has no layout implementation for ProseMirror's scroll request.
+    const scrollSpy = vi
+      .spyOn(
+        editor as typeof editor & { scrollToSelection(): void },
+        'scrollToSelection',
+      )
+      .mockImplementation(() => undefined);
+    const opened =
+      editorService.extensions.suggestions.command.openSuggestion()(
+        editor.state,
+        editor.dispatch,
+        editor,
+      );
+    scrollSpy.mockRestore();
+    expect(opened).toBe(true);
+    expect(editorText(domNode)).toContain('/');
+    await vi.waitFor(async () => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+      await expect(
+        services.fileSystem.readFileAsText(NOTE_WS_PATH),
+      ).resolves.toBe('- the original note body');
+    });
+
+    // The external bytes parse to the same list document as the save
+    // projection, but they are a genuine change whose exact source must become
+    // the new fidelity baseline. The live synthetic slash must not hide it.
+    await simulateExternalEdit(testEnv, services, '* the original note body\n');
+
+    await vi.waitFor(
+      () => {
+        expect(testEnv.store.get(editorService.$roundTripWarnings)).toContain(
+          NOTE_WS_PATH,
+        );
+      },
+      { timeout: 3_000 },
+    );
+    expect(editorText(domNode)).toBe('the original note body');
+    await expect(
+      services.fileSystem.readFileAsText(NOTE_WS_PATH),
+    ).resolves.toBe('* the original note body\n');
+
+    const snapshots = await services.noteSnapshot.listSnapshots();
+    expect(snapshots).toHaveLength(1);
+    await expect(
+      services.noteSnapshot.getSnapshot(snapshots[0]?.id ?? ''),
+    ).resolves.toMatchObject({ content: '- the original note body' });
+  });
+
+  it('turns externally written suggestion text into durable editor content', async () => {
+    const { testEnv, services, domNode } = await setupEditorWithNote(
+      '- the original note body\n',
+    );
+    const editorService = asPmEditor(services.editorEngine);
+    const editor = editorService.getEditor('main-test-editor');
+    expect(editor).toBeDefined();
+    if (!editor) {
+      return;
+    }
+
+    const scrollSpy = vi
+      .spyOn(
+        editor as typeof editor & { scrollToSelection(): void },
+        'scrollToSelection',
+      )
+      .mockImplementation(() => undefined);
+    const opened =
+      editorService.extensions.suggestions.command.openSuggestion()(
+        editor.state,
+        editor.dispatch,
+        editor,
+      );
+    scrollSpy.mockRestore();
+    expect(opened).toBe(true);
+
+    const markdown = markdownLoader(
+      [...Object.values(editorService.extensions)],
+      editor.state.schema,
+    );
+    const externalSource = markdown.serializer.serialize(editor.state.doc);
+    expect(externalSource).toContain('/');
+    await vi.waitFor(async () => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+      await expect(
+        services.fileSystem.readFileAsText(NOTE_WS_PATH),
+      ).resolves.not.toBe(externalSource);
+    });
+
+    const syntheticDoc = editor.state.doc;
+    await simulateExternalEdit(testEnv, services, externalSource);
+
+    await vi.waitFor(async () => {
+      expect(editor.state.doc).not.toBe(syntheticDoc);
+      expect(await services.noteSnapshot.listSnapshots()).toHaveLength(1);
+    });
+    expect(editorText(domNode)).toContain('/');
+
+    // A subsequent normal edit must preserve the external author's literal
+    // slash. If reconciliation only skipped the serializer-equal document,
+    // the slash would still be synthetic and the save projection would remove
+    // it here.
+    editor.dispatch(editor.state.tr.insertText('!'));
+    await vi.waitFor(async () => {
+      expect(services.editorEngine.hasPendingOrFailedSave()).toBe(false);
+      await expect(
+        services.fileSystem.readFileAsText(NOTE_WS_PATH),
+      ).resolves.toContain('/');
+    });
   });
 
   it('surfaces a refusal as a per-note warning toast and withdraws it once reconciled', async () => {

--- a/packages/core/editor/src/__tests__/external-content-sync.spec.ts
+++ b/packages/core/editor/src/__tests__/external-content-sync.spec.ts
@@ -53,6 +53,7 @@ function makeHost(overrides: Partial<ExternalContentSyncHost> = {}) {
     getMarkdown: vi.fn(() => {
       throw new Error('not needed in these tests');
     }),
+    getSaveProjection: vi.fn(() => 'current content'),
     getRetainedSource: vi.fn(() => undefined),
     replaceContent: vi.fn(async (): Promise<'applied'> => 'applied'),
     onStaleContentRefused: vi.fn(),
@@ -277,14 +278,7 @@ describe('refusal and reconciliation reporting', () => {
     const host = makeHost({
       getViews: vi.fn(() => [view]),
       readFileAsText: vi.fn(async () => 'same output'),
-      getMarkdown: vi.fn(
-        () =>
-          ({
-            parser: { parse: () => ({}) },
-            // Editor doc and disk content serialize identically → echo.
-            serializer: { serialize: () => 'same output' },
-          }) as never,
-      ),
+      getSaveProjection: vi.fn(() => 'same output'),
     });
     const sync = new ExternalContentSync(host);
 
@@ -297,6 +291,7 @@ describe('refusal and reconciliation reporting', () => {
     );
     expect(host.onContentReconciled).toHaveBeenCalledWith('ws:a.md');
     expect(host.onStaleContentRefused).not.toHaveBeenCalled();
+    expect(host.getMarkdown).not.toHaveBeenCalled();
     expect(host.replaceContent).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -355,9 +355,9 @@ export class ExternalContentSync {
         continue;
       }
 
-      let currentSerialized: string;
+      let saveProjection: string;
       try {
-        currentSerialized = this.host.getSaveProjection(view);
+        saveProjection = this.host.getSaveProjection(view);
       } catch (error) {
         if (mode === 'user-approved') {
           throw error;
@@ -373,7 +373,7 @@ export class ExternalContentSync {
       if (
         mode === 'automatic' &&
         retainedSource === undefined &&
-        diskText === currentSerialized
+        diskText === saveProjection
       ) {
         // The disk already contains exactly what this view's save path emits.
         // Whether the watcher record came from this app or another writer is
@@ -414,7 +414,7 @@ export class ExternalContentSync {
         // Serializer comparison coalesces echoes and normalization-only
         // differences. Retained source recognizes unchanged lossy Markdown.
         if (
-          currentSerialized === diskSerialized &&
+          saveProjection === diskSerialized &&
           retainedSource !== undefined &&
           isMarkdownRoundTripPreserved(diskText, retainedSource)
         ) {
@@ -438,22 +438,9 @@ export class ExternalContentSync {
           refused = true;
           continue;
         }
-        if (
-          currentSerialized === diskSerialized &&
-          retainedSource === undefined
-        ) {
-          // The doc changed since load, so a save writes exactly these bytes —
-          // nothing on disk can be silently reverted. Typically our own save's
-          // echo. With a retained baseline this falls through instead: disk
-          // holds different bytes than the baseline, and applying refreshes
-          // the baseline and the fidelity notice so a later save cannot
-          // silently revert the external author's formatting.
-          reconciled = true;
-          continue;
-        }
         // Agreeing reads can both land inside a writer's truncated state.
         // Never automatically blank a non-empty editor.
-        if (diskText.trim() === '' && currentSerialized.trim() !== '') {
+        if (diskText.trim() === '' && saveProjection.trim() !== '') {
           this.host.logger.warn(
             `External change emptied ${wsPath}; keeping the editor content`,
           );
@@ -473,7 +460,7 @@ export class ExternalContentSync {
 
       const replaceResult = await this.host.replaceContent({
         expectedDoc: docsBefore[index],
-        preservableSource: retainedSource ?? currentSerialized,
+        preservableSource: retainedSource ?? saveProjection,
         sourceMarkdown: diskText,
         transaction,
         view,

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -94,6 +94,8 @@ export interface ExternalContentSyncHost {
   hasPendingSaves(wsPath: string): boolean;
   readFileAsText(wsPath: string): Promise<string | undefined>;
   getMarkdown(schema: Schema): ReturnType<typeof markdownLoader>;
+  /** Exact Markdown bytes the save path currently projects from `view`. */
+  getSaveProjection(view: EditorView): string;
   /** Exact disk source retained while this view's document is unchanged. */
   getRetainedSource(view: EditorView): string | undefined;
   /**
@@ -344,28 +346,58 @@ export class ExternalContentSync {
         continue;
       }
 
-      const markdown = this.host.getMarkdown(view.state.schema);
-      let parsed: ReturnType<typeof markdown.parser.parse>;
+      // While the document is unchanged since load, the exact bytes it was
+      // parsed from are what must be preserved — a re-serialization would
+      // normalize away Markdown the editor cannot round-trip.
+      const retainedSource = this.host.getRetainedSource(view);
+      if (mode === 'automatic' && diskText === retainedSource) {
+        reconciled = true;
+        continue;
+      }
+
       let currentSerialized: string;
       try {
-        parsed = markdown.parser.parse(diskText);
-        currentSerialized = markdown.serializer.serialize(view.state.doc);
+        currentSerialized = this.host.getSaveProjection(view);
       } catch (error) {
         if (mode === 'user-approved') {
           throw error;
         }
         this.host.logger.warn(
-          `Could not parse or compare externally changed content for ${wsPath}`,
+          `Could not compare externally changed content for ${wsPath}`,
           error,
         );
         refused = true;
         continue;
       }
 
-      // While the document is unchanged since load, the exact bytes it was
-      // parsed from are what must be preserved — a re-serialization would
-      // normalize away Markdown the editor cannot round-trip.
-      const retainedSource = this.host.getRetainedSource(view);
+      if (
+        mode === 'automatic' &&
+        retainedSource === undefined &&
+        diskText === currentSerialized
+      ) {
+        // The disk already contains exactly what this view's save path emits.
+        // Whether the watcher record came from this app or another writer is
+        // irrelevant: parsing and replacing cannot make the durable content
+        // more current, but it can normalize Markdown and disturb the caret.
+        reconciled = true;
+        continue;
+      }
+
+      const markdown = this.host.getMarkdown(view.state.schema);
+      let parsed: ReturnType<typeof markdown.parser.parse>;
+      try {
+        parsed = markdown.parser.parse(diskText);
+      } catch (error) {
+        if (mode === 'user-approved') {
+          throw error;
+        }
+        this.host.logger.warn(
+          `Could not parse externally changed content for ${wsPath}`,
+          error,
+        );
+        refused = true;
+        continue;
+      }
 
       if (mode === 'automatic') {
         let diskSerialized: string;

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -10,7 +10,6 @@ import type { EditorAction, EditorEngineContract } from '@bangle.io/context';
 import {
   type EditorView,
   markdownLoader,
-  type PMNode,
   type Schema,
   TextSelection,
   type Transaction,
@@ -54,7 +53,7 @@ import { setupExtensions } from './extensions';
 import { ExternalContentSync } from './external-content-sync';
 import { findHeadingIndexBySlug } from './heading-slug';
 import { createLocalImageNodeView } from './local-image-node-view';
-import { createEditor } from './pm-setup';
+import { createEditor, serializeEditorDocumentForSave } from './pm-setup';
 import {
   getRememberedCursorPosition,
   resolveRememberedCursor,
@@ -226,6 +225,11 @@ export class PmEditorService
           signal: this.abortSignal,
         }),
       getMarkdown: (schema) => this.getMarkdown(schema),
+      getSaveProjection: (view) =>
+        serializeEditorDocumentForSave(
+          this.getMarkdown(view.state.schema),
+          view.state.doc,
+        ),
       getRetainedSource: (view) => this.getRetainedSource(view),
       replaceContent: (args) => this.replaceEditorContent(args),
       onStaleContentRefused: (wsPath) => {

--- a/packages/core/editor/src/pm-setup.ts
+++ b/packages/core/editor/src/pm-setup.ts
@@ -7,6 +7,7 @@ import {
   markdownLoader,
   type NodeViewConstructor,
   Plugin,
+  type PMNode,
   resolve,
   Schema,
   stripSyntheticSuggestionText,
@@ -15,6 +16,19 @@ import {
 import type { Store } from '@bangle.io/types';
 
 import type { setupExtensions } from './extensions';
+
+/**
+ * Produces the exact Markdown projection used for durable editor saves.
+ * Reconciliation must use this same projection when deciding whether disk
+ * already contains the current document, including removal of UI-only
+ * suggestion text that must never reach storage.
+ */
+export function serializeEditorDocumentForSave(
+  markdown: ReturnType<typeof markdownLoader>,
+  doc: PMNode,
+): string {
+  return markdown.serializer.serialize(stripSyntheticSuggestionText(doc));
+}
 
 export function createEditor({
   domNode,
@@ -52,8 +66,9 @@ export function createEditor({
                     // must never reach storage, even when a debounced save
                     // fires while the menu is still open or the editor
                     // unmounts mid-suggestion.
-                    const result = markdown.serializer.serialize(
-                      stripSyntheticSuggestionText(view.state.doc),
+                    const result = serializeEditorDocumentForSave(
+                      markdown,
+                      view.state.doc,
                     );
 
                     onDocChange(result);

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -15,22 +15,6 @@ import { getEditorLocator } from './common';
 
 const WORKSPACE_DIR = 'sync-notes';
 
-type EchoRead = { content: string | undefined };
-type EchoDebugWindow = Window &
-  typeof globalThis & {
-    __echoReads?: EchoRead[];
-    services: {
-      core: {
-        fileSystem: {
-          readFileAsText: (
-            wsPath: string,
-            options?: { signal?: AbortSignal },
-          ) => Promise<string | undefined>;
-        };
-      };
-    };
-  };
-
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((workspaceDir) => {
     (
@@ -131,11 +115,8 @@ async function restoreAppWrites(page: Page) {
   });
 }
 
-async function createNativeFsWorkspace(
-  page: Page,
-  { debug = false }: { debug?: boolean } = {},
-) {
-  await page.goto(debug ? '/?debug=true' : '/');
+async function createNativeFsWorkspace(page: Page) {
+  await page.goto('/');
   if (await page.getByRole('dialog').isVisible()) {
     await page.keyboard.press('Escape');
   }
@@ -247,7 +228,7 @@ test('a byte-identical watcher update cannot normalize a locally saved note', as
     'NativeFS workspaces are Chromium-only',
   );
 
-  await createNativeFsWorkspace(page, { debug: true });
+  await createNativeFsWorkspace(page);
   const observerSupported = await page.evaluate(
     () =>
       typeof (globalThis as { FileSystemObserver?: unknown })
@@ -277,9 +258,24 @@ test('a byte-identical watcher update cannot normalize a locally saved note', as
     })
     .toBe('xyz   ');
 
-  const selectionBefore = await editor.evaluate((root) => {
+  // First establish a visible conflict. Its later dismissal is the
+  // user-observable completion signal for the exact-content reconciliation;
+  // unrelated services reading the same file cannot satisfy this barrier.
+  await externallyWriteFile(
+    page,
+    'self-write-echo.md',
+    'see the spec\n\n[unused]: https://example.com/spec\n',
+  );
+  const conflictToast = page.getByText(/self-write-echo\.md changed on disk/);
+  await expect(conflictToast).toBeVisible();
+  await expect
+    .poll(() => editor.evaluate((root) => root.textContent))
+    .toBe('xyz   ');
+
+  const editorBefore = await editor.evaluate((root) => {
     const selection = root.ownerDocument.getSelection();
     return {
+      html: root.innerHTML,
       anchorOffset: selection?.anchorOffset,
       focusOffset: selection?.focusOffset,
     };
@@ -287,37 +283,9 @@ test('a byte-identical watcher update cannot normalize a locally saved note', as
 
   // OPFS does not report an app write back to its own observer consistently,
   // so repeat the exact saved bytes through a handle outside the app. Chrome
-  // reports this record identically to a self-write echo. Record reads through
-  // the same FileSystemService seam used by reconciliation so the assertions
-  // below wait for the stable-read protocol instead of relying on a timeout.
-  await page.evaluate(
-    ({ wsPath }) => {
-      const debugWindow = window as EchoDebugWindow;
-      const fileSystem = debugWindow.services.core.fileSystem;
-      const readFileAsText = fileSystem.readFileAsText.bind(fileSystem);
-      debugWindow.__echoReads = [];
-      fileSystem.readFileAsText = async (path, options) => {
-        const content = await readFileAsText(path, options);
-        if (path === wsPath) {
-          debugWindow.__echoReads?.push({ content });
-        }
-        return content;
-      };
-    },
-    {
-      wsPath: `${WORKSPACE_DIR}:self-write-echo.md`,
-    },
-  );
+  // reports this record identically to a self-write echo.
   await externallyWriteFile(page, 'self-write-echo.md', 'xyz   ');
-
-  await expect
-    .poll(() =>
-      page.evaluate(() => {
-        const reads = (window as EchoDebugWindow).__echoReads ?? [];
-        return reads.filter((read) => read.content === 'xyz   ').length;
-      }),
-    )
-    .toBeGreaterThanOrEqual(2);
+  await expect(conflictToast).not.toBeVisible();
 
   await expect
     .poll(() => editor.evaluate((root) => root.textContent))
@@ -326,11 +294,12 @@ test('a byte-identical watcher update cannot normalize a locally saved note', as
     await editor.evaluate((root) => {
       const selection = root.ownerDocument.getSelection();
       return {
+        html: root.innerHTML,
         anchorOffset: selection?.anchorOffset,
         focusOffset: selection?.focusOffset,
       };
     }),
-  ).toEqual(selectionBefore);
+  ).toEqual(editorBefore);
 });
 
 test('page-return revalidation refreshes external changes when FileSystemObserver is unavailable', async ({

--- a/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
+++ b/packages/tooling/e2e-tests/src/nativefs-external-refresh.e2e.ts
@@ -15,6 +15,22 @@ import { getEditorLocator } from './common';
 
 const WORKSPACE_DIR = 'sync-notes';
 
+type EchoRead = { content: string | undefined };
+type EchoDebugWindow = Window &
+  typeof globalThis & {
+    __echoReads?: EchoRead[];
+    services: {
+      core: {
+        fileSystem: {
+          readFileAsText: (
+            wsPath: string,
+            options?: { signal?: AbortSignal },
+          ) => Promise<string | undefined>;
+        };
+      };
+    };
+  };
+
 test.beforeEach(async ({ page }) => {
   await page.addInitScript((workspaceDir) => {
     (
@@ -115,8 +131,11 @@ async function restoreAppWrites(page: Page) {
   });
 }
 
-async function createNativeFsWorkspace(page: Page) {
-  await page.goto('/');
+async function createNativeFsWorkspace(
+  page: Page,
+  { debug = false }: { debug?: boolean } = {},
+) {
+  await page.goto(debug ? '/?debug=true' : '/');
   if (await page.getByRole('dialog').isVisible()) {
     await page.keyboard.press('Escape');
   }
@@ -217,6 +236,101 @@ test('externally created and edited files refresh the tree and the open note', a
   // The refresh pipeline must not have clobbered the other note.
   await explorer.getByRole('treeitem', { name: /local-note/ }).click();
   await expect(getEditorLocator(page, {})).toBeVisible();
+});
+
+test('a byte-identical watcher update cannot normalize a locally saved note', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== 'chromium',
+    'NativeFS workspaces are Chromium-only',
+  );
+
+  await createNativeFsWorkspace(page, { debug: true });
+  const observerSupported = await page.evaluate(
+    () =>
+      typeof (globalThis as { FileSystemObserver?: unknown })
+        .FileSystemObserver === 'function',
+  );
+  test.skip(
+    !observerSupported,
+    'FileSystemObserver is unavailable in this Chromium build',
+  );
+
+  await page.getByRole('button', { name: 'New Note' }).click();
+  await page.getByLabel('Note name').fill('self-write-echo');
+  await page.getByRole('button', { name: 'Create' }).click();
+  const editor = getEditorLocator(page, {});
+  await expect(editor).toBeVisible();
+
+  await editor.click();
+  await page.keyboard.insertText('xyz   ');
+  await expect
+    .poll(async () => {
+      return page.evaluate(async (workspaceDir) => {
+        const root = await navigator.storage.getDirectory();
+        const dir = await root.getDirectoryHandle(workspaceDir);
+        const handle = await dir.getFileHandle('self-write-echo.md');
+        return (await handle.getFile()).text();
+      }, WORKSPACE_DIR);
+    })
+    .toBe('xyz   ');
+
+  const selectionBefore = await editor.evaluate((root) => {
+    const selection = root.ownerDocument.getSelection();
+    return {
+      anchorOffset: selection?.anchorOffset,
+      focusOffset: selection?.focusOffset,
+    };
+  });
+
+  // OPFS does not report an app write back to its own observer consistently,
+  // so repeat the exact saved bytes through a handle outside the app. Chrome
+  // reports this record identically to a self-write echo. Record reads through
+  // the same FileSystemService seam used by reconciliation so the assertions
+  // below wait for the stable-read protocol instead of relying on a timeout.
+  await page.evaluate(
+    ({ wsPath }) => {
+      const debugWindow = window as EchoDebugWindow;
+      const fileSystem = debugWindow.services.core.fileSystem;
+      const readFileAsText = fileSystem.readFileAsText.bind(fileSystem);
+      debugWindow.__echoReads = [];
+      fileSystem.readFileAsText = async (path, options) => {
+        const content = await readFileAsText(path, options);
+        if (path === wsPath) {
+          debugWindow.__echoReads?.push({ content });
+        }
+        return content;
+      };
+    },
+    {
+      wsPath: `${WORKSPACE_DIR}:self-write-echo.md`,
+    },
+  );
+  await externallyWriteFile(page, 'self-write-echo.md', 'xyz   ');
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const reads = (window as EchoDebugWindow).__echoReads ?? [];
+        return reads.filter((read) => read.content === 'xyz   ').length;
+      }),
+    )
+    .toBeGreaterThanOrEqual(2);
+
+  await expect
+    .poll(() => editor.evaluate((root) => root.textContent))
+    .toBe('xyz   ');
+  expect(
+    await editor.evaluate((root) => {
+      const selection = root.ownerDocument.getSelection();
+      return {
+        anchorOffset: selection?.anchorOffset,
+        focusOffset: selection?.focusOffset,
+      };
+    }),
+  ).toEqual(selectionBefore);
 });
 
 test('page-return revalidation refreshes external changes when FileSystemObserver is unavailable', async ({


### PR DESCRIPTION
## Summary

- treat byte-identical Native FS observer records as already reconciled before Markdown parsing can normalize the live editor
- share the exact durable save projection between saving, echo detection, and recovery snapshots
- route every byte-different disk value through the existing stability, fidelity, snapshot, and replacement path
- cover trailing whitespace, synthetic suggestion text, and serializer-equal Markdown reformats with editor and Native FS regressions

## Reviewer callout

This deliberately does not restore time-based self-write suppression or add sidecar lock metadata. Writer provenance is unavailable for external tools; exact saved bytes are the reliable no-op boundary. Browsers without `FileSystemObserver` keep the existing page-return revalidation path; no polling loop or observer polyfill is added.