### PR TITLE
feat: preserve note references during relocation

### DIFF
--- a/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
+++ b/packages/core/command-handlers/src/__tests__/ws-command-handlers.spec.ts
@@ -230,6 +230,146 @@ describe('WS command handlers', () => {
       });
     });
 
+    test('routes Markdown renames through note relocation', async () => {
+      const SOURCE_WS_PATH = 'test-ws:source.md';
+      const DESTINATION_WS_PATH = 'test-ws:destination.md';
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ws:rename-ws-path',
+        workspaces: [{ name: 'test-ws', notes: [SOURCE_WS_PATH] }],
+      });
+      const relocationSpy = vi.spyOn(services.noteRelocation, 'relocate');
+
+      dispatch('command::ws:rename-ws-path', {
+        wsPath: SOURCE_WS_PATH,
+        newWsPath: DESTINATION_WS_PATH,
+      });
+
+      await vi.waitFor(() => {
+        expect(relocationSpy).toHaveBeenCalledWith({
+          destination: expect.objectContaining({ wsPath: DESTINATION_WS_PATH }),
+          source: expect.objectContaining({ wsPath: SOURCE_WS_PATH }),
+        });
+      });
+    });
+
+    test('warns when a Markdown reference could not be updated safely', async () => {
+      const SOURCE_WS_PATH = 'test-ws:source.md';
+      const DESTINATION_WS_PATH = 'test-ws:destination.md';
+      const { dispatch, services, getCommandResults } = await setupTest({
+        targetId: 'command::ws:rename-ws-path',
+        workspaces: [{ name: 'test-ws', notes: [SOURCE_WS_PATH] }],
+      });
+      await services.fileSystem.writeFile(
+        SOURCE_WS_PATH,
+        new File(['[[./missing]]'], 'source.md', { type: 'text/plain' }),
+      );
+      const warningSpy = vi.spyOn(toast, 'warning');
+
+      dispatch('command::ws:rename-ws-path', {
+        wsPath: SOURCE_WS_PATH,
+        newWsPath: DESTINATION_WS_PATH,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          getCommandResults().filter((result) => result.type === 'success'),
+        ).toHaveLength(1);
+        expect(warningSpy).toHaveBeenCalledWith(
+          t.app.toasts.fileRenameReferenceUpdateIncomplete({
+            fileName: 'destination.md',
+            warningCount: 1,
+          }),
+        );
+      });
+    });
+
+    test('reports the number and reason when a planned rewrite becomes stale', async () => {
+      const SOURCE_WS_PATH = 'test-ws:source.md';
+      const DESTINATION_WS_PATH = 'test-ws:destination.md';
+      const TARGET_WS_PATH = 'test-ws:target.md';
+      const { dispatch, services, getCommandResults } = await setupTest({
+        targetId: 'command::ws:rename-ws-path',
+        workspaces: [
+          { name: 'test-ws', notes: [SOURCE_WS_PATH, TARGET_WS_PATH] },
+        ],
+      });
+      await services.fileSystem.writeFile(
+        SOURCE_WS_PATH,
+        new File([['[[./target]]', '[[./target]]'].join('\n\n')], 'source.md', {
+          type: 'text/plain',
+        }),
+      );
+      const renameFile = services.fileSystem.renameFile.bind(
+        services.fileSystem,
+      );
+      const writeFile = services.fileSystem.writeFile.bind(services.fileSystem);
+      vi.spyOn(services.fileSystem, 'renameFile').mockImplementation(
+        async (args) => {
+          if (args.oldWsPath === SOURCE_WS_PATH) {
+            await writeFile(
+              SOURCE_WS_PATH,
+              new File(['[[./target]]'], 'source.md', {
+                type: 'text/plain',
+              }),
+            );
+          }
+          return renameFile(args);
+        },
+      );
+      const warningSpy = vi.spyOn(toast, 'warning');
+
+      dispatch('command::ws:rename-ws-path', {
+        wsPath: SOURCE_WS_PATH,
+        newWsPath: DESTINATION_WS_PATH,
+      });
+
+      await vi.waitFor(async () => {
+        expect(
+          getCommandResults().filter((result) => result.type === 'success'),
+        ).toHaveLength(1);
+        await expect(
+          services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+        ).resolves.toBe('[[./target]]');
+        expect(warningSpy).toHaveBeenCalledWith(
+          t.app.toasts.fileRenameReferenceUpdateSkipped({
+            fileName: 'destination.md',
+            reason: t.app.toasts.noteRelocationDestinationContentChanged,
+            warningCount: 2,
+          }),
+        );
+      });
+    });
+
+    test('keeps raw-file renames on the existing file-system path', async () => {
+      const SOURCE_WS_PATH = 'test-ws:source.txt';
+      const DESTINATION_WS_PATH = 'test-ws:destination.txt';
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ws:rename-ws-path',
+        workspaces: [{ name: 'test-ws', notes: [SOURCE_WS_PATH] }],
+      });
+      const relocationSpy = vi.spyOn(services.noteRelocation, 'relocate');
+      const renameSpy = vi.spyOn(services.fileSystem, 'renameFile');
+
+      dispatch('command::ws:rename-ws-path', {
+        wsPath: SOURCE_WS_PATH,
+        newWsPath: DESTINATION_WS_PATH,
+      });
+
+      await vi.waitFor(async () => {
+        await expect(
+          services.fileSystem.readFile(SOURCE_WS_PATH),
+        ).resolves.toBeUndefined();
+        await expect(
+          services.fileSystem.readFile(DESTINATION_WS_PATH),
+        ).resolves.toBeDefined();
+      });
+      expect(relocationSpy).not.toHaveBeenCalled();
+      expect(renameSpy).toHaveBeenCalledWith({
+        oldWsPath: SOURCE_WS_PATH,
+        newWsPath: DESTINATION_WS_PATH,
+      });
+    });
+
     test('blocks relocation when the source save cannot drain', async () => {
       const SOURCE_WS_PATH = 'test-ws:source.md';
       const DESTINATION_WS_PATH = 'test-ws:destination.md';
@@ -419,10 +559,7 @@ describe('WS command handlers', () => {
           }),
         );
       });
-      expect(renameSpy).toHaveBeenCalledWith({
-        oldWsPath: SOURCE_WS_PATH,
-        newWsPath: DESTINATION_WS_PATH,
-      });
+      expect(renameSpy).not.toHaveBeenCalled();
       await expect(
         services.fileSystem.readFile(SOURCE_WS_PATH),
       ).resolves.toBeDefined();
@@ -493,6 +630,58 @@ describe('WS command handlers', () => {
         await expect(
           services.fileSystem.readFile(DESTINATION_WS_PATH),
         ).resolves.toBeDefined();
+      });
+    });
+
+    test('routes Markdown moves through note relocation', async () => {
+      const SOURCE_WS_PATH = 'test-ws:source.md';
+      const DESTINATION_WS_PATH = 'test-ws:archive/source.md';
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ws:move-ws-path',
+        workspaces: [{ name: 'test-ws', notes: [SOURCE_WS_PATH] }],
+      });
+      const relocationSpy = vi.spyOn(services.noteRelocation, 'relocate');
+
+      dispatch('command::ws:move-ws-path', {
+        destDirWsPath: 'test-ws:archive/',
+        wsPath: SOURCE_WS_PATH,
+      });
+
+      await vi.waitFor(() => {
+        expect(relocationSpy).toHaveBeenCalledWith({
+          destination: expect.objectContaining({ wsPath: DESTINATION_WS_PATH }),
+          source: expect.objectContaining({ wsPath: SOURCE_WS_PATH }),
+        });
+      });
+    });
+
+    test('keeps raw-file moves on the existing file-system path', async () => {
+      const SOURCE_WS_PATH = 'test-ws:source.txt';
+      const DESTINATION_WS_PATH = 'test-ws:archive/source.txt';
+      const { dispatch, services } = await setupTest({
+        targetId: 'command::ws:move-ws-path',
+        workspaces: [{ name: 'test-ws', notes: [SOURCE_WS_PATH] }],
+      });
+      const relocationSpy = vi.spyOn(services.noteRelocation, 'relocate');
+      const renameSpy = vi.spyOn(services.fileSystem, 'renameFile');
+
+      dispatch('command::ws:move-ws-path', {
+        destDirWsPath: 'test-ws:archive/',
+        wsPath: SOURCE_WS_PATH,
+      });
+
+      await vi.waitFor(async () => {
+        await expect(
+          services.fileSystem.readFile(SOURCE_WS_PATH),
+        ).resolves.toBeUndefined();
+        await expect(
+          services.fileSystem.readFile(DESTINATION_WS_PATH),
+        ).resolves.toBeDefined();
+      });
+      expect(relocationSpy).not.toHaveBeenCalled();
+      expect(renameSpy).toHaveBeenCalledWith({
+        oldWsPath: SOURCE_WS_PATH,
+        newWsPath: DESTINATION_WS_PATH,
       });
     });
 
@@ -572,12 +761,9 @@ describe('WS command handlers', () => {
         );
       });
 
-      // Storage is the atomic conflict authority, and both the dragged note and
-      // the note it collides with keep their original content.
-      expect(renameSpy).toHaveBeenCalledWith({
-        oldWsPath: SOURCE_WS_PATH,
-        newWsPath: EXISTING_WS_PATH,
-      });
+      // The relocation service rejects the known collision before a storage
+      // rename, and both notes keep their original content.
+      expect(renameSpy).not.toHaveBeenCalled();
       await expect(
         services.fileSystem.readFileAsText(SOURCE_WS_PATH),
       ).resolves.toBe('source body');

--- a/packages/core/command-handlers/src/ws-command-handlers.ts
+++ b/packages/core/command-handlers/src/ws-command-handlers.ts
@@ -5,7 +5,11 @@ import {
   throwAppError,
 } from '@bangle.io/base-utils';
 import { EDITOR_SAVE_DRAIN_TIMEOUT_MS } from '@bangle.io/constants';
-import { waitForSaveQueueToDrain } from '@bangle.io/service-core';
+import {
+  NoteRelocationContentWriteError,
+  type NoteRelocationWarning,
+  waitForSaveQueueToDrain,
+} from '@bangle.io/service-core';
 import { toast } from '@bangle.io/ui-components';
 import { WsDirPath, WsPath } from '@bangle.io/ws-path';
 import { c, getCtx } from './helper';
@@ -55,6 +59,14 @@ function rethrowRelocationError(
   fileName: string,
   fallbackMessage: string,
 ): never {
+  if (error instanceof NoteRelocationContentWriteError) {
+    toast.error(
+      error.compensation === 'restored'
+        ? t.app.toasts.noteRelocationWriteRestored({ fileName })
+        : t.app.toasts.noteRelocationWriteRestoreFailed({ fileName }),
+    );
+    throw error;
+  }
   if (isAppError(error)) {
     if (getAppErrorCause(error)?.name === 'error::file:already-existing') {
       throwAppError(
@@ -68,6 +80,60 @@ function rethrowRelocationError(
 
   toast.error(fallbackMessage);
   throw error;
+}
+
+function showRelocationWarnings({
+  fileName,
+  operation,
+  warnings,
+}: {
+  fileName: string;
+  operation: 'move' | 'rename';
+  warnings: readonly NoteRelocationWarning[];
+}): void {
+  const unsupportedReferenceCount = warnings.reduce(
+    (count, warning) =>
+      warning.kind === 'unsupported-reference' ? count + warning.count : count,
+    0,
+  );
+  if (unsupportedReferenceCount > 0) {
+    toast.warning(
+      operation === 'rename'
+        ? t.app.toasts.fileRenameReferenceUpdateIncomplete({
+            fileName,
+            warningCount: unsupportedReferenceCount,
+          })
+        : t.app.toasts.fileMoveReferenceUpdateIncomplete({
+            fileName,
+            warningCount: unsupportedReferenceCount,
+          }),
+    );
+  }
+
+  for (const warning of warnings) {
+    if (warning.kind === 'unsupported-reference') {
+      continue;
+    }
+    const reason =
+      warning.kind === 'destination-content-changed'
+        ? t.app.toasts.noteRelocationDestinationContentChanged
+        : warning.kind === 'newer-local-edit'
+          ? t.app.toasts.noteRelocationNewerLocalEdit
+          : t.app.toasts.noteRelocationEditorContentUnavailable;
+    toast.warning(
+      operation === 'rename'
+        ? t.app.toasts.fileRenameReferenceUpdateSkipped({
+            fileName,
+            reason,
+            warningCount: warning.skippedReferences,
+          })
+        : t.app.toasts.fileMoveReferenceUpdateSkipped({
+            fileName,
+            reason,
+            warningCount: warning.skippedReferences,
+          }),
+    );
+  }
 }
 
 async function assertSourceSavesDrained(
@@ -228,10 +294,10 @@ export const wsCommandHandlers = [
   c(
     'command::ws:rename-ws-path',
     async (
-      { editorEngine, fileSystem, userActivityService },
+      { editorEngine, fileSystem, noteRelocation, userActivityService },
       { wsPath, newWsPath },
     ) => {
-      const oldPath = WsPath.fromString(wsPath);
+      const oldPath = WsPath.assertFile(wsPath);
       const newPath = WsPath.fromString(newWsPath);
 
       if (!oldPath.wsName) {
@@ -257,23 +323,31 @@ export const wsCommandHandlers = [
       }
 
       const newFilePath = WsPath.assertFile(newWsPath);
+      let relocationWarnings: readonly NoteRelocationWarning[] = [];
       if (wsPath === newWsPath) {
         return;
       }
 
-      await assertSourceSavesDrained(
-        editorEngine,
-        [{ oldWsPath: wsPath, newWsPath }],
-        'rename',
-      );
-
       // Keep the open note visible while the storage write is in flight.
       // WorkspaceState follows the durable rename event once it lands.
       try {
-        await fileSystem.renameFile({
-          oldWsPath: wsPath,
-          newWsPath,
-        });
+        if (oldPath.isMarkdown() && newFilePath.isMarkdown()) {
+          const receipt = await noteRelocation.relocate({
+            destination: newFilePath,
+            source: oldPath,
+          });
+          relocationWarnings = receipt.warnings;
+        } else {
+          await assertSourceSavesDrained(
+            editorEngine,
+            [{ oldWsPath: wsPath, newWsPath }],
+            'rename',
+          );
+          await fileSystem.renameFile({
+            oldWsPath: wsPath,
+            newWsPath,
+          });
+        }
       } catch (error) {
         rethrowRelocationError(
           error,
@@ -293,7 +367,13 @@ export const wsCommandHandlers = [
             fileName: newFilePath.fileName,
           }),
         );
-      } else {
+      }
+      showRelocationWarnings({
+        fileName: newFilePath.fileName,
+        operation: 'rename',
+        warnings: relocationWarnings,
+      });
+      if (starResult !== 'failed' && relocationWarnings.length === 0) {
         toast.success(
           t.app.toasts.fileRenamed({ fileName: newFilePath.fileName }),
         );
@@ -304,7 +384,7 @@ export const wsCommandHandlers = [
   c(
     'command::ws:move-ws-path',
     async (
-      { editorEngine, fileSystem, userActivityService },
+      { editorEngine, fileSystem, noteRelocation, userActivityService },
       { wsPath, destDirWsPath },
     ) => {
       const filePath = WsPath.assertFile(wsPath);
@@ -330,19 +410,28 @@ export const wsCommandHandlers = [
         return;
       }
 
-      await assertSourceSavesDrained(
-        editorEngine,
-        [{ oldWsPath: wsPath, newWsPath }],
-        'move',
-      );
-
+      let relocationWarnings: readonly NoteRelocationWarning[] = [];
       // Keep the open note visible while the storage write is in flight.
       // WorkspaceState follows the durable rename event once it lands.
       try {
-        await fileSystem.renameFile({
-          oldWsPath: wsPath,
-          newWsPath,
-        });
+        const newFilePath = WsPath.assertFile(newWsPath);
+        if (filePath.isMarkdown() && newFilePath.isMarkdown()) {
+          const receipt = await noteRelocation.relocate({
+            destination: newFilePath,
+            source: filePath,
+          });
+          relocationWarnings = receipt.warnings;
+        } else {
+          await assertSourceSavesDrained(
+            editorEngine,
+            [{ oldWsPath: wsPath, newWsPath }],
+            'move',
+          );
+          await fileSystem.renameFile({
+            oldWsPath: wsPath,
+            newWsPath,
+          });
+        }
       } catch (error) {
         rethrowRelocationError(
           error,
@@ -362,7 +451,13 @@ export const wsCommandHandlers = [
             fileName: filePath.fileName,
           }),
         );
-      } else {
+      }
+      showRelocationWarnings({
+        fileName: filePath.fileName,
+        operation: 'move',
+        warnings: relocationWarnings,
+      });
+      if (starResult !== 'failed' && relocationWarnings.length === 0) {
         toast.success(t.app.toasts.fileMoved({ fileName: filePath.fileName }));
       }
     },

--- a/packages/core/context/src/service-types.ts
+++ b/packages/core/context/src/service-types.ts
@@ -5,6 +5,7 @@ import type {
   EditorService,
   FileSystemService,
   NavigationService,
+  NoteRelocationService,
   NoteSnapshotService,
   ShortcutService,
   UserActivityService,
@@ -104,6 +105,7 @@ export type CoreServices<
   editorService: EditorService;
   fileSystem: FileSystemService;
   navigation: NavigationService;
+  noteRelocation: NoteRelocationService;
   noteSnapshot: NoteSnapshotService;
   shortcut: ShortcutService;
   userActivityService: UserActivityService;

--- a/packages/core/editor/src/__tests__/editor-save-queue.spec.ts
+++ b/packages/core/editor/src/__tests__/editor-save-queue.spec.ts
@@ -553,4 +553,49 @@ describe('EditorSaveQueue', () => {
     expect(status.error.message).toBe('sync unavailable');
     expect(emitAppError).toHaveBeenCalledTimes(1);
   });
+
+  it('runs a relocation rewrite before an edit that arrives while it writes', async () => {
+    const relocationWrite = createDeferred<void>();
+    const writes: string[] = [];
+    const queue = new EditorSaveQueue((_: string, doc: string) => {
+      writes.push(doc);
+      return writes.length === 1 ? relocationWrite.promise : Promise.resolve();
+    }, vi.fn());
+
+    const relocation = queue.enqueueRelocationWrite(
+      'workspace:renamed.md',
+      'rewritten durable snapshot',
+    );
+    queue.enqueue('workspace:renamed.md', 'newer editor content');
+
+    expect(writes).toEqual(['rewritten durable snapshot']);
+    relocationWrite.resolve();
+
+    await expect(relocation).resolves.toBe('written');
+    await vi.waitFor(() => {
+      expect(queue.getStatus('workspace:renamed.md')).toEqual({
+        status: 'clean',
+      });
+    });
+    expect(writes).toEqual([
+      'rewritten durable snapshot',
+      'newer editor content',
+    ]);
+  });
+
+  it('does not queue a relocation rewrite over a newer pending edit', async () => {
+    const pendingWrite = createDeferred<void>();
+    const queue = new EditorSaveQueue(() => pendingWrite.promise, vi.fn());
+
+    queue.enqueue('workspace:renamed.md', 'newer editor content');
+
+    await expect(
+      queue.enqueueRelocationWrite(
+        'workspace:renamed.md',
+        'stale relocation snapshot',
+      ),
+    ).resolves.toBe('superseded');
+
+    pendingWrite.resolve();
+  });
 });

--- a/packages/core/editor/src/__tests__/note-relocation-editor-integration.spec.ts
+++ b/packages/core/editor/src/__tests__/note-relocation-editor-integration.spec.ts
@@ -1,0 +1,541 @@
+// @vitest-environment jsdom
+
+import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import { createTestEnvironment } from '@bangle.io/test-utils';
+import { WsFilePath } from '@bangle.io/ws-path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createEditorSaveCoordinator } from '../editor-save-queue';
+import { PmEditorService } from '../pm-editor-service';
+
+const WS_NAME = 'test-ws';
+const SOURCE_WS_PATH = `${WS_NAME}:notes/source.md`;
+const DESTINATION_WS_PATH = `${WS_NAME}:archive/source.md`;
+const TARGET_WS_PATH = `${WS_NAME}:notes/target.md`;
+
+let controllers: AbortController[] = [];
+let domNodes: HTMLElement[] = [];
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  for (const controller of controllers) {
+    controller.abort();
+  }
+  controllers = [];
+  for (const domNode of domNodes) {
+    domNode.remove();
+  }
+  domNodes = [];
+});
+
+function asPmEditor(editorEngine: unknown): PmEditorService {
+  if (!(editorEngine instanceof PmEditorService)) {
+    throw new Error('Expected the ProseMirror editor engine');
+  }
+  return editorEngine;
+}
+
+describe('open-note relocation', () => {
+  it('keeps rebased links after an unrelated edit and reload', async () => {
+    const controller = new AbortController();
+    controllers.push(controller);
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+    await services.workspaceOps.createWorkspaceInfo({
+      name: WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.fileSystem.createTextFile(
+      SOURCE_WS_PATH,
+      [
+        'body',
+        '',
+        '[Open linked note](./target.md)',
+        '',
+        '![Relocation image](./assets/relocation.png)',
+      ].join('\n'),
+    );
+    await services.fileSystem.createTextFile(TARGET_WS_PATH, 'target body');
+    await services.fileSystem.createTextFile(
+      `${WS_NAME}:notes/assets/relocation.png`,
+      'not-an-image',
+    );
+
+    const domNode = document.createElement('div');
+    document.body.append(domNode);
+    domNodes.push(domNode);
+    const unmount = services.editorEngine.mountEditor({
+      domNode,
+      name: 'relocation-editor',
+      wsPath: SOURCE_WS_PATH,
+      focus: false,
+    });
+    await vi.waitFor(() => expect(domNode.textContent).toContain('body'));
+
+    const destinationWriteStarted = createDeferred<void>();
+    const allowDestinationWrite = createDeferred<void>();
+    const writeFile = services.fileSystem.writeFile.bind(services.fileSystem);
+    let delayed = false;
+    vi.spyOn(services.fileSystem, 'writeFile').mockImplementation(
+      async (wsPath, file) => {
+        if (wsPath === DESTINATION_WS_PATH && !delayed) {
+          delayed = true;
+          destinationWriteStarted.resolve();
+          await allowDestinationWrite.promise;
+        }
+        await writeFile(wsPath, file);
+      },
+    );
+
+    const relocation = services.noteRelocation.relocate({
+      destination: WsFilePath.fromString(DESTINATION_WS_PATH),
+      source: WsFilePath.fromString(SOURCE_WS_PATH),
+    });
+    await destinationWriteStarted.promise;
+
+    // PageEditor uses wsPath in its key, so route updates can replace the
+    // view during the destination write. The late mount must not retain the
+    // pre-rewrite read it began after the rename.
+    unmount();
+    const lateMountDomNode = document.createElement('div');
+    document.body.append(lateMountDomNode);
+    domNodes.push(lateMountDomNode);
+    const unmountLateMount = services.editorEngine.mountEditor({
+      domNode: lateMountDomNode,
+      name: 'late-relocation-editor',
+      wsPath: DESTINATION_WS_PATH,
+      focus: false,
+    });
+    await vi.waitFor(() =>
+      expect(lateMountDomNode.querySelector('a')).toBeNull(),
+    );
+    allowDestinationWrite.resolve();
+    await expect(relocation).resolves.toMatchObject({
+      rewrittenReferences: 2,
+      warnings: [],
+    });
+    await vi.waitFor(() => {
+      expect(lateMountDomNode.querySelector('a')?.getAttribute('href')).toBe(
+        '../notes/target.md',
+      );
+    });
+
+    const editor = asPmEditor(services.editorEngine).getEditor(
+      'late-relocation-editor',
+    );
+    if (!editor) {
+      throw new Error('Expected mounted editor');
+    }
+    expect(editor.dom.querySelector('a')?.getAttribute('href')).toBe(
+      '../notes/target.md',
+    );
+    editor.dispatch(editor.state.tr.insertText('changed ', 1));
+
+    await vi.waitFor(async () => {
+      expect(
+        services.editorEngine.hasPendingOrFailedSave(DESTINATION_WS_PATH),
+      ).toBe(false);
+      await expect(
+        services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+      ).resolves.toContain('[Open linked note](../notes/target.md)');
+      await expect(
+        services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+      ).resolves.toContain(
+        '![Relocation image](../notes/assets/relocation.png)',
+      );
+    });
+
+    unmountLateMount();
+    const reloadedDomNode = document.createElement('div');
+    document.body.append(reloadedDomNode);
+    domNodes.push(reloadedDomNode);
+    services.editorEngine.mountEditor({
+      domNode: reloadedDomNode,
+      name: 'reloaded-relocation-editor',
+      wsPath: DESTINATION_WS_PATH,
+      focus: false,
+    });
+    await vi.waitFor(() => {
+      expect(reloadedDomNode.textContent).toContain('changed body');
+      expect(reloadedDomNode.querySelector('a')?.getAttribute('href')).toBe(
+        '../notes/target.md',
+      );
+    });
+  });
+
+  it('uses the relocation handoff when a destination read finishes after the rewrite', async () => {
+    const controller = new AbortController();
+    controllers.push(controller);
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+    await services.workspaceOps.createWorkspaceInfo({
+      name: WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.fileSystem.createTextFile(
+      SOURCE_WS_PATH,
+      '[Open linked note](./target.md)',
+    );
+    await services.fileSystem.createTextFile(TARGET_WS_PATH, 'target body');
+
+    const sourceDomNode = document.createElement('div');
+    document.body.append(sourceDomNode);
+    domNodes.push(sourceDomNode);
+    const unmountSource = services.editorEngine.mountEditor({
+      domNode: sourceDomNode,
+      name: 'source-relocation-editor',
+      wsPath: SOURCE_WS_PATH,
+      focus: false,
+    });
+    await vi.waitFor(() =>
+      expect(sourceDomNode.querySelector('a')).toBeTruthy(),
+    );
+
+    const relocationHandoffStarted = createDeferred<void>();
+    const allowRelocationHandoff = createDeferred<void>();
+    const pmEditor = asPmEditor(services.editorEngine);
+    const writeRelocatedMarkdown =
+      pmEditor.writeRelocatedMarkdown.bind(pmEditor);
+    vi.spyOn(pmEditor, 'writeRelocatedMarkdown').mockImplementation(
+      async (params) => {
+        relocationHandoffStarted.resolve();
+        await allowRelocationHandoff.promise;
+        return writeRelocatedMarkdown(params);
+      },
+    );
+
+    const relocation = services.noteRelocation.relocate({
+      destination: WsFilePath.fromString(DESTINATION_WS_PATH),
+      source: WsFilePath.fromString(SOURCE_WS_PATH),
+    });
+    // The durable rename has succeeded, but the editor handoff is not yet
+    // installed. A route change can mount the destination in this gap.
+    await relocationHandoffStarted.promise;
+
+    const destinationReadStarted = createDeferred<void>();
+    const allowDestinationRead = createDeferred<void>();
+    const readFileAsText = services.fileSystem.readFileAsText.bind(
+      services.fileSystem,
+    );
+    let delayedRead = false;
+    vi.spyOn(services.fileSystem, 'readFileAsText').mockImplementation(
+      async (wsPath, options) => {
+        const content = await readFileAsText(wsPath, options);
+        if (wsPath === DESTINATION_WS_PATH && !delayedRead) {
+          delayedRead = true;
+          destinationReadStarted.resolve();
+          await allowDestinationRead.promise;
+        }
+        return content;
+      },
+    );
+
+    unmountSource();
+    const destinationDomNode = document.createElement('div');
+    document.body.append(destinationDomNode);
+    domNodes.push(destinationDomNode);
+    services.editorEngine.mountEditor({
+      domNode: destinationDomNode,
+      name: 'slow-destination-read-editor',
+      wsPath: DESTINATION_WS_PATH,
+      focus: false,
+    });
+    await destinationReadStarted.promise;
+
+    // Install, durably write, and complete the handoff before returning the
+    // destination loader's stale disk snapshot. The in-flight load must still
+    // select the relocation Markdown after cleanup would otherwise occur.
+    allowRelocationHandoff.resolve();
+    await expect(relocation).resolves.toMatchObject({
+      rewrittenReferences: 1,
+      warnings: [],
+    });
+    allowDestinationRead.resolve();
+
+    await vi.waitFor(() => {
+      expect(destinationDomNode.querySelector('a')?.getAttribute('href')).toBe(
+        '../notes/target.md',
+      );
+    });
+  });
+
+  it('restores the view editable predicate after applying a relocation rewrite', async () => {
+    const controller = new AbortController();
+    controllers.push(controller);
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+    await services.workspaceOps.createWorkspaceInfo({
+      name: WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.fileSystem.createTextFile(SOURCE_WS_PATH, '[[./target]]');
+    await services.fileSystem.createTextFile(TARGET_WS_PATH, 'target body');
+
+    const domNode = document.createElement('div');
+    document.body.append(domNode);
+    domNodes.push(domNode);
+    services.editorEngine.mountEditor({
+      domNode,
+      name: 'noneditable-relocation-editor',
+      wsPath: SOURCE_WS_PATH,
+      focus: false,
+    });
+    const pmEditor = asPmEditor(services.editorEngine);
+    await vi.waitFor(() =>
+      expect(pmEditor.getEditor('noneditable-relocation-editor')).toBeDefined(),
+    );
+    const editor = pmEditor.getEditor('noneditable-relocation-editor');
+    if (!editor) {
+      throw new Error('Expected mounted editor');
+    }
+    const originalEditable = () => false;
+    editor.setProps({ editable: originalEditable });
+
+    await expect(
+      services.noteRelocation.relocate({
+        destination: WsFilePath.fromString(DESTINATION_WS_PATH),
+        source: WsFilePath.fromString(SOURCE_WS_PATH),
+      }),
+    ).resolves.toMatchObject({ rewrittenReferences: 1, warnings: [] });
+
+    expect(editor.props.editable).toBe(originalEditable);
+  });
+
+  it('shares an in-flight relocation handoff with a replacement service graph', async () => {
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    controllers.push(firstController, secondController);
+    const saveCoordinator = createEditorSaveCoordinator();
+    const firstTestEnv = createTestEnvironment({
+      controller: firstController,
+      editorSaveCoordinator: saveCoordinator,
+    });
+    const firstServices = firstTestEnv.instantiateAll();
+    await firstTestEnv.mountAll();
+    await firstServices.workspaceOps.createWorkspaceInfo({
+      name: WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await firstServices.fileSystem.createTextFile(
+      SOURCE_WS_PATH,
+      ['body', '', '[Open linked note](./target.md)'].join('\n'),
+    );
+    await firstServices.fileSystem.createTextFile(
+      TARGET_WS_PATH,
+      'target body',
+    );
+
+    const sourceDomNode = document.createElement('div');
+    document.body.append(sourceDomNode);
+    domNodes.push(sourceDomNode);
+    firstServices.editorEngine.mountEditor({
+      domNode: sourceDomNode,
+      name: 'reload-source-editor',
+      wsPath: SOURCE_WS_PATH,
+      focus: false,
+    });
+    await vi.waitFor(() =>
+      expect(sourceDomNode.querySelector('a')?.getAttribute('href')).toBe(
+        './target.md',
+      ),
+    );
+
+    const destinationWriteStarted = createDeferred<void>();
+    const allowDestinationWrite = createDeferred<void>();
+    const firstWriteFile = firstServices.fileSystem.writeFile.bind(
+      firstServices.fileSystem,
+    );
+    let delayedWrite = false;
+    vi.spyOn(firstServices.fileSystem, 'writeFile').mockImplementation(
+      async (wsPath, file) => {
+        if (wsPath === DESTINATION_WS_PATH && !delayedWrite) {
+          delayedWrite = true;
+          destinationWriteStarted.resolve();
+          await allowDestinationWrite.promise;
+        }
+        await firstWriteFile(wsPath, file);
+      },
+    );
+
+    const relocation = firstServices.noteRelocation.relocate({
+      destination: WsFilePath.fromString(DESTINATION_WS_PATH),
+      source: WsFilePath.fromString(SOURCE_WS_PATH),
+    });
+    await destinationWriteStarted.promise;
+
+    // A UI reload creates a fresh editor service graph while retaining only
+    // browser-root state. Seed its persistent-storage equivalent with the
+    // post-rename bytes the new graph would read from disk.
+    const secondTestEnv = createTestEnvironment({
+      controller: secondController,
+      editorSaveCoordinator: saveCoordinator,
+    });
+    const secondServices = secondTestEnv.instantiateAll();
+    await secondTestEnv.mountAll();
+    await secondServices.workspaceOps.createWorkspaceInfo({
+      name: WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await secondServices.fileSystem.createTextFile(
+      DESTINATION_WS_PATH,
+      ['body', '', '[Open linked note](./target.md)'].join('\n'),
+    );
+    await secondServices.fileSystem.createTextFile(
+      TARGET_WS_PATH,
+      'target body',
+    );
+
+    const destinationDomNode = document.createElement('div');
+    document.body.append(destinationDomNode);
+    domNodes.push(destinationDomNode);
+    secondServices.editorEngine.mountEditor({
+      domNode: destinationDomNode,
+      name: 'reload-destination-editor',
+      wsPath: DESTINATION_WS_PATH,
+      focus: false,
+    });
+    await vi.waitFor(() =>
+      expect(destinationDomNode.querySelector('a')).toBeNull(),
+    );
+
+    allowDestinationWrite.resolve();
+    await expect(relocation).resolves.toMatchObject({
+      rewrittenReferences: 1,
+      warnings: [],
+    });
+    await vi.waitFor(() => {
+      expect(destinationDomNode.querySelector('a')?.getAttribute('href')).toBe(
+        '../notes/target.md',
+      );
+    });
+
+    const reloadedEditor = asPmEditor(secondServices.editorEngine).getEditor(
+      'reload-destination-editor',
+    );
+    if (!reloadedEditor) {
+      throw new Error('Expected editor from replacement service graph');
+    }
+    reloadedEditor.dispatch(reloadedEditor.state.tr.insertText('changed ', 1));
+    await vi.waitFor(async () => {
+      expect(
+        secondServices.editorEngine.hasPendingOrFailedSave(DESTINATION_WS_PATH),
+      ).toBe(false);
+      await expect(
+        secondServices.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+      ).resolves.toContain('[Open linked note](../notes/target.md)');
+    });
+  });
+
+  it('re-reads durable content when a relocation write fails', async () => {
+    const controller = new AbortController();
+    controllers.push(controller);
+    const testEnv = createTestEnvironment({ controller });
+    const services = testEnv.instantiateAll();
+    await testEnv.mountAll();
+    await services.workspaceOps.createWorkspaceInfo({
+      name: WS_NAME,
+      type: WORKSPACE_STORAGE_TYPE.Memory,
+      metadata: {},
+    });
+    await services.fileSystem.createTextFile(
+      SOURCE_WS_PATH,
+      '[Open linked note](./target.md)',
+    );
+    await services.fileSystem.createTextFile(TARGET_WS_PATH, 'target body');
+
+    const sourceDomNode = document.createElement('div');
+    document.body.append(sourceDomNode);
+    domNodes.push(sourceDomNode);
+    const unmountSource = services.editorEngine.mountEditor({
+      domNode: sourceDomNode,
+      name: 'failing-source-relocation-editor',
+      wsPath: SOURCE_WS_PATH,
+      focus: false,
+    });
+    await vi.waitFor(() =>
+      expect(sourceDomNode.querySelector('a')).toBeTruthy(),
+    );
+
+    const destinationWriteStarted = createDeferred<void>();
+    const failDestinationWrite = createDeferred<void>();
+    const writeFile = services.fileSystem.writeFile.bind(services.fileSystem);
+    let failingWrite = true;
+    vi.spyOn(services.fileSystem, 'writeFile').mockImplementation(
+      async (wsPath, file) => {
+        if (wsPath === DESTINATION_WS_PATH && failingWrite) {
+          failingWrite = false;
+          destinationWriteStarted.resolve();
+          await failDestinationWrite.promise;
+          throw new Error('destination write failed');
+        }
+        await writeFile(wsPath, file);
+      },
+    );
+
+    const relocation = services.noteRelocation.relocate({
+      destination: WsFilePath.fromString(DESTINATION_WS_PATH),
+      source: WsFilePath.fromString(SOURCE_WS_PATH),
+    });
+    await destinationWriteStarted.promise;
+
+    const destinationReadStarted = createDeferred<void>();
+    const readFileAsText = services.fileSystem.readFileAsText.bind(
+      services.fileSystem,
+    );
+    let observedDestinationRead = false;
+    vi.spyOn(services.fileSystem, 'readFileAsText').mockImplementation(
+      async (wsPath, options) => {
+        if (wsPath === DESTINATION_WS_PATH && !observedDestinationRead) {
+          observedDestinationRead = true;
+          destinationReadStarted.resolve();
+        }
+        return readFileAsText(wsPath, options);
+      },
+    );
+
+    unmountSource();
+    const destinationDomNode = document.createElement('div');
+    document.body.append(destinationDomNode);
+    domNodes.push(destinationDomNode);
+    services.editorEngine.mountEditor({
+      domNode: destinationDomNode,
+      name: 'failing-destination-relocation-editor',
+      wsPath: DESTINATION_WS_PATH,
+      focus: false,
+    });
+    await destinationReadStarted.promise;
+
+    // The destination loader has captured the proposed handoff, but it must
+    // not mount that content until the queued write has a durable outcome.
+    await vi.waitFor(() => {
+      expect(destinationDomNode.querySelector('a')).toBeNull();
+    });
+    failDestinationWrite.resolve();
+    await expect(relocation).rejects.toThrow('restored to its original path');
+
+    await vi.waitFor(async () => {
+      await expect(
+        services.fileSystem.readFileAsText(SOURCE_WS_PATH),
+      ).resolves.toBe('[Open linked note](./target.md)');
+      await expect(
+        services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+      ).resolves.toBeUndefined();
+      expect(destinationDomNode.textContent).not.toContain('Open linked note');
+      expect(destinationDomNode.querySelector('a')).toBeNull();
+    });
+  });
+});

--- a/packages/core/editor/src/editor-save-queue.ts
+++ b/packages/core/editor/src/editor-save-queue.ts
@@ -10,6 +10,10 @@ type ErrorHandler = (error: BaseError) => void;
 
 type SaveTask = {
   doc: string;
+  relocationCompletion?: {
+    reject: (reason?: unknown) => void;
+    resolve: (value: 'written') => void;
+  };
 };
 
 type EditorSaveSession = {
@@ -35,6 +39,20 @@ type SaveStatusSubscription = {
   wsPath?: string;
 };
 
+export type RelocationHandoff = {
+  markdown: string;
+  outcome: Promise<'discarded' | 'written'>;
+  settle: (outcome: 'discarded' | 'written') => void;
+};
+
+function createRelocationHandoff(markdown: string): RelocationHandoff {
+  let settle!: (outcome: 'discarded' | 'written') => void;
+  const outcome = new Promise<'discarded' | 'written'>((resolve) => {
+    settle = resolve;
+  });
+  return { markdown, outcome, settle };
+}
+
 /**
  * Browser-root state shared by each editor service graph created in this tab.
  * Queued documents can outlive a UI reload, while the current session always
@@ -45,6 +63,9 @@ export type EditorSaveCoordinator = {
   entries: Map<string, SaveEntry>;
   hasPendingOrFailedSave(wsPath?: string): boolean;
   lastHasPendingOrFailed: boolean;
+  loadingEditorCounts: Map<string, number>;
+  relocationHandoffs: Map<string, RelocationHandoff>;
+  settledRelocationHandoffs: Set<string>;
   subscriptions: Set<SaveStatusSubscription>;
 };
 
@@ -65,6 +86,9 @@ export function createEditorSaveCoordinator(): EditorSaveCoordinator {
       return false;
     },
     lastHasPendingOrFailed: false,
+    loadingEditorCounts: new Map(),
+    relocationHandoffs: new Map(),
+    settledRelocationHandoffs: new Set(),
     subscriptions: new Set(),
   };
 }
@@ -88,6 +112,78 @@ export class EditorSaveQueue {
     if (!entry.active) {
       this.startFlush(entry);
     }
+  }
+
+  /**
+   * Writes relocation-generated Markdown through the same per-note queue as
+   * editor changes. If a newer editor change is already pending, leave that
+   * change authoritative instead of applying a stale pre-relocation snapshot.
+   */
+  enqueueRelocationWrite(
+    wsPath: string,
+    doc: string,
+  ): Promise<'superseded' | 'written'> {
+    const existing = this.coordinator.entries.get(wsPath);
+    if (
+      existing &&
+      (existing.active ||
+        existing.pendingTask !== undefined ||
+        existing.failedTask !== undefined ||
+        existing.status.status !== 'clean')
+    ) {
+      return Promise.resolve('superseded');
+    }
+
+    const entry = this.getEntry(wsPath);
+    return new Promise<'written'>((resolve, reject) => {
+      entry.pendingTask = {
+        doc,
+        relocationCompletion: { reject, resolve },
+      };
+      entry.status = { status: 'pending' };
+      this.notifySaveStatusChanged(wsPath);
+      this.startFlush(entry);
+    });
+  }
+
+  beginRelocationAwareLoad(wsPath: string): () => void {
+    this.coordinator.loadingEditorCounts.set(
+      wsPath,
+      (this.coordinator.loadingEditorCounts.get(wsPath) ?? 0) + 1,
+    );
+    return () => {
+      const remaining =
+        (this.coordinator.loadingEditorCounts.get(wsPath) ?? 1) - 1;
+      if (remaining > 0) {
+        this.coordinator.loadingEditorCounts.set(wsPath, remaining);
+      } else {
+        this.coordinator.loadingEditorCounts.delete(wsPath);
+      }
+      this.discardSettledRelocationHandoffIfUnused(wsPath);
+    };
+  }
+
+  getRelocationHandoff(wsPath: string): RelocationHandoff | undefined {
+    return this.coordinator.relocationHandoffs.get(wsPath);
+  }
+
+  createRelocationHandoff(wsPath: string, markdown: string): void {
+    this.coordinator.relocationHandoffs.set(
+      wsPath,
+      createRelocationHandoff(markdown),
+    );
+  }
+
+  completeRelocationHandoff(wsPath: string): void {
+    this.coordinator.relocationHandoffs.get(wsPath)?.settle('written');
+    this.coordinator.settledRelocationHandoffs.add(wsPath);
+    this.discardSettledRelocationHandoffIfUnused(wsPath);
+  }
+
+  discardRelocationHandoff(wsPath: string): void {
+    this.coordinator.relocationHandoffs.get(wsPath)?.settle('discarded');
+    this.coordinator.settledRelocationHandoffs.add(wsPath);
+    this.discardSettledRelocationHandoffIfUnused(wsPath);
   }
 
   getStatus(wsPath: string): EditorSaveStatus {
@@ -201,6 +297,17 @@ export class EditorSaveQueue {
     return entry;
   }
 
+  private discardSettledRelocationHandoffIfUnused(wsPath: string): void {
+    if (
+      !this.coordinator.settledRelocationHandoffs.has(wsPath) ||
+      this.coordinator.loadingEditorCounts.has(wsPath)
+    ) {
+      return;
+    }
+    this.coordinator.relocationHandoffs.delete(wsPath);
+    this.coordinator.settledRelocationHandoffs.delete(wsPath);
+  }
+
   private async flush(entry: SaveEntry): Promise<void> {
     while (entry.pendingTask !== undefined) {
       const task = entry.pendingTask;
@@ -223,7 +330,18 @@ export class EditorSaveQueue {
           throw new Error('Editor save coordinator has no active session');
         }
         await session.writeDoc(writeWsPath, task.doc);
+        task.relocationCompletion?.resolve('written');
       } catch (cause) {
+        if (task.relocationCompletion) {
+          task.relocationCompletion.reject(cause);
+          entry.failedTask = undefined;
+          entry.status =
+            entry.pendingTask === undefined
+              ? { status: 'clean' }
+              : { status: 'pending' };
+          this.notifySaveStatusChanged(entry.wsPath);
+          continue;
+        }
         if (entry.retired) {
           continue;
         }

--- a/packages/core/editor/src/external-content-sync.ts
+++ b/packages/core/editor/src/external-content-sync.ts
@@ -59,7 +59,7 @@ function sleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
  * content while preserving the selection near its previous position. Returns
  * undefined when applying a non-empty document would unexpectedly blank it.
  */
-function buildExternalDocReplace(
+export function buildExternalDocReplace(
   view: EditorView,
   parsedDoc: EditorView['state']['doc'],
 ): Transaction | undefined {

--- a/packages/core/editor/src/pm-editor-service.ts
+++ b/packages/core/editor/src/pm-editor-service.ts
@@ -8,6 +8,7 @@ import {
 import { SERVICE_NAME } from '@bangle.io/constants';
 import type { EditorAction, EditorEngineContract } from '@bangle.io/context';
 import {
+  type EditorProps,
   type EditorView,
   markdownLoader,
   type Schema,
@@ -48,9 +49,13 @@ import type { MarkdownAssetReference } from './asset-file-plugin';
 import {
   type EditorSaveCoordinator,
   EditorSaveQueue,
+  type RelocationHandoff,
 } from './editor-save-queue';
 import { setupExtensions } from './extensions';
-import { ExternalContentSync } from './external-content-sync';
+import {
+  buildExternalDocReplace,
+  ExternalContentSync,
+} from './external-content-sync';
 import { findHeadingIndexBySlug } from './heading-slug';
 import { createLocalImageNodeView } from './local-image-node-view';
 import { createEditor, serializeEditorDocumentForSave } from './pm-setup';
@@ -395,14 +400,7 @@ export class PmEditorService
     if (external && this.saveQueue.hasPendingOrFailed(oldWsPath)) {
       return;
     }
-    this.saveQueue.relocate(oldWsPath, newWsPath);
-
-    for (const [domNode, editor] of this.editors) {
-      if (editor.wsPath !== oldWsPath) {
-        continue;
-      }
-      this.editors.set(domNode, { ...editor, wsPath: newWsPath });
-    }
+    this.retargetRelocatedEditors(oldWsPath, newWsPath);
   }
 
   mountEditor({
@@ -442,8 +440,24 @@ export class PmEditorService
     name: string;
     wsPath: string;
   }): Promise<void> {
+    const finishEditorLoad = this.saveQueue.beginRelocationAwareLoad(wsPath);
     try {
-      const content = await this.dependencies.fileSystem.readFileAsText(wsPath);
+      // Capture a relocation handoff before the read begins. The relocation
+      // write can complete while this read is in flight and remove its
+      // temporary handoff; this load must still use the rebased source it
+      // observed when it started rather than mounting a stale disk snapshot.
+      const relocationHandoff = this.saveQueue.getRelocationHandoff(wsPath);
+      const diskContent =
+        await this.dependencies.fileSystem.readFileAsText(wsPath);
+      const handoff =
+        relocationHandoff ?? this.saveQueue.getRelocationHandoff(wsPath);
+      const content = handoff
+        ? await this.resolveRelocationHandoffContent({
+            diskContent,
+            handoff,
+            wsPath,
+          })
+        : diskContent;
       const editorEntry = this.editors.get(domNode);
       if (!editorEntry || 'editorView' in editorEntry) {
         // Editor was unmounted or already initialized, don't create new editorView
@@ -529,6 +543,8 @@ export class PmEditorService
           wsPath,
         }),
       );
+    } finally {
+      finishEditorLoad();
     }
   }
 
@@ -865,6 +881,205 @@ export class PmEditorService
 
   retryFailedSave(wsPath?: string): boolean {
     return this.saveQueue.retryFailed(wsPath);
+  }
+
+  async writeRelocatedMarkdown({
+    destinationWsPath,
+    markdown,
+    sourceWsPath,
+  }: {
+    destinationWsPath: string;
+    markdown: string;
+    sourceWsPath: string;
+  }): Promise<'superseded' | 'unavailable' | 'written'> {
+    if (
+      this.saveQueue.hasPendingOrFailed(sourceWsPath) ||
+      this.saveQueue.hasPendingOrFailed(destinationWsPath)
+    ) {
+      return 'superseded';
+    }
+
+    this.retargetRelocatedEditors(sourceWsPath, destinationWsPath);
+
+    const views = [...this.readyEditors()].filter(
+      (editor) => editor.wsPath === destinationWsPath,
+    );
+    const replacements = [] as Array<{
+      editor: ReadyEditorEntry;
+      originalEditable: EditorProps['editable'];
+      originalDoc: EditorView['state']['doc'];
+      originalMarkdown: string;
+      replacement: Transaction;
+    }>;
+
+    for (const editor of views) {
+      if (editor.editorView.composing) {
+        return 'unavailable';
+      }
+
+      let parsed: EditorView['state']['doc'];
+      try {
+        parsed = this.getMarkdown(editor.editorView.state.schema).parser.parse(
+          markdown,
+        );
+      } catch {
+        return 'unavailable';
+      }
+      if (!isMarkdownContentPreserved(markdown, collectLinkTargets(parsed))) {
+        return 'unavailable';
+      }
+
+      const replacement = buildExternalDocReplace(editor.editorView, parsed);
+      if (!replacement) {
+        return 'unavailable';
+      }
+      replacements.push({
+        editor,
+        originalEditable: editor.editorView.props.editable,
+        originalDoc: editor.editorView.state.doc,
+        originalMarkdown: editor.loadedMarkdown,
+        replacement,
+      });
+    }
+
+    this.saveQueue.createRelocationHandoff(destinationWsPath, markdown);
+    this.setRelocationEditorsEditable(replacements, false);
+    this.applyRelocationEditorReplacements(replacements, markdown);
+    let writeResult: 'superseded' | 'written' | undefined;
+    try {
+      writeResult = await this.saveQueue.enqueueRelocationWrite(
+        destinationWsPath,
+        markdown,
+      );
+      if (writeResult === 'superseded') {
+        this.restoreRelocationEditorReplacements(replacements);
+        this.saveQueue.discardRelocationHandoff(destinationWsPath);
+      } else {
+        this.saveQueue.completeRelocationHandoff(destinationWsPath);
+      }
+      return writeResult;
+    } catch (error) {
+      this.restoreRelocationEditorReplacements(replacements);
+      throw error;
+    } finally {
+      this.setRelocationEditorsEditable(replacements, true);
+    }
+  }
+
+  discardRelocatedMarkdownHandoff(destinationWsPath: string): void {
+    this.saveQueue.discardRelocationHandoff(destinationWsPath);
+  }
+
+  private async resolveRelocationHandoffContent({
+    diskContent,
+    handoff,
+    wsPath,
+  }: {
+    diskContent: string | undefined;
+    handoff: RelocationHandoff | undefined;
+    wsPath: string;
+  }): Promise<string | undefined> {
+    if (!handoff) {
+      return diskContent;
+    }
+    if ((await handoff.outcome) === 'written') {
+      return handoff.markdown;
+    }
+    return this.dependencies.fileSystem.readFileAsText(wsPath);
+  }
+
+  private retargetRelocatedEditors(
+    sourceWsPath: string,
+    destinationWsPath: string,
+  ): void {
+    // File-system rename events normally perform this retarget first. Keep
+    // this idempotent fallback because a relocation can resume immediately
+    // after `renameFile()` while event delivery or route replacement is still
+    // being scheduled; without it the editor handoff can miss the open view.
+    this.saveQueue.relocate(sourceWsPath, destinationWsPath);
+    for (const [domNode, editor] of this.editors) {
+      if (editor.wsPath === sourceWsPath) {
+        this.editors.set(domNode, { ...editor, wsPath: destinationWsPath });
+      }
+    }
+  }
+
+  private setRelocationEditorsEditable(
+    replacements: readonly {
+      editor: ReadyEditorEntry;
+      originalEditable: EditorProps['editable'];
+    }[],
+    editable: boolean,
+  ): void {
+    for (const { editor, originalEditable } of replacements) {
+      if (!editor.editorView.isDestroyed) {
+        editor.editorView.setProps({
+          editable: editable ? originalEditable : () => false,
+        });
+      }
+    }
+  }
+
+  private applyRelocationEditorReplacements(
+    replacements: readonly {
+      editor: ReadyEditorEntry;
+      originalEditable: EditorProps['editable'];
+      replacement: Transaction;
+    }[],
+    markdown: string,
+  ): void {
+    this.applyingExternalSync = true;
+    try {
+      for (const { editor, replacement } of replacements) {
+        if (!editor.editorView.isDestroyed) {
+          editor.editorView.dispatch(replacement);
+          editor.loadedDoc = editor.editorView.state.doc;
+          editor.loadedMarkdown = markdown;
+          this.checkRoundTripFidelity({
+            content: markdown,
+            editorView: editor.editorView,
+            wsPath: editor.wsPath,
+          });
+        }
+      }
+    } finally {
+      this.applyingExternalSync = false;
+    }
+  }
+
+  private restoreRelocationEditorReplacements(
+    replacements: readonly {
+      editor: ReadyEditorEntry;
+      originalEditable: EditorProps['editable'];
+      originalDoc: EditorView['state']['doc'];
+      originalMarkdown: string;
+    }[],
+  ): void {
+    this.applyingExternalSync = true;
+    try {
+      for (const { editor, originalDoc, originalMarkdown } of replacements) {
+        if (editor.editorView.isDestroyed) {
+          continue;
+        }
+        const replacement = buildExternalDocReplace(
+          editor.editorView,
+          originalDoc,
+        );
+        if (!replacement) {
+          continue;
+        }
+        editor.editorView.dispatch(replacement);
+        editor.loadedDoc = editor.editorView.state.doc;
+        editor.loadedMarkdown = originalMarkdown;
+        this.checkRoundTripFidelity({
+          content: originalMarkdown,
+          editorView: editor.editorView,
+          wsPath: editor.wsPath,
+        });
+      }
+    } finally {
+      this.applyingExternalSync = false;
+    }
   }
 
   getEditor(name: string) {

--- a/packages/core/initialize-services/setup.ts
+++ b/packages/core/initialize-services/setup.ts
@@ -4,6 +4,7 @@
  * loaded.
  */
 
+export type { EditorSaveCoordinator } from '@bangle.io/editor';
 export { createEditorSaveCoordinator } from '@bangle.io/editor';
 export type { CoreConfigOverrides } from './src/service-setup';
 export { createServiceSetup } from './src/service-setup';

--- a/packages/core/initialize-services/src/service-setup.ts
+++ b/packages/core/initialize-services/src/service-setup.ts
@@ -24,6 +24,8 @@ import {
   EditorService,
   FileSystemService,
   NavigationService,
+  type NoteRelocationEditorAdapter,
+  NoteRelocationService,
   NoteSnapshotService,
   ShortcutService,
   type ShortcutServiceConfig,
@@ -31,6 +33,7 @@ import {
   WorkbenchStateService,
   WorkspaceOpsService,
   WorkspaceStateService,
+  waitForSaveQueueToDrain,
 } from '@bangle.io/service-core';
 import type {
   BaseFileStorageService,
@@ -58,6 +61,7 @@ export const coreServiceClasses = {
   commandRegistry: CommandRegistryService,
   fileSystem: FileSystemService,
   navigation: NavigationService,
+  noteRelocation: NoteRelocationService,
   noteSnapshot: NoteSnapshotService,
   shortcut: ShortcutService,
   editorService: EditorService,
@@ -256,12 +260,36 @@ type CoreInstances = ConstructorToInstance<CoreServiceClassMap> & {
   editorEngine: EditorEngineContract;
 };
 
+function createNoteRelocationEditorAdapter(
+  editorEngine: EditorEngineContract,
+): NoteRelocationEditorAdapter {
+  const waitForSourceSaveDrain = (wsPath: string, timeoutMs: number) =>
+    waitForSaveQueueToDrain(editorEngine, timeoutMs, wsPath);
+
+  if (editorEngine instanceof PmEditorService) {
+    return {
+      discardRelocatedMarkdownHandoff: (destinationWsPath) =>
+        editorEngine.discardRelocatedMarkdownHandoff(destinationWsPath),
+      waitForSourceSaveDrain,
+      writeRelocatedMarkdown: (params) =>
+        editorEngine.writeRelocatedMarkdown(params),
+    };
+  }
+
+  return {
+    discardRelocatedMarkdownHandoff: () => {},
+    waitForSourceSaveDrain,
+    writeRelocatedMarkdown: async () => 'unavailable',
+  };
+}
+
 function toCoreServices(s: CoreInstances): CoreServices {
   return {
     commandDispatcher: s.commandDispatcher,
     commandRegistry: s.commandRegistry,
     fileSystem: s.fileSystem,
     navigation: s.navigation,
+    noteRelocation: s.noteRelocation,
     noteSnapshot: s.noteSnapshot,
     shortcut: s.shortcut,
     editorService: s.editorService,
@@ -358,6 +386,13 @@ export function createServiceSetup<
       })),
     ),
     navigation: slot(NavigationService),
+    noteRelocation: slot(
+      NoteRelocationService,
+      withOverride('noteRelocation', () => ({
+        getEditorAdapter: () =>
+          createNoteRelocationEditorAdapter(getCoreInstances().editorEngine),
+      })),
+    ),
     noteSnapshot: slot(
       NoteSnapshotService,
       withOverride('noteSnapshot', () => ({
@@ -480,6 +515,7 @@ export function createServiceSetup<
       commandRegistry: s.commandRegistry,
       fileSystem: s.fileSystem,
       navigation: s.navigation,
+      noteRelocation: s.noteRelocation,
       noteSnapshot: s.noteSnapshot,
       shortcut: s.shortcut,
       editorService: s.editorService,

--- a/packages/core/service-core/src/__tests__/note-relocation-reference-rewrite.spec.ts
+++ b/packages/core/service-core/src/__tests__/note-relocation-reference-rewrite.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { planNoteRelocationReferenceRewrite } from '../note-relocation-reference-rewrite';
+
+const source = 'notes:projects/drafts/relocate.md';
+const destination = 'notes:archive/2026/relocate.md';
+
+function plan(markdown: string, existingWsPaths: readonly string[]) {
+  return planNoteRelocationReferenceRewrite({
+    markdown,
+    source,
+    destination,
+    existingWsPaths: [source, ...existingWsPaths],
+  });
+}
+
+describe('planNoteRelocationReferenceRewrite', () => {
+  it('rewrites explicit wiki paths while preserving aliases and fragments', () => {
+    const result = plan(
+      [
+        '[[./sibling|Sibling label]]',
+        '[[../shared/overview.md#section-two|Overview]]',
+        '[[/reference/guide#intro]]',
+        '[[bare note|Never rewrite this]]',
+      ].join('\n\n'),
+      [
+        'notes:projects/drafts/sibling.md',
+        'notes:projects/shared/overview.md',
+        'notes:reference/guide.md',
+        'notes:bare note.md',
+      ],
+    );
+
+    expect(result.markdown).toBe(
+      [
+        '[[../../projects/drafts/sibling.md|Sibling label]]',
+        '[[../../projects/shared/overview.md#section-two|Overview]]',
+        '[[../../reference/guide.md#intro]]',
+        '[[bare note|Never rewrite this]]',
+      ].join('\n\n'),
+    );
+    expect(result.rewrittenReferences).toBe(3);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('rewrites direct Markdown notes, images, and local files with URL-safe paths', () => {
+    const result = plan(
+      [
+        '[Roadmap](./Roadmap%202026.md#future)',
+        '![Diagram](../assets/na%C3%AFve%20diagram.png "Keep title")',
+        '[PDF](/assets/Project%20Plan.pdf)',
+      ].join('\n\n'),
+      [
+        'notes:projects/drafts/Roadmap 2026.md',
+        'notes:projects/assets/naïve diagram.png',
+        'notes:assets/Project Plan.pdf',
+      ],
+    );
+
+    expect(result.markdown).toBe(
+      [
+        '[Roadmap](../../projects/drafts/Roadmap%202026.md#future)',
+        '![Diagram](../../projects/assets/na%C3%AFve%20diagram.png "Keep title")',
+        '[PDF](../../assets/Project%20Plan.pdf)',
+      ].join('\n\n'),
+    );
+    expect(result.rewrittenReferences).toBe(3);
+  });
+
+  it('uses the existing local-file resolver ordering for non-root copied paths', () => {
+    const result = plan('[File](docs/setup.pdf)', [
+      'notes:projects/drafts/docs/setup.pdf',
+      'notes:docs/setup.pdf',
+    ]);
+
+    expect(result.markdown).toBe(
+      '[File](../../projects/drafts/docs/setup.pdf)',
+    );
+  });
+
+  it('skips containers and uncertain inline syntax without warning', () => {
+    const markdown = [
+      '---',
+      'related: [[./frontmatter]]',
+      '---',
+      '',
+      '> ```md',
+      '> [[./quoted-fence]]',
+      '> ```',
+      '',
+      '> > ```md',
+      '> > [[./nested-fence]]',
+      '> > ```',
+      '',
+      '- list item',
+      '  [continuation](./list.md)',
+      '',
+      '<span>context</span> [adjacent](./html.md)',
+      '',
+      '[[ ./spaced-target ]]',
+      '',
+      '`[[./inline-code]]` and `[code](./code.md)`',
+      '',
+      '[reference]: ./reference.md',
+    ].join('\n');
+
+    const result = plan(markdown, [
+      'notes:projects/drafts/frontmatter.md',
+      'notes:projects/drafts/quoted-fence.md',
+      'notes:projects/drafts/nested-fence.md',
+      'notes:projects/drafts/list.md',
+      'notes:projects/drafts/html.md',
+      'notes:projects/drafts/spaced-target.md',
+      'notes:projects/drafts/inline-code.md',
+      'notes:projects/drafts/code.md',
+      'notes:projects/drafts/reference.md',
+    ]);
+
+    expect(result.markdown).toBe(markdown);
+    expect(result.rewrittenReferences).toBe(0);
+    expect(result.unsupportedReferences).toBe(0);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('warns only for an extensionless target recognized in a safe line', () => {
+    const result = plan(
+      ['[extensionless](./extensionless)', '', '> [[./quoted-missing]]'].join(
+        '\n',
+      ),
+      ['notes:projects/drafts/extensionless.md'],
+    );
+
+    expect(result.markdown).toBe(
+      '[extensionless](./extensionless)\n\n> [[./quoted-missing]]',
+    );
+    expect(result.rewrittenReferences).toBe(0);
+    expect(result.unsupportedReferences).toBe(1);
+    expect(result.warnings).toEqual([
+      { kind: 'unsupported-reference', count: 1 },
+    ]);
+  });
+
+  it('changes only destination spans and preserves CRLF byte-for-byte elsewhere', () => {
+    const markdown =
+      'Before  [[./target|Alias]]  after ![Alt](../assets/picture.png "Title")\r\n';
+    const result = plan(markdown, [
+      'notes:projects/drafts/target.md',
+      'notes:projects/assets/picture.png',
+    ]);
+
+    expect(result.markdown).toBe(
+      'Before  [[../../projects/drafts/target.md|Alias]]  after ![Alt](../../projects/assets/picture.png "Title")\r\n',
+    );
+    expect(result.markdown).toContain('Before  [[');
+    expect(result.markdown).toContain('|Alias]]  after ![Alt](');
+    expect(result.markdown.endsWith(' "Title")\r\n')).toBe(true);
+  });
+
+  it('leaves same-path and cross-workspace inputs unchanged', () => {
+    const markdown = '[[./target]]';
+    expect(
+      planNoteRelocationReferenceRewrite({
+        markdown,
+        source,
+        destination: source,
+        existingWsPaths: [source, 'notes:projects/drafts/target.md'],
+      }),
+    ).toEqual({
+      markdown,
+      rewrittenReferences: 0,
+      unsupportedReferences: 0,
+      warnings: [],
+    });
+    expect(
+      planNoteRelocationReferenceRewrite({
+        markdown,
+        source,
+        destination: 'other:relocate.md',
+        existingWsPaths: [source, 'notes:projects/drafts/target.md'],
+      }),
+    ).toEqual({
+      markdown,
+      rewrittenReferences: 0,
+      unsupportedReferences: 0,
+      warnings: [],
+    });
+  });
+});

--- a/packages/core/service-core/src/__tests__/note-relocation-service.spec.ts
+++ b/packages/core/service-core/src/__tests__/note-relocation-service.spec.ts
@@ -1,0 +1,372 @@
+import { getAppErrorCause, isAppError } from '@bangle.io/base-utils';
+import { WORKSPACE_STORAGE_TYPE } from '@bangle.io/constants';
+import { createTestEnvironment } from '@bangle.io/test-utils';
+import { WsFilePath } from '@bangle.io/ws-path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  NoteRelocationContentWriteError,
+  type NoteRelocationEditorAdapter,
+} from '../note-relocation-service';
+
+const WS_NAME = 'test-ws';
+const SOURCE_WS_PATH = `${WS_NAME}:notes/source.md`;
+const DESTINATION_WS_PATH = `${WS_NAME}:archive/source.md`;
+const TARGET_WS_PATH = `${WS_NAME}:notes/target.md`;
+
+let controllers: AbortController[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  for (const controller of controllers) {
+    controller.abort();
+  }
+  controllers = [];
+});
+
+async function setupRelocation({
+  editorAdapter,
+  editorEngineId,
+  source = 'plain note body',
+  target = 'target body',
+}: {
+  editorAdapter?: NoteRelocationEditorAdapter;
+  editorEngineId?: 'wordgard';
+  source?: string;
+  target?: string;
+} = {}) {
+  const controller = new AbortController();
+  controllers.push(controller);
+  const testEnv = createTestEnvironment({
+    controller,
+    ...(editorEngineId ? { editorEngineId } : {}),
+    ...(editorAdapter
+      ? {
+          coreConfigOverrides: {
+            noteRelocation: (base) => ({
+              ...base,
+              getEditorAdapter: () => editorAdapter,
+            }),
+          },
+        }
+      : {}),
+  });
+  const services = testEnv.instantiateAll();
+  await testEnv.mountAll();
+  await services.workspaceOps.createWorkspaceInfo({
+    name: WS_NAME,
+    type: WORKSPACE_STORAGE_TYPE.Memory,
+    metadata: {},
+  });
+  await services.fileSystem.createTextFile(SOURCE_WS_PATH, source);
+  await services.fileSystem.createTextFile(TARGET_WS_PATH, target);
+
+  return { services, testEnv };
+}
+
+function createEditorAdapter({
+  writeError,
+  writeResult = 'written',
+}: {
+  writeError?: Error;
+  writeResult?: 'superseded' | 'unavailable' | 'written';
+} = {}): NoteRelocationEditorAdapter {
+  return {
+    discardRelocatedMarkdownHandoff: vi.fn(),
+    waitForSourceSaveDrain: vi.fn(async () => true),
+    writeRelocatedMarkdown: vi.fn(async () => {
+      if (writeError) {
+        throw writeError;
+      }
+      return writeResult;
+    }),
+  };
+}
+
+function request({
+  source = SOURCE_WS_PATH,
+  destination = DESTINATION_WS_PATH,
+}: {
+  destination?: string;
+  source?: string;
+} = {}) {
+  return {
+    destination: WsFilePath.fromString(destination),
+    source: WsFilePath.fromString(source),
+  };
+}
+
+function expectAppError(error: unknown, name: string): void {
+  if (!isAppError(error)) {
+    throw error;
+  }
+  expect(getAppErrorCause(error)?.name).toBe(name);
+}
+
+describe('NoteRelocationService', () => {
+  it('returns a no-op receipt without touching storage', async () => {
+    const { services } = await setupRelocation();
+    const readSpy = vi.spyOn(services.fileSystem, 'readFileAsText');
+    const renameSpy = vi.spyOn(services.fileSystem, 'renameFile');
+
+    await expect(
+      services.noteRelocation.relocate(
+        request({ destination: SOURCE_WS_PATH }),
+      ),
+    ).resolves.toMatchObject({
+      rewrittenReferences: 0,
+      warnings: [],
+    });
+
+    expect(readSpy).not.toHaveBeenCalled();
+    expect(renameSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing source before changing the destination', async () => {
+    const { services } = await setupRelocation();
+    const missing = `${WS_NAME}:notes/missing.md`;
+    const renameSpy = vi.spyOn(services.fileSystem, 'renameFile');
+
+    await services.noteRelocation
+      .relocate(request({ source: missing }))
+      .catch((error: unknown) => {
+        expectAppError(error, 'error::file:invalid-note-path');
+      });
+
+    expect(renameSpy).not.toHaveBeenCalled();
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a destination collision without overwriting either note', async () => {
+    const { services } = await setupRelocation();
+    await services.fileSystem.createTextFile(
+      DESTINATION_WS_PATH,
+      'destination body',
+    );
+    const renameSpy = vi.spyOn(services.fileSystem, 'renameFile');
+
+    await services.noteRelocation
+      .relocate(request())
+      .catch((error: unknown) => {
+        expectAppError(error, 'error::file:already-existing');
+      });
+
+    expect(renameSpy).not.toHaveBeenCalled();
+    await expect(
+      services.fileSystem.readFileAsText(SOURCE_WS_PATH),
+    ).resolves.toBe('plain note body');
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe('destination body');
+  });
+
+  it('renames unchanged content without a destination write', async () => {
+    const { services } = await setupRelocation();
+
+    await expect(
+      services.noteRelocation.relocate(request()),
+    ).resolves.toMatchObject({ rewrittenReferences: 0, warnings: [] });
+
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe('plain note body');
+  });
+
+  it('rewrites supported paths after the durable rename', async () => {
+    const { services } = await setupRelocation({
+      source: 'unrelated body\n\n[[./target]]',
+    });
+
+    await expect(
+      services.noteRelocation.relocate(request()),
+    ).resolves.toMatchObject({ rewrittenReferences: 1, warnings: [] });
+
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe('unrelated body\n\n[[../notes/target.md]]');
+  });
+
+  it('keeps a changed source body instead of overwriting it with a stale rewrite plan', async () => {
+    const editorAdapter = createEditorAdapter();
+    const originalMarkdown = ['[[./target]]', '[[./target]]'].join('\n\n');
+    const changedMarkdown = '[[./target]]';
+    const { services } = await setupRelocation({
+      editorAdapter,
+      source: originalMarkdown,
+    });
+    const renameFile = services.fileSystem.renameFile.bind(services.fileSystem);
+    const writeFile = services.fileSystem.writeFile.bind(services.fileSystem);
+    vi.spyOn(services.fileSystem, 'renameFile').mockImplementation(
+      async (args) => {
+        if (args.oldWsPath === SOURCE_WS_PATH) {
+          await writeFile(
+            SOURCE_WS_PATH,
+            new File([changedMarkdown], 'source.md', {
+              type: 'text/plain',
+            }),
+          );
+        }
+        return renameFile(args);
+      },
+    );
+
+    await expect(
+      services.noteRelocation.relocate(request()),
+    ).resolves.toMatchObject({
+      rewrittenReferences: 0,
+      warnings: [
+        {
+          kind: 'destination-content-changed',
+          skippedReferences: 2,
+        },
+      ],
+    });
+
+    expect(editorAdapter.writeRelocatedMarkdown).not.toHaveBeenCalled();
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe(changedMarkdown);
+  });
+
+  it('preserves a newer local edit instead of applying the planned rewrite', async () => {
+    const editorAdapter = createEditorAdapter({ writeResult: 'superseded' });
+    const { services } = await setupRelocation({
+      editorAdapter,
+      source: '[[./target]]',
+    });
+
+    await expect(
+      services.noteRelocation.relocate(request()),
+    ).resolves.toMatchObject({
+      rewrittenReferences: 0,
+      warnings: [{ kind: 'newer-local-edit', skippedReferences: 1 }],
+    });
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe('[[./target]]');
+  });
+
+  it('reports when the editor cannot safely apply the planned rewrite', async () => {
+    const editorAdapter = createEditorAdapter({ writeResult: 'unavailable' });
+    const { services } = await setupRelocation({
+      editorAdapter,
+      source: [
+        '[[./target]]',
+        '[[./target]]',
+        '[Extensionless target](./target)',
+      ].join('\n\n'),
+    });
+
+    await expect(
+      services.noteRelocation.relocate(request()),
+    ).resolves.toMatchObject({
+      rewrittenReferences: 0,
+      warnings: [
+        { count: 1, kind: 'unsupported-reference' },
+        { kind: 'editor-content-unavailable', skippedReferences: 2 },
+      ],
+    });
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe(
+      ['[[./target]]', '[[./target]]', '[Extensionless target](./target)'].join(
+        '\n\n',
+      ),
+    );
+  });
+
+  it('keeps the physical move and reports unavailable rewrites in the read-only engine', async () => {
+    const { services } = await setupRelocation({
+      editorEngineId: 'wordgard',
+      source: '[[./target]]',
+    });
+
+    await expect(
+      services.noteRelocation.relocate(request()),
+    ).resolves.toMatchObject({
+      rewrittenReferences: 0,
+      warnings: [{ kind: 'editor-content-unavailable', skippedReferences: 1 }],
+    });
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe('[[./target]]');
+  });
+
+  it('blocks relocation when the initiating save queue cannot drain', async () => {
+    const editorAdapter = createEditorAdapter();
+    vi.mocked(editorAdapter.waitForSourceSaveDrain).mockResolvedValue(false);
+    const { services } = await setupRelocation({ editorAdapter });
+    const renameSpy = vi.spyOn(services.fileSystem, 'renameFile');
+
+    await services.noteRelocation
+      .relocate(request())
+      .catch((error: unknown) => {
+        expectAppError(error, 'error::file:invalid-operation');
+      });
+
+    expect(renameSpy).not.toHaveBeenCalled();
+    await expect(
+      services.fileSystem.readFileAsText(SOURCE_WS_PATH),
+    ).resolves.toBe('plain note body');
+  });
+
+  it('restores the original path when the rewritten destination write fails', async () => {
+    const editorAdapter = createEditorAdapter({
+      writeError: new Error('destination write failed'),
+    });
+    const { services } = await setupRelocation({
+      editorAdapter,
+      source: '[[./target]]',
+    });
+
+    let caught: unknown;
+    try {
+      await services.noteRelocation.relocate(request());
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(NoteRelocationContentWriteError);
+    expect(caught).toMatchObject({ compensation: 'restored' });
+    await expect(
+      services.fileSystem.readFileAsText(SOURCE_WS_PATH),
+    ).resolves.toBe('[[./target]]');
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reports unsuccessful write-failure compensation without deleting the destination', async () => {
+    const editorAdapter = createEditorAdapter({
+      writeError: new Error('destination write failed'),
+    });
+    const { services } = await setupRelocation({
+      editorAdapter,
+      source: '[[./target]]',
+    });
+    const renameFile = services.fileSystem.renameFile.bind(services.fileSystem);
+    vi.spyOn(services.fileSystem, 'renameFile').mockImplementation((args) => {
+      if (args.oldWsPath === DESTINATION_WS_PATH) {
+        return Promise.reject(new Error('restore failed'));
+      }
+      return renameFile(args);
+    });
+
+    let caught: unknown;
+    try {
+      await services.noteRelocation.relocate(request());
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(NoteRelocationContentWriteError);
+    expect(caught).toMatchObject({ compensation: 'failed' });
+    await expect(
+      services.fileSystem.readFileAsText(SOURCE_WS_PATH),
+    ).resolves.toBe(undefined);
+    await expect(
+      services.fileSystem.readFileAsText(DESTINATION_WS_PATH),
+    ).resolves.toBe('[[./target]]');
+  });
+});

--- a/packages/core/service-core/src/index.ts
+++ b/packages/core/service-core/src/index.ts
@@ -11,6 +11,14 @@ export type {
 export { FileSystemService } from './file-system-service';
 export { NavigationService } from './navigation-service';
 export {
+  NoteRelocationContentWriteError,
+  type NoteRelocationEditorAdapter,
+  type NoteRelocationReceipt,
+  type NoteRelocationRequest,
+  NoteRelocationService,
+  type NoteRelocationWarning,
+} from './note-relocation-service';
+export {
   computeSnapshotEvictions,
   NOTE_SNAPSHOT_MAX_PER_WORKSPACE,
   NOTE_SNAPSHOT_MIN_CAPTURE_INTERVAL_MS,

--- a/packages/core/service-core/src/note-relocation-reference-rewrite.ts
+++ b/packages/core/service-core/src/note-relocation-reference-rewrite.ts
@@ -1,0 +1,410 @@
+import {
+  createBaseMarkdownTokenizer,
+  frontmatterTokenizer,
+  parseWikiLinkContent,
+  wikiLinkTokenizer,
+} from '@bangle.io/markdown-syntax';
+import {
+  createWikiLinkIndex,
+  normalizeStoredMarkdownLinkTarget,
+  relativeMarkdownAssetHref,
+  resolveInternalWsPath,
+  resolveWikiLinkTarget,
+  resolveWorkspaceMarkdownAssetReferenceCandidates,
+  type WsFilePath,
+  WsPath,
+} from '@bangle.io/ws-path';
+
+export type NoteRelocationReferenceRewriteWarning = Readonly<{
+  kind: 'unsupported-reference';
+  count: number;
+}>;
+
+export type NoteRelocationReferenceRewritePlan = Readonly<{
+  markdown: string;
+  rewrittenReferences: number;
+  unsupportedReferences: number;
+  warnings: readonly NoteRelocationReferenceRewriteWarning[];
+}>;
+
+export type NoteRelocationReferenceRewriteRequest = Readonly<{
+  markdown: string;
+  source: string | WsFilePath;
+  destination: string | WsFilePath;
+  existingWsPaths: readonly (string | WsFilePath)[];
+}>;
+
+type Span = { start: number; end: number; value: string; next: number };
+type Replacement = Omit<Span, 'next'>;
+type SourceLine = Pick<Span, 'start' | 'value'>;
+
+const relocationMarkdownTokenizer = createBaseMarkdownTokenizer()
+  .use(wikiLinkTokenizer)
+  .use(frontmatterTokenizer);
+
+function unchanged(markdown: string): NoteRelocationReferenceRewritePlan {
+  return {
+    markdown,
+    rewrittenReferences: 0,
+    unsupportedReferences: 0,
+    warnings: [],
+  };
+}
+
+function matchingCloser(
+  source: string,
+  start: number,
+  opening: string,
+  closing: string,
+): number {
+  let depth = 0;
+  for (let position = start; position < source.length; position += 1) {
+    const character = source[position];
+    if (character === opening) {
+      depth += 1;
+    } else if (character === closing) {
+      if (depth === 0) {
+        return position;
+      }
+      depth -= 1;
+    }
+  }
+  return -1;
+}
+
+function hasOnlyTitle(value: string): boolean {
+  if (!value) {
+    return true;
+  }
+  if (!/^[ \t]+/.test(value)) {
+    return false;
+  }
+  const title = value.trim();
+  return (
+    title.length >= 2 &&
+    ((title[0] === '"' && title.at(-1) === '"') ||
+      (title[0] === "'" && title.at(-1) === "'") ||
+      (title[0] === '(' && title.at(-1) === ')'))
+  );
+}
+
+function inlineMarkdownLink(source: string, start: number): Span | undefined {
+  if (source[start] !== '[') {
+    return undefined;
+  }
+  const labelEnd = matchingCloser(source, start + 1, '[', ']');
+  if (labelEnd < 0 || source[labelEnd + 1] !== '(') {
+    return undefined;
+  }
+  const end = matchingCloser(source, labelEnd + 2, '(', ')');
+  if (end < 0) {
+    return undefined;
+  }
+
+  let hrefStart = labelEnd + 2;
+  while (source[hrefStart] === ' ' || source[hrefStart] === '\t') {
+    hrefStart += 1;
+  }
+  let hrefEnd = hrefStart;
+  while (hrefEnd < end && source[hrefEnd] !== ' ' && source[hrefEnd] !== '\t') {
+    hrefEnd += 1;
+  }
+  if (hrefEnd === hrefStart || !hasOnlyTitle(source.slice(hrefEnd, end))) {
+    return undefined;
+  }
+  return {
+    start: hrefStart,
+    end: hrefEnd,
+    value: source.slice(hrefStart, hrefEnd),
+    next: end + 1,
+  };
+}
+
+function wikiLink(source: string, start: number): Span | undefined {
+  if (source.slice(start, start + 2) !== '[[' || source[start - 1] === '!') {
+    return undefined;
+  }
+  const close = source.indexOf(']]', start + 2);
+  const attrs =
+    close < 0
+      ? undefined
+      : parseWikiLinkContent(source.slice(start + 2, close));
+  if (
+    !attrs ||
+    attrs.target.trim() !== attrs.target ||
+    source[close + 2] === '('
+  ) {
+    return undefined;
+  }
+  return {
+    start: start + 2,
+    end: start + 2 + attrs.target.length,
+    value: attrs.target,
+    next: close + 2,
+  };
+}
+
+function lineStarts(markdown: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < markdown.length; index += 1) {
+    if (markdown[index] === '\n') {
+      starts.push(index + 1);
+    }
+  }
+  return starts;
+}
+
+function sourceLine(
+  markdown: string,
+  starts: readonly number[],
+  line: number,
+): string {
+  const start = starts[line];
+  const end = starts[line + 1] ?? markdown.length;
+  return markdown.slice(start, end).replace(/\r?\n$/, '');
+}
+
+/**
+ * Selects only one-line, root-level paragraph tokens whose raw source exactly
+ * matches the tokenizer's inline content. Containers, frontmatter, code
+ * blocks, headings, and multi-line paragraphs cannot satisfy this contract.
+ * Lines with code markers, escapes, or HTML delimiters are also skipped because
+ * their inline token positions do not provide source offsets for safe edits.
+ */
+function directInlineSourceLines(markdown: string): readonly SourceLine[] {
+  const starts = lineStarts(markdown);
+  const tokens = relocationMarkdownTokenizer.parse(markdown, {});
+  const lines: SourceLine[] = [];
+
+  for (const [index, token] of tokens.entries()) {
+    const previous = tokens[index - 1];
+    const map = token.map;
+    if (
+      token.type !== 'inline' ||
+      !map ||
+      map[1] !== map[0] + 1 ||
+      token.level !== 1 ||
+      previous?.type !== 'paragraph_open' ||
+      previous.level !== 0
+    ) {
+      continue;
+    }
+    const line = sourceLine(markdown, starts, map[0]);
+    if (
+      token.content !== line ||
+      line.includes('`') ||
+      line.includes('\\') ||
+      line.includes('<') ||
+      line.includes('>')
+    ) {
+      continue;
+    }
+    lines.push({
+      start: starts[map[0]] ?? 0,
+      value: line,
+    });
+  }
+  return lines;
+}
+
+function splitFragment(value: string): { path: string; fragment: string } {
+  const index = value.indexOf('#');
+  return index < 0
+    ? { path: value, fragment: '' }
+    : { path: value.slice(0, index), fragment: value.slice(index) };
+}
+
+function explicitWikiHref(href: string): string {
+  return /^(?:\.\/|\.\.\/)/.test(href) ? href : `./${href}`;
+}
+
+function existingFiles(
+  wsPaths: readonly (string | WsFilePath)[],
+): Map<string, WsFilePath> {
+  const files = new Map<string, WsFilePath>();
+  for (const wsPath of wsPaths) {
+    const file = WsPath.safeParse(wsPath).data?.asFile();
+    if (file) {
+      files.set(file.wsPath, file);
+    }
+  }
+  return files;
+}
+
+function movedTarget(
+  target: WsFilePath,
+  source: WsFilePath,
+  destination: WsFilePath,
+): WsFilePath {
+  return target.wsPath === source.wsPath ? destination : target;
+}
+
+function markdownTarget(
+  source: WsFilePath,
+  href: string,
+  files: ReadonlyMap<string, WsFilePath>,
+): WsFilePath | undefined {
+  const normalized = normalizeStoredMarkdownLinkTarget(href);
+  if (normalized?.kind !== 'internal' || normalized.href.startsWith('#')) {
+    return undefined;
+  }
+  const resolved = resolveInternalWsPath(source, normalized.href);
+  return resolved ? files.get(resolved.wsPath) : undefined;
+}
+
+function localFileTarget(
+  source: WsFilePath,
+  href: string,
+  files: ReadonlyMap<string, WsFilePath>,
+): WsFilePath | undefined {
+  return resolveWorkspaceMarkdownAssetReferenceCandidates(source, href)
+    .map((candidate) => files.get(candidate.wsPath))
+    .find((candidate): candidate is WsFilePath => Boolean(candidate));
+}
+
+function extensionlessMarkdownTarget(
+  source: WsFilePath,
+  href: string,
+  files: ReadonlyMap<string, WsFilePath>,
+): WsFilePath | undefined {
+  const { path, fragment } = splitFragment(href);
+  const fileName = path.split('/').at(-1);
+  if (
+    !path ||
+    !fileName ||
+    fileName.includes('.') ||
+    path.includes('?') ||
+    path.includes('://') ||
+    path.includes(':')
+  ) {
+    return undefined;
+  }
+  const matches = new Map<string, WsFilePath>();
+  for (const extension of ['.md', '.markdown']) {
+    const resolved = resolveInternalWsPath(
+      source,
+      `${path}${extension}${fragment}`,
+    );
+    const target = resolved ? files.get(resolved.wsPath) : undefined;
+    if (target) {
+      matches.set(target.wsPath, target);
+    }
+  }
+  return matches.size === 1 ? matches.values().next().value : undefined;
+}
+
+function applyReplacements(
+  markdown: string,
+  replacements: readonly Replacement[],
+): string {
+  return [...replacements]
+    .sort((a, b) => b.start - a.start)
+    .reduce(
+      (rewritten, replacement) =>
+        rewritten.slice(0, replacement.start) +
+        replacement.value +
+        rewritten.slice(replacement.end),
+      markdown,
+    );
+}
+
+/**
+ * Plans source-only edits for explicit wiki links and inline Markdown links
+ * found in one-line root paragraphs. Other Markdown is intentionally skipped.
+ */
+export function planNoteRelocationReferenceRewrite({
+  markdown,
+  source: sourceInput,
+  destination: destinationInput,
+  existingWsPaths,
+}: NoteRelocationReferenceRewriteRequest): NoteRelocationReferenceRewritePlan {
+  const source = WsPath.safeParse(sourceInput).data?.asFile();
+  const destination = WsPath.safeParse(destinationInput).data?.asFile();
+  if (
+    !source ||
+    !destination ||
+    source.wsName !== destination.wsName ||
+    source.wsPath === destination.wsPath
+  ) {
+    return unchanged(markdown);
+  }
+
+  const files = existingFiles(existingWsPaths);
+  files.set(source.wsPath, source);
+  const wikiIndex = createWikiLinkIndex([...files.values()], source.wsName);
+  const replacements: Replacement[] = [];
+  let unsupportedReferences = 0;
+
+  for (const line of directInlineSourceLines(markdown)) {
+    for (let start = 0; start < line.value.length; start += 1) {
+      const markdownLink = inlineMarkdownLink(line.value, start);
+      if (markdownLink) {
+        const target =
+          markdownTarget(source, markdownLink.value, files) ??
+          localFileTarget(source, markdownLink.value, files);
+        if (target) {
+          const href = relativeMarkdownAssetHref(
+            destination,
+            movedTarget(target, source, destination),
+          );
+          if (href) {
+            const replacement = `${href}${splitFragment(markdownLink.value).fragment}`;
+            if (replacement !== markdownLink.value) {
+              replacements.push({
+                ...markdownLink,
+                start: line.start + markdownLink.start,
+                end: line.start + markdownLink.end,
+                value: replacement,
+              });
+            }
+          }
+        } else if (
+          extensionlessMarkdownTarget(source, markdownLink.value, files)
+        ) {
+          unsupportedReferences += 1;
+        }
+        start = markdownLink.next - 1;
+        continue;
+      }
+
+      const wiki = wikiLink(line.value, start);
+      if (!wiki) {
+        continue;
+      }
+      const { path, fragment } = splitFragment(wiki.value);
+      if (/^(?:\.\/|\.\.\/|\/)/.test(path)) {
+        const target = resolveWikiLinkTarget(source, path, wikiIndex);
+        if (target) {
+          const href = relativeMarkdownAssetHref(
+            destination,
+            movedTarget(target, source, destination),
+          );
+          if (href) {
+            const replacement = `${explicitWikiHref(href)}${fragment}`;
+            if (replacement !== wiki.value) {
+              replacements.push({
+                ...wiki,
+                start: line.start + wiki.start,
+                end: line.start + wiki.end,
+                value: replacement,
+              });
+            }
+          }
+        } else {
+          unsupportedReferences += 1;
+        }
+      }
+      start = wiki.next - 1;
+    }
+  }
+
+  const warnings = unsupportedReferences
+    ? [{ kind: 'unsupported-reference' as const, count: unsupportedReferences }]
+    : [];
+  return {
+    markdown: applyReplacements(markdown, replacements),
+    rewrittenReferences: replacements.length,
+    unsupportedReferences,
+    warnings,
+  };
+}

--- a/packages/core/service-core/src/note-relocation-service.ts
+++ b/packages/core/service-core/src/note-relocation-service.ts
@@ -1,0 +1,313 @@
+import {
+  BaseService,
+  type BaseServiceContext,
+  throwAppError,
+} from '@bangle.io/base-utils';
+import {
+  EDITOR_SAVE_DRAIN_TIMEOUT_MS,
+  SERVICE_NAME,
+} from '@bangle.io/constants';
+import type { WsFilePath } from '@bangle.io/ws-path';
+import type { FileSystemService } from './file-system-service';
+import {
+  type NoteRelocationReferenceRewriteWarning,
+  planNoteRelocationReferenceRewrite,
+} from './note-relocation-reference-rewrite';
+
+export type NoteRelocationWarning =
+  | NoteRelocationReferenceRewriteWarning
+  | {
+      kind:
+        | 'destination-content-changed'
+        | 'editor-content-unavailable'
+        | 'newer-local-edit';
+      skippedReferences: number;
+    };
+
+export type NoteRelocationRequest = Readonly<{
+  destination: WsFilePath;
+  source: WsFilePath;
+}>;
+
+export type NoteRelocationReceipt = Readonly<{
+  destination: WsFilePath;
+  rewrittenReferences: number;
+  source: WsFilePath;
+  warnings: readonly NoteRelocationWarning[];
+}>;
+
+/**
+ * Engine-specific bridge for applying a relocation rewrite after the durable
+ * move. Composition supplies the ProseMirror implementation; engines without
+ * a safe writable handoff report `unavailable`.
+ */
+export type NoteRelocationEditorAdapter = {
+  discardRelocatedMarkdownHandoff: (destinationWsPath: string) => void;
+  writeRelocatedMarkdown: (params: {
+    destinationWsPath: string;
+    markdown: string;
+    sourceWsPath: string;
+  }) => Promise<'superseded' | 'unavailable' | 'written'>;
+  waitForSourceSaveDrain: (
+    wsPath: string,
+    timeoutMs: number,
+  ) => Promise<boolean>;
+};
+
+/**
+ * Reports a failed post-rename content write and whether returning the only
+ * remaining durable file to its original path succeeded.
+ */
+export class NoteRelocationContentWriteError extends Error {
+  readonly compensation: 'failed' | 'restored';
+  readonly compensationError: unknown;
+  readonly destination: WsFilePath;
+  readonly source: WsFilePath;
+  readonly writeError: unknown;
+
+  constructor({
+    compensation,
+    compensationError,
+    destination,
+    source,
+    writeError,
+  }: {
+    compensation: 'failed' | 'restored';
+    compensationError?: unknown;
+    destination: WsFilePath;
+    source: WsFilePath;
+    writeError: unknown;
+  }) {
+    super(
+      compensation === 'restored'
+        ? 'Could not update the relocated note; it was restored to its original path'
+        : 'Could not update the relocated note and could not restore its original path',
+    );
+    this.name = 'NoteRelocationContentWriteError';
+    this.compensation = compensation;
+    this.compensationError = compensationError;
+    this.destination = destination;
+    this.source = source;
+    this.writeError = writeError;
+  }
+}
+
+/**
+ * Performs the durable, source-only portion of a Markdown note relocation.
+ * Callers retain their existing metadata work (such as star migration) after
+ * this service has completed successfully.
+ */
+export class NoteRelocationService extends BaseService {
+  static deps = ['fileSystem'] as const;
+
+  constructor(
+    context: BaseServiceContext,
+    private dependencies: {
+      fileSystem: FileSystemService;
+    },
+    private config: {
+      getEditorAdapter: () => NoteRelocationEditorAdapter;
+    },
+  ) {
+    super(SERVICE_NAME.noteRelocationService, context, dependencies);
+  }
+
+  hookMount(): void {}
+
+  async relocate({
+    destination,
+    source,
+  }: NoteRelocationRequest): Promise<NoteRelocationReceipt> {
+    source.assertMarkdown();
+    destination.assertMarkdown();
+
+    if (source.wsName !== destination.wsName) {
+      throwAppError(
+        'error::file:invalid-operation',
+        'Cannot relocate a note across workspaces',
+        {
+          operation: 'relocate',
+          oldWsPath: source.wsPath,
+          newWsPath: destination.wsPath,
+        },
+      );
+    }
+
+    if (source.wsPath === destination.wsPath) {
+      return this.receipt(source, destination, 0, []);
+    }
+
+    if (!(await this.dependencies.fileSystem.exists(source.wsPath))) {
+      throwAppError(
+        'error::file:invalid-note-path',
+        'Cannot relocate a missing note',
+        { invalidWsPath: source.wsPath },
+      );
+    }
+    if (await this.dependencies.fileSystem.exists(destination.wsPath)) {
+      throwAppError('error::file:already-existing', 'File already exists', {
+        wsPath: destination.wsPath,
+      });
+    }
+
+    const saved = await this.config
+      .getEditorAdapter()
+      .waitForSourceSaveDrain(source.wsPath, EDITOR_SAVE_DRAIN_TIMEOUT_MS);
+    if (!saved) {
+      throwAppError(
+        'error::file:invalid-operation',
+        'Cannot relocate a note with unsaved changes',
+        {
+          operation: 'relocate',
+          oldWsPath: source.wsPath,
+          newWsPath: destination.wsPath,
+        },
+      );
+    }
+
+    const markdown = await this.dependencies.fileSystem.readFileAsText(
+      source.wsPath,
+    );
+    if (markdown === undefined) {
+      throwAppError(
+        'error::file:invalid-note-path',
+        'Cannot relocate a missing note',
+        { invalidWsPath: source.wsPath },
+      );
+    }
+    const existingWsPaths =
+      await this.dependencies.fileSystem.listWorkspaceFiles(
+        source.wsName,
+        this.abortSignal,
+      );
+    const rewrite = planNoteRelocationReferenceRewrite({
+      destination,
+      existingWsPaths,
+      markdown,
+      source,
+    });
+
+    await this.dependencies.fileSystem.renameFile({
+      oldWsPath: source.wsPath,
+      newWsPath: destination.wsPath,
+    });
+
+    if (rewrite.markdown === markdown) {
+      return this.receipt(
+        source,
+        destination,
+        rewrite.rewrittenReferences,
+        rewrite.warnings,
+      );
+    }
+
+    // A sync tool or another tab can change the source after planning but
+    // before this rename. Never apply that stale plan over the moved bytes.
+    const destinationMarkdown =
+      await this.dependencies.fileSystem.readFileAsText(destination.wsPath);
+    if (destinationMarkdown !== markdown) {
+      return this.receipt(source, destination, 0, [
+        ...rewrite.warnings,
+        ...this.operationSkipWarning(
+          'destination-content-changed',
+          rewrite.rewrittenReferences,
+        ),
+      ]);
+    }
+
+    try {
+      const writeResult = await this.config
+        .getEditorAdapter()
+        .writeRelocatedMarkdown({
+          destinationWsPath: destination.wsPath,
+          markdown: rewrite.markdown,
+          sourceWsPath: source.wsPath,
+        });
+      if (writeResult === 'superseded') {
+        return this.receipt(source, destination, 0, [
+          ...rewrite.warnings,
+          ...this.operationSkipWarning(
+            'newer-local-edit',
+            rewrite.rewrittenReferences,
+          ),
+        ]);
+      }
+      if (writeResult === 'unavailable') {
+        return this.receipt(source, destination, 0, [
+          ...rewrite.warnings,
+          ...this.operationSkipWarning(
+            'editor-content-unavailable',
+            rewrite.rewrittenReferences,
+          ),
+        ]);
+      }
+    } catch (writeError) {
+      try {
+        await this.restoreSourceAfterWriteFailure({
+          destination,
+          source,
+          writeError,
+        });
+      } finally {
+        this.config
+          .getEditorAdapter()
+          .discardRelocatedMarkdownHandoff(destination.wsPath);
+      }
+    }
+
+    return this.receipt(
+      source,
+      destination,
+      rewrite.rewrittenReferences,
+      rewrite.warnings,
+    );
+  }
+
+  private receipt(
+    source: WsFilePath,
+    destination: WsFilePath,
+    rewrittenReferences: number,
+    warnings: readonly NoteRelocationWarning[],
+  ): NoteRelocationReceipt {
+    return { destination, rewrittenReferences, source, warnings };
+  }
+
+  private operationSkipWarning(
+    kind: Extract<NoteRelocationWarning, { skippedReferences: number }>['kind'],
+    skippedReferences: number,
+  ): readonly NoteRelocationWarning[] {
+    return skippedReferences === 0 ? [] : [{ kind, skippedReferences }];
+  }
+
+  private async restoreSourceAfterWriteFailure({
+    destination,
+    source,
+    writeError,
+  }: {
+    destination: WsFilePath;
+    source: WsFilePath;
+    writeError: unknown;
+  }): Promise<never> {
+    try {
+      await this.dependencies.fileSystem.renameFile({
+        oldWsPath: destination.wsPath,
+        newWsPath: source.wsPath,
+      });
+    } catch (compensationError) {
+      throw new NoteRelocationContentWriteError({
+        compensation: 'failed',
+        compensationError,
+        destination,
+        source,
+        writeError,
+      });
+    }
+
+    throw new NoteRelocationContentWriteError({
+      compensation: 'restored',
+      destination,
+      source,
+      writeError,
+    });
+  }
+}

--- a/packages/shared/commands/src/ws-commands.ts
+++ b/packages/shared/commands/src/ws-commands.ts
@@ -133,7 +133,12 @@ export const wsCommands = narrow([
     title: 'Rename Note',
     omniSearch: false,
     dependencies: {
-      services: ['editorEngine', 'fileSystem', 'userActivityService'],
+      services: [
+        'editorEngine',
+        'fileSystem',
+        'noteRelocation',
+        'userActivityService',
+      ],
     },
     args: {
       wsPath: T.String,
@@ -145,7 +150,12 @@ export const wsCommands = narrow([
     title: 'Move Note',
     omniSearch: false,
     dependencies: {
-      services: ['editorEngine', 'fileSystem', 'userActivityService'],
+      services: [
+        'editorEngine',
+        'fileSystem',
+        'noteRelocation',
+        'userActivityService',
+      ],
     },
     args: {
       wsPath: T.String,

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -130,6 +130,7 @@ export const SERVICE_NAME = {
   memoryRouterService: 'memory-router',
   memorySyncDatabaseService: 'memory-sync-database',
   navigationService: 'navigation-service',
+  noteRelocationService: 'note-relocation',
   nodeErrorHandlerService: 'node-error-handler',
   noteSnapshotService: 'note-snapshot',
   shortcutService: 'shortcut',

--- a/packages/shared/translations/src/languages/en.ts
+++ b/packages/shared/translations/src/languages/en.ts
@@ -661,11 +661,56 @@ export const t = {
       fileMoveFailed: 'Could not move file',
       fileMoveStarUpdateFailed: ({ fileName }: { fileName: string }) =>
         `Moved ${fileName}, but could not preserve its starred status`,
+      fileMoveReferenceUpdateIncomplete: ({
+        fileName,
+        warningCount,
+      }: {
+        fileName: string;
+        warningCount: number;
+      }) =>
+        `Moved ${fileName}, but ${warningCount} link reference${warningCount === 1 ? '' : 's'} could not be updated safely`,
+      fileMoveReferenceUpdateSkipped: ({
+        fileName,
+        reason,
+        warningCount,
+      }: {
+        fileName: string;
+        reason: string;
+        warningCount: number;
+      }) =>
+        `Moved ${fileName}, but ${warningCount} link reference${warningCount === 1 ? ' was' : 's were'} not updated because ${reason}`,
       fileRenamed: ({ fileName }: { fileName: string }) =>
         `Renamed to ${fileName}`,
       fileRenameFailed: 'Could not rename file',
       fileRenameStarUpdateFailed: ({ fileName }: { fileName: string }) =>
         `Renamed to ${fileName}, but could not preserve its starred status`,
+      fileRenameReferenceUpdateIncomplete: ({
+        fileName,
+        warningCount,
+      }: {
+        fileName: string;
+        warningCount: number;
+      }) =>
+        `Renamed ${fileName}, but ${warningCount} link reference${warningCount === 1 ? '' : 's'} could not be updated safely`,
+      fileRenameReferenceUpdateSkipped: ({
+        fileName,
+        reason,
+        warningCount,
+      }: {
+        fileName: string;
+        reason: string;
+        warningCount: number;
+      }) =>
+        `Renamed ${fileName}, but ${warningCount} link reference${warningCount === 1 ? ' was' : 's were'} not updated because ${reason}`,
+      noteRelocationDestinationContentChanged:
+        'the note changed during the move',
+      noteRelocationEditorContentUnavailable:
+        'the open editor could not safely apply the update',
+      noteRelocationNewerLocalEdit: 'a newer local edit takes precedence',
+      noteRelocationWriteRestoreFailed: ({ fileName }: { fileName: string }) =>
+        `Could not update ${fileName} and could not restore its original path. Check both paths before continuing.`,
+      noteRelocationWriteRestored: ({ fileName }: { fileName: string }) =>
+        `Could not update ${fileName}; it was restored to its original path`,
       folderDeleted: ({ folderName }: { folderName: string }) =>
         `Deleted ${folderName}`,
       folderDeleteFailed: 'Could not delete folder',

--- a/packages/shared/types/services.ts
+++ b/packages/shared/types/services.ts
@@ -30,6 +30,7 @@ export type CoreServiceSlotId =
   | 'editorService'
   | 'fileSystem'
   | 'navigation'
+  | 'noteRelocation'
   | 'noteSnapshot'
   | 'shortcut'
   | 'userActivityService'

--- a/packages/shared/ws-path/src/__tests__/ws-path.spec.ts
+++ b/packages/shared/ws-path/src/__tests__/ws-path.spec.ts
@@ -535,6 +535,14 @@ describe('WsPath', () => {
       }
     });
 
+    it('rejects a long repeated trailing separator run', () => {
+      const result = WsPath.safeParse(`ws:dir${'/'.repeat(10_000)}`);
+      expect(result.ok).toBe(false);
+      if (!result.ok && result.validationError) {
+        expect(result.validationError.reason).toMatch(/Contains consecutive/);
+      }
+    });
+
     it('should reject path with double slash at start', () => {
       const result = WsPath.safeParse('ws://file.txt');
       expect(result.ok).toBe(false);

--- a/packages/shared/ws-path/src/ws-path.ts
+++ b/packages/shared/ws-path/src/ws-path.ts
@@ -458,7 +458,7 @@ export class WsPath {
     }
 
     if (this.isDir) {
-      const normalizedPath = this.path.replace(/\/+$/, '');
+      const normalizedPath = trimTrailingPathSeparators(this.path);
       const parts = normalizedPath.split(WsPath.PATH_SEPARATOR);
       const lastPart = parts[parts.length - 1] || '';
       return lastPart.replace(/\/$/, '');
@@ -491,7 +491,7 @@ export class WsPath {
     }
 
     // Remove trailing slashes
-    const normalizedPath = this.path.replace(/\/+$/, '');
+    const normalizedPath = trimTrailingPathSeparators(this.path);
 
     let result = '';
 
@@ -782,6 +782,14 @@ export function toFSPathOrThrow(wsPath: string): string {
 
 export function ensureEndsWith(str: string, suffix: string): string {
   return str.endsWith(suffix) ? str : str + suffix;
+}
+
+function trimTrailingPathSeparators(path: string): string {
+  let end = path.length;
+  while (end > 0 && path[end - 1] === PATH_SEPARATOR) {
+    end -= 1;
+  }
+  return path.slice(0, end);
 }
 
 export function removeStartsWith(str: string, char: string): string {

--- a/packages/tooling/e2e-tests/src/note-relocation.e2e.ts
+++ b/packages/tooling/e2e-tests/src/note-relocation.e2e.ts
@@ -1,11 +1,21 @@
 import { expect, type Page, test } from '@playwright/test';
 import {
   createBrowserWorkspaceAndNote,
+  ctrlKey,
+  expandFileTreeFolder,
   getEditorLocator,
   readStoredMarkdown,
   waitForEditorFocus,
+  writeStoredFile,
   writeStoredMarkdown,
 } from './common';
+
+const PNG_1X1_BYTES = [
+  137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0,
+  0, 0, 1, 8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 13, 73, 68, 65, 84, 120,
+  156, 99, 248, 15, 4, 0, 9, 251, 3, 253, 167, 186, 48, 251, 0, 0, 0, 0, 73, 69,
+  78, 68, 174, 66, 96, 130,
+];
 
 async function openFileAction(
   page: Page,
@@ -28,6 +38,138 @@ function starredLink(page: Page, fileName: string) {
     .locator('..')
     .getByRole('link', { name: fileName });
 }
+
+async function openMarkdownLink(page: Page, name: string) {
+  await page.keyboard.down(ctrlKey);
+  await getEditorLocator(page, {}).getByRole('link', { name }).click();
+  await page.keyboard.up(ctrlKey);
+}
+
+test('moving a note preserves direct relative note and image links across an edit and reload', async ({
+  page,
+}, testInfo) => {
+  const workspaceName = `note-relocation-links-${testInfo.workerIndex}-${Date.now()}`;
+  const sourceName = 'projects/source';
+  const movedName = 'Archive/source';
+  const sourceWsPath = `${workspaceName}:${sourceName}.md`;
+  const movedWsPath = `${workspaceName}:${movedName}.md`;
+  const sourceMarkdown = [
+    '# Relocation source',
+    '',
+    '[Open linked note](./target.md)',
+    '',
+    '![Relocation image](./assets/relocation.png)',
+  ].join('\n');
+  const postMoveEdit = ' Saved after relocation.';
+
+  await createBrowserWorkspaceAndNote(page, {
+    workspaceName,
+    noteName: sourceName,
+  });
+  await writeStoredMarkdown(
+    page,
+    workspaceName,
+    'projects/target',
+    '# Linked target',
+  );
+  await writeStoredFile(
+    page,
+    workspaceName,
+    'projects/assets/relocation.png',
+    PNG_1X1_BYTES,
+    'image/png',
+  );
+  await writeStoredMarkdown(page, workspaceName, 'Archive/placeholder', '');
+  await writeStoredMarkdown(page, workspaceName, sourceName, sourceMarkdown);
+  await page.reload({ waitUntil: 'networkidle' });
+
+  const editor = getEditorLocator(page, {});
+  const linkedNote = editor.getByRole('link', { name: 'Open linked note' });
+  const image = editor.getByRole('img', { name: 'Relocation image' });
+  await expect(linkedNote).toHaveAttribute('href', './target.md');
+  await expect(image).toBeVisible();
+  await expect(image).toHaveAttribute('src', /^blob:/);
+
+  await expandFileTreeFolder(page, /^projects$/);
+  await openFileAction(page, 'source.md', 'Move');
+  const moveDialog = page.getByRole('dialog', {
+    name: 'Move "source"',
+  });
+  const archiveOption = moveDialog.getByRole('option', { name: /Archive\/?/ });
+  await expect(archiveOption).toBeVisible();
+  await archiveOption.click();
+
+  const movedUrl = `/ws#route=editor&wsPath=${encodeURIComponent(movedWsPath)}`;
+  await expect(page).toHaveURL(movedUrl);
+  await expect
+    .poll(() => editor.getAttribute('data-editor-name'))
+    .toContain(movedWsPath);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, movedName))
+    .toContain('[Open linked note](../projects/target.md)');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, movedName))
+    .toContain('![Relocation image](../projects/assets/relocation.png)');
+
+  // This save must keep the rewritten destinations, not write the mounted
+  // editor's pre-move snapshot back over them.
+  await editor.click();
+  await waitForEditorFocus(page, {});
+  await page.keyboard.press('End');
+  await page.keyboard.type(postMoveEdit);
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, movedName))
+    .toContain(postMoveEdit.trim());
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, movedName))
+    .toContain('[Open linked note](../projects/target.md)');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, movedName))
+    .toContain('![Relocation image](../projects/assets/relocation.png)');
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, sourceName))
+    .toBeUndefined();
+
+  await expect(linkedNote).toHaveAttribute('href', '../projects/target.md');
+  await expect(image).toBeVisible();
+  await expect(image).toHaveAttribute('src', /^blob:/);
+  await openMarkdownLink(page, 'Open linked note');
+  await expect(page).toHaveURL(
+    `/ws#route=editor&wsPath=${encodeURIComponent(`${workspaceName}:projects/target.md`)}`,
+  );
+  await expect(
+    getEditorLocator(page, {}).getByRole('heading', {
+      name: 'Linked target',
+    }),
+  ).toBeVisible();
+
+  await page.goBack();
+  await expect(page).toHaveURL(movedUrl);
+  await page.reload({ waitUntil: 'networkidle' });
+  await expect(page).toHaveURL(movedUrl);
+  await expect(linkedNote).toHaveAttribute('href', '../projects/target.md');
+  await expect(image).toBeVisible();
+  await expect(image).toHaveAttribute('src', /^blob:/);
+  await openMarkdownLink(page, 'Open linked note');
+  await expect(page).toHaveURL(
+    `/ws#route=editor&wsPath=${encodeURIComponent(`${workspaceName}:projects/target.md`)}`,
+  );
+  await expect(
+    getEditorLocator(page, {}).getByRole('heading', {
+      name: 'Linked target',
+    }),
+  ).toBeVisible();
+
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, movedName))
+    .toContain(postMoveEdit.trim());
+  await expect
+    .poll(() => readStoredMarkdown(page, workspaceName, sourceName))
+    .toBeUndefined();
+  await expect(page).not.toHaveURL(
+    `/ws#route=editor&wsPath=${encodeURIComponent(sourceWsPath)}`,
+  );
+});
 
 test('rename and move preserve the latest content and starred path across tabs and reload', async ({
   context,

--- a/packages/tooling/test-utils/test-service-setup.ts
+++ b/packages/tooling/test-utils/test-service-setup.ts
@@ -10,6 +10,7 @@ import {
   type CoreConfigOverrides,
   createEditorSaveCoordinator,
   createServiceSetup,
+  type EditorSaveCoordinator,
 } from '@bangle.io/initialize-services/setup';
 import { slot } from '@bangle.io/poor-mans-di';
 import {
@@ -67,6 +68,7 @@ function createTestServiceSetup(
   commandHandlers: Array<{ id: string; handler: CommandHandler }>,
   coreConfigOverrides: CoreConfigOverrides | undefined,
   editorEngineId: EditorEngineId,
+  editorSaveCoordinator: EditorSaveCoordinator,
 ): TestServiceSetup {
   return createServiceSetup({
     commonOpts,
@@ -91,7 +93,7 @@ function createTestServiceSetup(
     },
     fileStorageSlots: ['fileStorageMemory'],
     editorEngineId,
-    editorSaveCoordinator: createEditorSaveCoordinator(),
+    editorSaveCoordinator,
     coreConfigOverrides,
   });
 }
@@ -122,12 +124,14 @@ export function createTestEnvironment({
   commandHandlers = defaultCommandHandlers,
   coreConfigOverrides,
   editorEngineId = 'prosemirror',
+  editorSaveCoordinator = createEditorSaveCoordinator(),
 }: {
   controller?: AbortController;
   commands?: BangleAppCommand[];
   commandHandlers?: Array<{ id: string; handler: CommandHandler }>;
   coreConfigOverrides?: CoreConfigOverrides;
   editorEngineId?: EditorEngineId;
+  editorSaveCoordinator?: EditorSaveCoordinator;
 } = {}): TestEnvironment {
   const { commonOpts, mockLog, rootEmitter } = makeTestCommonOpts({
     controller,
@@ -140,6 +144,7 @@ export function createTestEnvironment({
     commandHandlers,
     coreConfigOverrides,
     editorEngineId,
+    editorSaveCoordinator,
   );
 
   return {

--- a/plans/021-safe-note-relocation.md
+++ b/plans/021-safe-note-relocation.md
@@ -1,6 +1,6 @@
 ---
 title: Safe Note Rename And Move
-status: planned
+status: active
 type: plan
 archived: false
 archived_on:
@@ -17,54 +17,44 @@ related_issues:
 
 ## Summary
 
-Treat a Bangle-initiated note rename or move as one semantic operation instead
-of a raw file rename. Preserve only references Bangle can already resolve and
-rewrite safely. Keep assets in place and rebase their links. Do not infer
-ownership, repair unsupported syntax, or introduce hidden note identities.
+Make Bangle-initiated rename and move preserve direct relative references from
+the relocated note without turning one file operation into a workspace-wide
+transaction. The first release handles one Markdown note in one workspace,
+keeps assets where they are, and edits only destination spans that can be
+identified exactly.
 
-The first release stays deliberately narrow: one Markdown note, one workspace,
-one `relocate()` entry point, exact source edits, and explicit failure when the
-operation cannot be proven safe.
-
-## Product Outcome
-
-After a successful rename or move:
-
-- the latest note content remains durable;
-- the route, open editor, file tree, stars, and snapshots follow the new path;
-- deterministically resolved incoming note links still reach the same note;
-- relative links and asset references from the moved note still reach the same
-  files;
-- backlinks rebuild from the corrected Markdown;
-- unrelated Markdown bytes do not change; and
-- reload and clean secondary tabs observe the same final state.
-
-Success must not imply that Bangle updated unsupported or unresolved syntax.
+Incoming references in other notes are intentionally not rewritten in this
+release. That follow-up requires separate product decisions about multi-note
+writes, dirty editors in other tabs, recovery, and external filesystem races.
 
 ## Current Status
 
-The low-level relocation foundation is already strong:
+Implementation and local verification are complete on the linked draft PR.
+An independent senior review approved the final design after the relocation
+handoff was moved onto the browser-root save coordinator so it survives an
+in-app UI-service reload.
 
-- command handlers wait for source saves before the storage rename;
-- storage adapters reject destination conflicts without overwriting;
-- Native FS keeps the source until its fallback copy is byte-verified;
-- logical rename events retarget the route, file tree, editor, save queue,
-  snapshots, stars, and other tabs after storage succeeds; and
-- current E2E coverage proves content, path, star, cross-tab, and reload
-  behavior.
+The existing relocation foundation already:
 
-The missing behavior is semantic reference preservation. Current rename and
-move operations do not rewrite incoming wiki/Markdown links or rebase outgoing
-relative note and asset links. The backlink index is derived from Markdown, so
-it correctly reflects whatever is stored but cannot repair broken sources.
+- drains the initiating note's save queue before rename or move;
+- rejects destination conflicts without overwriting;
+- keeps the source during Native FS copy fallback until verification succeeds;
+- retargets the route, tree, editor, save queue, stars, snapshots, and clean
+  secondary tabs through existing rename events; and
+- covers durable content, reload, stars, collisions, and cross-tab behavior.
 
-## KISS Product Decisions
+The remaining v1 problem is narrower: moving a note changes the base path of
+its direct relative note, image, and file links. Those links can silently point
+elsewhere or stop resolving even though the path move itself succeeds.
 
-### One note-only Module
+## Product Decisions
 
-Add a `NoteRelocationService` in `@bangle.io/service-core`. Rename and move
-commands become thin callers. Keep raw non-note file moves and directory
-renames on their existing paths until they receive separate product scope.
+### One note-oriented Module
+
+Add one `NoteRelocationService.relocate()` Module in
+`@bangle.io/service-core`. Existing rename and move callers use it only for
+Markdown notes. Raw file moves and directory operations retain their existing
+behavior.
 
 ```ts
 type NoteRelocationRequest = Readonly<{
@@ -75,247 +65,199 @@ type NoteRelocationRequest = Readonly<{
 type NoteRelocationReceipt = Readonly<{
   source: WsFilePath;
   destination: WsFilePath;
-  rewrittenNotes: number;
   rewrittenReferences: number;
   warnings: readonly NoteRelocationWarning[];
 }>;
 
 interface NoteRelocationService {
-  relocate(
-    request: NoteRelocationRequest,
-    options?: { signal?: AbortSignal },
-  ): Promise<NoteRelocationReceipt>;
+  relocate(request: NoteRelocationRequest): Promise<NoteRelocationReceipt>;
 }
 ```
 
-Do not expose separate public methods for planning, reference rewriting,
-editor retargeting, metadata migration, or recovery. Those are implementation
-details behind this interface.
+This is the only new caller-facing Interface. Reference planning, safe source
+edits, save coordination, and rollback details remain inside the Module. Do
+not add public preview, transaction, journal, lock, or cancellation interfaces.
 
-### Automatic only when deterministic
+### Source-only reference preservation
 
-For Bangle-initiated relocation, update a reference only when all of the
-following are true:
+V1 inspects and may edit only the Markdown note being relocated. It does not
+scan or mutate other notes.
 
-1. Bangle recognizes the syntax using shared Markdown/link semantics.
-2. The reference resolves to one exact workspace file before relocation.
-3. Its source destination span is known exactly.
-4. A replacement can be generated that resolves to the same mapped file after
-   relocation.
-5. The source file still matches the version used to plan the edit.
+Supported forms are deliberately limited to direct syntax on a one-line,
+root-level paragraph whose raw line exactly matches the Markdown tokenizer's
+inline content. Within those safe lines, v1 handles:
 
-If a recognized reference would break but Bangle cannot produce an exact safe
-edit, block the relocation with the source note and reason. Never guess or
-silently report full preservation.
+- explicit-path wiki links such as `[[./note]]`, `[[../note]]`, and
+  `[[/folder/note]]`, including aliases and fragments;
+- direct inline Markdown links to existing Markdown notes; and
+- direct inline Markdown images or file links to existing local files.
+
+Rewrite a destination only when it resolves to one existing workspace file
+before relocation and a replacement can be generated that resolves to that
+same file from the destination note path.
+
+V1 leaves these byte-identical:
+
+- bare wiki links;
+- reference-style Markdown definitions;
+- extensionless Markdown targets whose interpretation differs between current
+  resolvers;
+- external URLs, explicit schemes, and fragment-only links;
+- code, frontmatter, HTML, comments, escaped text, malformed syntax, and
+  unsupported dialect constructs; and
+- headings, lists, blockquotes, multi-line paragraphs, and any other container;
+- any destination whose exact source range or resolved identity is uncertain.
+
+Recognized-but-unsupported references do not block the physical relocation.
+Return a concise warning count instead. Syntax outside the safe-line contract
+is skipped without claiming it was analyzed. A destination changed after
+planning, a newer local edit, or an editor engine unable to perform the guarded
+write also keeps the physical move and warns with the exact number of planned
+edits skipped.
+
+Only data-safety failures block: source save failure, missing source,
+destination collision, read failure, rename failure, or destination content
+write failure. On a write failure, report whether returning the durable file to
+its original path succeeded.
 
 ### Assets stay where they are
 
-Moving a note does not move its `assets/` directory or any adjacent files.
-Asset ownership is ambiguous and assets may be shared. Recalculate supported
-relative Markdown asset targets in the moved note so they continue to resolve
-to the existing asset paths.
+Do not move an `assets/` directory or infer asset ownership. Rebase supported
+direct links in the note so they continue to resolve to the same existing
+files. Shared-asset analysis, orphan cleanup, and "move attachments with note"
+remain out of scope.
 
-Do not add orphan cleanup, shared-asset analysis, per-note asset ownership, or
-"move attachments with note" behavior in this plan.
+### Preserve Markdown bytes
 
-### Preserve source, not formatting output
-
-Apply descending source-range replacements to the stored Markdown. Never
-parse and serialize the whole note through either editor engine. Labels,
-aliases, fragments, encoding style, line endings, whitespace, and all bytes
-outside changed destination spans remain untouched.
-
-## Reference Preservation Rules
-
-Build a pre-relocation and projected post-relocation note index. For every
-supported reference, preserve resolved identity rather than literal spelling.
-
-The first release covers:
-
-- Bangle wiki links, including aliases, when their target resolves exactly;
-- internal CommonMark note links whose destination span is exact;
-- reference definitions when their shared destination span is exact;
-- Markdown images and local file links in the moved note; and
-- rooted and relative paths, extensions, fragments, and safe URL encoding.
-
-Rewrite:
-
-- incoming references to the moved note;
-- outgoing relative note and asset references from the moved note; and
-- any otherwise-resolved wiki link whose target would change because the move
-  changed duplicate-name proximity or ambiguity.
-
-Leave byte-identical:
-
-- external URLs and explicit schemes;
-- unresolved or already-ambiguous references;
-- code, frontmatter, raw HTML, comments, escaped text, and malformed syntax;
-- unsupported embeds or dialect-specific constructs; and
-- visible link labels, except where an unaliased wiki target is itself the
-  visible text.
-
-The reference analyzer becomes the shared source of truth for backlink
-extraction and relocation planning so those behaviors cannot drift.
+Apply descending replacements to exact destination ranges. Do not parse and
+serialize the complete note through an editor. Preserve labels, aliases,
+fragments, line endings, whitespace, and every byte outside changed ranges.
 
 ## Operation And Failure Semantics
 
-1. Validate file paths, Markdown type, same-workspace scope, no-op, source
-   existence, and destination conflict before mutation.
-2. Quiesce app writes for the workspace, drain affected editor save queues,
-   and acquire one workspace mutation lease shared with file writes.
-3. Read the current Markdown, build the pre/post indexes, and calculate exact
-   edits.
-4. Re-read/fingerprint affected files under the lease. Abort and re-plan if
-   any source changed.
-5. Persist one narrowly scoped recovery record containing the old/new path,
-   affected file fingerprints, and original affected Markdown before the
-   first write.
-6. Apply reference content edits and the durable file rename. Do not emit
-   logical file events until the complete operation succeeds.
-7. On failure, restore only files whose fingerprints prove they still contain
-   this operation's output. Never overwrite a later user or external edit.
-8. If safe compensation cannot finish, retain the recovery record and surface
-   `recovery-required`; never emit success.
-9. After durable success, emit the rename before content updates so editor
-   paths retarget first, then migrate stars and snapshot metadata. Metadata
-   failure is a warning and repair task, not a claim that the file move failed.
+1. Validate Markdown file paths, same-workspace scope, no-op, source existence,
+   and destination conflict.
+2. Drain the initiating tab's source save queue using existing editor-save
+   coordination.
+3. Read the latest durable source and calculate only supported exact edits.
+4. Relocate through the existing durable `FileSystemService.renameFile()` path
+   so current route, editor, storage-adapter, and cross-tab behavior remains in
+   force.
+5. Re-read the destination after rename and apply the plan only when its bytes
+   still equal the source snapshot used for planning. If they differ, keep the
+   move, leave the newer bytes untouched, and warn with the skipped edit count.
+6. For the ProseMirror engine, apply the rewritten Markdown through the
+   existing per-note save queue and a private relocation handoff so a route
+   remount or in-app UI-service reload cannot load and later re-save the
+   pre-rewrite body. Keep the handoff on the existing browser-root save
+   coordinator so replacement service graphs share the in-flight outcome. If a
+   newer local edit wins, keep it and warn. An editor engine without this safe
+   write path keeps the physical move and warns instead of pretending the
+   rewrite landed.
+7. If the destination content write fails, best-effort rename the destination
+   back to the source. Report whether compensation succeeded. Never delete the
+   only durable copy and never claim universal filesystem atomicity.
+8. Migrate stars after the content and path operation succeeds. Snapshot
+   migration remains the current event-driven, best-effort behavior.
 
-Memory and IndexedDB may implement this more atomically than Native FS. The
-product must not claim universal filesystem atomicity. The recovery record is
-the safety mechanism, not a new general transaction framework.
-
-## User Experience
-
-- Rename and move dialogs stay open with controls disabled while relocation is
-  pending.
-- Collision, save timeout, stale content, read failure, or unsafe recognized
-  reference keeps the dialog input and leaves the workspace unchanged.
-- Safe deterministic reference edits happen as part of the requested action;
-  there is no settings matrix in the first release.
-- Success copy reports useful impact, for example: "Moved plan.md and updated
-  7 references in 3 notes."
-- No-op relocation produces no success toast or storage event.
-- Cancellation is supported before the durable mutation begins. Once the
-  durability phase starts, the operation must settle to success, compensated
-  failure, or recovery-required rather than report a false cancellation.
+Existing file events remain immediate. V1 does not add deferred publication,
+conditional storage writes, fingerprints, durable journals, crash-repair UX,
+or cross-tab dirty-editor coordination.
 
 ## Scope
 
-- Rename one Markdown note within its workspace.
-- Move one Markdown note within its workspace.
-- Preserve deterministic supported incoming and outgoing references.
-- Rebase supported local asset references without moving asset files.
-- Preserve current editor, route, tree, star, snapshot, cross-tab, and reload
-  behavior.
-- Browser, memory, IndexedDB, and Native FS behavioral alignment.
+- Rename one Markdown note within one workspace.
+- Move one Markdown note within one workspace.
+- Preserve supported direct relative note and local-file destinations from the
+  relocated note.
+- Keep existing raw-file and directory behavior unchanged.
+- Preserve current route, editor, tree, star, snapshot, clean-cross-tab, and
+  reload behavior.
 
 ## Out Of Scope
 
-- Cross-workspace moves or copies.
-- Directory rename/move reference rewriting.
-- Moving or renaming assets and repairing their inbound references.
-- Automatically moving attachments with notes.
-- Stable IDs, hidden frontmatter IDs, redirect notes, aliases, or tombstones.
-- Repairing existing broken links.
-- Rewriting raw HTML, frontmatter, code, or unsupported Markdown dialects.
-- Reacting to external filesystem renames by modifying other files.
-- General preview, configurable `never/prompt/always` behavior, or user-facing
-  Undo in the first release.
+- Rewriting incoming references or scanning the full workspace.
+- Guaranteed backlink preservation after rename.
+- Bare wiki-link duplicate-proximity repair.
+- Reference-style Markdown links and generic dialect support.
+- Cross-workspace move or copy.
+- Directory reference rewriting.
+- Moving or renaming assets as part of a note move.
+- Stable IDs, redirects, tombstones, or automatic broken-link repair.
+- Workspace mutation leases, multi-file transactions, durable recovery
+  records, user-facing Undo, and dirty-secondary-tab guarantees.
+- Reacting to external filesystem renames by modifying Markdown.
 
-## Delivery Phases
+## Delivery
 
-### Phase 1: Pure reference analysis
-
-- Add a source-range-aware internal reference analyzer using the shared
-  Markdown tokenizer and `WsPath` resolvers.
-- Return resolved targets and exact editable destination spans.
-- Refactor backlink extraction to consume the same analyzer.
-- Add fidelity tests before wiring any mutation.
-
-### Phase 2: Narrow relocation Module
-
-- Add `NoteRelocationService.relocate()` and typed expected failures.
-- Add the workspace mutation lease, conditional fingerprint checks, deferred
-  event publication, and the minimal recovery record.
-- Test success, compensation, interrupted recovery, and unsafe rollback with
-  real memory storage and adapter contract coverage.
-
-### Phase 3: Existing callers and UX
-
-- Route current note rename, move dialog, tree drag/drop for Markdown notes,
-  and note-table actions through the Module.
-- Keep raw asset moves and directory operations unchanged.
-- Make dialogs await completion and retain their input on failure.
-- Add translations and completion impact counts.
-
-### Phase 4: Released workflow proof
-
-- Extend `note-relocation.e2e.ts` with wiki, Markdown, duplicate-name, image,
-  backlink, cross-tab, reload, collision, and failure cases.
-- Add Native FS recovery/fallback coverage for affected behavior.
-- Run the required project gates and the release-candidate manual persistence
-  smoke before release.
+1. Add a pure source-position-aware rewrite planner for the explicitly
+   supported direct forms.
+2. Prove aliases, fragments, CRLF, encoding, code/frontmatter exclusion, local
+   images, and byte preservation with focused fixtures.
+3. Add the narrow `NoteRelocationService` Module and test it through its single
+   Interface using real memory storage where practical.
+4. Route Markdown note rename and move callers through the Module while leaving
+   raw files and directories alone.
+5. Add a released-workflow Playwright E2E that moves a note containing a direct
+   relative note link and local image, then verifies both after reload.
+6. Run required repository checks and perform an independent code review before
+   updating the draft PR.
 
 ## Verification
 
-Pure analyzer coverage must include:
+Focused rewrite tests must cover:
 
-- wiki targets with aliases and duplicate stems;
-- inline and reference-style Markdown links;
-- relative/rooted paths, extensions, fragments, spaces, and Unicode;
-- incoming links and outgoing links from a moved source;
-- images and other local asset links;
-- code, frontmatter, HTML, escaped syntax, external URLs, and malformed input;
-- CRLF/LF and byte preservation outside replaced spans; and
-- projected links that would change to a different duplicate target.
+- supported wiki aliases and fragments on safe root-level lines;
+- inline Markdown links and images;
+- relative and rooted destinations, spaces, Unicode, and safe URL encoding;
+- code, frontmatter, HTML, escaped syntax, external URLs, malformed input,
+  headings, lists, blockquotes, and multi-line paragraphs;
+- LF and CRLF; and
+- byte identity outside changed destination spans.
 
-Module and adapter coverage must include:
+Module and integration tests must cover:
 
 - source missing, destination conflict, and same-path no-op;
-- pending, failed, and late editor saves;
-- affected files changing between analysis and commit;
-- read, permission, quota, content-write, rename, and compensation failures;
-- interrupted-operation recovery without overwriting subsequent edits;
-- final rename/content event ordering;
-- stars and snapshots after success or metadata degradation; and
-- clean and dirty secondary-tab behavior.
+- save drain failure and same-tab edits near relocation;
+- route remount and UI-service reload while the destination write is pending;
+- unchanged content when no supported rewrite is required;
+- destination bytes changing after planning, newer local edits, and an editor
+  engine without a guarded content-write path;
+- content-write failure with successful and unsuccessful compensation;
+- raw non-note files retaining their existing move behavior; and
+- stars, reload, and existing clean-cross-tab behavior.
 
-Implementation completion requires `pnpm lint:ci` and `pnpm test:ci`. Add or
-update Playwright coverage during implementation but run it for the final PR
-update according to repository policy. Before the final PR update, run
-`pnpm local-ci-check`.
+The released E2E must use user-visible rename or move controls and verify after
+reload that the moved note still opens its direct relative note link and renders
+its local image. Existing path, content, collision, star, and cross-tab tests
+remain part of the regression suite.
 
-## Known Blockers And Risks
+Implementation completion requires `pnpm lint:ci`, `pnpm test:ci`, and the
+relevant Playwright suite. Before the final PR update, `pnpm local-ci-check`
+must pass.
 
-- Markdown-it tokens do not currently expose every editable destination range;
-  the analyzer must prove source ranges without regex replacement or whole-note
-  serialization.
-- Rewriting dependent notes expands save coordination beyond the moved source,
-  especially when another tab has a dirty editor. The mutation lease must
-  prevent stale app writes from undoing reference edits.
-- Native FS cannot provide a universal multi-file transaction against external
-  OS writers. Fingerprints and conditional recovery are mandatory.
-- A full workspace scan is acceptable for the first release because relocation
-  is infrequent. Reuse the workspace index later only if measurements justify
-  the added cache invalidation complexity.
+Final local verification on 2026-08-03:
 
-## Alignment Questions
+- `pnpm lint:ci` passed;
+- `pnpm test:ci` passed 175 files and 3,731 tests, with one skipped;
+- `pnpm build` passed;
+- the focused note-relocation Playwright file passed all four workflows; and
+- `pnpm local-ci-check` passed, including 220 browser E2E tests, eight
+  component tests, desktop tests/build, and the Electron persistence smoke.
 
-1. Should safe deterministic inbound-link updates happen automatically, as
-   proposed, or should Bangle only rebase the moved note and show an impact
-   report for other notes?
-2. When a recognized reference would break but cannot be rewritten exactly,
-   should relocation block, as proposed, or allow an explicit "move anyway"
-   escape hatch?
-3. Please confirm that assets should stay at their current paths while the
-   moved note's supported links are rebased; moving asset files with the note
-   remains out of scope.
+## Known Risks
 
-## Next Steps
+- Exact source positions for Markdown destinations are not available from the
+  current backlink tokens. The rewrite planner must prove its own narrow spans
+  without becoming a second full Markdown parser.
+- Same-tab editor writes can race a post-rename content rewrite. Prefer a small
+  extension of existing queue coordination over a new locking framework.
+- Native FS and external programs cannot participate in an application-level
+  transaction. Compensation is best effort and must be reported honestly.
 
-- Resolve the three alignment questions above.
-- Validate an exact source-range approach for wiki and CommonMark destinations
-  with a small pure spike.
-- Split implementation into the analyzer, relocation Module, and UX/E2E phases
-  above rather than combining semantic rewriting and storage mutation in one
-  large change.
+## Follow-Up
+
+Create a separate plan for automatic inbound-link preservation only after the
+product chooses its multi-note consistency contract. That plan must explicitly
+address dirty editors in other tabs, conditional writes or conflict handling,
+event visibility, partial failure, and crash recovery.

--- a/plans/021-safe-note-relocation.md
+++ b/plans/021-safe-note-relocation.md
@@ -7,7 +7,8 @@ archived_on:
 created: 2026-08-03
 updated: 2026-08-03
 owner: mixed
-related_prs: []
+related_prs:
+  - https://github.com/bangle-io/bangle-io/pull/700
 related_issues:
   - https://github.com/bangle-io/bangle-io/issues/679
 ---

--- a/plans/021-safe-note-relocation.md
+++ b/plans/021-safe-note-relocation.md
@@ -1,0 +1,320 @@
+---
+title: Safe Note Rename And Move
+status: planned
+type: plan
+archived: false
+archived_on:
+created: 2026-08-03
+updated: 2026-08-03
+owner: mixed
+related_prs: []
+related_issues:
+  - https://github.com/bangle-io/bangle-io/issues/679
+---
+
+# Safe Note Rename And Move
+
+## Summary
+
+Treat a Bangle-initiated note rename or move as one semantic operation instead
+of a raw file rename. Preserve only references Bangle can already resolve and
+rewrite safely. Keep assets in place and rebase their links. Do not infer
+ownership, repair unsupported syntax, or introduce hidden note identities.
+
+The first release stays deliberately narrow: one Markdown note, one workspace,
+one `relocate()` entry point, exact source edits, and explicit failure when the
+operation cannot be proven safe.
+
+## Product Outcome
+
+After a successful rename or move:
+
+- the latest note content remains durable;
+- the route, open editor, file tree, stars, and snapshots follow the new path;
+- deterministically resolved incoming note links still reach the same note;
+- relative links and asset references from the moved note still reach the same
+  files;
+- backlinks rebuild from the corrected Markdown;
+- unrelated Markdown bytes do not change; and
+- reload and clean secondary tabs observe the same final state.
+
+Success must not imply that Bangle updated unsupported or unresolved syntax.
+
+## Current Status
+
+The low-level relocation foundation is already strong:
+
+- command handlers wait for source saves before the storage rename;
+- storage adapters reject destination conflicts without overwriting;
+- Native FS keeps the source until its fallback copy is byte-verified;
+- logical rename events retarget the route, file tree, editor, save queue,
+  snapshots, stars, and other tabs after storage succeeds; and
+- current E2E coverage proves content, path, star, cross-tab, and reload
+  behavior.
+
+The missing behavior is semantic reference preservation. Current rename and
+move operations do not rewrite incoming wiki/Markdown links or rebase outgoing
+relative note and asset links. The backlink index is derived from Markdown, so
+it correctly reflects whatever is stored but cannot repair broken sources.
+
+## KISS Product Decisions
+
+### One note-only Module
+
+Add a `NoteRelocationService` in `@bangle.io/service-core`. Rename and move
+commands become thin callers. Keep raw non-note file moves and directory
+renames on their existing paths until they receive separate product scope.
+
+```ts
+type NoteRelocationRequest = Readonly<{
+  source: WsFilePath;
+  destination: WsFilePath;
+}>;
+
+type NoteRelocationReceipt = Readonly<{
+  source: WsFilePath;
+  destination: WsFilePath;
+  rewrittenNotes: number;
+  rewrittenReferences: number;
+  warnings: readonly NoteRelocationWarning[];
+}>;
+
+interface NoteRelocationService {
+  relocate(
+    request: NoteRelocationRequest,
+    options?: { signal?: AbortSignal },
+  ): Promise<NoteRelocationReceipt>;
+}
+```
+
+Do not expose separate public methods for planning, reference rewriting,
+editor retargeting, metadata migration, or recovery. Those are implementation
+details behind this interface.
+
+### Automatic only when deterministic
+
+For Bangle-initiated relocation, update a reference only when all of the
+following are true:
+
+1. Bangle recognizes the syntax using shared Markdown/link semantics.
+2. The reference resolves to one exact workspace file before relocation.
+3. Its source destination span is known exactly.
+4. A replacement can be generated that resolves to the same mapped file after
+   relocation.
+5. The source file still matches the version used to plan the edit.
+
+If a recognized reference would break but Bangle cannot produce an exact safe
+edit, block the relocation with the source note and reason. Never guess or
+silently report full preservation.
+
+### Assets stay where they are
+
+Moving a note does not move its `assets/` directory or any adjacent files.
+Asset ownership is ambiguous and assets may be shared. Recalculate supported
+relative Markdown asset targets in the moved note so they continue to resolve
+to the existing asset paths.
+
+Do not add orphan cleanup, shared-asset analysis, per-note asset ownership, or
+"move attachments with note" behavior in this plan.
+
+### Preserve source, not formatting output
+
+Apply descending source-range replacements to the stored Markdown. Never
+parse and serialize the whole note through either editor engine. Labels,
+aliases, fragments, encoding style, line endings, whitespace, and all bytes
+outside changed destination spans remain untouched.
+
+## Reference Preservation Rules
+
+Build a pre-relocation and projected post-relocation note index. For every
+supported reference, preserve resolved identity rather than literal spelling.
+
+The first release covers:
+
+- Bangle wiki links, including aliases, when their target resolves exactly;
+- internal CommonMark note links whose destination span is exact;
+- reference definitions when their shared destination span is exact;
+- Markdown images and local file links in the moved note; and
+- rooted and relative paths, extensions, fragments, and safe URL encoding.
+
+Rewrite:
+
+- incoming references to the moved note;
+- outgoing relative note and asset references from the moved note; and
+- any otherwise-resolved wiki link whose target would change because the move
+  changed duplicate-name proximity or ambiguity.
+
+Leave byte-identical:
+
+- external URLs and explicit schemes;
+- unresolved or already-ambiguous references;
+- code, frontmatter, raw HTML, comments, escaped text, and malformed syntax;
+- unsupported embeds or dialect-specific constructs; and
+- visible link labels, except where an unaliased wiki target is itself the
+  visible text.
+
+The reference analyzer becomes the shared source of truth for backlink
+extraction and relocation planning so those behaviors cannot drift.
+
+## Operation And Failure Semantics
+
+1. Validate file paths, Markdown type, same-workspace scope, no-op, source
+   existence, and destination conflict before mutation.
+2. Quiesce app writes for the workspace, drain affected editor save queues,
+   and acquire one workspace mutation lease shared with file writes.
+3. Read the current Markdown, build the pre/post indexes, and calculate exact
+   edits.
+4. Re-read/fingerprint affected files under the lease. Abort and re-plan if
+   any source changed.
+5. Persist one narrowly scoped recovery record containing the old/new path,
+   affected file fingerprints, and original affected Markdown before the
+   first write.
+6. Apply reference content edits and the durable file rename. Do not emit
+   logical file events until the complete operation succeeds.
+7. On failure, restore only files whose fingerprints prove they still contain
+   this operation's output. Never overwrite a later user or external edit.
+8. If safe compensation cannot finish, retain the recovery record and surface
+   `recovery-required`; never emit success.
+9. After durable success, emit the rename before content updates so editor
+   paths retarget first, then migrate stars and snapshot metadata. Metadata
+   failure is a warning and repair task, not a claim that the file move failed.
+
+Memory and IndexedDB may implement this more atomically than Native FS. The
+product must not claim universal filesystem atomicity. The recovery record is
+the safety mechanism, not a new general transaction framework.
+
+## User Experience
+
+- Rename and move dialogs stay open with controls disabled while relocation is
+  pending.
+- Collision, save timeout, stale content, read failure, or unsafe recognized
+  reference keeps the dialog input and leaves the workspace unchanged.
+- Safe deterministic reference edits happen as part of the requested action;
+  there is no settings matrix in the first release.
+- Success copy reports useful impact, for example: "Moved plan.md and updated
+  7 references in 3 notes."
+- No-op relocation produces no success toast or storage event.
+- Cancellation is supported before the durable mutation begins. Once the
+  durability phase starts, the operation must settle to success, compensated
+  failure, or recovery-required rather than report a false cancellation.
+
+## Scope
+
+- Rename one Markdown note within its workspace.
+- Move one Markdown note within its workspace.
+- Preserve deterministic supported incoming and outgoing references.
+- Rebase supported local asset references without moving asset files.
+- Preserve current editor, route, tree, star, snapshot, cross-tab, and reload
+  behavior.
+- Browser, memory, IndexedDB, and Native FS behavioral alignment.
+
+## Out Of Scope
+
+- Cross-workspace moves or copies.
+- Directory rename/move reference rewriting.
+- Moving or renaming assets and repairing their inbound references.
+- Automatically moving attachments with notes.
+- Stable IDs, hidden frontmatter IDs, redirect notes, aliases, or tombstones.
+- Repairing existing broken links.
+- Rewriting raw HTML, frontmatter, code, or unsupported Markdown dialects.
+- Reacting to external filesystem renames by modifying other files.
+- General preview, configurable `never/prompt/always` behavior, or user-facing
+  Undo in the first release.
+
+## Delivery Phases
+
+### Phase 1: Pure reference analysis
+
+- Add a source-range-aware internal reference analyzer using the shared
+  Markdown tokenizer and `WsPath` resolvers.
+- Return resolved targets and exact editable destination spans.
+- Refactor backlink extraction to consume the same analyzer.
+- Add fidelity tests before wiring any mutation.
+
+### Phase 2: Narrow relocation Module
+
+- Add `NoteRelocationService.relocate()` and typed expected failures.
+- Add the workspace mutation lease, conditional fingerprint checks, deferred
+  event publication, and the minimal recovery record.
+- Test success, compensation, interrupted recovery, and unsafe rollback with
+  real memory storage and adapter contract coverage.
+
+### Phase 3: Existing callers and UX
+
+- Route current note rename, move dialog, tree drag/drop for Markdown notes,
+  and note-table actions through the Module.
+- Keep raw asset moves and directory operations unchanged.
+- Make dialogs await completion and retain their input on failure.
+- Add translations and completion impact counts.
+
+### Phase 4: Released workflow proof
+
+- Extend `note-relocation.e2e.ts` with wiki, Markdown, duplicate-name, image,
+  backlink, cross-tab, reload, collision, and failure cases.
+- Add Native FS recovery/fallback coverage for affected behavior.
+- Run the required project gates and the release-candidate manual persistence
+  smoke before release.
+
+## Verification
+
+Pure analyzer coverage must include:
+
+- wiki targets with aliases and duplicate stems;
+- inline and reference-style Markdown links;
+- relative/rooted paths, extensions, fragments, spaces, and Unicode;
+- incoming links and outgoing links from a moved source;
+- images and other local asset links;
+- code, frontmatter, HTML, escaped syntax, external URLs, and malformed input;
+- CRLF/LF and byte preservation outside replaced spans; and
+- projected links that would change to a different duplicate target.
+
+Module and adapter coverage must include:
+
+- source missing, destination conflict, and same-path no-op;
+- pending, failed, and late editor saves;
+- affected files changing between analysis and commit;
+- read, permission, quota, content-write, rename, and compensation failures;
+- interrupted-operation recovery without overwriting subsequent edits;
+- final rename/content event ordering;
+- stars and snapshots after success or metadata degradation; and
+- clean and dirty secondary-tab behavior.
+
+Implementation completion requires `pnpm lint:ci` and `pnpm test:ci`. Add or
+update Playwright coverage during implementation but run it for the final PR
+update according to repository policy. Before the final PR update, run
+`pnpm local-ci-check`.
+
+## Known Blockers And Risks
+
+- Markdown-it tokens do not currently expose every editable destination range;
+  the analyzer must prove source ranges without regex replacement or whole-note
+  serialization.
+- Rewriting dependent notes expands save coordination beyond the moved source,
+  especially when another tab has a dirty editor. The mutation lease must
+  prevent stale app writes from undoing reference edits.
+- Native FS cannot provide a universal multi-file transaction against external
+  OS writers. Fingerprints and conditional recovery are mandatory.
+- A full workspace scan is acceptable for the first release because relocation
+  is infrequent. Reuse the workspace index later only if measurements justify
+  the added cache invalidation complexity.
+
+## Alignment Questions
+
+1. Should safe deterministic inbound-link updates happen automatically, as
+   proposed, or should Bangle only rebase the moved note and show an impact
+   report for other notes?
+2. When a recognized reference would break but cannot be rewritten exactly,
+   should relocation block, as proposed, or allow an explicit "move anyway"
+   escape hatch?
+3. Please confirm that assets should stay at their current paths while the
+   moved note's supported links are rebased; moving asset files with the note
+   remains out of scope.
+
+## Next Steps
+
+- Resolve the three alignment questions above.
+- Validate an exact source-range approach for wiki and CommonMark destinations
+  with a small pure spike.
+- Split implementation into the analyzer, relocation Module, and UX/E2E phases
+  above rather than combining semantic rewriting and storage mutation in one
+  large change.


### PR DESCRIPTION
## Summary

- rebase deterministically resolved outgoing note and local-file references when one Markdown note is renamed or moved
- fail closed on unsupported Markdown, leave incoming links and assets untouched, and warn when planned edits are skipped
- protect open-note edits with save draining, a stale-byte guard, compensated write failures, and a reload-safe editor handoff

## Reviewer callouts

- v1 rewrites direct syntax only in one-line root-level paragraphs
- rename plus content rewrite is not crash-atomic on storage backends without transactions; a failed post-rename write attempts to restore the source path and reports whether that succeeded